### PR TITLE
Added the LArFormattingHelper class

### DIFF
--- a/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
@@ -26,8 +26,10 @@ CheatingCosmicRayTaggingTool::CheatingCosmicRayTaggingTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingCosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos)
+void CheatingCosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm)
 {
+    (void) pAlgorithm;
+
     if (this->GetPandora().GetSettings()->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 

--- a/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.h
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.h
@@ -24,7 +24,7 @@ public:
      */
     CheatingCosmicRayTaggingTool();
 
-    void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos);
+    void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -26,6 +26,7 @@
 #include "larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.h"
 
 #include "larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h"
+#include "larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.h"
 #include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
 #include "larpandoracontent/LArControlFlow/NeutrinoIdTool.h"
 #include "larpandoracontent/LArControlFlow/PostProcessingAlgorithm.h"
@@ -172,7 +173,7 @@
 
 #define LAR_ALGORITHM_LIST(d)                                                                                                   \
     d("LArEventValidation",                     EventValidationAlgorithm)                                                       \
-    d("LArPfoValidation",                     PfoValidationAlgorithm)                                                           \
+    d("LArPfoValidation",                       PfoValidationAlgorithm)                                                         \
     d("LArMCParticleMonitoring",                MCParticleMonitoringAlgorithm)                                                  \
     d("LArVisualMonitoring",                    VisualMonitoringAlgorithm)                                                      \
     d("LArEventReading",                        EventReadingAlgorithm)                                                          \
@@ -259,6 +260,7 @@
 
 #define LAR_ALGORITHM_TOOL_LIST(d)                                                                                              \
     d("LArCosmicRayTagging",                    CosmicRayTaggingTool)                                                           \
+    d("LArCosmicRayTaggingMonitoring",          CosmicRayTaggingMonitoringTool)                                                 \
     d("LArNeutrinoId",                          NeutrinoIdTool)                                                                 \
     d("LArStitchingCosmicRayMerging",           StitchingCosmicRayMergingTool)                                                  \
     d("LArCheatingEventSlicing",                CheatingEventSlicingTool)                                                       \

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -41,6 +41,7 @@
 #include "larpandoracontent/LArMonitoring/EventValidationAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h"
+#include "larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h"
 
 #include "larpandoracontent/LArPersistency/EventReadingAlgorithm.h"
 #include "larpandoracontent/LArPersistency/EventWritingAlgorithm.h"
@@ -171,6 +172,7 @@
 
 #define LAR_ALGORITHM_LIST(d)                                                                                                   \
     d("LArEventValidation",                     EventValidationAlgorithm)                                                       \
+    d("LArPfoValidation",                     PfoValidationAlgorithm)                                                           \
     d("LArMCParticleMonitoring",                MCParticleMonitoringAlgorithm)                                                  \
     d("LArVisualMonitoring",                    VisualMonitoringAlgorithm)                                                      \
     d("LArEventReading",                        EventReadingAlgorithm)                                                          \

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.cc
@@ -12,7 +12,6 @@
 #include "larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.h"
 
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
-#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 #include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
@@ -154,6 +153,7 @@ bool CosmicRayTaggingMonitoringTool::IsMainMCParticleMuon(const ParticleFlowObje
     catch (const StatusCodeException &) 
     {
     }
+
     return isMuon;
 }
 

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.cc
@@ -1,0 +1,326 @@
+/**
+ *  @file   larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.cc
+ *
+ *  @brief  Implementation of the cosmic-ray tagging monitoring tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "Pandora/PdgTable.h"
+
+#include "larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.h"
+
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
+
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+CosmicRayTaggingMonitoringTool::CosmicRayTaggingMonitoringTool() :
+    m_minHitsToConsiderTagging(15),
+    m_minPurity(0.95),
+    m_minImpurity(0.95),
+    m_minSignificance(0.1)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void CosmicRayTaggingMonitoringTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm)
+{
+    if (this->GetPandora().GetSettings()->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    const MCParticleList *pMCParticleList = nullptr;
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*pAlgorithm, pMCParticleList));
+
+    const CaloHitList *pCaloHitList = nullptr;
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*pAlgorithm, m_caloHitList2D, pCaloHitList));
+    
+    // Identify reconstructable MCParticles, and get mappings to their good hits
+    LArMCParticleHelper::MCContributionMap nuMCParticlesToGoodHitsMap;
+    LArMCParticleHelper::MCContributionMap beamMCParticlesToGoodHitsMap;
+    LArMCParticleHelper::MCContributionMap crMCParticlesToGoodHitsMap;
+
+    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
+
+    // Get the hit sharing maps between Pfos and reconstructable MCParticles
+    LArMCParticleHelper::MCContributionMapVector mcParticlesToGoodHitsMaps({nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap, crMCParticlesToGoodHitsMap});
+    
+    LArMCParticleHelper::PfoContributionMap pfoToReconstructable2DHitsMap;
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(parentCosmicRayPfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap);
+
+    LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCParticleHitSharingMap;
+    LArMCParticleHelper::MCParticleToPfoHitSharingMap mcParticleToPfoHitSharingMap;
+    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(pfoToReconstructable2DHitsMap, mcParticlesToGoodHitsMaps, pfoToMCParticleHitSharingMap, mcParticleToPfoHitSharingMap);
+    
+    // Calculate the purity and significane and classification of each Pfo
+    PfoToFloatMap pfoSignificanceMap;
+    PfoToFloatMap pfoPurityMap;
+    PfoClassificationMap pfoClassificationMap;
+    LArMCParticleHelper::MCContributionMapVector targetsToGoodHitsMaps({nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap});
+    this->CalculatePfoMetrics(pfoToMCParticleHitSharingMap, pfoToReconstructable2DHitsMap, targetsToGoodHitsMaps, pfoSignificanceMap, pfoPurityMap, pfoClassificationMap);
+
+    // -------------------------------------------------------------------------------------------------------------------------------------
+    
+    // Print the monte-carlo information for this event
+    MCParticleVector orderedMCParticleVector;
+    LArMonitoringHelper::GetOrderedMCParticleVector(mcParticlesToGoodHitsMaps, orderedMCParticleVector);
+
+    LArFormattingHelper::PrintHeader("MC : Reconstructable neutrino final state particles");
+    LArMonitoringHelper::PrintMCParticleTable(nuMCParticlesToGoodHitsMap, orderedMCParticleVector); 
+    
+    LArFormattingHelper::PrintHeader("MC : Reconstructable primary beam particles");
+    LArMonitoringHelper::PrintMCParticleTable(beamMCParticlesToGoodHitsMap, orderedMCParticleVector); 
+    
+    LArFormattingHelper::PrintHeader("MC : Reconstructable primary cosmic-rays");
+    LArMonitoringHelper::PrintMCParticleTable(crMCParticlesToGoodHitsMap, orderedMCParticleVector); 
+
+    LArFormattingHelper::PrintHeader("Reco : Primary cosmic-ray candidates");
+    std::cout << "Columns with headers [n] are the number of shared hits between the Pfo and the target MCParticle with ID n." << std::endl;
+    
+    PfoVector orderedPfoVector;
+    LArMonitoringHelper::GetOrderedPfoVector(pfoToReconstructable2DHitsMap, orderedPfoVector);
+    this->PrintPfoTable(orderedPfoVector, pfoToReconstructable2DHitsMap, pfoPurityMap, pfoSignificanceMap, pfoClassificationMap, ambiguousPfos);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void CosmicRayTaggingMonitoringTool::CalculatePfoMetrics(const LArMCParticleHelper::PfoToMCParticleHitSharingMap &hitSharingMap, const LArMCParticleHelper::PfoContributionMap &pfoToCaloHitListMap, const LArMCParticleHelper::MCContributionMapVector &targetsToGoodHitsMaps, PfoToFloatMap &pfoSignificanceMap, PfoToFloatMap &pfoPurityMap, PfoClassificationMap &pfoClassificationMap) const
+{
+    for (LArMCParticleHelper::PfoToMCParticleHitSharingMap::const_iterator it=hitSharingMap.begin(); it != hitSharingMap.end(); ++it)
+    {
+        if (pfoToCaloHitListMap.find(it->first) == pfoToCaloHitListMap.end())
+            throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+        const unsigned int n2DHits(pfoToCaloHitListMap.at(it->first).size());
+        float significance(0);
+        float purity(0);
+        
+        if (n2DHits != 0)
+        {
+            // Sum over all target/shared hits pairs
+            for (const LArMCParticleHelper::MCParticleIntPair &targetHitsShared : it->second)
+            {
+                bool foundTarget(false);
+                unsigned int nMCHits(std::numeric_limits<unsigned int>::max());
+                for (const LArMCParticleHelper::MCContributionMap &mcContributionMap : targetsToGoodHitsMaps)
+                {
+                    if (mcContributionMap.find(targetHitsShared.first) != mcContributionMap.end())
+                    {
+                        foundTarget = true;
+                        nMCHits = mcContributionMap.at(targetHitsShared.first).size();
+                        break;
+                    }
+                }
+                
+                if (!foundTarget)
+                    continue;
+    
+                significance += static_cast<float>(targetHitsShared.second) / static_cast<float>(nMCHits);
+                purity += static_cast<float>(targetHitsShared.second) / static_cast<float>(n2DHits);
+            }
+        }
+        
+        if (!pfoSignificanceMap.insert(PfoToFloatMap::value_type(it->first, significance)).second)
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+        
+        if (!pfoPurityMap.insert(PfoToFloatMap::value_type(it->first, purity)).second)
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+
+        Classification classification(this->ClassifyPfo(n2DHits, significance, purity, this->IsMainMCParticleMuon(it->first)));
+        if (!pfoClassificationMap.insert(PfoClassificationMap::value_type(it->first, classification)).second)
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool CosmicRayTaggingMonitoringTool::IsMainMCParticleMuon(const ParticleFlowObject *const pPfo) const
+{
+    bool isMuon(false);
+    try
+    {
+        isMuon = (std::abs(LArMCParticleHelper::GetMainMCParticle(pPfo)->GetParticleId()) == MU_MINUS);
+    }
+    catch (const StatusCodeException &) 
+    {
+    }
+    return isMuon;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+CosmicRayTaggingMonitoringTool::Classification CosmicRayTaggingMonitoringTool::ClassifyPfo(const unsigned int &nHits, const float &significance, const float &purity, const bool isMuon) const
+{
+    if (nHits < m_minHitsToConsiderTagging)
+        return SPARSE;
+
+    bool isPure(purity > m_minPurity);
+    bool isImpure((1 - purity) > m_minImpurity);
+    bool isSignificant(significance > m_minSignificance);
+
+    if (!isPure && !isImpure)
+        return MIXED;
+
+    if (isPure && isSignificant)
+        return TARGET;
+
+    if (isPure && !isSignificant)
+        return FRAGMENTED;
+
+    if (!isPure && isSignificant)
+        return ABSORBED;
+
+    if (!isPure && !isSignificant && isMuon)
+        return CR_MUON;
+
+    if (!isPure && !isSignificant && !isMuon)
+        return CR_OTHER;
+
+    return UNCLASSIFIED;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+    
+void CosmicRayTaggingMonitoringTool::PrintPfoTable(const PfoVector &orderedPfoVector, const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const PfoToFloatMap &pfoPurityMap, const PfoToFloatMap &pfoSignificanceMap, const PfoClassificationMap &pfoClassificationMap, const PfoList &ambiguousPfos) const
+{
+    if (orderedPfoVector.empty())
+    {
+        std::cout << "No Pfos supplied." << std::endl;
+        return;
+    }
+
+    LArFormattingHelper::Table table({"ID", "PID", "", "nHits", "U", "V", "W", "", "nGoodHits", "U", "V", "W", "", "Purity", "Significance", "Classification", "", "Tagged?"});
+ 
+    for (unsigned int id = 0; id < orderedPfoVector.size(); ++id)
+    {
+        const ParticleFlowObject *const pPfo(orderedPfoVector.at(id));
+        
+        LArMCParticleHelper::PfoContributionMap::const_iterator it = pfoToReconstructable2DHitsMap.find(pPfo);
+        if (pfoToReconstructable2DHitsMap.end() == it)
+            throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+        if (pfoPurityMap.end() == pfoPurityMap.find(pPfo))
+            throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        
+        if (pfoSignificanceMap.end() == pfoSignificanceMap.find(pPfo))
+            throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+        if (pfoClassificationMap.end() == pfoClassificationMap.find(pPfo))
+            throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+        table.AddElement(id);
+        table.AddElement(pPfo->GetParticleId());
+
+        CaloHitList all2DCaloHits;
+        LArMonitoringHelper::CollectCaloHits(pPfo, all2DCaloHits);
+            
+        table.AddElement(all2DCaloHits.size());
+        table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, all2DCaloHits));
+        table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, all2DCaloHits));
+        table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, all2DCaloHits));
+
+        table.AddElement(it->second.size());
+        table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, it->second));
+        table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, it->second));
+        table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, it->second));
+        
+        table.AddElement(pfoPurityMap.at(pPfo));
+        table.AddElement(pfoSignificanceMap.at(pPfo));
+
+        const Classification classification(pfoClassificationMap.at(pPfo));
+        table.AddElement(this->GetClassificationName(classification), LArFormattingHelper::INVERTED, this->GetClassificationColor(classification));
+
+        const bool isTagged(std::find(ambiguousPfos.begin(), ambiguousPfos.end(), pPfo) == ambiguousPfos.end());
+        const bool isGoodTag(isTagged && (classification == CR_MUON || classification == CR_OTHER));
+        const bool isBadTag(isTagged && (classification == TARGET));
+        const LArFormattingHelper::Color tagColor(isGoodTag ? LArFormattingHelper::LIGHT_GREEN : (isBadTag ? LArFormattingHelper::LIGHT_RED : LArFormattingHelper::LIGHT_YELLOW));
+        table.AddElement(isTagged ? "yes" : "no", LArFormattingHelper::INVERTED, tagColor); 
+    }
+
+    table.Print();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArFormattingHelper::Color CosmicRayTaggingMonitoringTool::GetClassificationColor(const Classification &classification) const
+{
+    switch (classification)
+    {
+        case TARGET: return LArFormattingHelper::LIGHT_GREEN;
+        case CR_MUON: return LArFormattingHelper::LIGHT_RED;
+        case CR_OTHER: return LArFormattingHelper::LIGHT_YELLOW;
+        case FRAGMENTED: return LArFormattingHelper::LIGHT_BLUE;
+        case ABSORBED: return LArFormattingHelper::LIGHT_MAGENTA;
+        case MIXED: return LArFormattingHelper::LIGHT_CYAN;
+        default: return LArFormattingHelper::LIGHT_GRAY;
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+std::string CosmicRayTaggingMonitoringTool::GetClassificationName(const Classification &classification) const
+{
+    switch (classification)
+    {
+        case TARGET: return "TARGET";
+        case CR_MUON: return "CR_MUON";
+        case CR_OTHER: return "CR_OTHER";
+        case FRAGMENTED: return "FRAGMENTED";
+        case ABSORBED: return "ABSORBED";
+        case MIXED: return "MIXED";
+        case SPARSE: return "SPARSE";
+        default: return "UNCLASSIFIED";
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode CosmicRayTaggingMonitoringTool::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
+        "CaloHitList2D", m_caloHitList2D));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinPrimaryGoodHits", m_parameters.m_minPrimaryGoodHits));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinHitsForGoodView", m_parameters.m_minHitsForGoodView));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinPrimaryGoodViews", m_parameters.m_minPrimaryGoodViews));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "SelectInputHits", m_parameters.m_selectInputHits));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MaxPhotonPropagation", m_parameters.m_maxPhotonPropagation));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinHitSharingFraction", m_parameters.m_minHitSharingFraction));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinHitsToConsiderTagging", m_minHitsToConsiderTagging));
+    
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinPurity", m_minPurity));
+    
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinImpurity", m_minImpurity));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinSignificance", m_minSignificance));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.h
@@ -1,0 +1,100 @@
+/**
+ *  @file   larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.h
+ *
+ *  @brief  Header file for the cosmic-ray tagging monitoring tool class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_COSMIC_RAY_TAGGING_MONITORING_TOOL_H
+#define LAR_COSMIC_RAY_TAGGING_MONITORING_TOOL_H 1
+
+#include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
+
+#include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+
+#include "PandoraMonitoringApi.h"
+
+#include <unordered_map>
+
+namespace lar_content
+{
+
+/**
+ *  @brief  CosmicRayTaggingMonitoringTool class
+ */
+class CosmicRayTaggingMonitoringTool : public CosmicRayTaggingBaseTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    CosmicRayTaggingMonitoringTool();
+
+    void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm);
+
+private:
+    LArMCParticleHelper::ValidationParameters  m_parameters;                 ///< Parameters used to decide when an MCParticle is reconstructable
+    unsigned int                               m_minHitsToConsiderTagging;   ///< The minimum number of hits to consider a Pfo for tagging
+    float                                      m_minPurity;                  ///< The minimum purity to consider a Pfo as "pure"
+    float                                      m_minImpurity;                ///< The minimum impurity to consider a Pfo as "impure"
+    float                                      m_minSignificance;            ///< The minimum significance to consider a Pfo as "significant"
+    std::string                                m_caloHitList2D;              ///< The 2D calo hit list 
+
+    /**
+     *  @brief
+     */
+    enum Classification
+    {
+        CR_MUON,
+        CR_OTHER,
+        TARGET,
+        FRAGMENTED,
+        ABSORBED,
+        MIXED,
+        SPARSE,
+        UNCLASSIFIED
+    };
+
+    typedef std::map<const pandora::ParticleFlowObject*, float > PfoToFloatMap;
+    typedef std::map<const pandora::ParticleFlowObject*, Classification > PfoClassificationMap;
+
+    /**
+     *  @brief
+     */
+    void CalculatePfoMetrics(const LArMCParticleHelper::PfoToMCParticleHitSharingMap &hitSharingMap, const LArMCParticleHelper::PfoContributionMap &pfoTo2DHitsMap, const LArMCParticleHelper::MCContributionMapVector &nuMCParticlesToGoodHitsMaps, PfoToFloatMap &pfoSignificanceMap, PfoToFloatMap &pfoPurityMap, PfoClassificationMap &pfoClassificationMap) const;
+
+    /**
+     *  @brief
+     */
+    bool IsMainMCParticleMuon(const pandora::ParticleFlowObject *const pPfo) const;
+
+    /**
+     *  @brief
+     */
+    Classification ClassifyPfo(const unsigned int &nHits, const float &significance, const float &purity, const bool isMuon) const;
+
+    /**
+     *  @brief
+     */
+    LArFormattingHelper::Color GetClassificationColor(const Classification &classification) const;
+
+    /**
+     *  @brief
+     */
+    std::string GetClassificationName(const Classification &classification) const;
+
+    /**
+     *  @brief
+     */
+    void PrintPfoTable(const pandora::PfoVector &orderedPfoVector, const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const PfoToFloatMap &pfoPurityMap, const PfoToFloatMap &pfoSignificanceMap, const PfoClassificationMap &pfoClassificationMap, const pandora::PfoList &ambiguousPfos) const;
+    /**
+     *  @brief
+     */
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_COSMIC_RAY_TAGGING_MONITORING_TOOL_H

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingMonitoringTool.h
@@ -34,13 +34,6 @@ public:
     void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm);
 
 private:
