### PR TITLE
APA Stitching

### DIFF
--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -67,11 +67,10 @@ void MasterAlgorithm::ShiftPfoHierarchy(const ParticleFlowObject *const pParentP
 
     PfoList pfoList;
     LArPfoHelper::GetAllDownstreamPfos(pParentPfo, pfoList);
-    const float signedX0(larTPCIter->second->IsDriftInPositiveX() ? -x0 : x0);
 
     if (m_visualizeOverallRecoStatus)
     {
-        std::cout << "ShiftPfoHierarchy: signedX0 " << signedX0 << std::endl;
+        std::cout << "ShiftPfoHierarchy: x0 " << x0 << std::endl;
         PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &pfoList, "BeforeShiftCRPfos", GREEN));
     }
 
@@ -87,14 +86,14 @@ void MasterAlgorithm::ShiftPfoHierarchy(const ParticleFlowObject *const pParentP
         for (const CaloHit *const pCaloHit : caloHitList)
         {
             PandoraContentApi::CaloHit::Metadata metadata;
-            metadata.m_x0 = signedX0;
+            metadata.m_x0 = x0;
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::AlterMetadata(*this, pCaloHit, metadata));
         }
 
         for (const Vertex *const pVertex : pDaughterPfo->GetVertexList())
         {
             PandoraContentApi::Vertex::Metadata metadata;
-            metadata.m_x0 = signedX0;
+            metadata.m_x0 = x0;
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Vertex::AlterMetadata(*this, pVertex, metadata));
         }
     }

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -532,13 +532,18 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
             {
                 if (pfoToLArTPCMap.find(pPfoToShift) != pfoToLArTPCMap.end())
                 {
+                    const LArTPC *const pLArTPC(pfoToLArTPCMap.at(pPfoToShift));
+
+                    if (pLArTPC && (stitchedLArTPCs.first == pLArTPC || stitchedLArTPCs.second == pLArTPC))
+                        continue;
+
                     if (!stitchedLArTPCs.first)
                     {
-                        stitchedLArTPCs.first = pfoToLArTPCMap.at(pPfoToShift);
+                        stitchedLArTPCs.first = pLArTPC;
                     }
                     else if (!stitchedLArTPCs.second)
                     {
-                        stitchedLArTPCs.second = pfoToLArTPCMap.at(pPfoToShift);
+                        stitchedLArTPCs.second = pLArTPC;
                     }
                     else
                     {

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -663,7 +663,7 @@ void StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
                 PfoToPointingVertexMap::iterator pfoToPointingVertexMapIter1(pfoToPointingVertexMap.find(pPfo1));
                 if (pfoToPointingVertexMapIter1 == pfoToPointingVertexMap.end())
                 {
-                    pfoToPointingVertexMap.insert(std::make_pair(pPfo1, pointingVertex1));
+                    (void) pfoToPointingVertexMap.insert(PfoToPointingVertexMap::value_type(pPfo1, pointingVertex1));
                 }
                 else
                 {
@@ -674,7 +674,7 @@ void StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
                 PfoToPointingVertexMap::iterator pfoToPointingVertexMapIter2(pfoToPointingVertexMap.find(pPfo2));
                 if (pfoToPointingVertexMapIter2 == pfoToPointingVertexMap.end())
                 {
-                    pfoToPointingVertexMap.insert(std::make_pair(pPfo2, pointingVertex2));
+                    (void) pfoToPointingVertexMap.insert(PfoToPointingVertexMap::value_type(pPfo2, pointingVertex2));
                 }
                 else
                 {

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -559,20 +559,17 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
             {
                 CaloHitList caloHitList3D;
                 LArPfoHelper::GetCaloHits(pPfoToShift, TPC_3D, caloHitList3D);
+                const unsigned int nCaloHits3D(caloHitList3D.size());
 
-                float xsum(0.f);
-                int count(0);
-
-                for (const CaloHit *const pCaloHit : caloHitList3D)
-                {
-                    xsum += pCaloHit->GetPositionVector().GetX();
-                    ++count;
-                }
-
-                if (count == 0)
+                if (nCaloHits3D == 0)
                     continue;
 
-                const float averageX(xsum / static_cast<float>(count));
+                float xSum(0.f);
+
+                for (const CaloHit *const pCaloHit : caloHitList3D)
+                    xSum += pCaloHit->GetPositionVector().GetX();
+
+                const float averageX(xSum / static_cast<float>(nCaloHits3D));
                 const float sign(averageX < tpcBoundaryCenterX ? 1.f : -1.f);
                 x0 = std::fabs(x0) * sign;
                 pAlgorithm->ShiftPfoHierarchy(pPfoToShift, pfoToLArTPCMap, x0);

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -5,7 +5,7 @@
  *
  *  $Log: $
  */
-# ifndef LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H
+#ifndef LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H
 #define LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H 1
 
 #include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -5,7 +5,7 @@
  *
  *  $Log: $
  */
-#ifndef LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H
+# ifndef LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H
 #define LAR_STITCHING_COSMIC_RAY_MERGING_TOOL_H 1
 
 #include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
@@ -184,6 +184,8 @@ private:
     void OrderPfoMerges(const PfoToLArTPCMap &pfoToLArTPCMap, const ThreeDPointingClusterMap &pointingClusterMap,
         const PfoMergeMap &inputPfoMerges, PfoMergeMap &outputPfoMerges) const;
 
+    typedef std::pair<const pandora::LArTPC*, const pandora::LArTPC*> LArTPCPair;
+
     /**
      *  @brief  Apply X0 corrections, and then stitch together Pfos
      *
@@ -195,6 +197,15 @@ private:
      */
     void StitchPfos(const MasterAlgorithm *const pAlgorithm, const ThreeDPointingClusterMap &pointingClusterMap,
         const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) const;
+
+    /**
+     *  @brief  Find the pair of LArTPCs that contain the pfos being stitched
+     *
+     *  @param  pfoVector vector of pfos being stitched
+     *  @param  pfoToLArTPCMap the pfo to lar tpc map
+     *  @param  stitchedLArTPCs the pair of LArTPCs containing the pfos being stitched
+     */
+    void FindStitchedLArTPCs(const pandora::PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap, LArTPCPair &stitchedLArTPCs) const;
 
     /**
      *  @brief  Calculate x0 shift for a group of associated Pfos

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -185,6 +185,7 @@ private:
         const PfoMergeMap &inputPfoMerges, PfoMergeMap &outputPfoMerges) const;
 
     typedef std::pair<const pandora::LArTPC*, const pandora::LArTPC*> LArTPCPair;
+    typedef std::map<const pandora::ParticleFlowObject*, LArPointingCluster::Vertex> PfoToPointingVertexMap;
 
     /**
      *  @brief  Apply X0 corrections, and then stitch together Pfos
@@ -214,9 +215,10 @@ private:
      *  @param  pointingClusterMap the mapping between Pfos and their corresponding 3D pointing clusters
      *  @param  pfoVector the vector of parent Pfos to stitch together
      *  @param  x0 the output x0 value
+     *  @param  pfoToPointingVertexMap map of pfo to pointing vertex used in stitching
      */
     void CalculateX0(const PfoToLArTPCMap &pfoToLArTPCMap, const ThreeDPointingClusterMap &pointingClusterMap,
-        const pandora::PfoVector &pfoVector, float &x0) const;
+        const pandora::PfoVector &pfoVector, float &x0, PfoToPointingVertexMap &pfoToPointingVertexMap) const;
 
     bool  m_useXcoordinate;
     int   m_halfWindowLayers;

--- a/larpandoracontent/LArHelpers/LArStitchingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArStitchingHelper.cc
@@ -275,13 +275,6 @@ float LArStitchingHelper::CalculateX0(const LArTPC &firstTPC, const LArTPC &seco
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-CartesianVector LArStitchingHelper::GetCorrectedPosition(const LArTPC &larTPC, const float x0, const CartesianVector &inputPosition)
-{
-  return (inputPosition + CartesianVector(larTPC.IsDriftInPositiveX() ? -x0 : x0, 0.f, 0.f));
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
 bool LArStitchingHelper::SortTPCs(const pandora::LArTPC *const pLhs, const pandora::LArTPC *const pRhs)
 {
     if (std::fabs(pLhs->GetCenterX() - pRhs->GetCenterX()) > std::numeric_limits<float>::epsilon())

--- a/larpandoracontent/LArHelpers/LArStitchingHelper.h
+++ b/larpandoracontent/LArHelpers/LArStitchingHelper.h
@@ -123,18 +123,6 @@ public:
         const LArPointingCluster::Vertex &firstVertex, const LArPointingCluster::Vertex &secondVertex);
 
     /**
-     *  @brief  Apply the X0 correction to an input position vector
-     *
-     *  @param  larTPC the tpc
-     *  @param  x0  the x0 value
-     *  @param  inputPosition  the input uncorrected position vector
-     *
-     *  @return the output corrected position vector
-     */
-    static pandora::CartesianVector GetCorrectedPosition(const pandora::LArTPC &larTPC, const float x0,
-        const pandora::CartesianVector &inputPosition);
-
-    /**
      *  @brief  Sort tpcs by central positions
      *
      *  @param  pLhs address of first tpc


### PR DESCRIPTION
Modification to sign of x0 to allow for stitching across APA and CPA boundaries.  Below are screenshots of stitching demonstrating that stitching now works as expected across CPAs and APAs.

![screenshot 2018-11-30 at 10 57 48](https://user-images.githubusercontent.com/11979712/49285494-737ef180-f48f-11e8-82bf-d331788d48c4.png)
![screenshot 2018-11-30 at 10 57 32](https://user-images.githubusercontent.com/11979712/49285495-737ef180-f48f-11e8-9557-508077d67a3a.png)
![screenshot 2018-11-30 at 10 57 23](https://user-images.githubusercontent.com/11979712/49285496-737ef180-f48f-11e8-97b1-43e7f77dd27b.png)