### PR TITLE
Moved the GetSigmaUVW function to the LArGeometryHelper.

### DIFF
--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -485,7 +485,7 @@ float LArGeometryHelper::CalculateGapDeltaZ(const Pandora &pandora, const float 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-double LArGeometryHelper::GetSigmaUVW(const Pandora &pandora, const double maxSigmaDiscrepancy) 
+float LArGeometryHelper::GetSigmaUVW(const Pandora &pandora, const float maxSigmaDiscrepancy) 
 {
     const LArTPCMap &larTPCMap(pandora.GetGeometry()->GetLArTPCMap());
 
@@ -496,7 +496,7 @@ double LArGeometryHelper::GetSigmaUVW(const Pandora &pandora, const double maxSi
     }
 
     const LArTPC *const pFirstLArTPC(larTPCMap.begin()->second);
-    const double sigmaUVW(pFirstLArTPC->GetSigmaUVW());
+    const float sigmaUVW(pFirstLArTPC->GetSigmaUVW());
 
     for (const LArTPCMap::value_type &mapEntry : larTPCMap)
     {

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -138,7 +138,7 @@ void LArGeometryHelper::MergeTwoPositions(const Pandora &pandora, const HitType 
     const float Z3(LArGeometryHelper::MergeTwoPositions(pandora, view1, view2, Z1, Z2));
 
     position3.SetValues(X3, 0.f, Z3);
-    const float sigmaUVW(pandora.GetGeometry()->GetLArTPC().GetSigmaUVW());
+    const float sigmaUVW(LArGeometryHelper::GetSigmaUVW(pandora));
     chiSquared = ((X3 - position1.GetX()) * (X3 - position1.GetX()) + (X3 - position2.GetX()) * (X3 - position2.GetX())) / (sigmaUVW * sigmaUVW);
 }
 
@@ -252,7 +252,7 @@ void LArGeometryHelper::MergeThreePositions(const Pandora &pandora, const Cartes
     outputV.SetValues(aveX, 0.f, aveV);
     outputW.SetValues(aveX, 0.f, aveW);
 
-    const float sigmaUVW(pandora.GetGeometry()->GetLArTPC().GetSigmaUVW());
+    const float sigmaUVW(LArGeometryHelper::GetSigmaUVW(pandora));
     chiSquared = ((outputU.GetX() - positionU.GetX()) * (outputU.GetX() - positionU.GetX()) +
         (outputV.GetX() - positionV.GetX()) * (outputV.GetX() - positionV.GetX()) +
         (outputW.GetX() - positionW.GetX()) * (outputW.GetX() - positionW.GetX()) +
@@ -481,6 +481,35 @@ float LArGeometryHelper::CalculateGapDeltaZ(const Pandora &pandora, const float 
     }
 
     return gapDeltaZ;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+double LArGeometryHelper::GetSigmaUVW(const Pandora &pandora, const double maxSigmaDiscrepancy) 
+{
+    const LArTPCMap &larTPCMap(pandora.GetGeometry()->GetLArTPCMap());
+
+    if (larTPCMap.empty())
+    {
+        std::cout << "LArGeometryHelper::GetSigmaUVW - LArTPC description not registered with Pandora as required " << std::endl;
+        throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
+    }
+
+    const LArTPC *const pFirstLArTPC(larTPCMap.begin()->second);
+    const double sigmaUVW(pFirstLArTPC->GetSigmaUVW());
+
+    for (const LArTPCMap::value_type &mapEntry : larTPCMap)
+    {
+        const LArTPC *const pLArTPC(mapEntry.second);
+
+        if (std::fabs(sigmaUVW - pLArTPC->GetSigmaUVW()) > maxSigmaDiscrepancy)
+        {
+            std::cout << "LArGeometryHelper::GetSigmaUVW - Plugin does not support provided LArTPC configurations " << std::endl;
+            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+        }
+    }
+
+    return sigmaUVW;
 }
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -250,7 +250,7 @@ public:
      *  @param  pandora the associated pandora instance
      *  @param  maxSigmaDiscrepancy maximum allowed discrepancy between lar tpc sigmaUVW values
      */
-    static double GetSigmaUVW(const pandora::Pandora &pandora, const double maxSigmaDiscrepancy = 0.01);
+    static float GetSigmaUVW(const pandora::Pandora &pandora, const float maxSigmaDiscrepancy = 0.01);
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -243,6 +243,14 @@ public:
      *  @param  hitType the hit type
      */
     static float CalculateGapDeltaZ(const pandora::Pandora &pandora, const float minZ, const float maxZ, const pandora::HitType hitType);
+
+    /**
+     *  @brief  Find the sigmaUVW value for the detector geometry
+     *
+     *  @param  pandora the associated pandora instance
+     *  @param  maxSigmaDiscrepancy maximum allowed discrepancy between lar tpc sigmaUVW values
+     */
+    static double GetSigmaUVW(const pandora::Pandora &pandora, const double maxSigmaDiscrepancy = 0.01);
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.cc
+++ b/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.cc
@@ -28,7 +28,6 @@ using namespace pandora;
 LArRotationalTransformationPlugin::LArRotationalTransformationPlugin() :
     m_thetaU(0.),
     m_thetaV(0.),
-    m_sigmaUVW(0.),
     m_sinUplusV(0.),
     m_sinU(0.),
     m_sinV(0.),
@@ -86,13 +85,6 @@ double LArRotationalTransformationPlugin::YZtoU(const double y, const double z) 
 double LArRotationalTransformationPlugin::YZtoV(const double y, const double z) const
 {
     return z * m_cosV + y * m_sinV;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-double LArRotationalTransformationPlugin::GetSigmaUVW() const
-{
-    return m_sigmaUVW;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -253,7 +245,7 @@ StatusCode LArRotationalTransformationPlugin::Initialize()
     const LArTPC *const pFirstLArTPC(larTPCMap.begin()->second);
     m_thetaU = pFirstLArTPC->GetWireAngleU();
     m_thetaV = pFirstLArTPC->GetWireAngleV();
-    m_sigmaUVW = pFirstLArTPC->GetSigmaUVW();
+    const double sigmaUVW(pFirstLArTPC->GetSigmaUVW());
 
     m_sinUplusV = std::sin(m_thetaU + m_thetaV);
     m_sinU = std::sin(m_thetaU);
@@ -267,7 +259,7 @@ StatusCode LArRotationalTransformationPlugin::Initialize()
 
         if ((std::fabs(m_thetaU - pLArTPC->GetWireAngleU()) > m_maxAngularDiscrepancy) ||
             (std::fabs(m_thetaV - pLArTPC->GetWireAngleV()) > m_maxAngularDiscrepancy) ||
-            (std::fabs(m_sigmaUVW - pLArTPC->GetSigmaUVW()) > m_maxSigmaDiscrepancy))
+            (std::fabs(sigmaUVW - pLArTPC->GetSigmaUVW()) > m_maxSigmaDiscrepancy))
         {
             std::cout << "LArRotationalTransformationPlugin::Initialize - Plugin does not support provided LArTPC configurations " << std::endl;
             return STATUS_CODE_INVALID_PARAMETER;

--- a/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.h
+++ b/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.h
@@ -31,7 +31,6 @@ public:
     virtual double UVtoZ(const double u, const double v) const;
     virtual double YZtoU(const double y, const double z) const;
     virtual double YZtoV(const double y, const double z) const;
-    virtual double GetSigmaUVW() const;
     virtual void GetMinChiSquaredYZ(const double u, const double v, const double w, const double sigmaU, const double sigmaV, const double sigmaW,
         double &y, double &z, double &chiSquared) const;
     virtual void GetMinChiSquaredYZ(const double u, const double v, const double w, const double sigmaU, const double sigmaV, const double sigmaW,
@@ -45,7 +44,6 @@ private:
 
     double    m_thetaU;          ///< inclination of U wires (radians)
     double    m_thetaV;          ///< inclination of V wires (radians)
-    double    m_sigmaUVW;        ///< resolution (cm), for calculation of chi2
     double    m_sinUplusV;       ///< sin(thetaU+thetaV)
     double    m_sinU;            ///< sin(thetaU)
     double    m_sinV;            ///< sin(thetaV)

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.cc
@@ -79,7 +79,7 @@ void HitCreationBaseTool::GetBestPosition3D(const HitType hitType1, const HitTyp
     const CaloHit *const pCaloHit2D(protoHit.GetParentCaloHit2D());
     const HitType hitType(pCaloHit2D->GetHitType());
 
-    const double sigmaFit(this->GetPandora().GetGeometry()->GetLArTPC().GetSigmaUVW());
+    const double sigmaFit(LArGeometryHelper::GetSigmaUVW(this->GetPandora()));
     const double sigmaHit(sigmaFit);
 
     CartesianVector position3D(0.f, 0.f, 0.f);
@@ -112,7 +112,7 @@ void HitCreationBaseTool::GetBestPosition3D(const HitType hitType, const Cartesi
 {
     // TODO Input better uncertainties into this method (sigmaHit, sigmaFit, sigmaX)
     const CaloHit *const pCaloHit2D(protoHit.GetParentCaloHit2D());
-    const double sigmaFit(this->GetPandora().GetGeometry()->GetLArTPC().GetSigmaUVW());
+    const double sigmaFit(LArGeometryHelper::GetSigmaUVW(this->GetPandora()));
 
     if (pCaloHit2D->GetHitType() == hitType)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.cc
@@ -191,7 +191,7 @@ void ThreeDHitCreationAlgorithm::ExtractResults(const ProtoHitVector &protoHitVe
 
 double ThreeDHitCreationAlgorithm::GetChi2WrtFit(const ThreeDSlidingFitResult &slidingFitResult, const ProtoHitVector &protoHitVector) const
 {
-    const double sigmaUVW(PandoraContentApi::GetGeometry(*this)->GetLArTPC().GetSigmaUVW());
+    const double sigmaUVW(LArGeometryHelper::GetSigmaUVW(this->GetPandora()));
     const double sigma3DFit(sigmaUVW * m_sigma3DFitMultiplier);
 
     double chi2WrtFit(0.);
@@ -223,7 +223,7 @@ double ThreeDHitCreationAlgorithm::GetChi2WrtFit(const ThreeDSlidingFitResult &s
 
 double ThreeDHitCreationAlgorithm::GetHitMovementChi2(const ProtoHitVector &protoHitVector) const
 {
-    const double sigmaUVW(PandoraContentApi::GetGeometry(*this)->GetLArTPC().GetSigmaUVW());
+    const double sigmaUVW(LArGeometryHelper::GetSigmaUVW(this->GetPandora()));
     double hitMovementChi2(0.);
 
     for (const ProtoHit &protoHit : protoHitVector)
@@ -244,7 +244,7 @@ double ThreeDHitCreationAlgorithm::GetHitMovementChi2(const ProtoHitVector &prot
 
 void ThreeDHitCreationAlgorithm::RefineHitPositions(const ThreeDSlidingFitResult &slidingFitResult, ProtoHitVector &protoHitVector) const
 {
-    const double sigmaUVW(PandoraContentApi::GetGeometry(*this)->GetLArTPC().GetSigmaUVW());
+    const double sigmaUVW(LArGeometryHelper::GetSigmaUVW(this->GetPandora()));
     const double sigmaFit(sigmaUVW); // ATTN sigmaFit and sigmaHit here should agree with treatment in HitCreation tools
     const double sigmaHit(sigmaUVW);
     const double sigma3DFit(sigmaUVW * m_sigma3DFitMultiplier);


### PR DESCRIPTION
Moved the GetSigmaUVW function to the LArGeometryHelper.  This prevents an exception being thrown when calling the GetLArTPC function in the GeometryManager when trying to find sigmaUVW in the case of multiple drift volumes. 