-    LArMCParticleHelper::ValidationParameters  m_parameters;                 ///< Parameters used to decide when an MCParticle is reconstructable
-    unsigned int                               m_minHitsToConsiderTagging;   ///< The minimum number of hits to consider a Pfo for tagging
-    float                                      m_minPurity;                  ///< The minimum purity to consider a Pfo as "pure"
-    float                                      m_minImpurity;                ///< The minimum impurity to consider a Pfo as "impure"
-    float                                      m_minSignificance;            ///< The minimum significance to consider a Pfo as "significant"
-    std::string                                m_caloHitList2D;              ///< The 2D calo hit list 
-
     /**
      *  @brief
      */
@@ -55,44 +48,70 @@ private:
         SPARSE,
         UNCLASSIFIED
     };
-
+    
     typedef std::map<const pandora::ParticleFlowObject*, float > PfoToFloatMap;
     typedef std::map<const pandora::ParticleFlowObject*, Classification > PfoClassificationMap;
-
+    
     /**
-     *  @brief
+     *  @brief  Calculate metrics to classify Pfos based on the target reconstructable MCParticles with which they share hits
+     *
+     *  @param  hitSharingMap input mapping from Pfos to MCParticles + number of shared hits pairs
+     *  @param  pfoToCaloHitListMap input mapping from Pfos to their reconstructable 2D hits
+     *  @param  targetsToGoodHitsMaps input mapping from target reconstructable MCParticles (those which shouldn't be tagged) to their good hits
+     *  @param  pfoSignificanceMap output mapping from Pfos to their target significance
+     *  @param  pfoPurityMap output mapping from Pfos to their target purities
+     *  @param  pfoClassificationMap output mapping from Pfos to their classification
      */
-    void CalculatePfoMetrics(const LArMCParticleHelper::PfoToMCParticleHitSharingMap &hitSharingMap, const LArMCParticleHelper::PfoContributionMap &pfoTo2DHitsMap, const LArMCParticleHelper::MCContributionMapVector &nuMCParticlesToGoodHitsMaps, PfoToFloatMap &pfoSignificanceMap, PfoToFloatMap &pfoPurityMap, PfoClassificationMap &pfoClassificationMap) const;
+    void CalculatePfoMetrics(const LArMCParticleHelper::PfoToMCParticleHitSharingMap &hitSharingMap, const LArMCParticleHelper::PfoContributionMap &pfoToCaloHitListMap, const LArMCParticleHelper::MCContributionMapVector &targetsToGoodHitsMaps, PfoToFloatMap &pfoSignificanceMap, PfoToFloatMap &pfoPurityMap, PfoClassificationMap &pfoClassificationMap) const;
 
     /**
-     *  @brief
+     *  @brief  Returns true if the main MCParticle of the supplied Pfo is a muon
      */
     bool IsMainMCParticleMuon(const pandora::ParticleFlowObject *const pPfo) const;
 
     /**
-     *  @brief
+     *  @brief  Classify a pfo given some metrics
+     *
+     *  @param  nHits the number of reconstructable hits in the Pfo
+     *  @param  significance the number of target MCParticles represented by the Pfo
+     *  @param  purity the fraction of reconstructable hits in the Pfo that come from a target MCParticle
+     *  @param  isMuon is the main MCParticle that the Pfo represents a muon?
      */
     Classification ClassifyPfo(const unsigned int &nHits, const float &significance, const float &purity, const bool isMuon) const;
 
     /**
-     *  @brief
+     *  @brief  Returns a unique color for each possible Pfo classification
      */
     LArFormattingHelper::Color GetClassificationColor(const Classification &classification) const;
 
     /**
-     *  @brief
+     *  @brief  Returns a string for each classification
      */
     std::string GetClassificationName(const Classification &classification) const;
 
     /**
-     *  @brief
+     *  @brief  Prints a table detailing all input Pfos and their classifications
+     *
+     *  @param  orderedPfoVector input vector of Pfos in print order
+     *  @param  pfoToReconstructable2DHitsMap input mapping from Pfos to their reconstructable 2D hits
+     *  @param  pfoPurityMap input mapping from Pfos to their purity
+     *  @param  pfoSignificanceMap input mapping from Pfos to their significance
+     *  @param  pfoClassificationMap input mapping from Pfos to their classification
+     *  @param  ambiguousPfos input list of ambiguous Pfos as (not) tagged by a previous CR tagging module
      */
     void PrintPfoTable(const pandora::PfoVector &orderedPfoVector, const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const PfoToFloatMap &pfoPurityMap, const PfoToFloatMap &pfoSignificanceMap, const PfoClassificationMap &pfoClassificationMap, const pandora::PfoList &ambiguousPfos) const;
+
     /**
-     *  @brief
+     *  @brief  Read settings
      */
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
+    LArMCParticleHelper::ValidationParameters  m_parameters;                 ///< Parameters used to decide when an MCParticle is reconstructable
+    unsigned int                               m_minHitsToConsiderTagging;   ///< The minimum number of hits to consider a Pfo for tagging
+    float                                      m_minPurity;                  ///< The minimum purity to consider a Pfo as "pure"
+    float                                      m_minImpurity;                ///< The minimum impurity to consider a Pfo as "impure"
+    float                                      m_minSignificance;            ///< The minimum significance to consider a Pfo as "significant"
+    std::string                                m_caloHitList2D;              ///< The 2D calo hit list 
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
@@ -71,8 +71,10 @@ StatusCode CosmicRayTaggingTool::Initialize()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos)
+void CosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm)
 {
+    (void) pAlgorithm;
+
     if (this->GetPandora().GetSettings()->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
@@ -29,7 +29,7 @@ public:
     CosmicRayTaggingTool();
 
     pandora::StatusCode Initialize();
-    void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos);
+    void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm);
 
 private:
     /**

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -331,7 +331,7 @@ StatusCode MasterAlgorithm::TagCosmicRayPfos(PfoList &clearCosmicRayPfos, PfoLis
     }
 
     for (CosmicRayTaggingBaseTool *const pCosmicRayTaggingTool : m_cosmicRayTaggingToolVector)
-        pCosmicRayTaggingTool->FindAmbiguousPfos(parentCosmicRayPfos, ambiguousPfos);
+        pCosmicRayTaggingTool->FindAmbiguousPfos(parentCosmicRayPfos, ambiguousPfos, this);
 
     for (const Pfo *const pPfo : parentCosmicRayPfos)
     {

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -341,8 +341,9 @@ public:
      *
      *  @param  parentCosmicRayPfos the list of parent cosmic-ray pfos
      *  @param  ambiguousPfos to receive the list of ambiguous pfos
+     *  @param  pAlgorithm the address of this master algorithm
      */
-    virtual void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos) = 0;
+    virtual void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm) = 0;
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.cc
@@ -6,8 +6,6 @@
  *  $Log: $
  */
 
