### PR TITLE
Resolve compiler error on MacOS

### DIFF
--- a/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.cc
+++ b/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.cc
@@ -82,7 +82,7 @@ void BdtBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *const pAl
     if (nSlices == 0) return;
 
     SliceFeaturesVector sliceFeaturesVector;
-    this->GetSliceFeatures(this, nuSliceHypotheses, crSliceHypotheses, sliceFeaturesVector);
+    this->GetSliceFeatures(nuSliceHypotheses, crSliceHypotheses, sliceFeaturesVector);
 
     if (m_useTrainingMode)
     {
@@ -124,10 +124,10 @@ void BdtBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *const pAl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BdtBeamParticleIdTool::GetSliceFeatures(const BdtBeamParticleIdTool *const pTool, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const
+void BdtBeamParticleIdTool::GetSliceFeatures(const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const
 {
     for (unsigned int sliceIndex = 0, nSlices = nuSliceHypotheses.size(); sliceIndex < nSlices; ++sliceIndex)
-        sliceFeaturesVector.push_back(SliceFeatures(nuSliceHypotheses.at(sliceIndex), crSliceHypotheses.at(sliceIndex), pTool, m_sliceFeatureParameters));
+        sliceFeaturesVector.push_back(SliceFeatures(nuSliceHypotheses.at(sliceIndex), crSliceHypotheses.at(sliceIndex), m_sliceFeatureParameters));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -423,10 +423,9 @@ void BdtBeamParticleIdTool::SliceFeatureParameters::Initialize(const float larTP
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-BdtBeamParticleIdTool::SliceFeatures::SliceFeatures(const PfoList &pfosNu, const PfoList &pfosCr, const BdtBeamParticleIdTool *const pTool, const SliceFeatureParameters &sliceFeatureParameters) :
+BdtBeamParticleIdTool::SliceFeatures::SliceFeatures(const PfoList &pfosNu, const PfoList &pfosCr, const SliceFeatureParameters &sliceFeatureParameters) :
     m_isAvailable(false),
-    m_sliceFeatureParameters(sliceFeatureParameters),
-    m_pTool(pTool)
+    m_sliceFeatureParameters(sliceFeatureParameters)
 {
     try
     {

--- a/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h
+++ b/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h
@@ -224,10 +224,9 @@ private:
          *
          *  @param  nuPfos input list of Pfos reconstructed under the neutrino hypothesis
          *  @param  crPfos input list of Pfos reconstructed under the cosmic ray hypothesis
-         *  @param  pTool address of the tool using this class
          *  @param  geometryInfo geometry information block
          */
-         SliceFeatures(const pandora::PfoList &nuPfos, const pandora::PfoList &crPfos, const BdtBeamParticleIdTool *const pTool, const SliceFeatureParameters &sliceFeatureParameters);
+         SliceFeatures(const pandora::PfoList &nuPfos, const pandora::PfoList &crPfos, const SliceFeatureParameters &sliceFeatureParameters);
 
         /**
          *  @brief  Copy constructor
@@ -303,7 +302,6 @@ private:
         bool                            m_isAvailable;               ///< Is the feature vector available
         const SliceFeatureParameters    m_sliceFeatureParameters;    ///< Geometry information block
         LArMvaHelper::MvaFeatureVector  m_featureVector;             ///< The MVA feature vector
-        const BdtBeamParticleIdTool    *m_pTool;                     ///< The tool that owns this
     };
 
     typedef std::vector<SliceFeatures> SliceFeaturesVector;
@@ -315,12 +313,11 @@ private:
     /**
      *  @brief  Get the features of each slice
      *
-     *  @param  pTool the address of the this NeutrinoId tool
      *  @param  nuSliceHypotheses the input neutrino slice hypotheses
      *  @param  crSliceHypotheses the input cosmic slice hypotheses
      *  @param  sliceFeaturesVector vector to hold the slice features
      */
-    void GetSliceFeatures(const BdtBeamParticleIdTool *const pTool, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const;
+    void GetSliceFeatures(const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const;
 
     /**
      *  @brief  Select all pfos under the same hypothesis


### PR DESCRIPTION
Refactoring bdt beam particle id class to resolve compiler error on MacOS.