### PR TITLE
Feature event validation for protoDUNE

### DIFF
--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -376,11 +376,11 @@ bool LArPfoHelper::IsNeutrino(const ParticleFlowObject *const pPfo)
 
 bool LArPfoHelper::IsTestBeam(const ParticleFlowObject *const pPfo)
 {
-    const PropertiesMap properties(pPfo->GetPropertiesMap());
-    const PropertiesMap::const_iterator iter = properties.find("IsTestBeam");
+    const PropertiesMap &properties(pPfo->GetPropertiesMap());
+    const PropertiesMap::const_iterator iter(properties.find("IsTestBeam"));
 
     if (iter != properties.end())
-        return ((*iter).second > 0.f ? true : false);
+        return ((iter->second > 0.f) ? true : false);
 
     return false;
 }

--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -376,10 +376,11 @@ bool LArPfoHelper::IsNeutrino(const ParticleFlowObject *const pPfo)
 
 bool LArPfoHelper::IsTestBeam(const ParticleFlowObject *const pPfo)
 {
-    const int absoluteParticleId(std::abs(pPfo->GetParticleId()));
+    const PropertiesMap properties(pPfo->GetPropertiesMap());
+    const PropertiesMap::const_iterator iter = properties.find("IsTestBeam");
 
-    if ((E_MINUS == absoluteParticleId) || (PI_PLUS == absoluteParticleId))
-        return true;
+    if (iter != properties.end())
+        return ((*iter).second > 0.f ? true : false);
 
     return false;
 }

--- a/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
@@ -249,6 +249,7 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
             const CaloHitList &pfoHitList(validationInfo.GetPfoToHitsMap().at(pfoToSharedHits.first));
 
             const bool isRecoNeutrinoFinalState(LArPfoHelper::IsNeutrinoFinalState(pfoToSharedHits.first));
+            const bool isRecoTestBeam(LArPfoHelper::IsTestBeam(pfoToSharedHits.first));
             const bool isGoodMatch(this->IsGoodMatch(mcPrimaryHitList, pfoHitList, sharedHitList));
 
             const int pfoId(pfoToIdMap.at(pfoToSharedHits.first));
@@ -260,7 +261,7 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
                 bestMatchPfoPdg.push_back(pfoToSharedHits.first->GetParticleId());
                 bestMatchPfoIsRecoNu.push_back(isRecoNeutrinoFinalState ? 1 : 0);
                 bestMatchPfoRecoNuId.push_back(recoNuId);
-                bestMatchPfoIsTestBeam.push_back(LArPfoHelper::IsTestBeam(pfoToSharedHits.first) ? 1 : 0);
+                bestMatchPfoIsTestBeam.push_back(isRecoTestBeam ? 1 : 0);
                 bestMatchPfoNHitsTotal.push_back(pfoHitList.size());
                 bestMatchPfoNHitsU.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, pfoHitList));
                 bestMatchPfoNHitsV.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, pfoHitList));
@@ -308,7 +309,8 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
                      << "MatchedPfoId " << pfoId
                      << ", Nu " << isRecoNeutrinoFinalState;
             if (isRecoNeutrinoFinalState) targetSS << " [NuId: " << recoNuId << "]";
-            targetSS << ", CR " << !isRecoNeutrinoFinalState
+            targetSS << ", TB " << isRecoTestBeam
+                     << ", CR " << (!isRecoNeutrinoFinalState && !isRecoTestBeam)
                      << ", PDG " << pfoToSharedHits.first->GetParticleId()
                      << ", nMatchedHits " << sharedHitList.size()
                      << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList)

--- a/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
@@ -114,7 +114,7 @@ void EventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pM
         validationInfo.SetTargetMCParticleToHitsMap(targetMCParticleToHitsMap);
         validationInfo.SetAllMCParticleToHitsMap(allMCParticleToHitsMap);
     }