-#include "Pandora/StatusCodes.h"
-
 #include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
 
 #include <iomanip>

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.cc
@@ -1,0 +1,184 @@
+/**
+ *  @file   larpandoracontent/LArHelpers/LArFormattingHelper.cc
+ *
+ *  @brief  Implementation of the formatting helper class.
+ *
+ *  $Log: $
+ */
+
+#include <iomanip>
+
+#include "Pandora/StatusCodes.h"
+
+#include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+    void LArFormattingHelper::SetStyle(const LArFormattingHelper::Style &style, std::ostream &stream)
+    {
+        LArFormattingHelper::PrintFormatCharacter(static_cast<unsigned int>(style), stream);
+    }
+   
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    void LArFormattingHelper::SetColour(const LArFormattingHelper::Colour &colour, std::ostream &stream)
+    {
+        LArFormattingHelper::PrintFormatCharacter(static_cast<unsigned int>(colour), stream);
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    void LArFormattingHelper::ResetStyle(std::ostream &stream)
+    {
+        LArFormattingHelper::SetStyle(REGULAR, stream);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    void LArFormattingHelper::ResetColour(std::ostream &stream)
+    {
+        LArFormattingHelper::SetColour(DEFAULT, stream);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    void LArFormattingHelper::Reset(std::ostream &stream)
+    {
+        LArFormattingHelper::ResetColour(stream);
+        LArFormattingHelper::ResetStyle(stream);
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    void LArFormattingHelper::PrintFormatCharacter(const unsigned int &code, std::ostream &stream)
+    {
+        stream << LArFormattingHelper::GetFormatCharacter(code);
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    std::string LArFormattingHelper::GetFormatCharacter(const unsigned int &code)
+    {
+        return ("\x1B[" + std::to_string(code) + "m");
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    void LArFormattingHelper::PrintHeader(const std::string &title, const unsigned int &width)
+    {
+        LArFormattingHelper::SetStyle(BOLD);
+        std::cout << std::endl << std::string(width, '-') << "\r-" << title << std::endl;
+        LArFormattingHelper::Reset();
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    void LArFormattingHelper::PrintRule(const unsigned int &width)
+    {
+        LArFormattingHelper::PrintHeader("", width);
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    
+    LArFormattingHelper::Table::Table(const std::vector<std::string> &columnTitles, const unsigned int &precision) :
+        m_columnTitles(columnTitles),
+        m_precision(precision)
+    {
+        m_stringstream.precision(m_precision);
+
+        for (const std::string &title : m_columnTitles)
+            m_widths.push_back(title.length());
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    
+    void LArFormattingHelper::Table::CheckForSeparatorColumn()
+    {
+        if (m_columnTitles[m_elements.size() % m_columnTitles.size()] == "")
+        {
+            m_format.push_back("");
+            m_elements.push_back("");
+        }
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    
+    bool LArFormattingHelper::Table::IsSeparatorColumn(const unsigned int &column)
+    {
+        if (column>=m_columnTitles.size())
+            throw StatusCodeException(STATUS_CODE_OUT_OF_RANGE);
+
+        return (m_columnTitles[column] == "");
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    
+    void LArFormattingHelper::Table::UpdateColumnWidth()
+    {
+        const unsigned int currentElementIndex(m_elements.size()-1);
+        const unsigned int column(currentElementIndex % m_widths.size());
+        m_widths[column] = std::max(static_cast<unsigned int>(m_elements[currentElementIndex].length()), m_widths[column]);
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+   
+    void LArFormattingHelper::Table::Print()
+    {
+        if (m_columnTitles.size() == 0)
+            return;
+
+        this->PrintColumnTitles();
+        this->PrintHorizontalLine();
+        this->PrintTableElements();
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    
+    void LArFormattingHelper::Table::PrintColumnTitles()
+    {
+        for (unsigned int i=0; i<m_columnTitles.size(); i++)
+            this->PrintTableCell(m_columnTitles[i], LArFormattingHelper::GetFormatCharacter(LArFormattingHelper::BOLD), i);
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    
+    void LArFormattingHelper::Table::PrintHorizontalLine()
+    {
+        for (unsigned int i=0; i<m_columnTitles.size(); i++) 
+            this->PrintTableCell(std::string(m_widths[i], '-'), LArFormattingHelper::GetFormatCharacter(LArFormattingHelper::REGULAR), i);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    
+    void LArFormattingHelper::Table::PrintTableElements()
+    {
+        const unsigned int nRows((m_elements.size() + m_columnTitles.size() - 1)/m_columnTitles.size());
+        if (nRows*m_columnTitles.size() != m_elements.size())
+        {
+            std::cerr << "LArFormattingHelper::Table::PrintTableElements - Error: Number of table elements added doesn't fill a whole row" << std::endl;
+            throw StatusCodeException(STATUS_CODE_OUT_OF_RANGE);
+        }
+
+        for (unsigned int i=0; i<nRows*m_columnTitles.size(); i++)
+            this->PrintTableCell(m_elements[i], m_format[i], i);
+    }
+    
+    //--------------------------------------------------------------------------------------------------------------------------------------
+    
+    void LArFormattingHelper::Table::PrintTableCell(const std::string &value, const std::string &format, const unsigned int &index)
+    {
+        const unsigned int column(index % m_columnTitles.size());
+
+        std::string separator(this->IsSeparatorColumn(column) ? "" : " ");
+        std::cout << "|" << format << separator << std::setw(m_widths[column]) << std::internal << value << separator;
+        LArFormattingHelper::ResetStyle();
+
+        if (column == m_columnTitles.size()-1)
+            std::cout << "|" << std::endl;
+    }
+
+} // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.cc
@@ -61,7 +61,9 @@ void LArFormattingHelper::PrintFormatCharacter(const unsigned int code, std::ost
 
 std::string LArFormattingHelper::GetFormatCharacter(const unsigned int code)
 {
-    return ("\x1B[" + std::to_string(code) + "m");
+    const std::string startFormattingCode("\x1B[");
+    const std::string endFormattingCode("m");
+    return (startFormattingCode + std::to_string(code) + endFormattingCode);
 }
 
 //--------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.cc
@@ -120,6 +120,9 @@ bool LArFormattingHelper::Table::IsSeparatorColumn(const unsigned int column) co
 
 void LArFormattingHelper::Table::UpdateColumnWidth()
 {
+    if (m_widths.empty() || m_elements.empty())
+        throw StatusCodeException(STATUS_CODE_OUT_OF_RANGE);
+
     const unsigned int currentElementIndex(m_elements.size() - 1);
     const unsigned int column(currentElementIndex % m_widths.size());
     m_widths[column] = std::max(static_cast<unsigned int>(m_elements[currentElementIndex].length()), m_widths[column]);
@@ -141,8 +144,7 @@ void LArFormattingHelper::Table::Print() const
 
 void LArFormattingHelper::Table::PrintColumnTitles() const
 {
-    const unsigned int nColumns(m_columnTitles.size());
-    for (unsigned int i = 0; i < nColumns; ++i)
+    for (unsigned int i = 0, nColumns = m_columnTitles.size(); i < nColumns; ++i)
         this->PrintTableCell(m_columnTitles[i], LArFormattingHelper::GetFormatCharacter(LArFormattingHelper::BOLD), i);
 }
 
@@ -150,8 +152,7 @@ void LArFormattingHelper::Table::PrintColumnTitles() const
 
 void LArFormattingHelper::Table::PrintHorizontalLine() const
 {
-    const unsigned int nColumns(m_columnTitles.size());
-    for (unsigned int i = 0; i < nColumns; ++i) 
+    for (unsigned int i = 0, nColumns = m_columnTitles.size(); i < nColumns; ++i)
         this->PrintTableCell(std::string(m_widths[i], '-'), LArFormattingHelper::GetFormatCharacter(LArFormattingHelper::REGULAR), i);
 }
 
@@ -181,7 +182,7 @@ void LArFormattingHelper::Table::PrintTableCell(const std::string &value, const 
     if (m_columnTitles.empty())
         return;
 
-    const unsigned int column(index % m_columnTitles.size());
+    const unsigned int column(index % m_widths.size());
 
     const std::string separator(this->IsSeparatorColumn(column) ? "" : " ");
     std::cout << "|" << format << separator << std::setw(m_widths[column]) << std::internal << value << separator;

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.cc
@@ -1,184 +1,194 @@
 /**
  *  @file   larpandoracontent/LArHelpers/LArFormattingHelper.cc
  *
- *  @brief  Implementation of the formatting helper class.
+ *  @brief  Implementation of the lar formatting helper class.
  *
  *  $Log: $
  */
 
-#include <iomanip>
-
 #include "Pandora/StatusCodes.h"
 
 #include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
+
+#include <iomanip>
 
 using namespace pandora;
 
 namespace lar_content
 {
 
-    void LArFormattingHelper::SetStyle(const LArFormattingHelper::Style &style, std::ostream &stream)
-    {
-        LArFormattingHelper::PrintFormatCharacter(static_cast<unsigned int>(style), stream);
-    }
-   
-    //--------------------------------------------------------------------------------------------------------------------------------------
+void LArFormattingHelper::SetStyle(const LArFormattingHelper::Style style, std::ostream &stream)
+{
+    LArFormattingHelper::PrintFormatCharacter(static_cast<unsigned int>(style), stream);
+}
 
-    void LArFormattingHelper::SetColour(const LArFormattingHelper::Colour &colour, std::ostream &stream)
-    {
-        LArFormattingHelper::PrintFormatCharacter(static_cast<unsigned int>(colour), stream);
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------------------------------------------
 
-    void LArFormattingHelper::ResetStyle(std::ostream &stream)
+void LArFormattingHelper::SetColor(const LArFormattingHelper::Color color, std::ostream &stream)
+{
+    LArFormattingHelper::PrintFormatCharacter(static_cast<unsigned int>(color), stream);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::ResetStyle(std::ostream &stream)
+{
+    LArFormattingHelper::SetStyle(REGULAR, stream);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::ResetColor(std::ostream &stream)
+{
+    LArFormattingHelper::SetColor(DEFAULT, stream);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::Reset(std::ostream &stream)
+{
+    LArFormattingHelper::ResetColor(stream);
+    LArFormattingHelper::ResetStyle(stream);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::PrintFormatCharacter(const unsigned int code, std::ostream &stream)
+{
+    if (!(stream << LArFormattingHelper::GetFormatCharacter(code)))
+        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+std::string LArFormattingHelper::GetFormatCharacter(const unsigned int code)
+{
+    return ("\x1B[" + std::to_string(code) + "m");
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::PrintHeader(const std::string &title, const unsigned int width)
+{
+    LArFormattingHelper::SetStyle(BOLD);
+    std::cout << std::endl << std::string(width, '-') << "\r-" << title << std::endl;
+    LArFormattingHelper::Reset();
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::PrintRule(const unsigned int width)
+{
+    LArFormattingHelper::PrintHeader("", width);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+LArFormattingHelper::Table::Table(const StringVector &columnTitles, const unsigned int precision) :
+    m_columnTitles(columnTitles),
+    m_precision(precision)
+{
+    m_stringstream.precision(m_precision);
+
+    for (const std::string &title : m_columnTitles)
+        m_widths.push_back(title.length());
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::Table::CheckAndSetSeparatorColumn()
+{
+    if (m_columnTitles[m_elements.size() % m_columnTitles.size()] == "")
     {
-        LArFormattingHelper::SetStyle(REGULAR, stream);
+        m_format.push_back("");
+        m_elements.push_back("");
+    }
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+bool LArFormattingHelper::Table::IsSeparatorColumn(const unsigned int column) const
+{
+    if (column >= m_columnTitles.size())
+        throw StatusCodeException(STATUS_CODE_OUT_OF_RANGE);
+
+    return (m_columnTitles[column] == "");
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::Table::UpdateColumnWidth()
+{
+    const unsigned int currentElementIndex(m_elements.size() - 1);
+    const unsigned int column(currentElementIndex % m_widths.size());
+    m_widths[column] = std::max(static_cast<unsigned int>(m_elements[currentElementIndex].length()), m_widths[column]);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::Table::Print() const
+{
+    if (m_columnTitles.empty())
+        return;
+
+    this->PrintColumnTitles();
+    this->PrintHorizontalLine();
+    this->PrintTableElements();
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::Table::PrintColumnTitles() const
+{
+    const unsigned int nColumns(m_columnTitles.size());
+    for (unsigned int i = 0; i < nColumns; ++i)
+        this->PrintTableCell(m_columnTitles[i], LArFormattingHelper::GetFormatCharacter(LArFormattingHelper::BOLD), i);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::Table::PrintHorizontalLine() const
+{
+    const unsigned int nColumns(m_columnTitles.size());
+    for (unsigned int i = 0; i < nColumns; ++i) 
+        this->PrintTableCell(std::string(m_widths[i], '-'), LArFormattingHelper::GetFormatCharacter(LArFormattingHelper::REGULAR), i);
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+void LArFormattingHelper::Table::PrintTableElements() const
+{
+    if (m_columnTitles.empty())
+        return;
+
+    const unsigned int nRows((m_elements.size() + m_columnTitles.size() - 1)/m_columnTitles.size());
+    const unsigned int nColumns(m_columnTitles.size());
+    if (nRows * nColumns != m_elements.size())
+    {
+        std::cout << "LArFormattingHelper::Table::PrintTableElements - Error: Number of table elements added doesn't fill a whole row" << std::endl;
+        throw StatusCodeException(STATUS_CODE_OUT_OF_RANGE);
     }
 
-    //--------------------------------------------------------------------------------------------------------------------------------------
+    for (unsigned int i = 0; i < nRows * nColumns; i++)
+        this->PrintTableCell(m_elements[i], m_format[i], i);
+}
 
-    void LArFormattingHelper::ResetColour(std::ostream &stream)
-    {
-        LArFormattingHelper::SetColour(DEFAULT, stream);
-    }
+//--------------------------------------------------------------------------------------------------------------------------------------
 
-    //--------------------------------------------------------------------------------------------------------------------------------------
+void LArFormattingHelper::Table::PrintTableCell(const std::string &value, const std::string &format, const unsigned int index) const
+{
+    if (m_columnTitles.empty())
+        return;
 
-    void LArFormattingHelper::Reset(std::ostream &stream)
-    {
-        LArFormattingHelper::ResetColour(stream);
-        LArFormattingHelper::ResetStyle(stream);
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
+    const unsigned int column(index % m_columnTitles.size());
 
-    void LArFormattingHelper::PrintFormatCharacter(const unsigned int &code, std::ostream &stream)
-    {
-        stream << LArFormattingHelper::GetFormatCharacter(code);
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
+    const std::string separator(this->IsSeparatorColumn(column) ? "" : " ");
+    std::cout << "|" << format << separator << std::setw(m_widths[column]) << std::internal << value << separator;
+    LArFormattingHelper::ResetStyle();
 
-    std::string LArFormattingHelper::GetFormatCharacter(const unsigned int &code)
-    {
-        return ("\x1B[" + std::to_string(code) + "m");
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-
-    void LArFormattingHelper::PrintHeader(const std::string &title, const unsigned int &width)
-    {
-        LArFormattingHelper::SetStyle(BOLD);
-        std::cout << std::endl << std::string(width, '-') << "\r-" << title << std::endl;
-        LArFormattingHelper::Reset();
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-
-    void LArFormattingHelper::PrintRule(const unsigned int &width)
-    {
-        LArFormattingHelper::PrintHeader("", width);
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    
-    LArFormattingHelper::Table::Table(const std::vector<std::string> &columnTitles, const unsigned int &precision) :
-        m_columnTitles(columnTitles),
-        m_precision(precision)
-    {
-        m_stringstream.precision(m_precision);
-
-        for (const std::string &title : m_columnTitles)
-            m_widths.push_back(title.length());
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    
-    void LArFormattingHelper::Table::CheckForSeparatorColumn()
-    {
-        if (m_columnTitles[m_elements.size() % m_columnTitles.size()] == "")
-        {
-            m_format.push_back("");
-            m_elements.push_back("");
-        }
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    
-    bool LArFormattingHelper::Table::IsSeparatorColumn(const unsigned int &column)
-    {
-        if (column>=m_columnTitles.size())
-            throw StatusCodeException(STATUS_CODE_OUT_OF_RANGE);
-
-        return (m_columnTitles[column] == "");
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    
-    void LArFormattingHelper::Table::UpdateColumnWidth()
-    {
-        const unsigned int currentElementIndex(m_elements.size()-1);
-        const unsigned int column(currentElementIndex % m_widths.size());
-        m_widths[column] = std::max(static_cast<unsigned int>(m_elements[currentElementIndex].length()), m_widths[column]);
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-   
-    void LArFormattingHelper::Table::Print()
-    {
-        if (m_columnTitles.size() == 0)
-            return;
-
-        this->PrintColumnTitles();
-        this->PrintHorizontalLine();
-        this->PrintTableElements();
-    }
-
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    
-    void LArFormattingHelper::Table::PrintColumnTitles()
-    {
-        for (unsigned int i=0; i<m_columnTitles.size(); i++)
-            this->PrintTableCell(m_columnTitles[i], LArFormattingHelper::GetFormatCharacter(LArFormattingHelper::BOLD), i);
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    
-    void LArFormattingHelper::Table::PrintHorizontalLine()
-    {
-        for (unsigned int i=0; i<m_columnTitles.size(); i++) 
-            this->PrintTableCell(std::string(m_widths[i], '-'), LArFormattingHelper::GetFormatCharacter(LArFormattingHelper::REGULAR), i);
-    }
-
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    
-    void LArFormattingHelper::Table::PrintTableElements()
-    {
-        const unsigned int nRows((m_elements.size() + m_columnTitles.size() - 1)/m_columnTitles.size());
-        if (nRows*m_columnTitles.size() != m_elements.size())
-        {
-            std::cerr << "LArFormattingHelper::Table::PrintTableElements - Error: Number of table elements added doesn't fill a whole row" << std::endl;
-            throw StatusCodeException(STATUS_CODE_OUT_OF_RANGE);
-        }
-
-        for (unsigned int i=0; i<nRows*m_columnTitles.size(); i++)
-            this->PrintTableCell(m_elements[i], m_format[i], i);
-    }
-    
-    //--------------------------------------------------------------------------------------------------------------------------------------
-    
-    void LArFormattingHelper::Table::PrintTableCell(const std::string &value, const std::string &format, const unsigned int &index)
-    {
-        const unsigned int column(index % m_columnTitles.size());
-
-        std::string separator(this->IsSeparatorColumn(column) ? "" : " ");
-        std::cout << "|" << format << separator << std::setw(m_widths[column]) << std::internal << value << separator;
-        LArFormattingHelper::ResetStyle();
-
-        if (column == m_columnTitles.size()-1)
-            std::cout << "|" << std::endl;
-    }
+    if (column == m_columnTitles.size() - 1)
+        std::cout << "|" << std::endl;
+}
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.h
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.h
@@ -9,6 +9,7 @@
 #define LAR_FORMATTING_HELPER_H 1
 
 #include "Pandora/PandoraInternal.h"
+#include "Pandora/StatusCodes.h"
 
 #include <iostream>
 #include <sstream>
@@ -207,7 +208,7 @@ public:
         const unsigned int              m_precision;        ///< The number of significant figures to use when displaying number types
         pandora::StringVector           m_elements;         ///< The vector of flattened table elements
         pandora::StringVector           m_format;           ///< The formatting of each table element
-        pandora::UIntVector             m_widths;           ///< The widths of each column (in units of number of characters)
+        std::vector<unsigned int>       m_widths;           ///< The widths of each column (in units of number of characters)
         std::stringstream               m_stringstream;     ///< The stringstream to print objects to
     };
     
@@ -221,7 +222,7 @@ inline void LArFormattingHelper::Table::AddElement(const T &value, const Style s
     this->CheckAndSetSeparatorColumn();
 
     if (!(m_stringstream << value))
-        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+        throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
 
     m_elements.push_back(static_cast<std::string>(m_stringstream.str()));
     m_format.push_back(LArFormattingHelper::GetFormatCharacter(style) + LArFormattingHelper::GetFormatCharacter(color));

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.h
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.h
@@ -1,0 +1,222 @@
+/**
+ *  @file   larpandoracontent/LArHelpers/LArFormatting.h
+ *
+ *  @brief  Header file for the formatting helper class
+ *
+ *  $Log: $
+ */
+#ifndef LAR_FORMATTING_HELPER_H
+#define LAR_FORMATTING_HELPER_H 1
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace lar_content
+{
+
+/**
+ *  @brief  LArFormattingHelper class
+ */
+class LArFormattingHelper
+{
+public:
+
+    enum Colour : int;
+    enum Style : int;
+
+    /**
+     *  @brief  Set the format style (to standard output stream)
+     *
+     *  @param  style the style of choice
+     */
+    static void SetStyle(const Style &style, std::ostream &stream=std::cout);
+    
+    /**
+     *  @brief  Set the text colour (of standard output stream)
+     *
+     *  @param  colour the colour of choice
+     */
+    static void SetColour(const Colour &colour, std::ostream &stream=std::cout);
+    
+    /**
+     *  @brief  Reset the style of the standard output stream
+     */
+    static void ResetStyle(std::ostream &stream=std::cout);
+
+    /**
+     *  @brief  Reset the text colour of the standard output stream
+     */
+    static void ResetColour(std::ostream &stream=std::cout);
+
+    /**
+     *  @brief  Reset the formatting and text colour of the standard output stream
+     */
+    static void Reset(std::ostream &stream=std::cout);
+
+    /**
+     *  @brief  Print a formatting character to the standard output stream
+     *
+     *  @param  code the formatting code to output
+     */
+    static void PrintFormatCharacter(const unsigned int &code, std::ostream &stream=std::cout);
+
+    /**
+     *  @brief  Get a formatting character
+     *
+     *  @param  code the formatting code to output
+     */
+    static std::string GetFormatCharacter(const unsigned int &code);
+
+    /**
+     *  @brief  Print a header line of a given width
+     *
+     *  @param  title the title of the header
+     *  @param  width the width of the header line
+     */
+    static void PrintHeader(const std::string &title = "", const unsigned int &width = 140);
+
+    /**
+     *  @brief  Print a horizontal rule
+     *
+     *  @param  width the width of the rule line
+     */
+    static void PrintRule(const unsigned int &width = 140);
+
+    enum Style : int
+    {
+        REGULAR = 0,
+        BOLD = 1,
+        DIM = 2,
+        UNDERLINED = 4,
+        INVERTED = 7
+    };
+    
+    enum Colour : int
+    {
+        DEFAULT = 39,
+        BLACK = 30,
+        RED = 31,
+        GREEN = 32,
+        YELLOW = 33,
+        BLUE = 34,
+        MAGENTA = 35,
+        CYAN = 36,
+        LIGHT_GRAY = 37,
+        DARK_GRAY = 90,
+        LIGHT_RED = 91,
+        LIGHT_GREEN = 92,
+        LIGHT_YELLOW = 93,
+        LIGHT_BLUE = 94,
+        LIGHT_MAGENTA = 95,
+        LIGHT_CYAN = 96,
+        WHITE = 97
+    };
+
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    class Table 
+    {
+    public:
+
+        /**
+         * @brief  Table constructor
+         *
+         * @param  columnTitles the string columns titles use empty string for a separator column
+         * @param  precision the number of significant figures to display for number type table elements
+         */
+        Table(const std::vector<std::string> &columnTitles, const unsigned int &precision=3);
+
+        /**
+         * @brief  Add an element to the table into the next (non-separator) column
+         *
+         * @param  value the element to add to the table
+         * @param  style the style of the element
+         * @param  colour the colour of the element
+         */
+        template<class T>
+        void AddElement(const T &value, const Style &style=REGULAR, const Colour &colour=DEFAULT);
+
+        /**
+         * @brief  Print the table
+         */
+        void Print();
+    private:
+        const std::vector<std::string>  m_columnTitles;     ///< The vector of columns titles in the table
+        const unsigned int              m_precision;        ///< The number of significant figures to use when displaying number types
+        std::vector<std::string>        m_elements;         ///< The vector of flattened table elements
+        std::vector<std::string>        m_format;           ///< The formatting of each table element
+        std::vector<unsigned int>       m_widths;           ///< The widths of each column (in units of number of characters)
+        std::stringstream               m_stringstream;     ///< The stringstream to print objects to
+
+        /**
+         *  @brief  Check if the next table cell is in a separator column, if so add a blank element
+         */
+        void CheckForSeparatorColumn();
+
+        /**
+         *  @brief  If the supplied column is a separator (vertical rule)
+         *
+         *  @param  column the column index to check
+         *
+         *  @return true/false
+         */
+        bool IsSeparatorColumn(const unsigned int &column);
+    
+        /**
+         *  @brief  Update the width of the last column in which an element was added
+         */
+        void UpdateColumnWidth();
+
+        /**
+         *  @brief  Print the column titles
+         *
+         *  @param  widths a vector of the number of characters to include in each column 
+         */
+        void PrintColumnTitles();
+
+        /**
+         *  @brief  Print a horizontal line
+         *
+         *  @param  widths a vector of the number of characters to include in each column 
+         */
+        void PrintHorizontalLine();
+
+        /**
+         *  @brief  Print the table elements
+         *
+         *  @param  widths a vector of the number of characters to include in each column 
+         */
+        void PrintTableElements();
+
+        /**
+         *  @brief  Print a table cell
+         *
+         *  @param  value the string to print in the cell
+         *  @param  format a formatting string (see GetFormatCharacter(...))
+         *  @param  index the index of the table cell (0 --> number of elements) used to find the column
+         *  @param  widths a vector of the number of characters to include in each column 
+         */
+        void PrintTableCell(const std::string &value, const std::string &format, const unsigned int &index);
+    };
+    
+};
+
+template<class T>
+inline void LArFormattingHelper::Table::AddElement(const T &value, const Style &style, const Colour &colour)
+{
+    this->CheckForSeparatorColumn();
+
+    m_stringstream << value;
+    m_elements.push_back(static_cast<std::string>(m_stringstream.str()));
+    m_format.push_back(LArFormattingHelper::GetFormatCharacter(style) + LArFormattingHelper::GetFormatCharacter(colour));
+    m_stringstream.str("");
+
+    this->UpdateColumnWidth();
+    this->CheckForSeparatorColumn();
+}
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_FORMATTING_HELPER_H

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.h
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.h
@@ -122,8 +122,6 @@ public:
         WHITE = 97
     };
 
-    //--------------------------------------------------------------------------------------------------------------------------------------
-
     /**
      *  @brief  Table class
      */
@@ -211,7 +209,6 @@ public:
         std::vector<unsigned int>       m_widths;           ///< The widths of each column (in units of number of characters)
         std::stringstream               m_stringstream;     ///< The stringstream to print objects to
     };
-    
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.h
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.h
@@ -8,6 +8,8 @@
 #ifndef LAR_FORMATTING_HELPER_H
 #define LAR_FORMATTING_HELPER_H 1
 
+#include "Pandora/PandoraInternal.h"
+
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -22,52 +24,51 @@ namespace lar_content
 class LArFormattingHelper
 {
 public:
-
-    enum Colour : int;
-    enum Style : int;
+    enum Color : unsigned int;
+    enum Style : unsigned int;
 
     /**
      *  @brief  Set the format style (to standard output stream)
      *
      *  @param  style the style of choice
      */
-    static void SetStyle(const Style &style, std::ostream &stream=std::cout);
+    static void SetStyle(const Style style, std::ostream &stream = std::cout);
     
     /**
-     *  @brief  Set the text colour (of standard output stream)
+     *  @brief  Set the text color (of standard output stream)
      *
-     *  @param  colour the colour of choice
+     *  @param  color the color of choice
      */
-    static void SetColour(const Colour &colour, std::ostream &stream=std::cout);
+    static void SetColor(const Color color, std::ostream &stream = std::cout);
     
     /**
      *  @brief  Reset the style of the standard output stream
      */
-    static void ResetStyle(std::ostream &stream=std::cout);
+    static void ResetStyle(std::ostream &stream = std::cout);
 
     /**
-     *  @brief  Reset the text colour of the standard output stream
+     *  @brief  Reset the text color of the standard output stream
      */
-    static void ResetColour(std::ostream &stream=std::cout);
+    static void ResetColor(std::ostream &stream = std::cout);
 
     /**
-     *  @brief  Reset the formatting and text colour of the standard output stream
+     *  @brief  Reset the formatting and text color of the standard output stream
      */
-    static void Reset(std::ostream &stream=std::cout);
+    static void Reset(std::ostream &stream = std::cout);
 
     /**
      *  @brief  Print a formatting character to the standard output stream
      *
      *  @param  code the formatting code to output
      */
-    static void PrintFormatCharacter(const unsigned int &code, std::ostream &stream=std::cout);
+    static void PrintFormatCharacter(const unsigned int code, std::ostream &stream = std::cout);
 
     /**
      *  @brief  Get a formatting character
      *
      *  @param  code the formatting code to output
      */
-    static std::string GetFormatCharacter(const unsigned int &code);
+    static std::string GetFormatCharacter(const unsigned int code);
 
     /**
      *  @brief  Print a header line of a given width
@@ -75,16 +76,19 @@ public:
      *  @param  title the title of the header
      *  @param  width the width of the header line
      */
-    static void PrintHeader(const std::string &title = "", const unsigned int &width = 140);
+    static void PrintHeader(const std::string &title = "", const unsigned int width = 140);
 
     /**
      *  @brief  Print a horizontal rule
      *
      *  @param  width the width of the rule line
      */
-    static void PrintRule(const unsigned int &width = 140);
+    static void PrintRule(const unsigned int width = 140);
 
-    enum Style : int
+    /**
+     *  @brief  Style code enumeration
+     */
+    enum Style : unsigned int
     {
         REGULAR = 0,
         BOLD = 1,
@@ -93,7 +97,10 @@ public:
         INVERTED = 7
     };
     
-    enum Colour : int
+    /**
+     *  @brief  Style code enumeration
+     */
+    enum Color : unsigned int
     {
         DEFAULT = 39,
         BLACK = 30,
@@ -116,45 +123,36 @@ public:
 
     //--------------------------------------------------------------------------------------------------------------------------------------
 
+    /**
+     *  @brief  Table class
+     */
     class Table 
     {
     public:
-
         /**
          * @brief  Table constructor
          *
          * @param  columnTitles the string columns titles use empty string for a separator column
          * @param  precision the number of significant figures to display for number type table elements
          */
-        Table(const std::vector<std::string> &columnTitles, const unsigned int &precision=3);
+        Table(const pandora::StringVector &columnTitles, const unsigned int precision=3);
+
+        /**
+         * @brief  Print the table
+         */
+        void Print() const;
 
         /**
          * @brief  Add an element to the table into the next (non-separator) column
          *
          * @param  value the element to add to the table
          * @param  style the style of the element
-         * @param  colour the colour of the element
+         * @param  color the color of the element
          */
-        template<class T>
-        void AddElement(const T &value, const Style &style=REGULAR, const Colour &colour=DEFAULT);
+        template<typename T>
+        void AddElement(const T &value, const Style style=REGULAR, const Color color=DEFAULT);
 
-        /**
-         * @brief  Print the table
-         */
-        void Print();
     private:
-        const std::vector<std::string>  m_columnTitles;     ///< The vector of columns titles in the table
-        const unsigned int              m_precision;        ///< The number of significant figures to use when displaying number types
-        std::vector<std::string>        m_elements;         ///< The vector of flattened table elements
-        std::vector<std::string>        m_format;           ///< The formatting of each table element
-        std::vector<unsigned int>       m_widths;           ///< The widths of each column (in units of number of characters)
-        std::stringstream               m_stringstream;     ///< The stringstream to print objects to
-
-        /**
-         *  @brief  Check if the next table cell is in a separator column, if so add a blank element
-         */
-        void CheckForSeparatorColumn();
-
         /**
          *  @brief  If the supplied column is a separator (vertical rule)
          *
@@ -162,33 +160,28 @@ public:
          *
          *  @return true/false
          */
-        bool IsSeparatorColumn(const unsigned int &column);
+        bool IsSeparatorColumn(const unsigned int column) const;
     
-        /**
-         *  @brief  Update the width of the last column in which an element was added
-         */
-        void UpdateColumnWidth();
-
         /**
          *  @brief  Print the column titles
          *
          *  @param  widths a vector of the number of characters to include in each column 
          */
-        void PrintColumnTitles();
+        void PrintColumnTitles() const;
 
         /**
          *  @brief  Print a horizontal line
          *
          *  @param  widths a vector of the number of characters to include in each column 
          */
-        void PrintHorizontalLine();
+        void PrintHorizontalLine() const;
 
         /**
          *  @brief  Print the table elements
          *
          *  @param  widths a vector of the number of characters to include in each column 
          */
-        void PrintTableElements();
+        void PrintTableElements() const;
 
         /**
          *  @brief  Print a table cell
@@ -198,23 +191,44 @@ public:
          *  @param  index the index of the table cell (0 --> number of elements) used to find the column
          *  @param  widths a vector of the number of characters to include in each column 
          */
-        void PrintTableCell(const std::string &value, const std::string &format, const unsigned int &index);
+        void PrintTableCell(const std::string &value, const std::string &format, const unsigned int index) const;
+
+        /**
+         *  @brief  Check if the next table cell is in a separator column, if so add a blank element
+         */
+        void CheckAndSetSeparatorColumn();
+
+        /**
+         *  @brief  Update the width of the last column in which an element was added
+         */
+        void UpdateColumnWidth();
+        
+        const pandora::StringVector     m_columnTitles;     ///< The vector of columns titles in the table
+        const unsigned int              m_precision;        ///< The number of significant figures to use when displaying number types
+        pandora::StringVector           m_elements;         ///< The vector of flattened table elements
+        pandora::StringVector           m_format;           ///< The formatting of each table element
+        pandora::UIntVector             m_widths;           ///< The widths of each column (in units of number of characters)
+        std::stringstream               m_stringstream;     ///< The stringstream to print objects to
     };
     
 };
 
-template<class T>
-inline void LArFormattingHelper::Table::AddElement(const T &value, const Style &style, const Colour &colour)
-{
-    this->CheckForSeparatorColumn();
+//------------------------------------------------------------------------------------------------------------------------------------------
 
-    m_stringstream << value;
+template<typename T>
+inline void LArFormattingHelper::Table::AddElement(const T &value, const Style style, const Color color)
+{
+    this->CheckAndSetSeparatorColumn();
+
+    if (!(m_stringstream << value))
+        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+
     m_elements.push_back(static_cast<std::string>(m_stringstream.str()));
-    m_format.push_back(LArFormattingHelper::GetFormatCharacter(style) + LArFormattingHelper::GetFormatCharacter(colour));
+    m_format.push_back(LArFormattingHelper::GetFormatCharacter(style) + LArFormattingHelper::GetFormatCharacter(color));
     m_stringstream.str("");
 
     this->UpdateColumnWidth();
-    this->CheckForSeparatorColumn();
+    this->CheckAndSetSeparatorColumn();
 }
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -34,7 +34,8 @@ LArMCParticleHelper::ValidationParameters::ValidationParameters() :
     m_selectInputHits(true),
     m_maxPhotonPropagation(2.5f),
     m_minHitSharingFraction(0.9f)
-{}
+{
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -519,13 +520,16 @@ void LArMCParticleHelper::SelectGoodCaloHits(const CaloHitList *const pSelectedC
 void LArMCParticleHelper::SelectParticlesMatchingCriteria(const MCParticleVector &inputMCParticles, std::function<bool(const MCParticle *const)> fCriteria, MCParticleVector &selectedParticles)
 {
     for (const MCParticle *const pMCParticle : inputMCParticles)
+    {
         if (fCriteria(pMCParticle))
             selectedParticles.push_back(pMCParticle);
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const ValidationParameters &parameters, std::function<bool(const MCParticle *const)> fCriteria, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap)
+void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const ValidationParameters &parameters, 
+    std::function<bool(const MCParticle *const)> fCriteria, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap)
 {
     // Obtain map: [mc particle -> primary mc particle]
     LArMCParticleHelper::MCRelationMap mcToPrimaryMCMap;
@@ -552,6 +556,15 @@ void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList 
     MCParticleVector candidateTargets;
     LArMCParticleHelper::SelectParticlesMatchingCriteria(mcPrimaryVector, fCriteria, candidateTargets);
 
+    // Ensure the MCParticles have enough hits to be reconstructed
+    LArMCParticleHelper::SelectParticlesByHitCount(candidateTargets, mcToGoodTrueHitListMap, parameters, selectedMCParticlesToGoodHitsMap);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArMCParticleHelper::SelectParticlesByHitCount(const MCParticleVector &candidateTargets, const LArMonitoringHelper::MCContributionMap &mcToGoodTrueHitListMap, 
+    const ValidationParameters &parameters, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap)
+{
     // Apply restrictions on the number of good hits associated with the MCParticles
     for (const MCParticle * const pMCTarget : candidateTargets)
     {
@@ -591,7 +604,7 @@ bool LArMCParticleHelper::IsBeamNeutrinoFinalState(const MCParticle *const pMCPa
     if (pMCParticle->GetParentList().size() != 1)
         return false;
 
-    const int nuance(dynamic_cast<const LArMCParticle*>(pMCParticle->GetParentList().front())->GetNuanceCode());
+    const int nuance(LArMCParticleHelper::GetNuanceCode(pMCParticle->GetParentList().front()));
 
     // TODO These numbers should be enumerated? 0 = ?, 1001, 1002, ... = beam neutrino, 2000 = test beam particle, 3000 = cosmic (only in protoDUNE samples)
     return (LArMCParticleHelper::IsNeutrinoFinalState(pMCParticle) && nuance != 0 && nuance != 2000 && nuance != 3000);
@@ -601,27 +614,42 @@ bool LArMCParticleHelper::IsBeamNeutrinoFinalState(const MCParticle *const pMCPa
 
 bool LArMCParticleHelper::IsBeamParticle(const MCParticle *const pMCParticle)
 {
-    return (LArMCParticleHelper::IsPrimary(pMCParticle) && (dynamic_cast<const LArMCParticle*>(pMCParticle))->GetNuanceCode() == 2000);
+    const int nuance(LArMCParticleHelper::GetNuanceCode(pMCParticle));
+    return (LArMCParticleHelper::IsPrimary(pMCParticle) && nuance == 2000);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 bool LArMCParticleHelper::IsCosmicRay(const MCParticle *const pMCParticle)
 {
-    const int nuance((dynamic_cast<const LArMCParticle*>(pMCParticle))->GetNuanceCode());
+    const int nuance(LArMCParticleHelper::GetNuanceCode(pMCParticle));
     return (LArMCParticleHelper::IsPrimary(pMCParticle) && ((nuance == 0 && !LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle)) || nuance == 3000));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+unsigned int LArMCParticleHelper::GetNuanceCode(const MCParticle *const pMCParticle)
+{
+    const LArMCParticle *const pLArMCParticle(dynamic_cast<const LArMCParticle*>(pMCParticle));
+    if (!pLArMCParticle)
+    {
+        std::cout << "LArMCParticleHelper::GetNuanceCode - Error: Can't cast to LArMCParticle" << std::endl;
+        throw StatusCodeException(STATUS_CODE_NOT_ALLOWED);
+    }
+    
+    return pLArMCParticle->GetNuanceCode();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const LArMonitoringHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap)
 {
-    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(pfoList, std::vector<LArMonitoringHelper::MCContributionMap>({selectedMCParticleToGoodHitsMap}), pfoToReconstructable2DHitsMap);
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(pfoList, MCContributionMapVector({selectedMCParticleToGoodHitsMap}), pfoToReconstructable2DHitsMap);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap)
+void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap)
 {
     for (const ParticleFlowObject *const pPfo : pfoList)
     {
@@ -635,23 +663,11 @@ void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoLis
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject *const pPfo, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D)
+void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D)
 {
     // Collect all 2D calo hits
     CaloHitList caloHitList2D;
-
-    // TODO could use LArMonitoringHelper::CollectCaloHits here but it also gets isolated hits. Is this what we want or not?
-    CaloHitList caloHitListU;
-    CaloHitList caloHitListV;
-    CaloHitList caloHitListW;
-
-    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, caloHitListU);
-    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, caloHitListV);
-    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, caloHitListW);
-
-    caloHitList2D.insert(caloHitList2D.end(), caloHitListU.begin(), caloHitListU.end());
-    caloHitList2D.insert(caloHitList2D.end(), caloHitListV.begin(), caloHitListV.end());
-    caloHitList2D.insert(caloHitList2D.end(), caloHitListW.begin(), caloHitListW.end());
+    LArMonitoringHelper::CollectCaloHits(pPfo, caloHitList2D);
 
     // Filter for only reconstructable hits
     for (const CaloHit *const pCaloHit : caloHitList2D)
@@ -659,9 +675,9 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject 
         bool isTargetHit(false);
         for (const LArMonitoringHelper::MCContributionMap &mcParticleToGoodHitsMap : selectedMCParticleToGoodHitsMaps)
         {
-            for (LArMonitoringHelper::MCContributionMap::const_iterator it = mcParticleToGoodHitsMap.begin(); it != mcParticleToGoodHitsMap.end(); ++it)
+            for (const LArMonitoringHelper::MCContributionMap::value_type &mapEntry : mcParticleToGoodHitsMap)
             {
-                if (std::find(it->second.begin(), it->second.end(), pCaloHit) != it->second.end())
+                if (std::find(mapEntry.second.begin(), mapEntry.second.end(), pCaloHit) != mapEntry.second.end())
                 {
                     isTargetHit = true;
                     break;
@@ -677,7 +693,7 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap)
+void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap)
 {
     for (LArMonitoringHelper::PfoContributionMap::const_iterator pfoIt = pfoToReconstructable2DHitsMap.begin(); pfoIt != pfoToReconstructable2DHitsMap.end(); ++pfoIt)
     {

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -640,10 +640,12 @@ void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoLis
 void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject *const pPfo, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D)
 {
     // Collect all 2D calo hits
+    CaloHitList caloHitList2D;
+
+    // TODO could use LArMonitoringHelper::CollectCaloHits here but it also gets isolated hits. Is this what we want or not?
     CaloHitList caloHitListU;
     CaloHitList caloHitListV;
     CaloHitList caloHitListW;
-    CaloHitList caloHitList2D;
 
     LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, caloHitListU);
     LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, caloHitListV);

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -616,21 +616,21 @@ bool LArMCParticleHelper::IsCosmicRay(const MCParticle *const pMCParticle)
 
 //------------------------------------------------------------------------------------------------------------------------------------------
     
-void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const LArMonitoringHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, PfoToCaloHitListMap &pfoToReconstructable2DHitsMap)
+void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const LArMonitoringHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap)
 {
     LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(pfoList, std::vector<LArMonitoringHelper::MCContributionMap>({selectedMCParticleToGoodHitsMap}), pfoToReconstructable2DHitsMap);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
     
-void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToCaloHitListMap &pfoToReconstructable2DHitsMap)
+void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap)
 {
     for (const ParticleFlowObject *const pPfo : pfoList)
     {
         CaloHitList pfoHitList;                                                                                                              
         LArMCParticleHelper::CollectReconstructable2DHits(pPfo, selectedMCParticleToGoodHitsMaps, pfoHitList);
         
-        if (!pfoToReconstructable2DHitsMap.insert(PfoToCaloHitListMap::value_type(pPfo, pfoHitList)).second)
+        if (!pfoToReconstructable2DHitsMap.insert(LArMonitoringHelper::PfoContributionMap::value_type(pPfo, pfoHitList)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);       
     }
 }
@@ -679,9 +679,9 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
     
-void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const PfoToCaloHitListMap &pfoToReconstructable2DHitsMap, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap)
+void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap)
 {
-    for (PfoToCaloHitListMap::const_iterator pfoIt = pfoToReconstructable2DHitsMap.begin(); pfoIt != pfoToReconstructable2DHitsMap.end(); ++pfoIt)
+    for (LArMonitoringHelper::PfoContributionMap::const_iterator pfoIt = pfoToReconstructable2DHitsMap.begin(); pfoIt != pfoToReconstructable2DHitsMap.end(); ++pfoIt)
     {
         for (const LArMonitoringHelper::MCContributionMap &mcParticleToGoodHitsMap : selectedMCParticleToGoodHitsMaps)
         {

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -25,6 +25,12 @@ namespace lar_content
 class LArMCParticleHelper
 {
 public:
+    typedef std::map<const pandora::ParticleFlowObject*, pandora::CaloHitList > PfoToCaloHitListMap;
+    typedef std::pair<const pandora::MCParticle*, unsigned int > MCParticleIntPair;
+    typedef std::pair<const pandora::ParticleFlowObject*, unsigned int > PfoIntPair;
+    typedef std::map<const pandora::ParticleFlowObject*, std::vector<MCParticleIntPair> > PfoToMCParticleHitSharingMap;
+    typedef std::map<const pandora::MCParticle*, std::vector<PfoIntPair> > MCParticleToPfoHitSharingMap;
+
     /**
      *  @brief   ValidationParameters class
      */
@@ -303,6 +309,54 @@ public:
      *  @brief  Return true if passed a primary cosmic ray MCParticle
      */
     static bool IsCosmicRay(const pandora::MCParticle *const pMCParticle);
+
+    /**
+     *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
+     *
+     *  @param  pfoList the input list of Pfos
+     *  @param  selectedMCParticleToGoodHitsMap the input mapping from selected reconstructable MCParticles to their good hits
+     *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
+     */
+    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const LArMonitoringHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, PfoToCaloHitListMap &pfoToReconstructable2DHitsMap);
+    
+    /**
+     *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
+     *
+     *  @param  pfoList the input list of Pfos
+     *  @param  selectedMCParticleToGoodHitsMaps the input vector of mappings from selected reconstructable MCParticles to their good hits
+     *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
+     */
+    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToCaloHitListMap &pfoToReconstructable2DHitsMap);
+
+    /**
+     *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
+     *
+     *  @param  pPfo the input pfo
+     *  @param  selectedMCParticleToGoodHitsMaps the input mappings from selected reconstructable MCParticles to their good hits
+     *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
+     */
+    static void CollectReconstructable2DHits(const pandora::ParticleFlowObject *const pPfo, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D);
+
+    /**
+     *  @brief  Get the mappings from Pfo -> pair (reconstructable MCparticles, number of reconstructable 2D hits shared with Pfo)
+     *                                reconstructable MCParticle -> pair (Pfo, number of reconstructable 2D hits shared with MCParticle)
+     *
+     *  @param  pfoToReconstructable2DHitsMap the input mapping from Pfos to reconstructable 2D hits
+     *  @param  selectedMCParticleToGoodHitsMaps the input mappings from selected reconstructable MCParticles to good hits
+     *  @param  pfoToMCParticleHitSharingMap the output mapping from Pfos to selected reconstructable MCParticles and the number hits shared
+     *  @param  mcParticleToPfoHitSharingMap the output mapping from selected reconstructable MCParticles to Pfos and the number hits shared
+     */
+    static void GetPfoMCParticleHitSharingMaps(const PfoToCaloHitListMap &pfoToReconstructable2DHitsMap, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
+
+    /**
+     *  @brief  Count the number of hits in the intersection of two hit lists
+     *
+     *  @param  hitListA an input hit list
+     *  @param  hitListB another input hit list
+     *
+     *  @return The number of hits that are found in both hitListA and hitListB
+     */
+    static unsigned int CountSharedHits(const pandora::CaloHitList &hitListA, const pandora::CaloHitList &hitListB);
 
     /**
      *  @brief  Get the interaction type of an event

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -25,7 +25,6 @@ namespace lar_content
 class LArMCParticleHelper
 {
 public:
-    typedef std::map<const pandora::ParticleFlowObject*, pandora::CaloHitList > PfoToCaloHitListMap;
     typedef std::pair<const pandora::MCParticle*, unsigned int > MCParticleIntPair;
     typedef std::pair<const pandora::ParticleFlowObject*, unsigned int > PfoIntPair;
     typedef std::map<const pandora::ParticleFlowObject*, std::vector<MCParticleIntPair> > PfoToMCParticleHitSharingMap;
@@ -292,8 +291,7 @@ public:
      *  @param  fCriteria a function which returns a bool (= shouldSelect) for a given input MCParticle
      *  @param  selectedMCParticlesToGoodHitsMap the output mapping from selected mcparticles to their good hits
      */
-    static void SelectReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList, 
-        const ValidationParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap);
+    static void SelectReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList, const ValidationParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap);
 
     /**
      *  @brief  Returns true if passed a primary neutrino final state MCParticle
@@ -317,7 +315,7 @@ public:
      *  @param  selectedMCParticleToGoodHitsMap the input mapping from selected reconstructable MCParticles to their good hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      */
-    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const LArMonitoringHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, PfoToCaloHitListMap &pfoToReconstructable2DHitsMap);
+    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const LArMonitoringHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap);
     
     /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
@@ -326,7 +324,7 @@ public:
      *  @param  selectedMCParticleToGoodHitsMaps the input vector of mappings from selected reconstructable MCParticles to their good hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      */
-    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToCaloHitListMap &pfoToReconstructable2DHitsMap);
+    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap);
 
     /**
      *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -346,7 +344,7 @@ public:
      *  @param  pfoToMCParticleHitSharingMap the output mapping from Pfos to selected reconstructable MCParticles and the number hits shared
      *  @param  mcParticleToPfoHitSharingMap the output mapping from selected reconstructable MCParticles to Pfos and the number hits shared
      */
-    static void GetPfoMCParticleHitSharingMaps(const PfoToCaloHitListMap &pfoToReconstructable2DHitsMap, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
+    static void GetPfoMCParticleHitSharingMaps(const LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
 
     /**
      *  @brief  Count the number of hits in the intersection of two hit lists

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -29,6 +29,7 @@ public:
     typedef std::pair<const pandora::ParticleFlowObject*, unsigned int > PfoIntPair;
     typedef std::map<const pandora::ParticleFlowObject*, std::vector<MCParticleIntPair> > PfoToMCParticleHitSharingMap;
     typedef std::map<const pandora::MCParticle*, std::vector<PfoIntPair> > MCParticleToPfoHitSharingMap;
+    typedef std::vector<LArMonitoringHelper::MCContributionMap> MCContributionMapVector; 
 
     /**
      *  @brief   ValidationParameters class
@@ -293,6 +294,17 @@ public:
      */
     static void SelectReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList, const ValidationParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap);
 
+    /** 
+     *  @brief  Filter an input vector of MCParticles to ensure they have sufficient good hits to be reconstructable 
+     *
+     *  @param  candidateTargets candidate recontructable MCParticles
+     *  @param  mcToGoodTrueHitListMap mapping from candidates reconstructable MCParticles to their good hits
+     *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
+     *  @param  selectedMCParticlesToGoodHitsMap the output mapping from selected mcparticles to their good hits
+     */
+    static void SelectParticlesByHitCount(const pandora::MCParticleVector &candidateTargets, const LArMonitoringHelper::MCContributionMap &mcToGoodTrueHitListMap, 
+    const ValidationParameters &parameters, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap);
+
     /**
      *  @brief  Returns true if passed a primary neutrino final state MCParticle
      */
@@ -307,6 +319,11 @@ public:
      *  @brief  Return true if passed a primary cosmic ray MCParticle
      */
     static bool IsCosmicRay(const pandora::MCParticle *const pMCParticle);
+
+    /**
+     *  @brief  Get the nuance code of an MCParticle
+     */
+    static unsigned int GetNuanceCode(const pandora::MCParticle *const pMCParticle);
 
     /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
@@ -324,7 +341,7 @@ public:
      *  @param  selectedMCParticleToGoodHitsMaps the input vector of mappings from selected reconstructable MCParticles to their good hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      */
-    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap);
+    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap);
 
     /**
      *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -333,7 +350,7 @@ public:
      *  @param  selectedMCParticleToGoodHitsMaps the input mappings from selected reconstructable MCParticles to their good hits
      *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
      */
-    static void CollectReconstructable2DHits(const pandora::ParticleFlowObject *const pPfo, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D);
+    static void CollectReconstructable2DHits(const pandora::ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D);
 
     /**
      *  @brief  Get the mappings from Pfo -> pair (reconstructable MCparticles, number of reconstructable 2D hits shared with Pfo)
@@ -344,7 +361,7 @@ public:
      *  @param  pfoToMCParticleHitSharingMap the output mapping from Pfos to selected reconstructable MCParticles and the number hits shared
      *  @param  mcParticleToPfoHitSharingMap the output mapping from selected reconstructable MCParticles to Pfos and the number hits shared
      */
-    static void GetPfoMCParticleHitSharingMaps(const LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const std::vector<LArMonitoringHelper::MCContributionMap> &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
+    static void GetPfoMCParticleHitSharingMaps(const LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
 
     /**
      *  @brief  Count the number of hits in the intersection of two hit lists

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -11,7 +11,6 @@
 #include "Pandora/PandoraInternal.h"
 
 #include "larpandoracontent/LArObjects/LArMCParticle.h"
-#include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 
 #include <unordered_map>
 #include <functional>
@@ -25,11 +24,26 @@ namespace lar_content
 class LArMCParticleHelper
 {
 public:
+    typedef std::unordered_map<const pandora::MCParticle*, const pandora::MCParticle*> MCRelationMap;
+
+    typedef std::unordered_map<const pandora::MCParticle*, const pandora::ParticleFlowObject*> MCToPfoMap;
+
+    typedef std::unordered_map<const pandora::CaloHit*, const pandora::MCParticle*> CaloHitToMCMap;
+    typedef std::unordered_map<const pandora::CaloHit*, const pandora::ParticleFlowObject*> CaloHitToPfoMap;
+
+    typedef std::unordered_map<const pandora::MCParticle*, pandora::CaloHitList> MCContributionMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject*, pandora::CaloHitList> PfoContributionMap;
+
+    typedef std::unordered_map<const pandora::MCParticle*, PfoContributionMap> MCToPfoMatchingMap;
+
+    typedef std::pair<const pandora::MCParticle*, pandora::CaloHitList > MCParticleCaloHitListPair;
+    typedef std::pair<const pandora::ParticleFlowObject*, pandora::CaloHitList > PfoCaloHitListPair;
+
     typedef std::pair<const pandora::MCParticle*, unsigned int > MCParticleIntPair;
     typedef std::pair<const pandora::ParticleFlowObject*, unsigned int > PfoIntPair;
     typedef std::map<const pandora::ParticleFlowObject*, std::vector<MCParticleIntPair> > PfoToMCParticleHitSharingMap;
     typedef std::map<const pandora::MCParticle*, std::vector<PfoIntPair> > MCParticleToPfoHitSharingMap;
-    typedef std::vector<LArMonitoringHelper::MCContributionMap> MCContributionMapVector; 
+    typedef std::vector<MCContributionMap> MCContributionMapVector; 
 
     /**
      *  @brief   ValidationParameters class
@@ -177,8 +191,6 @@ public:
     template <typename T>
     static void GetNeutrinoWeight(const T *const pT, float &neutrinoWeight, float &totalWeight);
 
-    typedef std::unordered_map<const pandora::MCParticle*, const pandora::MCParticle*> MCRelationMap;
-
     /**
      *  @brief  Whether a provided mc particle matches the implemented definition of being primary
      *
@@ -256,7 +268,7 @@ public:
      *  @param  selectInputHits whether to select input hits
      *  @param  maxPhotonPropagation the maximum photon propagation length
      */
-    static void SelectCaloHits(const pandora::CaloHitList *const pCaloHitList, const LArMCParticleHelper::MCRelationMap &mcToPrimaryMCMap,
+    static void SelectCaloHits(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
         pandora::CaloHitList &selectedCaloHitList, const bool selectInputHits, const float maxPhotonPropagation);
 
     /**
@@ -270,7 +282,7 @@ public:
      *  @param  minHitSharingFraction the minimum Hit sharing fraction
      *
      */
-    static void SelectGoodCaloHits(const pandora::CaloHitList *const pSelectedCaloHitList, const LArMCParticleHelper::MCRelationMap &mcToPrimaryMCMap,
+    static void SelectGoodCaloHits(const pandora::CaloHitList *const pSelectedCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
         pandora::CaloHitList &selectedGoodCaloHitList, const bool selectInputHits, const float minHitSharingFraction);
 
     /**
@@ -292,7 +304,7 @@ public:
      *  @param  fCriteria a function which returns a bool (= shouldSelect) for a given input MCParticle
      *  @param  selectedMCParticlesToGoodHitsMap the output mapping from selected mcparticles to their good hits
      */
-    static void SelectReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList, const ValidationParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap);
+    static void SelectReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList, const ValidationParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToGoodHitsMap);
 
     /** 
      *  @brief  Filter an input vector of MCParticles to ensure they have sufficient good hits to be reconstructable 
@@ -302,8 +314,8 @@ public:
      *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
      *  @param  selectedMCParticlesToGoodHitsMap the output mapping from selected mcparticles to their good hits
      */
-    static void SelectParticlesByHitCount(const pandora::MCParticleVector &candidateTargets, const LArMonitoringHelper::MCContributionMap &mcToGoodTrueHitListMap, 
-    const ValidationParameters &parameters, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap);
+    static void SelectParticlesByHitCount(const pandora::MCParticleVector &candidateTargets, const MCContributionMap &mcToGoodTrueHitListMap, 
+    const ValidationParameters &parameters, MCContributionMap &selectedMCParticlesToGoodHitsMap);
 
     /**
      *  @brief  Returns true if passed a primary neutrino final state MCParticle
@@ -332,7 +344,7 @@ public:
      *  @param  selectedMCParticleToGoodHitsMap the input mapping from selected reconstructable MCParticles to their good hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      */
-    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const LArMonitoringHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap);
+    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToGoodHitsMap, PfoContributionMap &pfoToReconstructable2DHitsMap);
     
     /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
@@ -341,7 +353,7 @@ public:
      *  @param  selectedMCParticleToGoodHitsMaps the input vector of mappings from selected reconstructable MCParticles to their good hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      */
-    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap);
+    static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, PfoContributionMap &pfoToReconstructable2DHitsMap);
 
     /**
      *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -361,7 +373,7 @@ public:
      *  @param  pfoToMCParticleHitSharingMap the output mapping from Pfos to selected reconstructable MCParticles and the number hits shared
      *  @param  mcParticleToPfoHitSharingMap the output mapping from selected reconstructable MCParticles to Pfos and the number hits shared
      */
-    static void GetPfoMCParticleHitSharingMaps(const LArMonitoringHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
+    static void GetPfoMCParticleHitSharingMaps(const PfoContributionMap &pfoToReconstructable2DHitsMap, const MCContributionMapVector &selectedMCParticleToGoodHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
 
     /**
      *  @brief  Count the number of hits in the intersection of two hit lists

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -14,6 +14,7 @@
 #include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 
 #include <unordered_map>
+#include <functional>
 
 namespace lar_content
 {
@@ -24,6 +25,27 @@ namespace lar_content
 class LArMCParticleHelper
 {
 public:
+    /**
+     *  @brief   ValidationParameters class
+     */
+    class ValidationParameters
+    {
+    public:
+        /**
+         *  @brief  Constructor
+         */
+        ValidationParameters();
+
+        unsigned int  m_minPrimaryGoodHits;       ///< the minimum number of primary good Hits
+        unsigned int  m_minHitsForGoodView;       ///< the minimum number of Hits for a good view
+        unsigned int  m_minPrimaryGoodViews;      ///< the minimum number of primary good views
+        bool          m_selectInputHits;          ///< whether to select input hits
+        float         m_maxPhotonPropagation;     ///< the maximum photon propagation length
+        float         m_minHitSharingFraction;    ///< the minimum Hit sharing fraction
+    };
+
+    // -------------------------------------------------------------------------------------------------------------------------------------
+
     /**
      *  @brief   InteractionType enum
      */
@@ -244,6 +266,43 @@ public:
      */
     static void SelectGoodCaloHits(const pandora::CaloHitList *const pSelectedCaloHitList, const LArMCParticleHelper::MCRelationMap &mcToPrimaryMCMap,
         pandora::CaloHitList &selectedGoodCaloHitList, const bool selectInputHits, const float minHitSharingFraction);
+
+    /**
+     *  @brief  Select mc particles matching given criteria from an input list
+     *
+     *  @param  inputMCParticles input vector of MCParticles
+     *  @param  fCriteria a function which returns a bool (= shouldSelect) for a given input MCParticle
+     *  @param  selectedParticles the output vector of particles selected
+     */
+    static void SelectParticlesMatchingCriteria(const pandora::MCParticleVector &inputMCParticles, std::function<bool(const pandora::MCParticle *const)> fCriteria,
+        pandora::MCParticleVector &selectedParticles);
+
+    /**
+     *  @brief  Select primary, reconstructable mc particles that match given criteria.
+     *
+     *  @param  pMCParticleList the address of the list of MCParticles
+     *  @param  pCaloHitList the address of the list of CaloHits
+     *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
+     *  @param  fCriteria a function which returns a bool (= shouldSelect) for a given input MCParticle
+     *  @param  selectedMCParticlesToGoodHitsMap the output mapping from selected mcparticles to their good hits
+     */
+    static void SelectReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList, 
+        const ValidationParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, LArMonitoringHelper::MCContributionMap &selectedMCParticlesToGoodHitsMap);
+
+    /**
+     *  @brief  Returns true if passed a primary neutrino final state MCParticle
+     */
+    static bool IsBeamNeutrinoFinalState(const pandora::MCParticle *const pMCParticle);
+
+    /**
+     *  @brief  Returns true if passed a primary beam MCParticle
+     */
+    static bool IsBeamParticle(const pandora::MCParticle *const pMCParticle);
+
+    /**
+     *  @brief  Return true if passed a primary cosmic ray MCParticle
+     */
+    static bool IsCosmicRay(const pandora::MCParticle *const pMCParticle);
 
     /**
      *  @brief  Get the interaction type of an event

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
@@ -18,7 +18,6 @@
 #include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
-#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 #include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
 
 #include <algorithm>
@@ -64,7 +63,7 @@ void LArMonitoringHelper::ExtractTargetPfos(const PfoList &inputPfoList, const b
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMonitoringHelper::GetNeutrinoMatches(const CaloHitList *const pCaloHitList, const PfoList &recoNeutrinos,
-    const CaloHitToMCMap &hitToPrimaryMCMap, MCToPfoMap &outputPrimaryMap)
+    const LArMCParticleHelper::CaloHitToMCMap &hitToPrimaryMCMap, LArMCParticleHelper::MCToPfoMap &outputPrimaryMap)
 {
     const CaloHitSet caloHitSet(pCaloHitList->begin(), pCaloHitList->end());
 
@@ -79,14 +78,14 @@ void LArMonitoringHelper::GetNeutrinoMatches(const CaloHitList *const pCaloHitLi
         CaloHitList clusterHits;
         LArMonitoringHelper::CollectCaloHits(pfoList, clusterHits);
 
-        MCContributionMap inputContributionMap;
+        LArMCParticleHelper::MCContributionMap inputContributionMap;
 
         for (const CaloHit *const pCaloHit : clusterHits)
         {
             if (!caloHitSet.count(pCaloHit))
                 continue;
 
-            CaloHitToMCMap::const_iterator mcIter = hitToPrimaryMCMap.find(pCaloHit);
+            LArMCParticleHelper::CaloHitToMCMap::const_iterator mcIter = hitToPrimaryMCMap.find(pCaloHit);
 
             if (mcIter == hitToPrimaryMCMap.end())
                 continue;
@@ -125,8 +124,8 @@ void LArMonitoringHelper::GetNeutrinoMatches(const CaloHitList *const pCaloHitLi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMonitoringHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
-    CaloHitToMCMap &hitToPrimaryMCMap, MCContributionMap &mcToTrueHitListMap)
+void LArMonitoringHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const pCaloHitList, const LArMCParticleHelper::MCRelationMap &mcToPrimaryMCMap,
+    LArMCParticleHelper::CaloHitToMCMap &hitToPrimaryMCMap, LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap)
 {
     for (const CaloHit *const pCaloHit : *pCaloHitList)
     {
@@ -134,7 +133,7 @@ void LArMonitoringHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const
         {
             const MCParticle *const pHitParticle(MCParticleHelper::GetMainMCParticle(pCaloHit));
 
-            MCRelationMap::const_iterator mcIter = mcToPrimaryMCMap.find(pHitParticle);
+            LArMCParticleHelper::MCRelationMap::const_iterator mcIter = mcToPrimaryMCMap.find(pHitParticle);
 
             if (mcToPrimaryMCMap.end() == mcIter)
                 continue;
@@ -154,7 +153,7 @@ void LArMonitoringHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMonitoringHelper::GetPfoToCaloHitMatches(const CaloHitList *const pCaloHitList, const PfoList &pfoList, const bool collapseToPrimaryPfos,
-    CaloHitToPfoMap &hitToPfoMap, PfoContributionMap &pfoToHitListMap)
+    LArMCParticleHelper::CaloHitToPfoMap &hitToPfoMap, LArMCParticleHelper::PfoContributionMap &pfoToHitListMap)
 {
     const CaloHitSet caloHitSet(pCaloHitList->begin(), pCaloHitList->end());
 
@@ -206,9 +205,9 @@ void LArMonitoringHelper::GetPfoToCaloHitMatches(const CaloHitList *const pCaloH
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMonitoringHelper::GetMCParticleToPfoMatches(const CaloHitList *const pCaloHitList, const PfoContributionMap &pfoToHitListMap,
-    const CaloHitToMCMap &hitToPrimaryMCMap, MCToPfoMap &mcToBestPfoMap, MCContributionMap &mcToBestPfoHitsMap,
-    MCToPfoMatchingMap &mcToFullPfoMatchingMap)
+void LArMonitoringHelper::GetMCParticleToPfoMatches(const CaloHitList *const pCaloHitList, const LArMCParticleHelper::PfoContributionMap &pfoToHitListMap,
+    const LArMCParticleHelper::CaloHitToMCMap &hitToPrimaryMCMap, LArMCParticleHelper::MCToPfoMap &mcToBestPfoMap, LArMCParticleHelper::MCContributionMap &mcToBestPfoHitsMap,
+    LArMCParticleHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap)
 {
     const CaloHitSet caloHitSet(pCaloHitList->begin(), pCaloHitList->end());
 
@@ -228,7 +227,7 @@ void LArMonitoringHelper::GetMCParticleToPfoMatches(const CaloHitList *const pCa
             if (!caloHitSet.count(pCaloHit))
                 continue;
 
-            CaloHitToMCMap::const_iterator mcIter = hitToPrimaryMCMap.find(pCaloHit);
+            LArMCParticleHelper::CaloHitToMCMap::const_iterator mcIter = hitToPrimaryMCMap.find(pCaloHit);
 
             if (mcIter == hitToPrimaryMCMap.end())
                 continue;
@@ -244,7 +243,7 @@ void LArMonitoringHelper::GetMCParticleToPfoMatches(const CaloHitList *const pCa
 
     for (const MCParticle *const pPrimaryParticle : mcParticleList)
     {
-        const PfoContributionMap &pfoContributionMap(mcToFullPfoMatchingMap.at(pPrimaryParticle));
+        const LArMCParticleHelper::PfoContributionMap &pfoContributionMap(mcToFullPfoMatchingMap.at(pPrimaryParticle));
         const ParticleFlowObject *pBestMatchPfo(nullptr);
         CaloHitList bestMatchCaloHitList;
 
@@ -315,19 +314,19 @@ unsigned int LArMonitoringHelper::CountHitsByType(const HitType hitType, const C
 
 //------------------------------------------------------------------------------------------------------------------------------------------
     
-void LArMonitoringHelper::GetOrderedMCParticleVector(const std::vector<MCContributionMap> &selectedMCParticleToGoodHitsMaps, MCParticleVector &orderedMCParticleVector)
+void LArMonitoringHelper::GetOrderedMCParticleVector(const LArMCParticleHelper::LArMCParticleHelper::MCContributionMapVector &selectedMCParticleToGoodHitsMaps, MCParticleVector &orderedMCParticleVector)
 {
-    for (const MCContributionMap &mcParticleToGoodHitsMap : selectedMCParticleToGoodHitsMaps)
+    for (const LArMCParticleHelper::MCContributionMap &mcParticleToGoodHitsMap : selectedMCParticleToGoodHitsMaps)
     {
         if (mcParticleToGoodHitsMap.empty())
             continue;
 
         // Copy map contents to vector it can be sorted
-        std::vector<MCParticleCaloHitListPair> mcParticleToGoodHitsVect;
+        std::vector<LArMCParticleHelper::MCParticleCaloHitListPair> mcParticleToGoodHitsVect;
         std::copy(mcParticleToGoodHitsMap.begin(), mcParticleToGoodHitsMap.end(), std::back_inserter(mcParticleToGoodHitsVect));
 
         // Sort by number of hits descending
-        std::sort(mcParticleToGoodHitsVect.begin(), mcParticleToGoodHitsVect.end(), [] (const MCParticleCaloHitListPair &a, const MCParticleCaloHitListPair &b) -> bool 
+        std::sort(mcParticleToGoodHitsVect.begin(), mcParticleToGoodHitsVect.end(), [] (const LArMCParticleHelper::MCParticleCaloHitListPair &a, const LArMCParticleHelper::MCParticleCaloHitListPair &b) -> bool 
         {
             if (a.second.size() != b.second.size())
                 return (a.second.size() > b.second.size());
@@ -336,7 +335,7 @@ void LArMonitoringHelper::GetOrderedMCParticleVector(const std::vector<MCContrib
             return (a.first < b.first);
         });
 
-        for (const MCParticleCaloHitListPair &mcParticleCaloHitPair : mcParticleToGoodHitsVect)
+        for (const LArMCParticleHelper::MCParticleCaloHitListPair &mcParticleCaloHitPair : mcParticleToGoodHitsVect)
             orderedMCParticleVector.push_back(mcParticleCaloHitPair.first);
     }
 
@@ -348,14 +347,14 @@ void LArMonitoringHelper::GetOrderedMCParticleVector(const std::vector<MCContrib
 
 //------------------------------------------------------------------------------------------------------------------------------------------
     
-void LArMonitoringHelper::GetOrderedPfoVector(const PfoContributionMap &pfoToReconstructable2DHitsMap, pandora::PfoVector &orderedPfoVector)
+void LArMonitoringHelper::GetOrderedPfoVector(const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, pandora::PfoVector &orderedPfoVector)
 {
     // Copy map contents to vector it can be sorted
-    std::vector<PfoCaloHitListPair> pfoToReconstructable2DHitsVect;
+    std::vector<LArMCParticleHelper::PfoCaloHitListPair> pfoToReconstructable2DHitsVect;
     std::copy(pfoToReconstructable2DHitsMap.begin(), pfoToReconstructable2DHitsMap.end(), std::back_inserter(pfoToReconstructable2DHitsVect));
 
     // Sort by number of hits descending putting neutrino final states first
-    std::sort(pfoToReconstructable2DHitsVect.begin(), pfoToReconstructable2DHitsVect.end(), [] (const PfoCaloHitListPair &a, const PfoCaloHitListPair &b) -> bool 
+    std::sort(pfoToReconstructable2DHitsVect.begin(), pfoToReconstructable2DHitsVect.end(), [] (const LArMCParticleHelper::PfoCaloHitListPair &a, const LArMCParticleHelper::PfoCaloHitListPair &b) -> bool 
     {
         bool isANuFinalState(LArPfoHelper::IsNeutrinoFinalState(a.first));
         bool isBNuFinalState(LArPfoHelper::IsNeutrinoFinalState(b.first));
@@ -370,7 +369,7 @@ void LArMonitoringHelper::GetOrderedPfoVector(const PfoContributionMap &pfoToRec
         return (a.first->GetEnergy() > b.first->GetEnergy());
     });
 
-    for (const PfoCaloHitListPair &pfoCaloHitPair : pfoToReconstructable2DHitsVect)
+    for (const LArMCParticleHelper::PfoCaloHitListPair &pfoCaloHitPair : pfoToReconstructable2DHitsVect)
         orderedPfoVector.push_back(pfoCaloHitPair.first);
 
     // Check that all elements of the vector are unique
@@ -381,7 +380,7 @@ void LArMonitoringHelper::GetOrderedPfoVector(const PfoContributionMap &pfoToRec
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMonitoringHelper::PrintMCParticleTable(const MCContributionMap &selectedMCParticleToGoodHitsMap, const MCParticleVector &orderedMCParticleVector)
+void LArMonitoringHelper::PrintMCParticleTable(const LArMCParticleHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, const MCParticleVector &orderedMCParticleVector)
 {
     if (selectedMCParticleToGoodHitsMap.empty())
     {
@@ -396,12 +395,12 @@ void LArMonitoringHelper::PrintMCParticleTable(const MCContributionMap &selected
     {
         const MCParticle *const pMCParticle(orderedMCParticleVector.at(id));
 
-        MCContributionMap::const_iterator it = selectedMCParticleToGoodHitsMap.find(pMCParticle);
+        LArMCParticleHelper::MCContributionMap::const_iterator it = selectedMCParticleToGoodHitsMap.find(pMCParticle);
         if (selectedMCParticleToGoodHitsMap.end() == it)
             continue;  // ATTN MCParticles in selectedMCParticleToGoodHitsMap may be a subset of orderedMCParticleVector
 
         table.AddElement(id);
-        table.AddElement((dynamic_cast<const LArMCParticle*>(pMCParticle))->GetNuanceCode());
+        table.AddElement(LArMCParticleHelper::GetNuanceCode(pMCParticle));
         table.AddElement(PdgTable::GetParticleName(pMCParticle->GetParticleId()));
 
         table.AddElement(pMCParticle->GetEnergy());
@@ -424,7 +423,7 @@ void LArMonitoringHelper::PrintMCParticleTable(const MCContributionMap &selected
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMonitoringHelper::PrintPfoTable(const PfoContributionMap &pfoToReconstructable2DHitsMap, const PfoVector &orderedPfoVector)
+void LArMonitoringHelper::PrintPfoTable(const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const PfoVector &orderedPfoVector)
 {
     if (pfoToReconstructable2DHitsMap.empty())
     {
@@ -438,7 +437,7 @@ void LArMonitoringHelper::PrintPfoTable(const PfoContributionMap &pfoToReconstru
     {
         const ParticleFlowObject *const pPfo(orderedPfoVector.at(id));
 
-        PfoContributionMap::const_iterator it = pfoToReconstructable2DHitsMap.find(pPfo);
+        LArMCParticleHelper::PfoContributionMap::const_iterator it = pfoToReconstructable2DHitsMap.find(pPfo);
         if (pfoToReconstructable2DHitsMap.end() == it)
             throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
@@ -361,15 +361,17 @@ void LArMonitoringHelper::PrintMCParticleTable(const MCContributionMap &selected
     }
 
     LArFormattingHelper::Table table({"ID", "NUANCE", "TYPE", "", "E", "dist", "", "nGoodHits", "U", "V", "W"});
-   
-    unsigned int id(0);
-    for (const MCParticle *const pMCParticle : orderedMCParticleVector)
+ 
+    unsigned int usedParticleCount(0);
+    for (unsigned int id = 0; id < orderedMCParticleVector.size(); id++)
     {
+        const MCParticle *const pMCParticle(orderedMCParticleVector.at(id));
+
         LArMonitoringHelper::MCContributionMap::const_iterator it = selectedMCParticleToGoodHitsMap.find(pMCParticle);
         if (selectedMCParticleToGoodHitsMap.end() == it)
             continue;  // ATTN MCParticles in selectedMCParticleToGoodHitsMap may be a subset of orderedMCParticleVector
 
-        table.AddElement(id++);
+        table.AddElement(id);
         table.AddElement((dynamic_cast<const LArMCParticle*>(pMCParticle))->GetNuanceCode());
         table.AddElement(PdgTable::GetParticleName(pMCParticle->GetParticleId()));
 
@@ -380,10 +382,12 @@ void LArMonitoringHelper::PrintMCParticleTable(const MCContributionMap &selected
         table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, it->second));
         table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, it->second));
         table.AddElement(LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, it->second));
+
+        usedParticleCount++;
     }
 
     // Check every MCParticle in selectedMCParticleToGoodHitsMap has been printed
-    if (id != selectedMCParticleToGoodHitsMap.size() - 1)
+    if (usedParticleCount != selectedMCParticleToGoodHitsMap.size())
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
             
     table.Print();

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
@@ -365,8 +365,8 @@ void LArMonitoringHelper::GetOrderedPfoVector(const LArMCParticleHelper::PfoCont
         if (a.second.size() != b.second.size())
             return (a.second.size() > b.second.size());
 
-        // ATTN fall back on energy as a tie-breaker
-        return (a.first->GetEnergy() > b.first->GetEnergy());
+        // ATTN fall back on using all hits as a tie-breaker
+        return LArPfoHelper::SortByNHits(a.first, b.first);
     });
 
     for (const LArMCParticleHelper::PfoCaloHitListPair &pfoCaloHitPair : pfoToReconstructable2DHitsVect)

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.h
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.h
@@ -9,6 +9,7 @@
 #define LAR_MONITORING_HELPER_H 1
 
 #include "Pandora/PandoraInternal.h"
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 
 #include <unordered_map>
 
@@ -21,21 +22,6 @@ namespace lar_content
 class LArMonitoringHelper
 {
 public:
-    typedef std::unordered_map<const pandora::MCParticle*, const pandora::MCParticle*> MCRelationMap;
-
-    typedef std::unordered_map<const pandora::MCParticle*, const pandora::ParticleFlowObject*> MCToPfoMap;
-
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::MCParticle*> CaloHitToMCMap;
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::ParticleFlowObject*> CaloHitToPfoMap;
-
-    typedef std::unordered_map<const pandora::MCParticle*, pandora::CaloHitList> MCContributionMap;
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, pandora::CaloHitList> PfoContributionMap;
-
-    typedef std::unordered_map<const pandora::MCParticle*, PfoContributionMap> MCToPfoMatchingMap;
-
-    typedef std::pair<const pandora::MCParticle*, pandora::CaloHitList > MCParticleCaloHitListPair;
-    typedef std::pair<const pandora::ParticleFlowObject*, pandora::CaloHitList > PfoCaloHitListPair;
-
     /**
      *  @brief  Extract a list of target pfos consisting of either i) primary/final-state pfos only, or ii) a full list of all
      *          non-neutrino pfos and their daughters
@@ -55,7 +41,7 @@ public:
      *  @param  outputPrimaryMap ouput mapping between from true to reconstructed neutrinos
      */
     static void GetNeutrinoMatches(const pandora::CaloHitList *const pCaloHitList, const pandora::PfoList &recoNeutrinos,
-        const CaloHitToMCMap &hitToPrimaryMCMap, MCToPfoMap &outputNeutrinoMap);
+        const LArMCParticleHelper::CaloHitToMCMap &hitToPrimaryMCMap, LArMCParticleHelper::MCToPfoMap &outputNeutrinoMap);
 
     /**
      *  @brief  Match calo hits to their parent particles
@@ -65,8 +51,8 @@ public:
      *  @param  hitToPrimaryMCMap output mapping between calo hits and their main primary MC particle
      *  @param  mcToTrueHitListMap output mapping between MC particles and their associated hits
      */
-    static void GetMCParticleToCaloHitMatches(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
-        CaloHitToMCMap &hitToPrimaryMCMap, MCContributionMap &mcToTrueHitListMap);
+    static void GetMCParticleToCaloHitMatches(const pandora::CaloHitList *const pCaloHitList, const LArMCParticleHelper::MCRelationMap &mcToPrimaryMCMap,
+        LArMCParticleHelper::CaloHitToMCMap &hitToPrimaryMCMap, LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap);
 
     /**
      *  @brief  Match calo hits to their parent Pfos
@@ -78,7 +64,7 @@ public:
      *  @param  pfoToHitListMap output mapping between Pfos and associated hits
      */
     static void GetPfoToCaloHitMatches(const pandora::CaloHitList *const pCaloHitList, const pandora::PfoList &pfoList,
-        const bool collapseToPrimaryPfos, CaloHitToPfoMap &hitToPfoMap, PfoContributionMap &pfoToHitListMap);
+        const bool collapseToPrimaryPfos, LArMCParticleHelper::CaloHitToPfoMap &hitToPfoMap, LArMCParticleHelper::PfoContributionMap &pfoToHitListMap);
 
     /**
      *  @brief  Match MC particle and Pfos
@@ -90,9 +76,9 @@ public:
      *  @param  mcToBestPfoHitsMap output mapping between MC particles and list of matched hits in best pfo
      *  @param  mcToFullPfoMatchingMap output mapping between MC particles and all matched pfos (and matched hits)
      */
-    static void GetMCParticleToPfoMatches(const pandora::CaloHitList *const pCaloHitList, const PfoContributionMap &pfoToHitListMap,
-        const CaloHitToMCMap &hitToPrimaryMCMap, MCToPfoMap &mcToBestPfoMap, MCContributionMap &mcToBestPfoHitsMap,
-        MCToPfoMatchingMap &mcToFullPfoMatchingMap);
+    static void GetMCParticleToPfoMatches(const pandora::CaloHitList *const pCaloHitList, const LArMCParticleHelper::PfoContributionMap &pfoToHitListMap,
+        const LArMCParticleHelper::CaloHitToMCMap &hitToPrimaryMCMap, LArMCParticleHelper::MCToPfoMap &mcToBestPfoMap, LArMCParticleHelper::MCContributionMap &mcToBestPfoHitsMap,
+        LArMCParticleHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap);
 
     /**
      *  @brief  Collect up all calo hits associated with a Pfo and its daughters
@@ -126,7 +112,7 @@ public:
      *  @param  selectedMCParticleToGoodHitsMaps the input vector of mappings from selected reconstructable MCParticles to their good hits
      *  @param  orderedMCParticleVector the output vector of ordered MCParticles
      */
-    static void GetOrderedMCParticleVector(const std::vector<MCContributionMap> &selectedMCParticleToGoodHitsMaps, pandora::MCParticleVector &orderedMCParticleVector);
+    static void GetOrderedMCParticleVector(const LArMCParticleHelper::MCContributionMapVector &selectedMCParticleToGoodHitsMaps, pandora::MCParticleVector &orderedMCParticleVector);
     
     /**
      *  @brief  Order input Pfos by their number of hits.
@@ -134,7 +120,7 @@ public:
      *  @param  pfoToReconstructable2DHitsMap the input vector of mappings from Pfos to their reconstructable hits
      *  @param  orderedPfoVector the output vector of ordered Pfos
      */
-    static void GetOrderedPfoVector(const PfoContributionMap &pfoToReconstructable2DHitsMap, pandora::PfoVector &orderedPfoVector);
+    static void GetOrderedPfoVector(const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, pandora::PfoVector &orderedPfoVector);
 
     /**
      *  @brief  Print details of selected MCParticles to the terminal in a table.
@@ -142,7 +128,7 @@ public:
      *  @param  selectedMCParticleToGoodHitsMap the input mapping from selected reconstructable MCParticles to their good hits
      *  @param  orderedMCParticleVector the input vector of ordered MCParticles
      */
-    static void PrintMCParticleTable(const MCContributionMap &selectedMCParticleToGoodHitsMaps, const pandora::MCParticleVector &orderedMCParticleVector);
+    static void PrintMCParticleTable(const LArMCParticleHelper::MCContributionMap &selectedMCParticleToGoodHitsMaps, const pandora::MCParticleVector &orderedMCParticleVector);
     
     /**
      *  @brief  Print details of input Pfos to the terminal in a table.
@@ -150,7 +136,7 @@ public:
      *  @param  pfoToReconstructable2DHitsMap the input vector of mappings from Pfos to their reconstructable hits
      *  @param  orderedPfoVector the input vector of ordered Pfos
      */
-    static void PrintPfoTable(const PfoContributionMap &pfoToReconstructable2DHitsMap, const pandora::PfoVector &orderedPfoVector);
+    static void PrintPfoTable(const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const pandora::PfoVector &orderedPfoVector);
 
     /**
      *  @brief  Print the shared good hits between all Pfos and MCParticles

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.h
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.h
@@ -33,6 +33,8 @@ public:
 
     typedef std::unordered_map<const pandora::MCParticle*, PfoContributionMap> MCToPfoMatchingMap;
 
+    typedef std::pair<const pandora::MCParticle*, pandora::CaloHitList > MCParticleCaloHitPair;
+
     /**
      *  @brief  Extract a list of target pfos consisting of either i) primary/final-state pfos only, or ii) a full list of all
      *          non-neutrino pfos and their daughters
@@ -116,6 +118,22 @@ public:
      *  @return the number of calo hits of the specified type
      */
     static unsigned int CountHitsByType(const pandora::HitType hitType, const pandora::CaloHitList &caloHitList);
+
+    /**
+     *  @brief  Order input MCParticles by their number of hits.
+     *
+     *  @param  selectedMCParticleToGoodHitsMaps the input vector of mappings from selected reconstructable MCParticles to their good hits
+     *  @param  orderedMCParticleVector the output vector of ordered MCParticles
+     */
+    static void GetOrderedMCParticleVector(const std::vector<MCContributionMap> &selectedMCParticleToGoodHitsMaps, pandora::MCParticleVector &orderedMCParticleVector);
+
+    /**
+     *  @brief  Print details of selected MCParticles to the terminal in a table.
+     *
+     *  @param  selectedMCParticleToGoodHitsMap the input mapping from selected reconstructable MCParticles to their good hits
+     *  @param  orderedMCParticleVector the input vector of ordered MCParticles
+     */
+    static void PrintMCParticleTable(const MCContributionMap &selectedMCParticleToGoodHitsMaps, const pandora::MCParticleVector &orderedMCParticleVector);
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.h
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.h
@@ -33,7 +33,8 @@ public:
 
     typedef std::unordered_map<const pandora::MCParticle*, PfoContributionMap> MCToPfoMatchingMap;
 
-    typedef std::pair<const pandora::MCParticle*, pandora::CaloHitList > MCParticleCaloHitPair;
+    typedef std::pair<const pandora::MCParticle*, pandora::CaloHitList > MCParticleCaloHitListPair;
+    typedef std::pair<const pandora::ParticleFlowObject*, pandora::CaloHitList > PfoCaloHitListPair;
 
     /**
      *  @brief  Extract a list of target pfos consisting of either i) primary/final-state pfos only, or ii) a full list of all
@@ -126,6 +127,14 @@ public:
      *  @param  orderedMCParticleVector the output vector of ordered MCParticles
      */
     static void GetOrderedMCParticleVector(const std::vector<MCContributionMap> &selectedMCParticleToGoodHitsMaps, pandora::MCParticleVector &orderedMCParticleVector);
+    
+    /**
+     *  @brief  Order input Pfos by their number of hits.
+     *
+     *  @param  pfoToReconstructable2DHitsMap the input vector of mappings from Pfos to their reconstructable hits
+     *  @param  orderedPfoVector the output vector of ordered Pfos
+     */
+    static void GetOrderedPfoVector(const PfoContributionMap &pfoToReconstructable2DHitsMap, pandora::PfoVector &orderedPfoVector);
 
     /**
      *  @brief  Print details of selected MCParticles to the terminal in a table.
@@ -134,6 +143,24 @@ public:
      *  @param  orderedMCParticleVector the input vector of ordered MCParticles
      */
     static void PrintMCParticleTable(const MCContributionMap &selectedMCParticleToGoodHitsMaps, const pandora::MCParticleVector &orderedMCParticleVector);
+    
+    /**
+     *  @brief  Print details of input Pfos to the terminal in a table.
+     *
+     *  @param  pfoToReconstructable2DHitsMap the input vector of mappings from Pfos to their reconstructable hits
+     *  @param  orderedPfoVector the input vector of ordered Pfos
+     */
+    static void PrintPfoTable(const PfoContributionMap &pfoToReconstructable2DHitsMap, const pandora::PfoVector &orderedPfoVector);
+
+    /**
+     *  @brief  Print the shared good hits between all Pfos and MCParticles
+     *
+     *  @param  orderedPfoVector the input vector of ordered Pfos
+     *  @param  orderedMCParticleVector the input vector of ordered MCParticles
+     *  @param  mcParticleToPfoHitSharingMap the output mapping from selected reconstructable MCParticles to Pfos and the number hits shared
+     */
+    // TODO
+    // static void PrintMatchingTable(const pandora::PfoVector &orderedPfoVector, const pandora::MCParticleVector &orderedMCParticleVector, const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
@@ -10,7 +10,7 @@
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
-#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArMonitoring/EventValidationAlgorithm.h"
@@ -121,19 +121,19 @@ StatusCode EventValidationAlgorithm::Run()
     LArMCParticleHelper::SelectCaloHits(pCaloHitList, mcToPrimaryMCMap, selectedCaloHitList, m_selectInputHits, m_maxPhotonPropagation);
 
     // Obtain maps: [hit -> primary mc particle], [primary mc particle -> list of hits]
-    LArMonitoringHelper::CaloHitToMCMap hitToPrimaryMCMap;
-    LArMonitoringHelper::MCContributionMap mcToTrueHitListMap;
+    LArMCParticleHelper::CaloHitToMCMap hitToPrimaryMCMap;
+    LArMCParticleHelper::MCContributionMap mcToTrueHitListMap;
     LArMonitoringHelper::GetMCParticleToCaloHitMatches(&selectedCaloHitList, mcToPrimaryMCMap, hitToPrimaryMCMap, mcToTrueHitListMap);
 
     // Obtain maps: [hit -> pfo], [pfo -> list of hits]
-    LArMonitoringHelper::CaloHitToPfoMap hitToPfoMap;
-    LArMonitoringHelper::PfoContributionMap pfoToHitListMap;
+    LArMCParticleHelper::CaloHitToPfoMap hitToPfoMap;
+    LArMCParticleHelper::PfoContributionMap pfoToHitListMap;
     LArMonitoringHelper::GetPfoToCaloHitMatches(&selectedCaloHitList, pfoList, m_collapseToPrimaryPfos, hitToPfoMap, pfoToHitListMap);
 
     // Obtain maps: [mc particle -> best matched pfo], [mc particle -> list of hits included in best pfo], [mc particle -> all matched pfos (and matched hits)]
-    LArMonitoringHelper::MCToPfoMap mcToBestPfoMap;
-    LArMonitoringHelper::MCContributionMap mcToBestPfoHitsMap;
-    LArMonitoringHelper::MCToPfoMatchingMap mcToFullPfoMatchingMap;
+    LArMCParticleHelper::MCToPfoMap mcToBestPfoMap;
+    LArMCParticleHelper::MCContributionMap mcToBestPfoHitsMap;
+    LArMCParticleHelper::MCToPfoMatchingMap mcToFullPfoMatchingMap;
     LArMonitoringHelper::GetMCParticleToPfoMatches(&selectedCaloHitList, pfoToHitListMap, hitToPrimaryMCMap, mcToBestPfoMap, mcToBestPfoHitsMap, mcToFullPfoMatchingMap);
 
     // Remove shared hits where target particle deposits below threshold energy fraction
@@ -141,8 +141,8 @@ StatusCode EventValidationAlgorithm::Run()
     LArMCParticleHelper::SelectGoodCaloHits(&selectedCaloHitList, mcToPrimaryMCMap, goodCaloHitList, m_selectInputHits, m_minHitSharingFraction);
 
     // Obtain maps: [good hit -> primary mc particle], [primary mc particle -> list of good hits]
-    LArMonitoringHelper::CaloHitToMCMap goodHitToPrimaryMCMap;
-    LArMonitoringHelper::MCContributionMap mcToGoodTrueHitListMap;
+    LArMCParticleHelper::CaloHitToMCMap goodHitToPrimaryMCMap;
+    LArMCParticleHelper::MCContributionMap mcToGoodTrueHitListMap;
     LArMonitoringHelper::GetMCParticleToCaloHitMatches(&goodCaloHitList, mcToPrimaryMCMap, goodHitToPrimaryMCMap, mcToGoodTrueHitListMap);
 
     // Obtain vector: simple mc primaries
@@ -218,8 +218,8 @@ void EventValidationAlgorithm::SelectRecoNeutrinos(const PfoList &allRecoParticl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventValidationAlgorithm::GetSimpleMCPrimaryList(const MCParticleVector &mcPrimaryVector, const LArMonitoringHelper::MCContributionMap &mcToTrueHitListMap,
-    const LArMonitoringHelper::MCContributionMap &mcToGoodTrueHitListMap, const LArMonitoringHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap,
+void EventValidationAlgorithm::GetSimpleMCPrimaryList(const MCParticleVector &mcPrimaryVector, const LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap,
+    const LArMCParticleHelper::MCContributionMap &mcToGoodTrueHitListMap, const LArMCParticleHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap,
     SimpleMCPrimaryList &simpleMCPrimaryList) const
 {
     for (const MCParticle *const pMCPrimary : mcPrimaryVector)
@@ -236,7 +236,7 @@ void EventValidationAlgorithm::GetSimpleMCPrimaryList(const MCParticleVector &mc
         simpleMCPrimary.m_vertex = pMCPrimary->GetVertex();
         simpleMCPrimary.m_endpoint = pMCPrimary->GetEndpoint();
 
-        LArMonitoringHelper::MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCPrimary);
+        LArMCParticleHelper::MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCPrimary);
 
         if (mcToTrueHitListMap.end() != trueHitsIter)
         {
@@ -247,7 +247,7 @@ void EventValidationAlgorithm::GetSimpleMCPrimaryList(const MCParticleVector &mc
             simpleMCPrimary.m_nMCHitsW = LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, caloHitList);
         }
 
-        LArMonitoringHelper::MCContributionMap::const_iterator goodTrueHitsIter = mcToGoodTrueHitListMap.find(pMCPrimary);
+        LArMCParticleHelper::MCContributionMap::const_iterator goodTrueHitsIter = mcToGoodTrueHitListMap.find(pMCPrimary);
 
         if (mcToGoodTrueHitListMap.end() != goodTrueHitsIter)
         {
@@ -258,7 +258,7 @@ void EventValidationAlgorithm::GetSimpleMCPrimaryList(const MCParticleVector &mc
             simpleMCPrimary.m_nGoodMCHitsW = LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, caloHitList);
         }
 
-        LArMonitoringHelper::MCToPfoMatchingMap::const_iterator matchedPfoIter = mcToFullPfoMatchingMap.find(pMCPrimary);
+        LArMCParticleHelper::MCToPfoMatchingMap::const_iterator matchedPfoIter = mcToFullPfoMatchingMap.find(pMCPrimary);
 
         if (mcToFullPfoMatchingMap.end() != matchedPfoIter)
             simpleMCPrimary.m_nMatchedPfos = matchedPfoIter->second.size();
@@ -276,18 +276,18 @@ void EventValidationAlgorithm::GetSimpleMCPrimaryList(const MCParticleVector &mc
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void EventValidationAlgorithm::GetMCPrimaryMatchingMap(const SimpleMCPrimaryList &simpleMCPrimaryList, const PfoIdMap &pfoIdMap,
-    const LArMonitoringHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap, const LArMonitoringHelper::PfoContributionMap &pfoToHitListMap,
+    const LArMCParticleHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap, const LArMCParticleHelper::PfoContributionMap &pfoToHitListMap,
     MCPrimaryMatchingMap &mcPrimaryMatchingMap) const
 {
     for (const SimpleMCPrimary &simpleMCPrimary : simpleMCPrimaryList)
     {
         // First loop over unordered list of matched pfos
         SimpleMatchedPfoList simpleMatchedPfoList;
-        LArMonitoringHelper::MCToPfoMatchingMap::const_iterator matchedPfoIter = mcToFullPfoMatchingMap.find(simpleMCPrimary.m_pPandoraAddress);
+        LArMCParticleHelper::MCToPfoMatchingMap::const_iterator matchedPfoIter = mcToFullPfoMatchingMap.find(simpleMCPrimary.m_pPandoraAddress);
 
         if (mcToFullPfoMatchingMap.end() != matchedPfoIter)
         {
-            for (const LArMonitoringHelper::PfoContributionMap::value_type contribution : matchedPfoIter->second)
+            for (const LArMCParticleHelper::PfoContributionMap::value_type contribution : matchedPfoIter->second)
             {
                 const ParticleFlowObject *const pMatchedPfo(contribution.first);
                 const CaloHitList &matchedCaloHitList(contribution.second);
@@ -309,7 +309,7 @@ void EventValidationAlgorithm::GetMCPrimaryMatchingMap(const SimpleMCPrimaryList
                 simpleMatchedPfo.m_nMatchedHitsV = LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, matchedCaloHitList);
                 simpleMatchedPfo.m_nMatchedHitsW = LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, matchedCaloHitList);
 
-                LArMonitoringHelper::PfoContributionMap::const_iterator pfoHitsIter = pfoToHitListMap.find(pMatchedPfo);
+                LArMCParticleHelper::PfoContributionMap::const_iterator pfoHitsIter = pfoToHitListMap.find(pMatchedPfo);
 
                 if (pfoToHitListMap.end() == pfoHitsIter)
                     throw StatusCodeException(STATUS_CODE_FAILURE);

--- a/larpandoracontent/LArMonitoring/EventValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventValidationAlgorithm.h
@@ -10,7 +10,7 @@
 
 #include "Pandora/Algorithm.h"
 
-#include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 
 #ifdef MONITORING
 #include "PandoraMonitoringApi.h"
@@ -149,8 +149,8 @@ private:
      *  @param  mcToFullPfoMatchingMap the mc to full pfo matching map (to record number of matched pfos)
      *  @param  simpleMCPrimaryList to receive the populated simple mc primary list
      */
-    void GetSimpleMCPrimaryList(const pandora::MCParticleVector &mcPrimaryList, const LArMonitoringHelper::MCContributionMap &mcToTrueHitListMap,
-        const LArMonitoringHelper::MCContributionMap &mcToGoodTrueHitListMap, const LArMonitoringHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap,
+    void GetSimpleMCPrimaryList(const pandora::MCParticleVector &mcPrimaryList, const LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap,
+        const LArMCParticleHelper::MCContributionMap &mcToGoodTrueHitListMap, const LArMCParticleHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap,
         SimpleMCPrimaryList &simpleMCPrimaryList) const;
 
     typedef std::unordered_map<const pandora::ParticleFlowObject*, int> PfoIdMap;
@@ -166,7 +166,7 @@ private:
      *  @param  mcPrimaryMatchingMap to receive the populated mc primary matching map
      */
     void GetMCPrimaryMatchingMap(const SimpleMCPrimaryList &simpleMCPrimaryList, const PfoIdMap &pfoIdMap,
-        const LArMonitoringHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap, const LArMonitoringHelper::PfoContributionMap &pfoToHitListMap,
+        const LArMCParticleHelper::MCToPfoMatchingMap &mcToFullPfoMatchingMap, const LArMCParticleHelper::PfoContributionMap &pfoToHitListMap,
         MCPrimaryMatchingMap &mcPrimaryMatchingMap) const;
 
     /**

--- a/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.cc
@@ -10,7 +10,7 @@
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
-#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.h"
@@ -46,8 +46,8 @@ StatusCode MCParticleMonitoringAlgorithm::Run()
     LArMCParticleHelper::MCRelationMap mcToPrimaryMCMap;
     LArMCParticleHelper::GetMCPrimaryMap(pMCParticleList, mcToPrimaryMCMap);
 
-    LArMonitoringHelper::CaloHitToMCMap hitToPrimaryMCMap;
-    LArMonitoringHelper::MCContributionMap mcPrimaryToTrueHitListMap;
+    LArMCParticleHelper::CaloHitToMCMap hitToPrimaryMCMap;
+    LArMCParticleHelper::MCContributionMap mcPrimaryToTrueHitListMap;
     LArMonitoringHelper::GetMCParticleToCaloHitMatches(pCaloHitList, mcToPrimaryMCMap, hitToPrimaryMCMap, mcPrimaryToTrueHitListMap);
 
     SimpleMCParticleList simpleMCPrimaryList;
@@ -59,8 +59,8 @@ StatusCode MCParticleMonitoringAlgorithm::Run()
     LArMCParticleHelper::MCRelationMap mcParticleToSelfMap;
     for (const MCParticle *const pMCParticle : mcParticleVector) mcParticleToSelfMap[pMCParticle] = pMCParticle;
 
-    LArMonitoringHelper::CaloHitToMCMap hitToMCMap;
-    LArMonitoringHelper::MCContributionMap mcToTrueHitListMap;
+    LArMCParticleHelper::CaloHitToMCMap hitToMCMap;
+    LArMCParticleHelper::MCContributionMap mcToTrueHitListMap;
     LArMonitoringHelper::GetMCParticleToCaloHitMatches(pCaloHitList, mcParticleToSelfMap, hitToMCMap, mcToTrueHitListMap);    
 
     SimpleMCParticleList simpleMCParticleList;
@@ -79,7 +79,7 @@ StatusCode MCParticleMonitoringAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MCParticleMonitoringAlgorithm::GetSimpleMCParticleList(const MCParticleVector &mcPrimaryVector, const LArMonitoringHelper::MCContributionMap &mcToTrueHitListMap,
+void MCParticleMonitoringAlgorithm::GetSimpleMCParticleList(const MCParticleVector &mcPrimaryVector, const LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap,
     SimpleMCParticleList &simpleMCParticleList) const
 {
     for (const MCParticle *const pMCPrimary : mcPrimaryVector)
@@ -96,7 +96,7 @@ void MCParticleMonitoringAlgorithm::GetSimpleMCParticleList(const MCParticleVect
         simpleMCParticle.m_vertex = pMCPrimary->GetVertex();
         simpleMCParticle.m_endpoint = pMCPrimary->GetEndpoint();
 
-        LArMonitoringHelper::MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCPrimary);
+        LArMCParticleHelper::MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCPrimary);
 
         if (mcToTrueHitListMap.end() != trueHitsIter)
         {

--- a/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.h
@@ -10,7 +10,7 @@
 
 #include "Pandora/Algorithm.h"
 
-#include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 
 namespace lar_content
 {
@@ -73,7 +73,7 @@ private:
      *  @param  mcToTrueHitListMap the mc to true hit list map
      *  @param  simpleMCParticleList to receive the populated simple mc particle list
      */
-    void GetSimpleMCParticleList(const pandora::MCParticleVector &mcParticleList, const LArMonitoringHelper::MCContributionMap &mcToTrueHitListMap,
+    void GetSimpleMCParticleList(const pandora::MCParticleVector &mcParticleList, const LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap,
         SimpleMCParticleList &simpleMCParticleList) const;
 
     /**

--- a/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
@@ -11,7 +11,7 @@
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 #include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 #include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
-    #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h"
 
@@ -38,15 +38,15 @@ StatusCode PfoValidationAlgorithm::Run()
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_pfoListName, pPfoList));
 
     // Identify reconstructable MCParticles, and get mappings to their good hits
-    LArMonitoringHelper::MCContributionMap nuMCParticlesToGoodHitsMap;
-    LArMonitoringHelper::MCContributionMap beamMCParticlesToGoodHitsMap;
-    LArMonitoringHelper::MCContributionMap crMCParticlesToGoodHitsMap;
+    LArMCParticleHelper::MCContributionMap nuMCParticlesToGoodHitsMap;
+    LArMCParticleHelper::MCContributionMap beamMCParticlesToGoodHitsMap;
+    LArMCParticleHelper::MCContributionMap crMCParticlesToGoodHitsMap;
 
     LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
     LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
     LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
 
-    std::vector<LArMonitoringHelper::MCContributionMap> mcParticlesToGoodHitsMaps;
+    LArMCParticleHelper::MCContributionMapVector mcParticlesToGoodHitsMaps;
     mcParticlesToGoodHitsMaps.push_back(nuMCParticlesToGoodHitsMap);
     mcParticlesToGoodHitsMaps.push_back(beamMCParticlesToGoodHitsMap);
     mcParticlesToGoodHitsMaps.push_back(crMCParticlesToGoodHitsMap);
@@ -56,10 +56,12 @@ StatusCode PfoValidationAlgorithm::Run()
 
     // TODO use helper function in LArMonitoringHelper, not sure if it currently give the right output
     for (const ParticleFlowObject *const pPfo : *pPfoList)
+    {
         if (LArPfoHelper::IsFinalState(pPfo))
             finalStatePfos.push_back(pPfo);
+    }
 
-    LArMonitoringHelper::PfoContributionMap pfoToReconstructable2DHitsMap;
+    LArMCParticleHelper::PfoContributionMap pfoToReconstructable2DHitsMap;
     LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap);
 
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCParticleHitSharingMap;

--- a/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
@@ -1,0 +1,102 @@
+/**
+ *  @file   larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
+ *
+ *  @brief  Implementation of the pfo validation algorithm.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
+#include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
+
+#include "larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+PfoValidationAlgorithm::PfoValidationAlgorithm()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PfoValidationAlgorithm::Run()
+{
+    const MCParticleList *pMCParticleList = nullptr;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pMCParticleList));
+
+    const CaloHitList *pCaloHitList = nullptr;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_caloHitListName, pCaloHitList));
+    
+    const PfoList *pPfoList = nullptr;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_pfoListName, pPfoList));
+
+    // Identify reconstructable MCParticles, and get mappings to their good hits
+    LArMonitoringHelper::MCContributionMap nuMCParticlesToGoodHitsMap;
+    LArMonitoringHelper::MCContributionMap beamMCParticlesToGoodHitsMap;
+    LArMonitoringHelper::MCContributionMap crMCParticlesToGoodHitsMap;
+
+    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
+
+    const std::vector<LArMonitoringHelper::MCContributionMap> mcParticlesToGoodHitsMaps({nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap, crMCParticlesToGoodHitsMap});
+
+    // Get the mappings detailing the hits shared between Pfos and reconstructable MCParticles
+    LArMCParticleHelper::PfoToCaloHitListMap pfoToReconstructable2DHitsMap;
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(*pPfoList, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap);
+
+    LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCParticleHitSharingMap;
+    LArMCParticleHelper::MCParticleToPfoHitSharingMap mcParticleToPfoHitSharingMap;
+    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(pfoToReconstructable2DHitsMap, mcParticlesToGoodHitsMaps, pfoToMCParticleHitSharingMap, mcParticleToPfoHitSharingMap);
+
+    // Print the monte-carlo information for this event
+    MCParticleVector orderedMCParticleVector;
+    LArMonitoringHelper::GetOrderedMCParticleVector(mcParticlesToGoodHitsMaps, orderedMCParticleVector);
+
+    LArFormattingHelper::PrintHeader("MC : Reconstructable neutrino final state particles");
+    LArMonitoringHelper::PrintMCParticleTable(nuMCParticlesToGoodHitsMap, orderedMCParticleVector); 
+    
+    LArFormattingHelper::PrintHeader("MC : Reconstructable primary beam particles");
+    LArMonitoringHelper::PrintMCParticleTable(beamMCParticlesToGoodHitsMap, orderedMCParticleVector); 
+    
+    LArFormattingHelper::PrintHeader("MC : Reconstructable primary cosmic-rays");
+    LArMonitoringHelper::PrintMCParticleTable(crMCParticlesToGoodHitsMap, orderedMCParticleVector); 
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PfoValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinPrimaryGoodHits", m_parameters.m_minPrimaryGoodHits));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinHitsForGoodView", m_parameters.m_minHitsForGoodView));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinPrimaryGoodViews", m_parameters.m_minPrimaryGoodViews));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "SelectInputHits", m_parameters.m_selectInputHits));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MaxPhotonPropagation", m_parameters.m_maxPhotonPropagation));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinHitSharingFraction", m_parameters.m_minHitSharingFraction));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h
@@ -1,0 +1,38 @@
+/**
+ *  @file   larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h
+ *
+ *  @brief  Header file for the pfo validation algorithm.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_PFO_VALIDATION_ALGORITHM_H
+#define LAR_PFO_VALIDATION_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  PfoValidationAlgorithm class
+ */
+class PfoValidationAlgorithm: public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    PfoValidationAlgorithm();
+
+private:
+    pandora::StatusCode Run();
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    std::string                                m_caloHitListName;          ///< Name of input calo hit list
+    std::string                                m_pfoListName;              ///< Name of input pfo list
+    LArMCParticleHelper::ValidationParameters  m_parameters;               ///< Parameters used to decide when an MCParticle is reconstructable
+};
+
+} // namespace lar_content
+
+#endif // LAR_PFO_VALIDATION_ALGORITHM_H

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
@@ -189,8 +189,8 @@ bool EventWritingAlgorithm::PassMCParticleFilter() const
     LArMCParticleHelper::MCRelationMap mcToPrimaryMCMap;            // [mc particles -> primary mc particle]
     LArMCParticleHelper::GetMCPrimaryMap(pMCParticleList, mcToPrimaryMCMap);
 
-    LArMonitoringHelper::CaloHitToMCMap hitToPrimaryMCMap;          // [hit -> primary mc particle]
-    LArMonitoringHelper::MCContributionMap mcToTrueHitListMap;      // [primary mc particle -> true hit list]
+    LArMCParticleHelper::CaloHitToMCMap hitToPrimaryMCMap;          // [hit -> primary mc particle]
+    LArMCParticleHelper::MCContributionMap mcToTrueHitListMap;      // [primary mc particle -> true hit list]
     LArMonitoringHelper::GetMCParticleToCaloHitMatches(pCaloHitList, mcToPrimaryMCMap, hitToPrimaryMCMap, mcToTrueHitListMap);
 
     unsigned int nNonNeutrons(0), nMuons(0), nElectrons(0), nProtons(0), nPhotons(0), nChargedPions(0);
@@ -200,7 +200,7 @@ bool EventWritingAlgorithm::PassMCParticleFilter() const
         if (m_neutrinoInducedOnly && !LArMCParticleHelper::IsNeutrinoInduced(pMCPrimary))
             continue;
 
-        LArMonitoringHelper::MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCPrimary);
+        LArMCParticleHelper::MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCPrimary);
         const unsigned int nMCHitsTotal((mcToTrueHitListMap.end() != trueHitsIter) ? trueHitsIter->second.size() : 0);
 
         if (nMCHitsTotal < m_matchingMinPrimaryHits)


### PR DESCRIPTION
# LArFormattingHelper

A helper class to allow for modification of the colour / style of terminal output, and to draw tables. 

## Colour / style changes

Colour and style changes are made using ANSI escape sequences of the form:
```
\x1B[31m
```
- `\x1B` is the Hex ASCII escape character
- `[ & m` are the required characters to wrap the colour/style code
- `31` is an example colour/style code

When a user calls `SetColour` or `SetStyle`, the helper simply prints the ANSI sequence to the specified `ostream` (defaults to `std::cout`). A user must then use the `Reset` functions which print another ANSI sequence, resetting the formatting to default.

## Tables

LArFormattingHelper contains a `Table` class which can be used to quickly draw ASCII tables to the terminal. The table has three phases: definition, filling and printing.

### Table definition (construction)
The `Table` constructor takes the column headers as a vector of `std::string`. Users can use the special blank header `""` to draw a vertical rule. For example,
```c++
LArFormattingHelper::Table table(std::vector<std::string>({"Left", "", "Middle", "Right"}));
```
would produce a table with a header that looks like this
```
| Left || Middle | Right |
| ---- || ------ | ----- |
```
Users can also (optionally) specify, on construction, the precision to which numbers should be printed. This defaults to 3 significant figures.

### Table filling
The `Table` class flattens its data into vector. Users can only add elements in order (left to right, top to bottom). This is done using `AddElement`, which is templated to take any class that has a `<<` method defined.

Any `""` headers should be ignored when filling the table. For the above example, the table could be filled as follows:
```c++
table.AddElement(1);
table.AddElement("test");
table.AddElement(37.2);
```
This would produce the following output
```
| Left || Middle | Right |
| ---- || ------ | ----- |
|    1 ||   test |  37.2 |
```
Optionally, users can also specify a style and/or a colour for each table element added. 

### Printing
Once a table has been filled, it can be printed to the terminal using the `Print` method. Users must have added elements to fill rows entirely, otherwise an exception will be thrown. 

The tables *should* also be renderable as markdown (however tables are not part of the core Markdown spec, and some renderers will have trouble with the vertical rule).