### PR TITLE
Altering method for finding intercepts between fit and TPC boundaries.

### DIFF
--- a/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.cc
+++ b/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.cc
@@ -389,7 +389,8 @@ BdtBeamParticleIdTool::SliceFeatureParameters::SliceFeatureParameters() :
     m_beamLArTPCIntersection(0.f, 0.f, 0.f),
     m_beamDirection(0.f, 0.f, 0.f),
     m_selectedFraction(10.f),
-    m_nSelectedHits(100)
+    m_nSelectedHits(100),
+    m_containmentLimit(0.01f)
 {
 }
 
@@ -573,14 +574,29 @@ void BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts(const CartesianVe
     {
         const CartesianVector intercept(plane.GetLineIntersection(a0, lineUnitVector));
 
-        if (this->IsContained(intercept))
+        if (this->IsContained(intercept, m_sliceFeatureParameters.GetContainmentLimit()))
             intercepts.push_back(intercept);
     }
 
-    if (intercepts.size() == 2)
+    if (intercepts.size() > 1)
     {
-        interceptOne = intercepts.at(0);
-        interceptTwo = intercepts.at(1);
+        float maximumSeparationSquared(0.f);
+        for (unsigned int i = 0; i < intercepts.size(); i++)
+        {
+            for (unsigned int j = i + 1; j < intercepts.size(); j++)
+            {
+                const CartesianVector candidateInterceptOne(intercepts.at(i));
+                const CartesianVector candidateInterceptTwo(intercepts.at(j));
+                const float separationSquared((candidateInterceptOne - candidateInterceptTwo).GetMagnitudeSquared());
+
+                if (separationSquared > maximumSeparationSquared)
+                {
+                    maximumSeparationSquared = separationSquared;
+                    interceptOne = candidateInterceptOne;
+                    interceptTwo = candidateInterceptTwo;
+                }
+            }
+        }
     }
     else
     {
@@ -591,11 +607,11 @@ void BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts(const CartesianVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool BdtBeamParticleIdTool::SliceFeatures::IsContained(const CartesianVector &spacePoint) const
+bool BdtBeamParticleIdTool::SliceFeatures::IsContained(const CartesianVector &spacePoint, const float limit) const
 {
-    if ((m_sliceFeatureParameters.GetLArTPCMinX() - spacePoint.GetX() > std::numeric_limits<float>::epsilon()) || (spacePoint.GetX() - m_sliceFeatureParameters.GetLArTPCMaxX() > std::numeric_limits<float>::epsilon()) ||
-        (m_sliceFeatureParameters.GetLArTPCMinY() - spacePoint.GetY() > std::numeric_limits<float>::epsilon()) || (spacePoint.GetY() - m_sliceFeatureParameters.GetLArTPCMaxY() > std::numeric_limits<float>::epsilon()) ||
-        (m_sliceFeatureParameters.GetLArTPCMinZ() - spacePoint.GetZ() > std::numeric_limits<float>::epsilon()) || (spacePoint.GetZ() - m_sliceFeatureParameters.GetLArTPCMaxZ() > std::numeric_limits<float>::epsilon()))
+    if ((m_sliceFeatureParameters.GetLArTPCMinX() - spacePoint.GetX() > limit) || (spacePoint.GetX() - m_sliceFeatureParameters.GetLArTPCMaxX() > limit) ||
+        (m_sliceFeatureParameters.GetLArTPCMinY() - spacePoint.GetY() > limit) || (spacePoint.GetY() - m_sliceFeatureParameters.GetLArTPCMaxY() > limit) ||
+        (m_sliceFeatureParameters.GetLArTPCMinZ() - spacePoint.GetZ() > limit) || (spacePoint.GetZ() - m_sliceFeatureParameters.GetLArTPCMaxZ() > limit))
     {
         return false;
     }
@@ -756,6 +772,14 @@ StatusCode BdtBeamParticleIdTool::ReadSettings(const TiXmlHandle xmlHandle)
 
     if (nSelectedHits > 0)
         m_sliceFeatureParameters.SetNSelectedHits(nSelectedHits);
+
+    float containmentLimit(0.f);
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContainmentLimit", containmentLimit));
+
+    if (containmentLimit > 0.f)
+        m_sliceFeatureParameters.SetContainmentLimit(containmentLimit);
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h
+++ b/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h
@@ -132,6 +132,13 @@ private:
        void SetNSelectedHits(const unsigned int nSelectedHits);
 
        /**
+        *  @brief  Set m_containmentLimit
+        *
+        *  @param  containmentLimit limit used in is contained definition
+        */
+       void SetContainmentLimit(const float containmentLimit);
+
+       /**
         *  @brief  Get m_larTPCMinX
         */
        float GetLArTPCMinX() const;
@@ -183,10 +190,13 @@ private:
 
        /**
         *  @brief  Get m_nSelectedHits
-        *
-        *  @param  nSelectedHits minimum number of hits to use in 3D cluster fits
         */
        unsigned int GetNSelectedHits() const;
+
+       /**
+        *  @brief  Get m_containmentLimit
+        */
+       float GetContainmentLimit() const;
 
     private:
         float                       m_larTPCMinX;             ///< Global LArTPC volume minimum x extent
@@ -200,6 +210,7 @@ private:
         pandora::CartesianVector    m_beamDirection;          ///< Beam direction
         float                       m_selectedFraction;       ///< Fraction of hits to use in 3D cluster fits
         unsigned int                m_nSelectedHits;          ///< Minimum number of hits to use in 3D cluster fits
+        float                       m_containmentLimit;       ///< Limit applied in is contained definition
     };
 
     /**
@@ -287,7 +298,7 @@ private:
          *
          *  @param  spacePoint
          */
-        bool IsContained(const pandora::CartesianVector &spacePoint) const;
+        bool IsContained(const pandora::CartesianVector &spacePoint, const float limit) const;
 
         bool                            m_isAvailable;               ///< Is the feature vector available
         const SliceFeatureParameters    m_sliceFeatureParameters;    ///< Geometry information block
@@ -424,6 +435,13 @@ inline void BdtBeamParticleIdTool::SliceFeatureParameters::SetNSelectedHits(cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+inline void BdtBeamParticleIdTool::SliceFeatureParameters::SetContainmentLimit(const float containmentLimit)
+{
+    m_containmentLimit = containmentLimit;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 inline float BdtBeamParticleIdTool::SliceFeatureParameters::GetLArTPCMinX() const
 {
     return m_larTPCMinX;
@@ -497,6 +515,13 @@ inline float BdtBeamParticleIdTool::SliceFeatureParameters::GetSelectedFraction(
 inline unsigned int BdtBeamParticleIdTool::SliceFeatureParameters::GetNSelectedHits() const
 {
     return m_nSelectedHits;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline float BdtBeamParticleIdTool::SliceFeatureParameters::GetContainmentLimit() const
+{
+    return m_containmentLimit;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This method applies a limit on the isContained function and then selected the two intercepts that are furthest apart from each other.  I'm currently testing, but so far there are no changes in the results apart from the events that previously threw exceptions now no longer do.