### PR TITLE
RegisterCustomContent

### DIFF
--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -909,6 +909,7 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPC &larTPC, const
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, LArContent::RegisterBasicPlugins(*pPandora));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetPseudoLayerPlugin(*pPandora, new lar_content::LArPseudoLayerPlugin));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetLArTransformationPlugin(*pPandora, new lar_content::LArRotationalTransformationPlugin));
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RegisterCustomContent(pPandora));
     MultiPandoraApi::AddDaughterPandoraInstance(&(this->GetPandora()), pPandora);
 
     // The LArTPC
@@ -979,6 +980,7 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPCMap &larTPCMap,
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, LArContent::RegisterBasicPlugins(*pPandora));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetPseudoLayerPlugin(*pPandora, new lar_content::LArPseudoLayerPlugin));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetLArTransformationPlugin(*pPandora, new lar_content::LArRotationalTransformationPlugin));
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RegisterCustomContent(pPandora));
     MultiPandoraApi::AddDaughterPandoraInstance(&(this->GetPandora()), pPandora);
 
     // The Parent LArTPC
@@ -1039,6 +1041,13 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPCMap &larTPCMap,
     // Configuration
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ReadSettings(*pPandora, settingsFile));
     return pPandora;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode MasterAlgorithm::RegisterCustomContent(const Pandora *const /*pPandora*/) const
+{
+    return STATUS_CODE_SUCCESS;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -282,6 +282,13 @@ private:
     const pandora::Pandora *CreateWorkerInstance(const pandora::LArTPCMap &larTPCMap, const pandora::DetectorGapList &gapList,
         const std::string &settingsFile, const std::string &name) const;
 
+    /**
+     *  @brief  Register custom content, such as algorithms or algorithm tools, with a specified pandora instance
+     *
+     *  @param  pPandora the address of the pandora instance
+     */
+    virtual pandora::StatusCode RegisterCustomContent(const pandora::Pandora *const pPandora) const;
+
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     /**


### PR DESCRIPTION
Add ability to register custom content in algorithms deriving from the Master algorithm. Intended for use with uboone Pandora development area, but works to support any experiment-specific content area: [ubreco feature](https://cdcvs.fnal.gov/redmine/projects/ubreco/repository/show/ubreco/MicroBooNEPandora?rev=feature%2FPandoraDevelopmentArea)

In this area, there's a MicroBooNEPandora_module, which is essentially the same as StandardPandora_module, but registers a MicroBooNEMaster algorithm. The MicroBooNEMaster algorithm derives from the Master algorithm, but registers additional local MicroBooNE-specific algorithms via this RegisterCustomContent callback. These algs can then be used via experiment-specific PandoraSettings files, as usual.