-    
+
     if (pPfoList)
     {
         PfoList allConnectedPfos;
@@ -182,7 +182,7 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
     FloatVector mcPrimaryE, mcPrimaryPX, mcPrimaryPY, mcPrimaryPZ;
     FloatVector mcPrimaryVtxX, mcPrimaryVtxY, mcPrimaryVtxZ, mcPrimaryEndX, mcPrimaryEndY, mcPrimaryEndZ;
     IntVector nPrimaryMatchedPfos, nPrimaryMatchedNuPfos, nPrimaryMatchedCRPfos;
-    IntVector bestMatchPfoId, bestMatchPfoPdg, bestMatchPfoIsRecoNu, bestMatchPfoRecoNuId;
+    IntVector bestMatchPfoId, bestMatchPfoPdg, bestMatchPfoIsRecoNu, bestMatchPfoRecoNuId, bestMatchPfoIsTestBeam;
     IntVector bestMatchPfoNHitsTotal, bestMatchPfoNHitsU, bestMatchPfoNHitsV, bestMatchPfoNHitsW;
     IntVector bestMatchPfoNSharedHitsTotal, bestMatchPfoNSharedHitsU, bestMatchPfoNSharedHitsV, bestMatchPfoNSharedHitsW;
 
@@ -260,6 +260,7 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
                 bestMatchPfoPdg.push_back(pfoToSharedHits.first->GetParticleId());
                 bestMatchPfoIsRecoNu.push_back(isRecoNeutrinoFinalState ? 1 : 0);
                 bestMatchPfoRecoNuId.push_back(recoNuId);
+                bestMatchPfoIsTestBeam.push_back(LArPfoHelper::IsTestBeam(pfoToSharedHits.first) ? 1 : 0);
                 bestMatchPfoNHitsTotal.push_back(pfoHitList.size());
                 bestMatchPfoNHitsU.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, pfoHitList));
                 bestMatchPfoNHitsV.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, pfoHitList));
@@ -322,7 +323,7 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
         if (mcToPfoHitSharingMap.at(pMCPrimary).empty())
         {
             targetSS << "-No matched Pfo" << std::endl;
-            bestMatchPfoId.push_back(-1); bestMatchPfoPdg.push_back(0); bestMatchPfoIsRecoNu.push_back(0); bestMatchPfoRecoNuId.push_back(-1);
+            bestMatchPfoId.push_back(-1); bestMatchPfoPdg.push_back(0); bestMatchPfoIsRecoNu.push_back(0); bestMatchPfoRecoNuId.push_back(-1); bestMatchPfoIsTestBeam.push_back(0);
             bestMatchPfoNHitsTotal.push_back(0); bestMatchPfoNHitsU.push_back(0); bestMatchPfoNHitsV.push_back(0); bestMatchPfoNHitsW.push_back(0);
             bestMatchPfoNSharedHitsTotal.push_back(0); bestMatchPfoNSharedHitsU.push_back(0); bestMatchPfoNSharedHitsV.push_back(0); bestMatchPfoNSharedHitsW.push_back(0);
         }
@@ -386,6 +387,11 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetMatches", nTargetMatches));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetNuMatches", nTargetNuMatches));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetCRMatches", nTargetCRMatches));
+
+            if (m_testBeamMode)
+            {
+                PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "bestMatchPfoIsTestBeam", &bestMatchPfoIsTestBeam));
+            }
 
             if (!m_testBeamMode)
             {
@@ -464,7 +470,7 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
             mcPrimaryE.clear(); mcPrimaryPX.clear(); mcPrimaryPY.clear(); mcPrimaryPZ.clear();
             mcPrimaryVtxX.clear(); mcPrimaryVtxY.clear(); mcPrimaryVtxZ.clear(); mcPrimaryEndX.clear(); mcPrimaryEndY.clear(); mcPrimaryEndZ.clear();
             nPrimaryMatchedPfos.clear(); nPrimaryMatchedNuPfos.clear(); nPrimaryMatchedCRPfos.clear();
-            bestMatchPfoId.clear(); bestMatchPfoPdg.clear(); bestMatchPfoIsRecoNu.clear(); bestMatchPfoRecoNuId.clear();
+            bestMatchPfoId.clear(); bestMatchPfoPdg.clear(); bestMatchPfoIsRecoNu.clear(); bestMatchPfoRecoNuId.clear(); bestMatchPfoIsTestBeam.clear();
             bestMatchPfoNHitsTotal.clear(); bestMatchPfoNHitsU.clear(); bestMatchPfoNHitsV.clear(); bestMatchPfoNHitsW.clear();
             bestMatchPfoNSharedHitsTotal.clear(); bestMatchPfoNSharedHitsU.clear(); bestMatchPfoNSharedHitsV.clear(); bestMatchPfoNSharedHitsW.clear();
         }


### PR DESCRIPTION
This PR contains two changes:

- Change the LArPfoHelper IsTestBeam function to use the pfo properties map to id whether the pfo is a test beam.  This fixes the issue of shower like cosmics being mistaken as test beam particles.

- Add the IsTestBeam outcome for the best matched pfo in the event validation algorithm (bestMatchPfoIsTestBeam) when running in test beam mode.  This will allow the user to persist the IsTestBeam information outside of Pandora.