### PR TITLE
Added method to get the MCParticle best matched to a PFO

### DIFF
--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -164,6 +164,15 @@ public:
     static const pandora::MCParticle *GetMainMCParticle(const pandora::ParticleFlowObject *const pPfo);
 
     /**
+     *  @brief  Find the best mc particle making the largest contribution to 2D hits in a specified pfo
+     *
+     *  @param  pPfo address of the pfo to examine
+     *
+     *  @return address of the best mc particle
+     */
+    static const pandora::MCParticle *GetBestMCParticle(const pandora::ParticleFlowObject *const pPfo);
+
+    /**
      *  @brief  Sort mc particles by their momentum
      *
      *  @param  pLhs address of first mc particle
@@ -306,6 +315,15 @@ private:
      *  @return The hits that are found in both hitListA and hitListB
      */
     static pandora::CaloHitList GetSharedHits(const pandora::CaloHitList &hitListA, const pandora::CaloHitList &hitListB);
+
+    /**
+     *  @brief  Get the MCParticle weight map for a set of CaloHits
+     *
+     *  @param  caloHitList the list of CaloHits
+     *
+     *  @return the MCParticle weight map
+     */
+    static pandora::MCParticleWeightMap GetMCParticleWeightMap(const pandora::CaloHitList &caloHitList);
 };
 
 } // namespace lar_content


### PR DESCRIPTION
Unlike `LArMCParticleHelper::GetMainMCParticle`, there's no need for agreement in multiple views. Every 2D hit in each view votes with a float between 0 and 1 (from their MC particle weight map), then the MC particle with the highest weight is chosen. The method should return `nullptr` iff the MC particle weight map is empty for every considered hit.

A variation on this could be weighting each hit's vote by its energy.

This is simplified from similar logic in my `LArPhysicsContent` repo.