### PR TITLE
Reset Hit Positions

### DIFF
--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -18,6 +18,7 @@
 #include "larpandoracontent/LArHelpers/LArFileHelper.h"
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArHelpers/LArStitchingHelper.h"
 
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
 #include "larpandoracontent/LArObjects/LArMCParticle.h"
@@ -420,7 +421,7 @@ StatusCode MasterAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguousPfos)
         const VertexList vertexList(pPfoToDelete->GetVertexList());
 
         // ATTN: If an ambiguous pfo has been stitched, reset the calo hit positions in preparation for subsequent algorithm chains
-        if (pPfoToDelete->GetPropertiesMap().count("X0"))
+        if (LArStitchingHelper::HasPfoBeenStitched(pPfoToDelete))
         {
             PfoList downstreamPfos;
             LArPfoHelper::GetAllDownstreamPfos(pPfoToDelete, downstreamPfos);

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -423,16 +423,13 @@ StatusCode MasterAlgorithm::RunCosmicRayHitRemoval(const PfoList &ambiguousPfos)
         // ATTN: If an ambiguous pfo has been stitched, reset the calo hit positions in preparation for subsequent algorithm chains
         if (LArStitchingHelper::HasPfoBeenStitched(pPfoToDelete))
         {
-            PfoList downstreamPfos;
-            LArPfoHelper::GetAllDownstreamPfos(pPfoToDelete, downstreamPfos);
-
             CaloHitList caloHitList2D;
-            LArPfoHelper::GetCaloHits(downstreamPfos, TPC_VIEW_U, caloHitList2D);
-            LArPfoHelper::GetCaloHits(downstreamPfos, TPC_VIEW_V, caloHitList2D);
-            LArPfoHelper::GetCaloHits(downstreamPfos, TPC_VIEW_W, caloHitList2D);
-            LArPfoHelper::GetIsolatedCaloHits(downstreamPfos, TPC_VIEW_U, caloHitList2D);
-            LArPfoHelper::GetIsolatedCaloHits(downstreamPfos, TPC_VIEW_V, caloHitList2D);
-            LArPfoHelper::GetIsolatedCaloHits(downstreamPfos, TPC_VIEW_W, caloHitList2D);
+            LArPfoHelper::GetCaloHits(pPfoToDelete, TPC_VIEW_U, caloHitList2D);
+            LArPfoHelper::GetCaloHits(pPfoToDelete, TPC_VIEW_V, caloHitList2D);
+            LArPfoHelper::GetCaloHits(pPfoToDelete, TPC_VIEW_W, caloHitList2D);
+            LArPfoHelper::GetIsolatedCaloHits(pPfoToDelete, TPC_VIEW_U, caloHitList2D);
+            LArPfoHelper::GetIsolatedCaloHits(pPfoToDelete, TPC_VIEW_V, caloHitList2D);
+            LArPfoHelper::GetIsolatedCaloHits(pPfoToDelete, TPC_VIEW_W, caloHitList2D);
 
             for (const CaloHit *const pCaloHit : caloHitList2D)
             {

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -564,7 +564,13 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
                 const float t0Sign(isCPAStitch ? -1.f : 1.f);
                 object_creation::ParticleFlowObject::Metadata metadata;
                 metadata.m_propertiesToAdd["X0"] = x0 * t0Sign;
-                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfoToShift, metadata));
+
+                // ATTN: Set the X0 shift for all particles in hierarchy
+                PfoList downstreamPfoList;
+                LArPfoHelper::GetAllDownstreamPfos(pPfoToShift, downstreamPfoList);
+
+                for (const ParticleFlowObject *const pHierarchyPfo : downstreamPfoList)
+                    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pHierarchyPfo, metadata));
 
                 const float shiftSign(pfoToPointingVertexMap.at(pPfoToShift).GetPosition().GetX() < tpcBoundaryCenterX ? 1.f : -1.f);
                 const float signedX0(std::fabs(x0) * shiftSign);

--- a/larpandoracontent/LArHelpers/LArStitchingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArStitchingHelper.cc
@@ -286,4 +286,29 @@ bool LArStitchingHelper::SortTPCs(const pandora::LArTPC *const pLhs, const pando
     return (pLhs->GetCenterZ() < pRhs->GetCenterZ());
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------ 
+
+bool LArStitchingHelper::HasPfoBeenStitched(const ParticleFlowObject *const pPfo)
+{
+    const PropertiesMap &properties(pPfo->GetPropertiesMap());
+    const PropertiesMap::const_iterator iter(properties.find("X0"));
+
+    if (iter != properties.end())
+        return true;
+
+    return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------ 
+
+float LArStitchingHelper::GetPfoX0(const ParticleFlowObject *const pPfo)
+{
+    // ATTN: If no stitch is present return a shift of 0.f
+    if (!LArStitchingHelper::HasPfoBeenStitched(pPfo))
+        return 0.f;
+
+    // ATTN: HasPfoBeenStitched ensures X0 is present in the properties map
+    return pPfo->GetPropertiesMap().at("X0");
+}
+
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArStitchingHelper.h
+++ b/larpandoracontent/LArHelpers/LArStitchingHelper.h
@@ -129,6 +129,22 @@ public:
      *  @param  pRhs address of second tpc
      */
     static bool SortTPCs(const pandora::LArTPC *const pLhs, const pandora::LArTPC *const pRhs);
+
+    /**
+     *  @brief  Whether a pfo has been stitched
+     *
+     *  @param  pPfo the address of the Pfo
+     *
+     *  @return boolean
+     */
+    static bool HasPfoBeenStitched(const pandora::ParticleFlowObject *const pPfo);
+
+    /**
+     *  @brief  Return the x0 for a pfo
+     *
+     *  @param  pPfo the address of the Pfo
+     */
+    static float GetPfoX0(const pandora::ParticleFlowObject *const pPfo);
 };
 
 } // namespace lar_content


### PR DESCRIPTION
Post cosmic ray tagging, reset calo hit positions for ambiguous pfos that have been stitched.