### PR TITLE
Vertex selection now uses GetInputEnergy

### DIFF
--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -729,4 +729,18 @@ bool LArClusterHelper::SortCoordinatesByPosition(const CartesianVector &lhs, con
     return (deltaPosition.GetY() > std::numeric_limits<float>::epsilon());
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LArClusterHelper::GetInputEnergy(const Cluster *const pCluster)
+{
+    CaloHitList caloHitList;
+    pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
+
+    float inputEnergy(0.f);
+    
+    for (const CaloHit *const pCaloHit : caloHitList)
+        inputEnergy += pCaloHit->GetInputEnergy();
+
+    return inputEnergy;
+}
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArClusterHelper.h
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.h
@@ -346,6 +346,15 @@ public:
      *  @param  rhs second point
      */
     static bool SortCoordinatesByPosition(const pandora::CartesianVector &lhs, const pandora::CartesianVector &rhs);
+
+    /**
+     *  @brief  Get the cluster's total input energy
+     *
+     *  @param  pCluster address of the cluster
+     * 
+     *  @return the total input energy
+     */
+    static float GetInputEnergy(const pandora::Cluster *const pCluster);
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/EnergyKickFeatureTool.h
+++ b/larpandoracontent/LArVertex/EnergyKickFeatureTool.h
@@ -60,9 +60,11 @@ private:
      *  @param  totEnergy the total energy
      *  @param  totHitKick the total hit kick
      *  @param  totHits the total number of hits
+     *  @param  clusterEnergy the cluster energy
      */
     void IncrementEnergyKickParameters(const pandora::Cluster *const pCluster, const pandora::CartesianVector &clusterDisplacement,
-        const pandora::CartesianVector &clusterDirection, float &totEnergyKick, float &totEnergy, float &totHitKick, unsigned int &totHits) const;
+        const pandora::CartesianVector &clusterDirection, float &totEnergyKick, float &totEnergy, float &totHitKick, unsigned int &totHits,
+        const float clusterEnergy) const;
 
     float    m_rOffset;    ///< The r offset parameter in the energy score
     float    m_xOffset;    ///< The x offset parameter in the energy score

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
@@ -55,8 +55,9 @@ float GlobalAsymmetryFeatureTool::GetGlobalAsymmetryForView(const CartesianVecto
     for (const VertexSelectionBaseAlgorithm::SlidingFitData &slidingFitData : slidingFitDataList)
     {
         const Cluster *const pCluster(slidingFitData.GetCluster());
+        const float clusterEnergy(LArClusterHelper::GetInputEnergy(pCluster));
 
-        if (pCluster->GetElectromagneticEnergy() < std::numeric_limits<float>::epsilon())
+        if (clusterEnergy < std::numeric_limits<float>::epsilon())
             useEnergy = false;
 
         const CartesianVector vertexToMinLayer(slidingFitData.GetMinLayerPosition() - vertexPosition2D);
@@ -67,7 +68,7 @@ float GlobalAsymmetryFeatureTool::GetGlobalAsymmetryForView(const CartesianVecto
 
         if ((LArClusterHelper::GetClosestDistance(vertexPosition2D, pCluster) < m_maxAsymmetryDistance))
         {
-            this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
+            this->IncrementAsymmetryParameters(clusterEnergy, clusterDirection, energyWeightedDirectionSum);
             this->IncrementAsymmetryParameters(static_cast<float>(pCluster->GetNCaloHits()), clusterDirection, hitWeightedDirectionSum);
         }
     }
@@ -123,13 +124,13 @@ float GlobalAsymmetryFeatureTool::CalculateGlobalAsymmetry(const bool useEnergyM
         {
             if (pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection) < evtProjectedVtxPos)
             {
-                beforeVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
+                beforeVtxHitEnergy += pCaloHit->GetInputEnergy();
                 ++beforeVtxHitCount;
             }
 
             else
             {
-                afterVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
+                afterVtxHitEnergy += pCaloHit->GetInputEnergy();
                 ++afterVtxHitCount;
             }
         }

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
@@ -60,8 +60,9 @@ float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(const CartesianVector 
     for (const VertexSelectionBaseAlgorithm::SlidingFitData &slidingFitData : slidingFitDataList)
     {
         const Cluster *const pCluster(slidingFitData.GetCluster());
+        const float clusterEnergy(LArClusterHelper::GetInputEnergy(pCluster));
 
-        if (pCluster->GetElectromagneticEnergy() < std::numeric_limits<float>::epsilon())
+        if (clusterEnergy < std::numeric_limits<float>::epsilon())
             useEnergy = false;
 
         const CartesianVector vertexToMinLayer(slidingFitData.GetMinLayerPosition() - vertexPosition2D);
@@ -72,7 +73,7 @@ float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(const CartesianVector 
 
         if (useAsymmetry && (LArClusterHelper::GetClosestDistance(vertexPosition2D, pCluster) < m_maxAsymmetryDistance))
         {
-            useAsymmetry &= this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
+            useAsymmetry &= this->IncrementAsymmetryParameters(clusterEnergy, clusterDirection, energyWeightedDirectionSum);
             useAsymmetry &= this->IncrementAsymmetryParameters(static_cast<float>(pCluster->GetNCaloHits()), clusterDirection, hitWeightedDirectionSum);
             asymmetryClusters.push_back(pCluster);
         }
@@ -142,13 +143,13 @@ float LocalAsymmetryFeatureTool::CalculateLocalAsymmetry(const bool useEnergyMet
         {
             if (pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection) < evtProjectedVtxPos)
             {
-                beforeVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
+                beforeVtxHitEnergy += pCaloHit->GetInputEnergy();
                 ++beforeVtxHitCount;
             }
 
             else
             {
-                afterVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
+                afterVtxHitEnergy += pCaloHit->GetInputEnergy();
                 ++afterVtxHitCount;
             }
         }

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
@@ -111,10 +111,10 @@ void ShowerAsymmetryFeatureTool::CalculateAsymmetryParameters(const VertexSelect
         for (const CaloHit *const pCaloHit : caloHitVector)
         {
             if (pCaloHit->GetPositionVector().GetDotProduct(showerDirection) < projectedVtxPosition)
-                beforeVtxEnergy += pCaloHit->GetElectromagneticEnergy();
+                beforeVtxEnergy += pCaloHit->GetInputEnergy();
 
             else if (pCaloHit->GetPositionVector().GetDotProduct(showerDirection) > projectedVtxPosition)
-                afterVtxEnergy += pCaloHit->GetElectromagneticEnergy();
+                afterVtxEnergy += pCaloHit->GetInputEnergy();
         }
     }
 }

--- a/larpandoracontent/LArVertex/SvmVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/SvmVertexSelectionAlgorithm.cc
@@ -353,7 +353,7 @@ void SvmVertexSelectionAlgorithm::IncrementShoweryParameters(const ClusterList &
         if (this->IsClusterShowerLike(pCluster))
             nShoweryHits += pCluster->GetNCaloHits();
 
-        eventEnergy += pCluster->GetElectromagneticEnergy();
+        eventEnergy += LArClusterHelper::GetInputEnergy(pCluster);
         nHits += pCluster->GetNCaloHits();
     }
 }


### PR DESCRIPTION
Vertex selection now uses `GetInputEnergy` instead of `GetElectromagneticEnergy`.