### PR TITLE
Created the test beam particle creation algorithm.

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -69,6 +69,7 @@
 #include "larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoDaughterVerticesAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoPropertiesAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.h"
 
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/ClearLongitudinalTrackHitsTool.h"
@@ -200,6 +201,7 @@
     d("LArNeutrinoDaughterVertices",            NeutrinoDaughterVerticesAlgorithm)                                              \
     d("LArNeutrinoHierarchy",                   NeutrinoHierarchyAlgorithm)                                                     \
     d("LArNeutrinoProperties",                  NeutrinoPropertiesAlgorithm)                                                    \
+    d("LArTestBeamParticleCreation",            TestBeamParticleCreationAlgorithm)                                              \
     d("LArCosmicRayShowerMatching",             CosmicRayShowerMatchingAlgorithm)                                               \
     d("LArCosmicRayTrackMatching",              CosmicRayTrackMatchingAlgorithm)                                                \
     d("LArCosmicRayTrackRecovery",              CosmicRayTrackRecoveryAlgorithm)                                                \

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
@@ -38,7 +38,7 @@ StatusCode TestBeamParticleCreationAlgorithm::Run()
         if (!LArPfoHelper::IsNeutrino(pPfo))
             continue;
 
-        PfoList daughterList(pPfo->GetDaughterPfoList());
+        const PfoList &daughterList(pPfo->GetDaughterPfoList());
 
         const Pfo *pPrimaryPfo(nullptr);
         float caloHitMinZ(std::numeric_limits<float>::max());
@@ -66,6 +66,8 @@ StatusCode TestBeamParticleCreationAlgorithm::Run()
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPrimaryPfo, pPrimaryDaughterPfo));
         }
 
+        // ATTN: If the primary pfo is shower like, the target beam particle is most likely an electron/positron.  If the primary pfo is track like, the target 
+        // beam particle is most likely a pion as pion interactions are more frequent than proton, kaon and muon interactions in the CERN test beam. 
         if (std::abs(pPrimaryPfo->GetParticleId()) != E_MINUS)
         {
             PandoraContentApi::ParticleFlowObject::Metadata pfoMetadata;

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
@@ -1,0 +1,94 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
+ * 
+ *  @brief  Implementation of the test beam particle creation algorithm class.
+ * 
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+
+#include "larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+TestBeamParticleCreationAlgorithm::TestBeamParticleCreationAlgorithm() :
+    m_pfoListName("")
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TestBeamParticleCreationAlgorithm::Run()
+{
+    const PfoList *pPfoList(nullptr);
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_pfoListName, pPfoList));
+
+    PfoList neutrinoPfos;
+
+    for (const Pfo *const pPfo : *pPfoList)
+    {
+        if (!LArPfoHelper::IsNeutrino(pPfo))
+            continue;
+
+        PfoList daughterList(pPfo->GetDaughterPfoList());
+
+        const Pfo *pPrimaryPfo(nullptr);
+        float caloHitMinZ(std::numeric_limits<float>::max());
+
+        for (const Pfo *const pDaughterPfo : daughterList)
+        {
+            CaloHitList collectedHits;
+            LArPfoHelper::GetCaloHits(pDaughterPfo, TPC_3D, collectedHits);
+
+            for (const CaloHit *const pCaloHit : collectedHits)
+            {
+                if (pCaloHit->GetPositionVector().GetZ() < caloHitMinZ)
+                {
+                    caloHitMinZ = pCaloHit->GetPositionVector().GetZ();
+                    pPrimaryPfo = pDaughterPfo;
+                }
+            }
+        }
+
+        for (const Pfo *const pPrimaryDaughterPfo : daughterList)
+        {
+            if (pPrimaryDaughterPfo == pPrimaryPfo)
+                continue;
+
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPrimaryPfo, pPrimaryDaughterPfo));
+        }
+
+        if (std::abs(pPrimaryPfo->GetParticleId()) != E_MINUS)
+        {
+            PandoraContentApi::ParticleFlowObject::Metadata pfoMetadata;
+            pfoMetadata.m_particleId = PI_PLUS;
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pPrimaryPfo, pfoMetadata));
+        }
+
+        neutrinoPfos.push_back(pPfo);
+    }
+
+    for (const Pfo *const pNeutrinoPfo : neutrinoPfos)
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete<Pfo>(*this, pNeutrinoPfo));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TestBeamParticleCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h
@@ -1,0 +1,37 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h
+ * 
+ *  @brief  Header file for the test beam particle creation algorithm class.
+ * 
+ *  $Log: $
+ */
+#ifndef LAR_TEST_BEAM_PARTICLE_CLREATION_ALGORITHM_H
+#define LAR_TEST_BEAM_PARTICLE_CLREATION_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  TestBeamParticleCreationAlgorithm class
+ */
+class TestBeamParticleCreationAlgorithm : public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Constructor
+     */
+    TestBeamParticleCreationAlgorithm();
+
+private:
+    pandora::StatusCode Run();
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    std::string    m_pfoListName;    ///< Input pfo list name
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_TEST_BEAM_PARTICLE_CLREATION_ALGORITHM_H


### PR DESCRIPTION
This algorithm creates test beam particle PFOs from reconstructed neutrino PFOs.  The algorithm proceeds by finding the neutrino primary PFO that has the calorimeter hit with the smallest z coordinate and defines this as the test beam primary PFO.  The remaining neutrino primaries are then assigned as daughter PFOs to the new test beam primary.  The neutrino PFOs are then deleted.  If the primary particle is track like (i.e. particle id not E_MINUS) then the particle id is set to PI_PLUS as the majority of track like beam particles at ProtoDUNE are pions.  This has been tested for ProtoDUNE events running the test beam particle creation algorithm after the master algorithm.  

Comments and suggestions are welcome.  