### PR TITLE
Set the test beam score in the pfo properties map.

### DIFF
--- a/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h
+++ b/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h
@@ -314,10 +314,11 @@ private:
     /**
      *  @brief  Select all pfos under the same hypothesis
      *
+     *  @param  pAlgorithm address of the master algorithm
      *  @param  hypotheses the lists of slices under a certain hypothesis
      *  @param  selectedPfos the list of pfos to populate
      */
-    void SelectAllPfos(const SliceHypotheses &hypotheses, pandora::PfoList &selectedPfos) const;
+    void SelectAllPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &hypotheses, pandora::PfoList &selectedPfos) const;
 
     /**
      *  @brief  Add the given pfos to the selected Pfo list
@@ -367,12 +368,13 @@ private:
     /**
      *  @brief  Select pfos based on the AdaBDT score that the slice contains a beam particle interaction
      *
+     *  @param  pAlgorithm address of the master algorithm
      *  @param  nuSliceHypotheses the input neutrino slice hypotheses
      *  @param  crSliceHypotheses the input cosmic slice hypotheses
      *  @param  sliceFeaturesVector vector holding the slice features
      *  @param  selectedPfos the list of pfos to populate
      */
-    void SelectPfosByAdaBDTScore(const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, pandora::PfoList &selectedPfos) const;
+    void SelectPfosByAdaBDTScore(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, pandora::PfoList &selectedPfos) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 

--- a/larpandoracontent/LArControlFlow/BeamParticleIdTool.cc
+++ b/larpandoracontent/LArControlFlow/BeamParticleIdTool.cc
@@ -52,10 +52,7 @@ void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, con
             const PfoList &sliceOutput((m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex))) ?
                 beamSliceHypotheses.at(sliceIndex) : crSliceHypotheses.at(sliceIndex));
 
-            float score(-1.f);
-
-            if (m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex)))
-                score = 1.f;
+            const float score(m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex)) ? 1.f : -1.f);
 
             for (const ParticleFlowObject *const pPfo : sliceOutput)
             {
@@ -117,7 +114,8 @@ void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, con
 
         const PfoList &sliceOutput(usebeamHypothesis ? beamSliceHypotheses.at(sliceIndex) : crSliceHypotheses.at(sliceIndex));
         selectedPfos.insert(selectedPfos.end(), sliceOutput.begin(), sliceOutput.end());
-        float score(usebeamHypothesis ? 1.f : -1.f);
+
+        const float score(usebeamHypothesis ? 1.f : -1.f);
 
         for (const ParticleFlowObject *const pPfo : sliceOutput)
         {
@@ -186,7 +184,7 @@ void BeamParticleIdTool::GetSelectedCaloHits(const CaloHitList &inputCaloHitList
     typedef std::pair<const CaloHit*, float> HitDistancePair;
     typedef std::vector<HitDistancePair> HitDistanceVector;
     HitDistanceVector hitDistanceVector;
-    
+
     for (const CaloHit *const pCaloHit : inputCaloHitList)
         hitDistanceVector.emplace_back(pCaloHit, (pCaloHit->GetPositionVector() - m_beamTPCIntersection).GetMagnitudeSquared());
 

--- a/larpandoracontent/LArControlFlow/BeamParticleIdTool.cc
+++ b/larpandoracontent/LArControlFlow/BeamParticleIdTool.cc
@@ -39,7 +39,7 @@ BeamParticleIdTool::BeamParticleIdTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const /*pAlgorithm*/, const SliceHypotheses &beamSliceHypotheses, const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
+void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, const SliceHypotheses &beamSliceHypotheses, const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
 {
     if (beamSliceHypotheses.size() != crSliceHypotheses.size())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -51,6 +51,18 @@ void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const /*pAlgorithm*/,
         {
             const PfoList &sliceOutput((m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex))) ?
                 beamSliceHypotheses.at(sliceIndex) : crSliceHypotheses.at(sliceIndex));
+
+            float score(-1.f);
+
+            if (m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex)))
+                score = 1.f;
+
+            for (const ParticleFlowObject *const pPfo : sliceOutput)
+            {
+                object_creation::ParticleFlowObject::Metadata metadata;
+                metadata.m_propertiesToAdd["TestBeamScore"] = score;
+                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
+            }
 
             selectedPfos.insert(selectedPfos.end(), sliceOutput.begin(), sliceOutput.end());
         }
@@ -104,7 +116,15 @@ void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const /*pAlgorithm*/,
         }
 
         const PfoList &sliceOutput(usebeamHypothesis ? beamSliceHypotheses.at(sliceIndex) : crSliceHypotheses.at(sliceIndex));
-            selectedPfos.insert(selectedPfos.end(), sliceOutput.begin(), sliceOutput.end());
+        selectedPfos.insert(selectedPfos.end(), sliceOutput.begin(), sliceOutput.end());
+        float score(usebeamHypothesis ? 1.f : -1.f);
+
+        for (const ParticleFlowObject *const pPfo : sliceOutput)
+        {
+            object_creation::ParticleFlowObject::Metadata metadata;
+            metadata.m_propertiesToAdd["TestBeamScore"] = score;
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
+        }
     }
 }
 

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -211,20 +211,22 @@ private:
     /**
      *  @brief  Select all pfos under the same hypothesis
      *
+     *  @param  pAlgorithm address of the master algorithm
      *  @param  hypotheses the lists of slices under a certain hypothesis
      *  @param  selectedPfos the list of pfos to populate
      */
