### PR TITLE
Neutrino Id Training Purity & Completeness

### DIFF
--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -105,24 +105,25 @@ bool NeutrinoIdTool::GetBestMCSliceIndex(const Algorithm *const pAlgorithm, cons
     LArMCParticleHelper::SelectCaloHits(pAllReconstructedCaloHitList, mcToPrimaryMCMap, reconstructableCaloHitList, parameters.m_selectInputHits, parameters.m_maxPhotonPropagation);
 
     const int nuNHitsTotal(this->CountNeutrinoInducedHits(reconstructableCaloHitList));
+    const CaloHitSet reconstructableCaloHitSet(reconstructableCaloHitList.begin(), reconstructableCaloHitList.end()); 
 
     for (unsigned int sliceIndex = 0, nSlices = nuSliceHypotheses.size(); sliceIndex < nSlices; ++sliceIndex)
     {
-        CaloHitList reconstructedHits;
-        this->Collect2DHits(crSliceHypotheses.at(sliceIndex), reconstructedHits, reconstructableCaloHitList);
+        CaloHitList reconstructedCaloHitList;
+        this->Collect2DHits(crSliceHypotheses.at(sliceIndex), reconstructedCaloHitList, reconstructableCaloHitSet);
 
         for (const ParticleFlowObject *const pNeutrino : nuSliceHypotheses.at(sliceIndex))
         {
             const PfoList &nuFinalStates(pNeutrino->GetDaughterPfoList());
-            this->Collect2DHits(nuFinalStates, reconstructedHits, reconstructableCaloHitList);
+            this->Collect2DHits(nuFinalStates, reconstructedCaloHitList, reconstructableCaloHitSet);
         }
 
-        const unsigned int nNuHits(this->CountNeutrinoInducedHits(reconstructedHits));
+        const unsigned int nNuHits(this->CountNeutrinoInducedHits(reconstructedCaloHitList));
 
         if (nNuHits > nNuHitsInBestSlice)
         {
             nNuHitsInBestSlice = nNuHits;
-            nHitsInBestSlice = reconstructedHits.size();
+            nHitsInBestSlice = reconstructedCaloHitList.size();
             bestSliceIndex = sliceIndex;
         }
     }
@@ -146,7 +147,7 @@ bool NeutrinoIdTool::PassesQualityCuts(const Algorithm *const pAlgorithm, const 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void NeutrinoIdTool::Collect2DHits(const PfoList &pfos, CaloHitList &hitList, CaloHitList &reconstructableCaloHitList) const
+void NeutrinoIdTool::Collect2DHits(const PfoList &pfos, CaloHitList &reconstructedCaloHitList, const CaloHitSet &reconstructableCaloHitSet) const
 {
     CaloHitList collectedHits;
     LArPfoHelper::GetCaloHits(pfos, TPC_VIEW_U, collectedHits);
@@ -158,21 +159,21 @@ void NeutrinoIdTool::Collect2DHits(const PfoList &pfos, CaloHitList &hitList, Ca
         // ATTN hits collected from Pfos are copies of hits passed from master instance, we need to access their parent to use MC info
         const CaloHit *pParentCaloHit(static_cast<const CaloHit *>(pCaloHit->GetParentAddress()));
 
-        if (std::find(reconstructableCaloHitList.begin(), reconstructableCaloHitList.end(), pParentCaloHit) == reconstructableCaloHitList.end())
+        if (!reconstructableCaloHitSet.count(pParentCaloHit))
             continue;
 
         // Ensure no hits have been double counted
-        if (std::find(hitList.begin(), hitList.end(), pParentCaloHit) == hitList.end())
-            hitList.push_back(pParentCaloHit);
+        if (std::find(reconstructedCaloHitList.begin(), reconstructedCaloHitList.end(), pParentCaloHit) == reconstructedCaloHitList.end())
+            reconstructedCaloHitList.push_back(pParentCaloHit);
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-unsigned int NeutrinoIdTool::CountNeutrinoInducedHits(const CaloHitList &hitList) const
+unsigned int NeutrinoIdTool::CountNeutrinoInducedHits(const CaloHitList &caloHitList) const
 {
     unsigned int nNuHits(0);
-    for (const CaloHit *const pCaloHit : hitList)
+    for (const CaloHit *const pCaloHit : caloHitList)
     {
         try
         {
@@ -186,8 +187,6 @@ unsigned int NeutrinoIdTool::CountNeutrinoInducedHits(const CaloHitList &hitList
 
     return nNuHits;
 }
-
-
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -31,8 +31,6 @@ NeutrinoIdTool::NeutrinoIdTool() :
     m_nuance(-std::numeric_limits<int>::max()),
     m_minPurity(0.9f),
     m_minCompleteness(0.9f),
-    m_selectInputHits(true),
-    m_maxPhotonPropagation(2.5f),
     m_minProbability(0.0f),
     m_maxNeutrinos(1),
     m_filePathEnvironmentVariable("FW_SEARCH_PATH")
@@ -103,7 +101,8 @@ bool NeutrinoIdTool::GetBestMCSliceIndex(const Algorithm *const pAlgorithm, cons
 
     // Remove non-reconstructable hits, e.g. those downstream of a neutron
     CaloHitList reconstructableCaloHitList;
-    LArMCParticleHelper::SelectCaloHits(pAllReconstructedCaloHitList, mcToPrimaryMCMap, reconstructableCaloHitList, m_selectInputHits, m_maxPhotonPropagation);
+    LArMCParticleHelper::PrimaryParameters parameters;
+    LArMCParticleHelper::SelectCaloHits(pAllReconstructedCaloHitList, mcToPrimaryMCMap, reconstructableCaloHitList, parameters.m_selectInputHits, parameters.m_maxPhotonPropagation);
 
     const int nuNHitsTotal(this->CountNeutrinoInducedHits(reconstructableCaloHitList));
 
@@ -510,12 +509,6 @@ StatusCode NeutrinoIdTool::ReadSettings(const TiXmlHandle xmlHandle)
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "MinimumCompleteness", m_minCompleteness));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectInputHits", m_selectInputHits));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxPhotonPropagation", m_maxPhotonPropagation));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "SelectNuanceCode", m_selectNuanceCode));

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -186,8 +186,9 @@ private:
      *
      *  @param  pfos input list of pfos
      *  @param  hitList output list of all 2d hits in the input pfos
+     *  @param  reconstructableCaloHitList list of reconstructable calo hits
      */
-    void Collect2DHits(const pandora::PfoList &pfos, pandora::CaloHitList &hitList) const;
+    void Collect2DHits(const pandora::PfoList &pfos, pandora::CaloHitList &hitList, pandora::CaloHitList &reconstructableCaloHitList) const;
 
     /**
      *  @brief  Count the number of neutrino induced hits in a given list using MC information
@@ -242,6 +243,8 @@ private:
     int                   m_nuance;                       ///< Nuance code to select for training
     float                 m_minPurity;                    ///< Minimum purity of the best slice to use event for training
     float                 m_minCompleteness;              ///< Minimum completeness of the best slice to use event for training
+    bool                  m_selectInputHits;              ///< Whether to select input hits
+    float                 m_maxPhotonPropagation;         ///< The maximum photon propagation length
 
     // Classification
     float                 m_minProbability;               ///< Minimum probability required to classify a slice as the neutrino

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -185,19 +185,19 @@ private:
      *  @brief  Collect all 2D hits in a supplied list of Pfos and push them on to an existing hit list, check so not to double count
      *
      *  @param  pfos input list of pfos
-     *  @param  hitList output list of all 2d hits in the input pfos
-     *  @param  reconstructableCaloHitList list of reconstructable calo hits
+     *  @param  reconstructedCaloHitList output list of all 2d hits in the input pfos
+     *  @param  reconstructableCaloHitSet set of reconstructable calo hits
      */
-    void Collect2DHits(const pandora::PfoList &pfos, pandora::CaloHitList &hitList, pandora::CaloHitList &reconstructableCaloHitList) const;
+    void Collect2DHits(const pandora::PfoList &pfos, pandora::CaloHitList &reconstructedCaloHitList, const pandora::CaloHitSet &reconstructableCaloHitSet) const;
 
     /**
      *  @brief  Count the number of neutrino induced hits in a given list using MC information
      *
-     *  @param  hitList input list of calo hits
+     *  @param  caloHitSet input list of calo hits
      *
      *  @return the number of neutrino induced hits in the input list
      */
-    unsigned int CountNeutrinoInducedHits(const pandora::CaloHitList &hitList) const;
+    unsigned int CountNeutrinoInducedHits(const pandora::CaloHitList &caloHitList) const;
 
     /**
      *  @brief  Use the current MCParticle list to get the nuance code of the neutrino in the event

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -243,8 +243,6 @@ private:
     int                   m_nuance;                       ///< Nuance code to select for training
     float                 m_minPurity;                    ///< Minimum purity of the best slice to use event for training
     float                 m_minCompleteness;              ///< Minimum completeness of the best slice to use event for training
-    bool                  m_selectInputHits;              ///< Whether to select input hits
-    float                 m_maxPhotonPropagation;         ///< The maximum photon propagation length
 
     // Classification
     float                 m_minProbability;               ///< Minimum probability required to classify a slice as the neutrino

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -226,17 +226,6 @@ public:
     static void GetPfoMCParticleHitSharingMaps(const PfoContributionMap &pfoToReconstructable2DHitsMap, const MCContributionMapVector &selectedMCParticleToHitsMaps,
         PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
 
-private:
-    /**
-     *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
-     *
-     *  @param  pPfo the input pfo
-     *  @param  selectedMCParticleToHitsMaps the input mappings from selected reconstructable MCParticles to hits
-     *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
-     */
-    static void CollectReconstructable2DHits(const pandora::ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        pandora::CaloHitList &reconstructableCaloHitList2D);
-
     /**
      *  @brief  Select a subset of calo hits representing those that represent "reconstructable" regions of the event
      *
@@ -248,6 +237,17 @@ private:
      */
     static void SelectCaloHits(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
         pandora::CaloHitList &selectedCaloHitList, const bool selectInputHits, const float maxPhotonPropagation);
+
+private:
+    /**
+     *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
+     *
+     *  @param  pPfo the input pfo
+     *  @param  selectedMCParticleToHitsMaps the input mappings from selected reconstructable MCParticles to hits
+     *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
+     */
+    static void CollectReconstructable2DHits(const pandora::ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
+        pandora::CaloHitList &reconstructableCaloHitList2D);
 
     /**
      *  @brief  Apply further selection criteria to end up with a collection of "good" calo hits that can be use to define whether


### PR DESCRIPTION
Modifications to purity and completeness calculation in neutrino id training.

There is potential for a merge conflict in the LArMCParticleHelper.h file with the Bdt pull request (https://github.com/PandoraPFA/LArContent/pull/42) where the same change was made (making CollectReconstructable2DHits a public function).  This is the only change though and should be easy to fix up with some rebasing.  

This was tested on a few neutrino + cosmic events and the changes were minimal.  The purities and completenesses did change slightly, but in all cases seen the best slice index was unchanged. 

@a-d-smith If you have time to have a quick look over this to make sure there are no obvious issues that'd be great.  Thanks. 