### PR TITLE
ProtoDUNE Event Validation

### DIFF
--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -373,6 +373,18 @@ bool LArPfoHelper::IsNeutrino(const ParticleFlowObject *const pPfo)
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+bool LArPfoHelper::IsTestBeam(const ParticleFlowObject *const pPfo)
+{
+    const int absoluteParticleId(std::abs(pPfo->GetParticleId()));
+
+    if ((E_PLUS == absoluteParticleId) || (PI_PLUS == absoluteParticleId))
+        return true;
+
+    return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void LArPfoHelper::GetRecoNeutrinos(const PfoList *const pPfoList, PfoList &recoNeutrinos)
 {
     if (!pPfoList)

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -242,6 +242,15 @@ public:
     static bool IsNeutrino(const pandora::ParticleFlowObject *const pPfo);
 
     /**
+     *  @brief  Whether a pfo is a test beam particle 
+     *
+     *  @param  pPfo the address of the Pfo
+     *
+     *  @return boolean
+     */
+    static bool IsTestBeam(const pandora::ParticleFlowObject *const pPfo);
+
+    /**
      *  @brief  Get neutrino pfos from an input pfo list
      *
      *  @param  pPfoList the input pfo list

--- a/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
@@ -122,7 +122,9 @@ void EventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pM
         PfoList finalStatePfos;
         for (const ParticleFlowObject *const pPfo : allConnectedPfos)
         {
-            if (LArPfoHelper::IsFinalState(pPfo))
+// First change used in metric creation
+//            if (LArPfoHelper::IsFinalState(pPfo))
+            if (pPfo->GetParentPfoList().empty())
                 finalStatePfos.push_back(pPfo);
         }
 
@@ -290,8 +292,11 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
                 recoNeutrinos.insert(pRecoNeutrino);
             }
 
-            if (isRecoNeutrinoFinalState && isGoodMatch) ++nPrimaryNuMatches;
-            if (!isRecoNeutrinoFinalState && isGoodMatch) ++nPrimaryCRMatches;
+            bool isNeutrino(LArPfoHelper::IsNeutrino(pfoToSharedHits.first));
+            //if (isRecoNeutrinoFinalState && isGoodMatch) ++nPrimaryNuMatches;
+            if (isNeutrino && isGoodMatch) ++nPrimaryNuMatches;
+            //if (!isRecoNeutrinoFinalState && isGoodMatch) ++nPrimaryCRMatches;
+            if (!isNeutrino && isGoodMatch) ++nPrimaryCRMatches;
 
             targetSS << "-" << (!isGoodMatch ? "(Below threshold) " : "")
                      << "MatchedPfoId " << pfoId

--- a/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
@@ -299,8 +299,8 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
             else
             {
                 bool isTestBeam(LArPfoHelper::IsTestBeam(pfoToSharedHits.first));
-                if (isNeutrino && isGoodMatch) ++nPrimaryNuMatches;
-                if (!isNeutrino && isGoodMatch) ++nPrimaryCRMatches;
+                if (isTestBeam && isGoodMatch) ++nPrimaryNuMatches;
+                if (!isTestBeam && isGoodMatch) ++nPrimaryCRMatches;
             }
 
             targetSS << "-" << (!isGoodMatch ? "(Below threshold) " : "")
@@ -386,9 +386,13 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetMatches", nTargetMatches));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetNuMatches", nTargetNuMatches));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetCRMatches", nTargetCRMatches));
-            PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetGoodNuMatches", nTargetGoodNuMatches));
-            PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetNuSplits", nTargetNuSplits));
-            PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetNuLosses", nTargetNuLosses));
+
+            if (!m_testBeamMode)
+            {
+                PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetGoodNuMatches", nTargetGoodNuMatches));
+                PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetNuSplits", nTargetNuSplits));
+                PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetNuLosses", nTargetNuLosses));
+            }
         }
 
         if (isLastNeutrinoPrimary || isBeamParticle || isCosmicRay)
@@ -399,7 +403,7 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
 #endif
             // ATTN Some redundancy introduced to contributing variables
             const int isCorrectNu(isBeamNeutrinoFinalState && (nTargetGoodNuMatches == nTargetNuMatches) && (nTargetGoodNuMatches == nTargetPrimaries) && (nTargetCRMatches == 0) && (nTargetNuSplits == 0) && (nTargetNuLosses == 0));
-            const int isCorrectTB(isBeamParticle && (nTargetGoodNuMatches == nTargetNuMatches) && (nTargetGoodNuMatches == 1) && (nTargetCRMatches == 0) && (nTargetNuSplits == 0) && (nTargetNuLosses == 0));
+            const int isCorrectTB(isBeamParticle && (nTargetNuMatches == 1) && (nTargetCRMatches == 0));
             const int isCorrectCR(isCosmicRay && (nTargetNuMatches == 0) && (nTargetCRMatches == 1));
             const int isFakeNu(isCosmicRay && (nTargetNuMatches > 0));
             const int isFakeCR(!isCosmicRay && (nTargetCRMatches > 0));
@@ -444,7 +448,8 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
                 PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "isCorrectCR", isCorrectCR));
                 PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "isFakeNu", isFakeNu));
                 PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "isFakeCR", isFakeCR));
-                PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "isSplitNu", isSplitNu));
+                if (!m_testBeamMode)
+                    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "isSplitNu", isSplitNu));
                 PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "isSplitCR", isSplitCR));
                 PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "isLost", isLost));
                 PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_treeName.c_str()));

--- a/larpandoracontent/LArMonitoring/EventValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventValidationAlgorithm.h
@@ -220,6 +220,7 @@ private:
     std::string             m_pfoListName;                  ///< Name of input Pfo list
 
     bool                    m_useTrueNeutrinosOnly;         ///< Whether to consider only mc particles that were neutrino induced
+    bool                    m_testBeamMode;                 ///< Whether pandora is reconstructing test beam particles
 
     bool                    m_selectInputHits;              ///< Whether to use only hits passing mc-based quality (is "reconstructable") checks
     float                   m_minHitSharingFraction;        ///< Minimum fraction of energy deposited by selected primary in a single "good" hit


### PR DESCRIPTION
This branch alters the event validation algorithm to work with test beam particles.  This broadly splits into three pieces of work:

1. The check for "target" PFOs now uses the IsTestBeam helper function, while previously the checks were just is PFO a neutrino.
2. Matches between target PFOs and MC particles are made between the parent test beam particle rather than the daughters of the (propitiously neutrino) PFO.
3. Don't bother writing out variables that don't make sense in a test beam situation i.e. split neutrino, good neutrino matches and nu losses.

Point 3 will break the validation.C a little bit as a few variables are missing, but I think that should be easy to fix at a later date.

Thoughts on this modification would be welcome as I want to work towards some night cron jobs.