### PR TITLE
Define out of time slices in CR tagging using all pfos in slice.

### DIFF
--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
@@ -462,12 +462,23 @@ void CosmicRayTaggingTool::CheckIfTopToBottom(const CRCandidateList &candidates,
 void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsContainedMap,
     UIntSet &neutrinoSliceSet) const
 {
+    IntBoolMap sliceIdToIsInTimeMap;
+
+    for (const CRCandidate &candidate : candidates)
+    {
+        if (sliceIdToIsInTimeMap.find(candidate.m_sliceId) == sliceIdToIsInTimeMap.end())
+            sliceIdToIsInTimeMap.insert(std::make_pair(candidate.m_sliceId, true));
+
+        if (!pfoToInTimeMap.at(candidate.m_pPfo))
+            sliceIdToIsInTimeMap.at(candidate.m_sliceId) = false;
+    }
+
     for (const CRCandidate &candidate : candidates)
     {
         if (neutrinoSliceSet.count(candidate.m_sliceId))
             continue;
 
-        const bool likelyNeutrino(candidate.m_canFit && pfoToInTimeMap.at(candidate.m_pPfo) &&
+        const bool likelyNeutrino(candidate.m_canFit && sliceIdToIsInTimeMap.at(candidate.m_sliceId) &&
             (candidate.m_theta < m_maxNeutrinoCosTheta || pfoToIsContainedMap.at(candidate.m_pPfo)));
 
         if (likelyNeutrino)

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
@@ -156,6 +156,7 @@ private:
     void CheckIfTopToBottom(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsTopToBottomMap) const;
 
     typedef std::set<unsigned int> UIntSet;
+    typedef std::unordered_map<int, bool> IntBoolMap;
 
     /**
      *  @brief  Get the slice indices which contain a likely neutrino Pfo


### PR DESCRIPTION
A minor fix to the CR tagging that identifies whether a slice is out of time based on the information from all pfos in that slice as opposed to a single pfo in the slice.  

Tests of this branch have been done for ProtoDUNE and showed that this change resulted in a very small improvement to the cosmic ray and beam particle reconstruction metrics:

Cosmic Ray:
![CosmicRayEfficiencyVsNHits](https://user-images.githubusercontent.com/11979712/55633364-1c2dbc80-57b4-11e9-9e71-e8a190ef71e1.png)
![CosmicRayCompleteness](https://user-images.githubusercontent.com/11979712/55633360-19cb6280-57b4-11e9-8278-51f341e38158.png)
![CosmicRayPurity](https://user-images.githubusercontent.com/11979712/55633368-1df78000-57b4-11e9-8b65-5d979cf5ae5e.png)

Beam Particle: 
![BeamParticleEfficiencyVsNHits](https://user-images.githubusercontent.com/11979712/55633330-091aec80-57b4-11e9-93ec-4ac2ed8adb14.png)
![BeamParticleCompleteness](https://user-images.githubusercontent.com/11979712/55633323-03250b80-57b4-11e9-8f03-68e52c4a8dab.png)
![BeamParticlePurity](https://user-images.githubusercontent.com/11979712/55633349-12a45480-57b4-11e9-81f5-c71fc596c5c8.png)
