### PR TITLE
Removed neutrino reference in CheatingCosmicRayTaggingTool.

### DIFF
--- a/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
@@ -20,7 +20,7 @@ namespace lar_content
 {
 
 CheatingCosmicRayTaggingTool::CheatingCosmicRayTaggingTool() :
-    m_minNeutrinoFraction(0.75f)
+    m_maxCosmicRayFraction(0.25f)
 {
 }
 
@@ -32,7 +32,6 @@ void CheatingCosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmic
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     PfoList ambiguousParentPfos;
-    const float maxCosmicRayFraction(1.f - m_minNeutrinoFraction);
 
     for (const Pfo *const pParentCosmicRayPfo : parentCosmicRayPfos)
     {
@@ -42,7 +41,7 @@ void CheatingCosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmic
         float thisCosmicRayWeight(0.f), thisTotalWeight(0.f);
         CheatingSliceIdBaseTool::GetTargetParticleWeight(&downstreamPfos, true, thisCosmicRayWeight, thisTotalWeight, LArMCParticleHelper::IsCosmicRay);
 
-        if ((thisTotalWeight > 0.f) && ((thisCosmicRayWeight / thisTotalWeight) < maxCosmicRayFraction))
+        if ((thisTotalWeight > 0.f) && ((thisCosmicRayWeight / thisTotalWeight) < m_maxCosmicRayFraction))
             ambiguousParentPfos.push_back(pParentCosmicRayPfo);
     }
 
@@ -54,7 +53,7 @@ void CheatingCosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmic
 StatusCode CheatingCosmicRayTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinNeutrinoFraction", m_minNeutrinoFraction));
+        "MaxCosmicRayFraction", m_maxCosmicRayFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
@@ -32,16 +32,17 @@ void CheatingCosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmic
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     PfoList ambiguousParentPfos;
+    const float maxCosmicRayFraction(1.f - m_minNeutrinoFraction);
 
     for (const Pfo *const pParentCosmicRayPfo : parentCosmicRayPfos)
     {
         PfoList downstreamPfos;
         LArPfoHelper::GetAllDownstreamPfos(pParentCosmicRayPfo, downstreamPfos);
 
-        float thisNeutrinoWeight(0.f), thisTotalWeight(0.f);
-        CheatingSliceIdBaseTool::GetTargetParticleWeight(&downstreamPfos, true, thisNeutrinoWeight, thisTotalWeight, LArMCParticleHelper::IsNeutrino);
+        float thisCosmicRayWeight(0.f), thisTotalWeight(0.f);
+        CheatingSliceIdBaseTool::GetTargetParticleWeight(&downstreamPfos, true, thisCosmicRayWeight, thisTotalWeight, LArMCParticleHelper::IsCosmicRay);
 
-        if ((thisTotalWeight > 0.f) && ((thisNeutrinoWeight / thisTotalWeight) > m_minNeutrinoFraction))
+        if ((thisTotalWeight > 0.f) && ((thisCosmicRayWeight / thisTotalWeight) < maxCosmicRayFraction))
             ambiguousParentPfos.push_back(pParentCosmicRayPfo);
     }
 

--- a/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.h
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.h
@@ -29,7 +29,7 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float   m_minNeutrinoFraction;        ///< The minimum neutrino fraction for a cosmic-ray pfo to be declared ambiguous
+    float   m_maxCosmicRayFraction;        ///< The maximum cosmic ray fraction for a pfo to be declared an ambiguous cosmic ray
 };
 
 } // namespace lar_content


### PR DESCRIPTION
This pull request addresses the issues of the CheatingCosmicRayTaggingTool defining clear cosmic rays using neutrino weights.  By cutting on the cosmic ray weight instead, this tool then becomes generic and usable for ProtoDUNE. 

I tested this feature branch with respect to the original master.  For MicroBooNE events both with and without cosmics the reconstruction (PandoraSettings_Master_MicroBooNE.xml with LArCheatingCosmicRayTagging) the reconstruction output was floating point identical when running over 10 events.  

When testing this on ProtoDUNE events (PandoraSettings_Master_ProtoDUNE.xml with LArCheatingCosmicRayTagging) the results were significantly different.  This is expected as the original cheated cosmic ray tagging calls everything a cosmic ray (as the neutrino weight for all pfos).  While a direct diff was too messy to compare, the output using the new code gave some neutrino Pfos for test beam particles, which indicates that this new code is working as expected.  

One comment I would put up for discussion is whether we still use the m_minNeutrinoFraction variable in this tool as in the new code we cut on 1 - m_minNeutrinoFraction.  I think it's fairly clear what's going on here from a readability perspective, but I'd be happy to change this to a m_maxCosmicRayFraction that could be configured via xml if this is preferred.