### PR TITLE
Feature/stitching

### DIFF
--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -557,7 +557,7 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
             continue;
         }
 
-    if ((stitchedLArTPCs.first == nullptr) || (stitchedLArTPCs.second == nullptr))
+        if ((stitchedLArTPCs.first == nullptr) || (stitchedLArTPCs.second == nullptr))
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
         float x0(0.f);

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -637,10 +637,13 @@ void StitchingCosmicRayMergingTool::SelectLongestStitch(const PfoVector &pfoVect
 
     int totalHitsStitched(0);
 
-    for (const ParticleFlowObject *const pPfoToShift1 : pfoVector)
+    for (PfoVector::const_iterator iterPfo1 = pfoVector.begin(), iterPfoEnd = pfoVector.end(); iterPfo1 != iterPfoEnd; ++iterPfo1)
     {
-        for (const ParticleFlowObject *const pPfoToShift2 : pfoVector)
+        for (PfoVector::const_iterator iterPfo2 =  iterPfo1; iterPfo2 != iterPfoEnd; ++iterPfo2)
         {
+            const ParticleFlowObject *const pPfoToShift1(*iterPfo1);
+            const ParticleFlowObject *const pPfoToShift2(*iterPfo2);
+
             if (pPfoToShift2 == pPfoToShift1)
                 continue;
 

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -536,12 +536,16 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
         PfoVector pfoVector;
         for (const ParticleFlowObject *const pPfo : pfoList) pfoVector.push_back(pPfo);
         std::sort(pfoVector.begin(), pfoVector.end(), LArPfoHelper::SortByNHits);
+		
+		//LORENA
+		PfoVector reducedPfoVector;
+		const ParticleFlowObject *const selectedPfoToEnlarge(this->ReduceToLongestStitch(pfoVector, reducedPfoVector, pPfoToEnlarge, pfoToLArTPCMap));
 
         LArTPCPair stitchedLArTPCs(nullptr, nullptr);
 
         try
         {
-            this->FindStitchedLArTPCs(pfoVector, pfoToLArTPCMap, stitchedLArTPCs);
+            this->FindStitchedLArTPCs(reducedPfoVector, pfoToLArTPCMap, stitchedLArTPCs);
         }
         catch (const pandora::StatusCodeException &statusCodeException)
         {
@@ -564,14 +568,14 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
 
             try
             {
-                this->CalculateX0(pfoToLArTPCMap, pointingClusterMap, pfoVector, x0, pfoToPointingVertexMap);
+                this->CalculateX0(pfoToLArTPCMap, pointingClusterMap, reducedPfoVector, x0, pfoToPointingVertexMap);
             }
             catch (const pandora::StatusCodeException &)
             {
                 continue;
             }
 
-            for (const ParticleFlowObject *const pPfoToShift : pfoVector)
+            for (const ParticleFlowObject *const pPfoToShift : reducedPfoVector)
             {
                 const float t0Sign(isCPAStitch ? -1.f : 1.f);
                 object_creation::ParticleFlowObject::Metadata metadata;
@@ -590,15 +594,139 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
             }
         }
 
-        for (const ParticleFlowObject *const pPfoToDelete : pfoVector)
+        for (const ParticleFlowObject *const pPfoToDelete : reducedPfoVector)
         {
-            if (pPfoToEnlarge == pPfoToDelete)
+            if (selectedPfoToEnlarge == pPfoToDelete)
                 continue;
 
-            pAlgorithm->StitchPfos(pPfoToEnlarge, pPfoToDelete, pfoToLArTPCMap);
-	    stitchedPfosToX0Map.insert(PfoToFloatMap::value_type(pPfoToEnlarge, x0));
+            pAlgorithm->StitchPfos(selectedPfoToEnlarge, pPfoToDelete, pfoToLArTPCMap);
+	    stitchedPfosToX0Map.insert(PfoToFloatMap::value_type(selectedPfoToEnlarge, x0));
         }
     }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const ParticleFlowObject *StitchingCosmicRayMergingTool::ReduceToLongestStitch(PfoVector &pfoVector, PfoVector &reducedPfoVector,
+	const ParticleFlowObject *const pPfoToEnlarge, const PfoToLArTPCMap &pfoToLArTPCMap) const
+{
+	std::cout << "StitchingCosmicRayMergingTool::ReduceToLongestStitch" << std::endl; 
+	std::cout << " pfoVector.size() = " << pfoVector.size() << std::endl;
+	if (pfoVector.size() > 2 )
+	{
+		reducedPfoVector = this->SelectLongestStitch(pfoVector, pfoToLArTPCMap);
+		std::sort(reducedPfoVector.begin(), reducedPfoVector.end(), LArPfoHelper::SortByNHits);
+		
+		return this->GetClosestPfo(pPfoToEnlarge, reducedPfoVector);
+	}
+	else
+	{
+		for (const ParticleFlowObject *const pPfoToShift : pfoVector) reducedPfoVector.push_back(pPfoToShift);
+		std::sort(reducedPfoVector.begin(), reducedPfoVector.end(), LArPfoHelper::SortByNHits);	
+		
+		return pPfoToEnlarge;
+	}
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const ParticleFlowObject *StitchingCosmicRayMergingTool::GetClosestPfo(const ParticleFlowObject *const pPfoToEnlarge, const PfoVector &pfoVector) const
+{
+	std::cout << " StitchingCosmicRayMergingTool::GetClosestPfo " << std::endl;
+	float minDistance(std::numeric_limits<float>::max());
+	for (const ParticleFlowObject *const pPfoToShift : pfoVector)
+	{
+		if (pPfoToShift == pPfoToEnlarge)
+			return pPfoToEnlarge;
+		
+		const float thisDistance(LArPfoHelper::GetTwoDSeparation(pPfoToShift, pPfoToEnlarge));
+		if (thisDistance < minDistance)
+			minDistance = thisDistance;
+	}
+	
+	//TODO - better way to avoid this loop? maybe create a map pfo,distance? 
+	for (const ParticleFlowObject *const pPfoToShift : pfoVector)
+	{
+		if ((LArPfoHelper::GetTwoDSeparation(pPfoToShift, pPfoToEnlarge) - minDistance) < std::numeric_limits<float>::epsilon())
+			return pPfoToShift;
+	}
+
+	//ATTN: should not arrive here, but if we did, return the first element in pfoVector
+	PfoVector::const_iterator iter = pfoVector.begin();
+	return *iter;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+PfoVector StitchingCosmicRayMergingTool::SelectLongestStitch(PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap) const 
+{
+	std::cout << " StitchingCosmicRayMergingTool::SelectLongestStitch " << std::endl;
+	PfoVector selectedPfos;
+	int totalHitsStitched(0);
+	
+	for (const ParticleFlowObject *const pPfoToShift1 : pfoVector)
+	{
+		for (const ParticleFlowObject *const pPfoToShift2 : pfoVector)
+		{
+			if (pPfoToShift2 == pPfoToShift1)
+				continue;
+				
+			const unsigned int twoDHitsPfo1(this->NumberOfTwoDHits(pPfoToShift1)), twoDHitsPfo2(this->NumberOfTwoDHits(pPfoToShift2)); 
+			
+			PfoToLArTPCMap::const_iterator iter1(pfoToLArTPCMap.find(pPfoToShift1));
+			PfoToLArTPCMap::const_iterator iter2(pfoToLArTPCMap.find(pPfoToShift2));
+
+			if ((iter1 != pfoToLArTPCMap.end()) && (iter2 != pfoToLArTPCMap.end()))
+			{
+				const LArTPC *const pLArTPC1(iter1->second);
+				const LArTPC *const pLArTPC2(iter2->second);
+			
+				if (((twoDHitsPfo1 + twoDHitsPfo2) > totalHitsStitched) && LArStitchingHelper::CanTPCsBeStitched(*pLArTPC1, *pLArTPC2))
+				{
+					totalHitsStitched = twoDHitsPfo1 + twoDHitsPfo2;
+				}
+			}
+		}
+	}
+	
+	// TODO - better way to save the pfos? a map pfo, total hits created in loop above? 
+	for (const ParticleFlowObject *const pPfoToShift1 : pfoVector)
+	{
+		for (const ParticleFlowObject *const pPfoToShift2 : pfoVector)
+		{
+			if (pPfoToShift2 == pPfoToShift1)
+				continue;
+				
+			const unsigned int twoDHitsPfo1(this->NumberOfTwoDHits(pPfoToShift1)), twoDHitsPfo2(this->NumberOfTwoDHits(pPfoToShift2)); 
+				
+			if ((twoDHitsPfo1 + twoDHitsPfo2) == totalHitsStitched)
+			{
+				selectedPfos.push_back(pPfoToShift1);
+				selectedPfos.push_back(pPfoToShift2);
+				return selectedPfos;
+			}
+		}
+	}	
+	
+	//ATTN we shouldnt arrive here, but if we did, just resize to 2 (pfoVector is ordered by number of hits anyway) 
+	pfoVector.resize(2);
+	return pfoVector; 
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//This could be replaced by LArPfoHelper Get2DClusters and then LArClusterHelper GetOrderedCaloHitList, or this below could be moved to LArPfoHelper
+unsigned int StitchingCosmicRayMergingTool::NumberOfTwoDHits(const ParticleFlowObject *pfo) const 
+{
+	std::cout << "NumberOfTwoDHits " << std::endl;
+	unsigned int totalHits(0);
+	for (ClusterList::const_iterator iter = pfo->GetClusterList().begin(), iterEnd = pfo->GetClusterList().end(); iter != iterEnd; ++iter)
+		{
+			const Cluster *const pCluster = *iter;
+
+			if (TPC_3D != LArClusterHelper::GetClusterHitType(pCluster))
+				totalHits += pCluster->GetNCaloHits();
+		}
+	return totalHits;	
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -536,10 +536,9 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
         PfoVector pfoVector;
         for (const ParticleFlowObject *const pPfo : pfoList) pfoVector.push_back(pPfo);
         std::sort(pfoVector.begin(), pfoVector.end(), LArPfoHelper::SortByNHits);
-		
-		//LORENA
-		PfoVector reducedPfoVector;
-		const ParticleFlowObject *const selectedPfoToEnlarge(this->ReduceToLongestStitch(pfoVector, reducedPfoVector, pPfoToEnlarge, pfoToLArTPCMap));
+
+        PfoVector reducedPfoVector;
+        const ParticleFlowObject *const selectedPfoToEnlarge(this->ReduceToLongestStitch(pfoVector, reducedPfoVector, pPfoToEnlarge, pfoToLArTPCMap));
 
         LArTPCPair stitchedLArTPCs(nullptr, nullptr);
 
@@ -600,7 +599,7 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
                 continue;
 
             pAlgorithm->StitchPfos(selectedPfoToEnlarge, pPfoToDelete, pfoToLArTPCMap);
-	    stitchedPfosToX0Map.insert(PfoToFloatMap::value_type(selectedPfoToEnlarge, x0));
+            stitchedPfosToX0Map.insert(PfoToFloatMap::value_type(selectedPfoToEnlarge, x0));
         }
     }
 }
@@ -608,125 +607,120 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 const ParticleFlowObject *StitchingCosmicRayMergingTool::ReduceToLongestStitch(PfoVector &pfoVector, PfoVector &reducedPfoVector,
-	const ParticleFlowObject *const pPfoToEnlarge, const PfoToLArTPCMap &pfoToLArTPCMap) const
+    const ParticleFlowObject *const pPfoToEnlarge, const PfoToLArTPCMap &pfoToLArTPCMap) const
 {
-	std::cout << "StitchingCosmicRayMergingTool::ReduceToLongestStitch" << std::endl; 
-	std::cout << " pfoVector.size() = " << pfoVector.size() << std::endl;
-	if (pfoVector.size() > 2 )
-	{
-		reducedPfoVector = this->SelectLongestStitch(pfoVector, pfoToLArTPCMap);
-		std::sort(reducedPfoVector.begin(), reducedPfoVector.end(), LArPfoHelper::SortByNHits);
-		
-		return this->GetClosestPfo(pPfoToEnlarge, reducedPfoVector);
-	}
-	else
-	{
-		for (const ParticleFlowObject *const pPfoToShift : pfoVector) reducedPfoVector.push_back(pPfoToShift);
-		std::sort(reducedPfoVector.begin(), reducedPfoVector.end(), LArPfoHelper::SortByNHits);	
-		
-		return pPfoToEnlarge;
-	}
+    if (pfoVector.size() > 2 )
+    {
+        reducedPfoVector = this->SelectLongestStitch(pfoVector, pfoToLArTPCMap);
+        std::sort(reducedPfoVector.begin(), reducedPfoVector.end(), LArPfoHelper::SortByNHits);
+
+        return this->GetClosestPfo(pPfoToEnlarge, reducedPfoVector);
+    }
+    else
+    {
+        for (const ParticleFlowObject *const pPfoToShift : pfoVector) reducedPfoVector.push_back(pPfoToShift);
+        std::sort(reducedPfoVector.begin(), reducedPfoVector.end(), LArPfoHelper::SortByNHits);
+
+        return pPfoToEnlarge;
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 const ParticleFlowObject *StitchingCosmicRayMergingTool::GetClosestPfo(const ParticleFlowObject *const pPfoToEnlarge, const PfoVector &pfoVector) const
 {
-	std::cout << " StitchingCosmicRayMergingTool::GetClosestPfo " << std::endl;
-	float minDistance(std::numeric_limits<float>::max());
-	for (const ParticleFlowObject *const pPfoToShift : pfoVector)
-	{
-		if (pPfoToShift == pPfoToEnlarge)
-			return pPfoToEnlarge;
-		
-		const float thisDistance(LArPfoHelper::GetTwoDSeparation(pPfoToShift, pPfoToEnlarge));
-		if (thisDistance < minDistance)
-			minDistance = thisDistance;
-	}
-	
-	//TODO - better way to avoid this loop? maybe create a map pfo,distance? 
-	for (const ParticleFlowObject *const pPfoToShift : pfoVector)
-	{
-		if ((LArPfoHelper::GetTwoDSeparation(pPfoToShift, pPfoToEnlarge) - minDistance) < std::numeric_limits<float>::epsilon())
-			return pPfoToShift;
-	}
+    float minDistance(std::numeric_limits<float>::max());
+    for (const ParticleFlowObject *const pPfoToShift : pfoVector)
+    {
+        if (pPfoToShift == pPfoToEnlarge)
+            return pPfoToEnlarge;
 
-	//ATTN: should not arrive here, but if we did, return the first element in pfoVector
-	PfoVector::const_iterator iter = pfoVector.begin();
-	return *iter;
+        const float thisDistance(LArPfoHelper::GetTwoDSeparation(pPfoToShift, pPfoToEnlarge));
+        if (thisDistance < minDistance)
+            minDistance = thisDistance;
+    }
+
+    //TODO - better way to avoid this loop? maybe create a map pfo,distance?
+    for (const ParticleFlowObject *const pPfoToShift : pfoVector)
+    {
+        if ((LArPfoHelper::GetTwoDSeparation(pPfoToShift, pPfoToEnlarge) - minDistance) < std::numeric_limits<float>::epsilon())
+            return pPfoToShift;
+    }
+
+    //ATTN: should not arrive here, but if we did, return the first element in pfoVector
+    PfoVector::const_iterator iter = pfoVector.begin();
+    return *iter;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-PfoVector StitchingCosmicRayMergingTool::SelectLongestStitch(PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap) const 
+PfoVector StitchingCosmicRayMergingTool::SelectLongestStitch(PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap) const
 {
-	std::cout << " StitchingCosmicRayMergingTool::SelectLongestStitch " << std::endl;
-	PfoVector selectedPfos;
-	int totalHitsStitched(0);
-	
-	for (const ParticleFlowObject *const pPfoToShift1 : pfoVector)
-	{
-		for (const ParticleFlowObject *const pPfoToShift2 : pfoVector)
-		{
-			if (pPfoToShift2 == pPfoToShift1)
-				continue;
-				
-			const unsigned int twoDHitsPfo1(this->NumberOfTwoDHits(pPfoToShift1)), twoDHitsPfo2(this->NumberOfTwoDHits(pPfoToShift2)); 
-			
-			PfoToLArTPCMap::const_iterator iter1(pfoToLArTPCMap.find(pPfoToShift1));
-			PfoToLArTPCMap::const_iterator iter2(pfoToLArTPCMap.find(pPfoToShift2));
+    PfoVector selectedPfos;
+    int totalHitsStitched(0);
 
-			if ((iter1 != pfoToLArTPCMap.end()) && (iter2 != pfoToLArTPCMap.end()))
-			{
-				const LArTPC *const pLArTPC1(iter1->second);
-				const LArTPC *const pLArTPC2(iter2->second);
-			
-				if (((twoDHitsPfo1 + twoDHitsPfo2) > totalHitsStitched) && LArStitchingHelper::CanTPCsBeStitched(*pLArTPC1, *pLArTPC2))
-				{
-					totalHitsStitched = twoDHitsPfo1 + twoDHitsPfo2;
-				}
-			}
-		}
-	}
-	
-	// TODO - better way to save the pfos? a map pfo, total hits created in loop above? 
-	for (const ParticleFlowObject *const pPfoToShift1 : pfoVector)
-	{
-		for (const ParticleFlowObject *const pPfoToShift2 : pfoVector)
-		{
-			if (pPfoToShift2 == pPfoToShift1)
-				continue;
-				
-			const unsigned int twoDHitsPfo1(this->NumberOfTwoDHits(pPfoToShift1)), twoDHitsPfo2(this->NumberOfTwoDHits(pPfoToShift2)); 
-				
-			if ((twoDHitsPfo1 + twoDHitsPfo2) == totalHitsStitched)
-			{
-				selectedPfos.push_back(pPfoToShift1);
-				selectedPfos.push_back(pPfoToShift2);
-				return selectedPfos;
-			}
-		}
-	}	
-	
-	//ATTN we shouldnt arrive here, but if we did, just resize to 2 (pfoVector is ordered by number of hits anyway) 
-	pfoVector.resize(2);
-	return pfoVector; 
+    for (const ParticleFlowObject *const pPfoToShift1 : pfoVector)
+    {
+        for (const ParticleFlowObject *const pPfoToShift2 : pfoVector)
+        {
+            if (pPfoToShift2 == pPfoToShift1)
+                continue;
+
+            const unsigned int twoDHitsPfo1(this->NumberOfTwoDHits(pPfoToShift1)), twoDHitsPfo2(this->NumberOfTwoDHits(pPfoToShift2));
+
+            PfoToLArTPCMap::const_iterator iter1(pfoToLArTPCMap.find(pPfoToShift1));
+            PfoToLArTPCMap::const_iterator iter2(pfoToLArTPCMap.find(pPfoToShift2));
+
+            if ((iter1 != pfoToLArTPCMap.end()) && (iter2 != pfoToLArTPCMap.end()))
+            {
+                const LArTPC *const pLArTPC1(iter1->second);
+                const LArTPC *const pLArTPC2(iter2->second);
+
+                if (((twoDHitsPfo1 + twoDHitsPfo2) > totalHitsStitched) && LArStitchingHelper::CanTPCsBeStitched(*pLArTPC1, *pLArTPC2))
+                {
+                    totalHitsStitched = twoDHitsPfo1 + twoDHitsPfo2;
+                }
+            }
+        }
+    }
+
+    // TODO - better way to save the pfos? a map pfo, total hits created in loop above?
+    for (const ParticleFlowObject *const pPfoToShift1 : pfoVector)
+    {
+        for (const ParticleFlowObject *const pPfoToShift2 : pfoVector)
+        {
+            if (pPfoToShift2 == pPfoToShift1)
+                continue;
+
+            const unsigned int twoDHitsPfo1(this->NumberOfTwoDHits(pPfoToShift1)), twoDHitsPfo2(this->NumberOfTwoDHits(pPfoToShift2));
+
+            if ((twoDHitsPfo1 + twoDHitsPfo2) == totalHitsStitched)
+            {
+                selectedPfos.push_back(pPfoToShift1);
+                selectedPfos.push_back(pPfoToShift2);
+                return selectedPfos;
+            }
+        }
+    }
+
+    //ATTN we shouldnt arrive here, but if we did, just resize to 2 (pfoVector is ordered by number of hits anyway)
+    pfoVector.resize(2);
+    return pfoVector;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //This could be replaced by LArPfoHelper Get2DClusters and then LArClusterHelper GetOrderedCaloHitList, or this below could be moved to LArPfoHelper
-unsigned int StitchingCosmicRayMergingTool::NumberOfTwoDHits(const ParticleFlowObject *pfo) const 
+unsigned int StitchingCosmicRayMergingTool::NumberOfTwoDHits(const ParticleFlowObject *pfo) const
 {
-	std::cout << "NumberOfTwoDHits " << std::endl;
-	unsigned int totalHits(0);
-	for (ClusterList::const_iterator iter = pfo->GetClusterList().begin(), iterEnd = pfo->GetClusterList().end(); iter != iterEnd; ++iter)
-		{
-			const Cluster *const pCluster = *iter;
+    unsigned int totalHits(0);
+    for (ClusterList::const_iterator iter = pfo->GetClusterList().begin(), iterEnd = pfo->GetClusterList().end(); iter != iterEnd; ++iter)
+    {
+        const Cluster *const pCluster = *iter;
 
-			if (TPC_3D != LArClusterHelper::GetClusterHitType(pCluster))
-				totalHits += pCluster->GetNCaloHits();
-		}
-	return totalHits;	
+        if (TPC_3D != LArClusterHelper::GetClusterHitType(pCluster))
+        totalHits += pCluster->GetNCaloHits();
+    }
+    return totalHits;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -209,14 +209,27 @@ private:
      *
      * @return particleflow object to enlarge
      */
-    const pandora::ParticleFlowObject *ReduceToLongestStitch(pandora::PfoVector &pfoVector, pandora::PfoVector &reducedPfoVector,
-        const pandora::ParticleFlowObject *const pPfoToEnlarge, const PfoToLArTPCMap &pfoToLArTPCMap) const;
+    const pandora::ParticleFlowObject *ReduceToLongestStitch(const pandora::PfoVector &pfoVector, const pandora::ParticleFlowObject *const pPfoToEnlarge,
+        const PfoToLArTPCMap &pfoToLArTPCMap, pandora::PfoVector &reducedPfoVector) const;
 
-    // TODO - need doxygen info
-    pandora::PfoVector SelectLongestStitch(pandora::PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap) const;
-    const pandora::ParticleFlowObject *GetClosestPfo(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::PfoVector &pfoVector) const;
+    /**
+     * @brief Select the longest stitch if the pfoVector of pfos to stitch provided is larger than 2
+	 *
+     * @param pfoVector vector of pfos being stitched
+     * @param pfoToLArTPCMap the pfo to lar tpc map
+     * @param reducedPfoVector the pfo vector we returned with size just 2 if pfo vector was larger
+     */
+    void SelectLongestStitch(const pandora::PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap, pandora::PfoVector &reducedPfoVector) const;
 
-    unsigned int NumberOfTwoDHits(const pandora::ParticleFlowObject *pfo) const;
+	/**
+	 * @brief Get the closest pfo to pfoToEnlarge from pfoVector
+	 *
+	 * @param pPfoToEnlarge pfo we search for the closest one to
+	 * @param pfoVector vector of pfos in which to find the closest to pPfoToEnlarge
+	 *
+	 * @return the pfo closest to pPfoToEnlarge from those contained in pfoVector
+	 */
+	const pandora::ParticleFlowObject *GetClosestPfo(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::PfoVector &pfoVector) const;
 
     /**
      *  @brief  Find the pair of LArTPCs that contain the pfos being stitched

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -198,26 +198,25 @@ private:
      */
     void StitchPfos(const MasterAlgorithm *const pAlgorithm, const ThreeDPointingClusterMap &pointingClusterMap,
         const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) const;
-		
-	/**
-	 * @brief Reduce the original pfoVector to one of size 2 if its greater than that
-	 *
-	 * @param pfoVector vector of pfos being stitched
-	 * @param reducedPfoVector the reduced vector of pfos
-	 * @param pPfoToEnlarge the pfo we are enlarging 
-	 * @param pfoToLArTPCMap the pfo to lar tpc map
-	 * 
-	 * @return particleflow object to enlarge
-	 */
-	const pandora::ParticleFlowObject *ReduceToLongestStitch(pandora::PfoVector &pfoVector, pandora::PfoVector &reducedPfoVector,
-		const pandora::ParticleFlowObject *const pPfoToEnlarge, const PfoToLArTPCMap &pfoToLArTPCMap) const;
-	
-	// TODO - need doxygen info
-	pandora::PfoVector SelectLongestStitch(pandora::PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap) const;
-	const pandora::ParticleFlowObject *GetClosestPfo(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::PfoVector &pfoVector) const;
 
-	unsigned int NumberOfTwoDHits(const pandora::ParticleFlowObject *pfo) const;
-	
+    /**
+     * @brief Reduce the original pfoVector to one of size 2 if its greater than that
+     *
+     * @param pfoVector vector of pfos being stitched
+     * @param reducedPfoVector the reduced vector of pfos
+     * @param pPfoToEnlarge the pfo we are enlarging
+     * @param pfoToLArTPCMap the pfo to lar tpc map
+     *
+     * @return particleflow object to enlarge
+     */
+    const pandora::ParticleFlowObject *ReduceToLongestStitch(pandora::PfoVector &pfoVector, pandora::PfoVector &reducedPfoVector,
+        const pandora::ParticleFlowObject *const pPfoToEnlarge, const PfoToLArTPCMap &pfoToLArTPCMap) const;
+
+    // TODO - need doxygen info
+    pandora::PfoVector SelectLongestStitch(pandora::PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap) const;
+    const pandora::ParticleFlowObject *GetClosestPfo(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::PfoVector &pfoVector) const;
+
+    unsigned int NumberOfTwoDHits(const pandora::ParticleFlowObject *pfo) const;
 
     /**
      *  @brief  Find the pair of LArTPCs that contain the pfos being stitched

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -198,6 +198,26 @@ private:
      */
     void StitchPfos(const MasterAlgorithm *const pAlgorithm, const ThreeDPointingClusterMap &pointingClusterMap,
         const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) const;
+		
+	/**
+	 * @brief Reduce the original pfoVector to one of size 2 if its greater than that
+	 *
+	 * @param pfoVector vector of pfos being stitched
+	 * @param reducedPfoVector the reduced vector of pfos
+	 * @param pPfoToEnlarge the pfo we are enlarging 
+	 * @param pfoToLArTPCMap the pfo to lar tpc map
+	 * 
+	 * @return particleflow object to enlarge
+	 */
+	const pandora::ParticleFlowObject *ReduceToLongestStitch(pandora::PfoVector &pfoVector, pandora::PfoVector &reducedPfoVector,
+		const pandora::ParticleFlowObject *const pPfoToEnlarge, const PfoToLArTPCMap &pfoToLArTPCMap) const;
+	
+	// TODO - need doxygen info
+	pandora::PfoVector SelectLongestStitch(pandora::PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap) const;
+	const pandora::ParticleFlowObject *GetClosestPfo(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::PfoVector &pfoVector) const;
+
+	unsigned int NumberOfTwoDHits(const pandora::ParticleFlowObject *pfo) const;
+	
 
     /**
      *  @brief  Find the pair of LArTPCs that contain the pfos being stitched

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -221,15 +221,15 @@ private:
      */
     void SelectLongestStitch(const pandora::PfoVector &pfoVector, const PfoToLArTPCMap &pfoToLArTPCMap, pandora::PfoVector &reducedPfoVector) const;
 
-	/**
-	 * @brief Get the closest pfo to pfoToEnlarge from pfoVector
-	 *
-	 * @param pPfoToEnlarge pfo we search for the closest one to
-	 * @param pfoVector vector of pfos in which to find the closest to pPfoToEnlarge
-	 *
-	 * @return the pfo closest to pPfoToEnlarge from those contained in pfoVector
-	 */
-	const pandora::ParticleFlowObject *GetClosestPfo(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::PfoVector &pfoVector) const;
+    /**
+     * @brief Get the closest pfo to pfoToEnlarge from pfoVector
+     *
+     * @param pPfoToEnlarge pfo we search for the closest one to
+     * @param pfoVector vector of pfos in which to find the closest to pPfoToEnlarge
+     *
+     * @return the pfo closest to pPfoToEnlarge from those contained in pfoVector
+     */
+    const pandora::ParticleFlowObject *GetClosestPfo(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::PfoVector &pfoVector) const;
 
     /**
      *  @brief  Find the pair of LArTPCs that contain the pfos being stitched

--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -104,7 +104,6 @@ unsigned int LArPfoHelper::GetNumberOfTwoDHits(const ParticleFlowObject *const p
         totalHits += pCluster->GetNCaloHits();
 
     return totalHits;
-
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -94,6 +94,21 @@ void LArPfoHelper::GetClusters(const ParticleFlowObject *const pPfo, const HitTy
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+unsigned int LArPfoHelper::GetNumberOfTwoDHits(const ParticleFlowObject *const pPfo)
+{
+    unsigned int totalHits(0);
+
+    ClusterList clusterList;
+    LArPfoHelper::GetTwoDClusterList(pPfo, clusterList);
+    for (const Cluster *const pCluster : clusterList)
+        totalHits += pCluster->GetNCaloHits();
+
+    return totalHits;
+
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void LArPfoHelper::GetTwoDClusterList(const ParticleFlowObject *const pPfo, ClusterList &clusterList)
 {
     for (const Cluster *const pCluster : pPfo->GetClusterList())

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -88,6 +88,14 @@ public:
     static void GetClusters(const pandora::ParticleFlowObject *const pPfo, const pandora::HitType &hitType, pandora::ClusterList &clusterList);
 
     /**
+     * @brief Get the number of 2D hits of a PFO
+     *
+     * @param pPfo the pfo to check
+     * @return int of number of 2D hits
+     */
+    static unsigned int GetNumberOfTwoDHits(const pandora::ParticleFlowObject *const pPfo);
+
+    /**
      *  @brief Get the list of 2D clusters from an input pfo
      *
      *  @param  pPfo the input Pfo


### PR DESCRIPTION
Reduce vector of potential stitches to two to keep stitching across CPA now that APA hits are availalbe. This is a short term fix, prior to extend stitches across APAs in addition. This is a work in progress PR, not yet fully validated, but wanted to open it already for people to have a look. Feedback about map vs double loop (see TODO comments) are especially welcome. It has been tested on the single muon particle gun events created by Leigh. See a couple of examples in action [here](https://www.hep.phy.cam.ac.uk/~escudero/ProtoDUNEStitchingExample1.png) and [here](https://www.hep.phy.cam.ac.uk/~escudero/ProtoDUNEStitchingExample2.png). 