### PR TITLE
Added CheatingRemovingCosmicRays algorithm.

### DIFF
--- a/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.cc
+++ b/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.cc
@@ -18,14 +18,6 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingRemovingCosmicRays::CheatingRemovingCosmicRays() :
-    m_inputCaloHitListName(""),
-    m_mcParticleListName("")
-{
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
 StatusCode CheatingRemovingCosmicRays::Run()
 {
     const MCParticleList *pMCParticleList(nullptr);
@@ -40,14 +32,12 @@ StatusCode CheatingRemovingCosmicRays::Run()
     {
         try
         {
-            const MCParticle *const pHitParticle(MCParticleHelper::GetMainMCParticle(pCaloHit));
-
-            if (!LArMCParticleHelper::IsCosmicRay(pHitParticle))
+            if (!LArMCParticleHelper::IsCosmicRay(MCParticleHelper::GetMainMCParticle(pCaloHit)))
                 outputCaloHitList.push_back(pCaloHit);
         }
-        catch (...)
+        catch (const StatusCodeException &)
         {
-            std::cout << "CheatingRemovingCosmicRays::Run - Calo hit has no available MainMCParticle." << std::endl;
+            std::cout << "CheatingRemovingCosmicRays::Run - LArMCParticleHelper::IsCosmicRay function raised an exception." << std::endl;
             continue;
         }
     }

--- a/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.cc
+++ b/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.cc
@@ -37,7 +37,7 @@ StatusCode CheatingRemovingCosmicRays::Run()
         }
         catch (const StatusCodeException &)
         {
-            std::cout << "CheatingRemovingCosmicRays::Run - LArMCParticleHelper::IsCosmicRay function raised an exception." << std::endl;
+            std::cout << "CheatingRemovingCosmicRays::Run - Unable to determine MCParticle origin for an input CaloHit, which will be skipped." << std::endl;
             continue;
         }
     }

--- a/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.cc
+++ b/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.cc
@@ -1,0 +1,72 @@
+/**
+ *  @file   larpandoracontent/LArCheating/CheatingRemovingCosmicRays.cc
+ * 
+ *  @brief  Implementation of the cheating removing cosmic rays algorithm class.
+ * 
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "Helpers/MCParticleHelper.h"
+
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+
+#include "larpandoracontent/LArCheating/CheatingRemovingCosmicRays.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+CheatingRemovingCosmicRays::CheatingRemovingCosmicRays() :
+    m_inputCaloHitListName(""),
+    m_mcParticleListName("")
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode CheatingRemovingCosmicRays::Run()
+{
+    const MCParticleList *pMCParticleList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_mcParticleListName, pMCParticleList));
+
+    const CaloHitList *pCaloHitList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputCaloHitListName, pCaloHitList));
+
+    CaloHitList outputCaloHitList;
+
+    for (const CaloHit *pCaloHit : *pCaloHitList)
+    {
+        try
+        {
+            const MCParticle *const pHitParticle(MCParticleHelper::GetMainMCParticle(pCaloHit));
+
+            if (!LArMCParticleHelper::IsCosmicRay(pHitParticle))
+                outputCaloHitList.push_back(pCaloHit);
+        }
+        catch (...)
+        {
+            std::cout << "CheatingRemovingCosmicRays::Run - Calo hit has no available MainMCParticle." << std::endl;
+            continue;
+        }
+    }
+
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, outputCaloHitList, m_outputCaloHitListName));
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<CaloHit>(*this, m_outputCaloHitListName));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode CheatingRemovingCosmicRays::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputCaloHitListName", m_inputCaloHitListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputCaloHitListName", m_outputCaloHitListName));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.h
+++ b/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.h
@@ -1,0 +1,39 @@
+/**
+ *  @file   larpandoracontent/LArCheating/CheatingRemovingCosmicRays.h
+ * 
+ *  @brief  Header file for the cheating removing cosmic rays algorithm class.
+ * 
+ *  $Log: $
+ */
+#ifndef LAR_CHEATING_REMOVING_COSMIC_RAYS_H
+#define LAR_CHEATING_REMOVING_COSMIC_RAYS_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  CheatingRemovingCosmicRays::Algorithm class
+ */
+class CheatingRemovingCosmicRays : public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    CheatingRemovingCosmicRays();
+
+private:
+    pandora::StatusCode Run();
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    std::string m_inputCaloHitListName;     ///< Input calo hit list name
+    std::string m_outputCaloHitListName;    ///< Output calo hit list name
+    std::string m_mcParticleListName;       ///< MC Particle list name
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_CHEATING_REMOVING_COSMIC_RAYS_H

--- a/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.h
+++ b/larpandoracontent/LArCheating/CheatingRemovingCosmicRays.h
@@ -22,7 +22,7 @@ public:
     /**
      *  @brief  Default constructor
      */
-    CheatingRemovingCosmicRays();
+    CheatingRemovingCosmicRays() = default;
 
 private:
     pandora::StatusCode Run();

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -24,6 +24,7 @@
 #include "larpandoracontent/LArCheating/CheatingNeutrinoIdTool.h"
 #include "larpandoracontent/LArCheating/CheatingPfoCharacterisationAlgorithm.h"
 #include "larpandoracontent/LArCheating/CheatingPfoCreationAlgorithm.h"
+#include "larpandoracontent/LArCheating/CheatingRemovingCosmicRays.h"
 #include "larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.h"
 
 #include "larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h"
@@ -190,6 +191,7 @@
     d("LArCheatingNeutrinoDaughterVertices",    CheatingNeutrinoDaughterVerticesAlgorithm)                                      \
     d("LArCheatingPfoCharacterisation",         CheatingPfoCharacterisationAlgorithm)                                           \
     d("LArCheatingPfoCreation",                 CheatingPfoCreationAlgorithm)                                                   \
+    d("LArCheatingRemovingCosmicRays",          CheatingRemovingCosmicRays)                                                     \
     d("LArCheatingVertexCreation",              CheatingVertexCreationAlgorithm)                                                \
     d("LArPcaShowerParticleBuilding",           PcaShowerParticleBuildingAlgorithm)                                             \
     d("LArMaster",                              MasterAlgorithm)                                                                \


### PR DESCRIPTION
Algorithm designed to remove calo hits from an event if they originate from cosmic rays i.e. removes hit if main mc particle passes LArMCParticleHelper::IsCosmicRay.  