-    void SelectAllPfos(const SliceHypotheses &hypotheses, pandora::PfoList &selectedPfos) const;
+    void SelectAllPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &hypotheses, pandora::PfoList &selectedPfos) const;
 
     /**
      *  @brief  Select pfos based on the probability that their slice contains a neutrino interaction
      *
+     *  @param  pAlgorithm address of the master algorithm
      *  @param  nuSliceHypotheses the input neutrino slice hypotheses
      *  @param  crSliceHypotheses the input cosmic slice hypotheses
      *  @param  sliceFeaturesVector vector holding the slice features
      *  @param  selectedPfos the list of pfos to populate
      */
-    void SelectPfosByProbability(const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, pandora::PfoList &selectedPfos) const;
+    void SelectPfosByProbability(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, pandora::PfoList &selectedPfos) const;
 
     /**
      *  @brief  Add the given pfos to the selected Pfo list

--- a/larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.cc
@@ -33,7 +33,7 @@ void SimpleNeutrinoIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, c
         const PfoList &sliceOutput((m_selectAllNeutrinos || (m_selectOnlyFirstSliceNeutrinos && (0 == sliceIndex))) ?
             nuSliceHypotheses.at(sliceIndex) : crSliceHypotheses.at(sliceIndex));
 
-        float score(m_selectAllNeutrinos || (m_selectOnlyFirstSliceNeutrinos && (0 == sliceIndex)) ? 1.f : -1.f);
+        const float score(m_selectAllNeutrinos || (m_selectOnlyFirstSliceNeutrinos && (0 == sliceIndex)) ? 1.f : -1.f);
 
         for (const ParticleFlowObject *const pPfo : crSliceHypotheses.at(sliceIndex))
         {

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
@@ -41,8 +41,14 @@ StatusCode TestBeamParticleCreationAlgorithm::Run()
         if (!LArPfoHelper::IsNeutrino(pPfo))
             continue;
 
-        const PfoList &daughterList(pPfo->GetDaughterPfoList());
+        // ATTN: If the test beam score is not set in the neutrino pfo, set the score to 1 as it has been reconstructed under the neutrino hypothesis
+        const PropertiesMap properties(pPfo->GetPropertiesMap());
+        float testBeamScore(1.f);
 
+        if (properties.find("TestBeamScore") != properties.end())
+            testBeamScore = properties.at("TestBeamScore");
+
+        const PfoList &daughterList(pPfo->GetDaughterPfoList());
         const Pfo *pPrimaryPfo(nullptr);
         CartesianVector positionMinZCaloHit(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
 
@@ -71,6 +77,7 @@ StatusCode TestBeamParticleCreationAlgorithm::Run()
 
         PandoraContentApi::ParticleFlowObject::Metadata pfoMetadata;
         pfoMetadata.m_propertiesToAdd["IsTestBeam"] = 1.f;
+        pfoMetadata.m_propertiesToAdd["TestBeamScore"] = testBeamScore;
 
         // ATTN: If the primary pfo is shower like, the target beam particle is most likely an electron/positron.  If the primary pfo is track like, the target
         // beam particle is most likely a pion as pion interactions are more frequent than proton, kaon and muon interactions in the CERN test beam.

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
@@ -43,10 +43,8 @@ StatusCode TestBeamParticleCreationAlgorithm::Run()
 
         // ATTN: If the test beam score is not set in the neutrino pfo, set the score to 1 as it has been reconstructed under the neutrino hypothesis
         const PropertiesMap properties(pPfo->GetPropertiesMap());
-        float testBeamScore(1.f);
-
-        if (properties.find("TestBeamScore") != properties.end())
-            testBeamScore = properties.at("TestBeamScore");
+        PropertiesMap::const_iterator propertiesIter(properties.find("TestBeamScore"));
+        const float testBeamScore(propertiesIter != properties.end() ? (*propertiesIter).second : 1.f);
 
         const PfoList &daughterList(pPfo->GetDaughterPfoList());
         const Pfo *pPrimaryPfo(nullptr);


### PR DESCRIPTION
This commit fills the IsTestBeam property in PfoProperties map for all parent pfos that go through the test beam particle selection (either bdt or cut based).  

In the cut based approach all scores are set to +1 if they pass the cuts and -1 if they don't.  This has been checked also for the simple use cases of selecting all slices as test beam particles and just selecting the first slice as a test beam particle.  It seemed appropriate to add a score for the cut based id to prevent a discontinuity in what is contained in the properties map for any larsoft analysers comparing new and old beam particle ids (not that I think this is a study anyone will be doing any time soon, if ever though).

For the bdt id the bdt scores are passed into the map.  These scores are confined between -1 and +1, hence the use of +1 and -1 for test beam and cosmic ray scores respectively for the cut based approach.  This has been tested for both the default use case and in training mode where everything is defaulted to a comsic ray.  The SelectAllPfos function in the BdtBeamParticleId class implicitly assumes you're selecting all Pfos as cosmic rays, hence giving a score of -1, but this is only used if running in the training mode where everything is being set to cosmic rays.   Are you happy with this or would you like me to add further constrains on this function to allow you to define a nominal score? 

A minor addition to the TestBeamParticleCreation algorithm was required as the test beam score is attached to the neutrino pfo and this needs to e persisted into the pfo that becomes the parent in the test beam (previously a daughter of the neutrino and so it doesn't have the score attached).  