### PR TITLE
Resolving issue with 3D hit creation using fully cheated reconstruction

### DIFF
--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -331,35 +331,6 @@ CartesianVector LArGeometryHelper::ProjectDirection(const Pandora &pandora, cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float LArGeometryHelper::GetWireZPitch(const Pandora &pandora, const float maxWirePitchWDiscrepancy)
-{
-    const LArTPCMap &larTPCMap(pandora.GetGeometry()->GetLArTPCMap());
-
-    if (larTPCMap.empty())
-    {
-        std::cout << "LArGeometryHelper::GetWireZPitch - LArTPC description not registered with Pandora as required " << std::endl;
-        throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
-    }
-
-    const LArTPC *const pFirstLArTPC(larTPCMap.begin()->second);
-    const float wirePitchW(pFirstLArTPC->GetWirePitchW());
-
-    for (const LArTPCMap::value_type &mapEntry : larTPCMap)
-    {
-        const LArTPC *const pLArTPC(mapEntry.second);
-
-        if (std::fabs(wirePitchW - pLArTPC->GetWirePitchW()) > maxWirePitchWDiscrepancy)
-        {
-            std::cout << "LArGeometryHelper::GetWireZPitch - Plugin does not support provided LArTPC configurations " << std::endl;
-            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
-        }
-    }
-
-    return wirePitchW;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
 float LArGeometryHelper::GetWirePitch(const Pandora &pandora, const HitType view, const float maxWirePitchDiscrepancy)
 {
     if (view != TPC_VIEW_U && view != TPC_VIEW_V && view != TPC_VIEW_W)
@@ -383,7 +354,7 @@ float LArGeometryHelper::GetWirePitch(const Pandora &pandora, const HitType view
 
         if (std::fabs(wirePitch - alternateWirePitch) > maxWirePitchDiscrepancy)
         {
-            std::cout << "LArGeometryHelper::GetWirePitch - Plugin does not support provided LArTPC configurations " << std::endl;
+            std::cout << "LArGeometryHelper::GetWirePitch - LArTPC configuration not supported" << std::endl;
             throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
         }
     }

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -176,16 +176,18 @@ public:
      *  @brief  Return the wire pitch
      *
      *  @param  pandora the associated pandora instance
+     *  @param  maxWirePitchDiscrepancy maximum allowed discrepancy between lar tpc wire pitch value in the w view
      */
-    static float GetWireZPitch(const pandora::Pandora &pandora);
+    static float GetWireZPitch(const pandora::Pandora &pandora, const float maxWirePitchDiscrepancy = 0.01);
 
     /**
      *  @brief  Return the wire pitch
      *
      *  @param  pandora the associated pandora instance
      *  @param  view the 2D projection
+     *  @param  maxWirePitchDiscrepancy maximum allowed discrepancy between lar tpc wire pitch values
      */
-    static float GetWirePitch(const pandora::Pandora &pandora, const pandora::HitType view);
+    static float GetWirePitch(const pandora::Pandora &pandora, const pandora::HitType view, const float maxWirePitchDiscrepancy = 0.01);
 
     /**
      *  @brief  Return the wire axis (vector perpendicular to the wire direction and drift direction)

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -255,6 +255,13 @@ public:
     static float GetSigmaUVW(const pandora::Pandora &pandora, const float maxSigmaDiscrepancy = 0.01);
 };
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline float LArGeometryHelper::GetWireZPitch(const pandora::Pandora &pandora, const float maxWirePitchWDiscrepancy)
+{
+    return LArGeometryHelper::GetWirePitch(pandora, pandora::TPC_VIEW_W, maxWirePitchWDiscrepancy);
+}
+
 } // namespace lar_content
 
 #endif // #ifndef LAR_GEOMETRY_HELPER_H


### PR DESCRIPTION
Issue relates to accessing geometry information in the case of multiple LArTPCs in a single pandora instance.

This reconstructs the ci test event fully including 3D hits.   