### PR TITLE
Test Beam Particle Vertexing

### DIFF
--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
@@ -105,7 +105,7 @@ StatusCode TestBeamParticleCreationAlgorithm::Run()
                 PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Vertex>(*this, m_vertexListName));
             }
         }
-        catch (StatusCodeException &)
+        catch (const StatusCodeException &)
         {
             std::cout << "TestBeamParticleCreationAlgorithm::Run - unable to modify test beam particle vertex" << std::endl;
         }


### PR DESCRIPTION
Addressed test beam particle creation algorithm failure in case of multiple reconstructed particles.  In the case of two or more test beam particles the previous algorithm threw an exception when trying to change the position of the test beam particle vertices (i.e. keepInteractionVertex = false and keepStartVertex = true).  

The failure occurred because it was necessary to call PandoraContentApi::CreateTemporaryListAndSetCurrent in order to create a new vertex, but this left the current vertex list empty.  When the Pfo loop proceeded to second test beam particle and attempted to delete it's interaction vertex an exception was thrown because it was trying to delete the interaction vertex from the current list, which is null.  

Setting the new vertex list to be the current list at the end of the pfo loop resolves this problem between loops the current list is in a well defined state.  The try-catch block was added as a precaution to prevent algorithm failures should the primary daughter Pfo have no vertex, although I did not see this failure mode.  If this is triggered the test beam particle vertex will be the neutrino vertex, which is at least well defined.  
