### PR TITLE
MC To Pfo Matches

### DIFF
--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
@@ -240,11 +240,13 @@ void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, 
     // Make a new row for each MCParticle
     for (unsigned int mcParticleId = 0; mcParticleId < orderedMCParticleVector.size(); ++mcParticleId)
     {
-        LArMCParticleHelper::MCParticleToPfoHitSharingMap::const_iterator it = mcParticleToPfoHitSharingMap.find(orderedMCParticleVector.at(mcParticleId));
-        if (it == mcParticleToPfoHitSharingMap.end())
-            throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        const MCParticle *const pMCParticle(orderedMCParticleVector.at(mcParticleId));
+        LArMCParticleHelper::MCParticleToPfoHitSharingMap::const_iterator it = mcParticleToPfoHitSharingMap.find(pMCParticle);
+        LArMCParticleHelper::PfoToSharedHitsVector pfoToSharedHitsVector;
 
-        const MCParticle *const pMCParticle(it->first);
+        if (it != mcParticleToPfoHitSharingMap.end())
+            pfoToSharedHitsVector = it->second;
+
         const LArFormattingHelper::Color mcCol(
             LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle) ?
                 LArFormattingHelper::LIGHT_GREEN : (LArMCParticleHelper::IsBeamParticle(pMCParticle) ?
@@ -258,7 +260,7 @@ void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, 
         // Get the matched Pfos
         unsigned int nPfosShown(0);
         unsigned int nOtherHits(0);
-        for (const auto &pfoNSharedHitsPair : it->second)
+        for (const auto &pfoNSharedHitsPair : pfoToSharedHitsVector)
         {
             for (unsigned int pfoId = 0; pfoId < orderedPfoVector.size(); ++pfoId)
             {
@@ -292,7 +294,7 @@ void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, 
 
         if (nOtherHits != 0)
         {
-            table.AddElement(it->second.size() - nPfosShown);
+            table.AddElement(pfoToSharedHitsVector.size() - nPfosShown);
             table.AddElement(nOtherHits);
         }
         else

--- a/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
@@ -135,6 +135,19 @@ void EventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pM
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCHitSharingMap;
     LArMCParticleHelper::MCParticleToPfoHitSharingMap mcToPfoHitSharingMap;
     LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(validationInfo.GetPfoToHitsMap(), {validationInfo.GetAllMCParticleToHitsMap()}, pfoToMCHitSharingMap, mcToPfoHitSharingMap);
+
+    // ATTN : Ensure all mc primaries have an entry in mcToPfoHitSharingMap, even if no associated pfos.
+    MCParticleVector mcPrimaryVector;
+    LArMonitoringHelper::GetOrderedMCParticleVector({validationInfo.GetAllMCParticleToHitsMap()}, mcPrimaryVector);
+    for (const MCParticle *pMCParticle : mcPrimaryVector)
+    {
+        if (mcToPfoHitSharingMap.find(pMCParticle) == mcToPfoHitSharingMap.end())
+        {
+            LArMCParticleHelper::PfoToSharedHitsVector pfoToSharedHitsVector;
+            mcToPfoHitSharingMap.insert(LArMCParticleHelper::MCParticleToPfoHitSharingMap::value_type(pMCParticle, pfoToSharedHitsVector));
+        }
+    }
+
     validationInfo.SetMCToPfoHitSharingMap(mcToPfoHitSharingMap);
 
     LArMCParticleHelper::MCParticleToPfoHitSharingMap interpretedMCToPfoHitSharingMap;


### PR DESCRIPTION
Hi,

The aim of this PR is to ensure the mcToPfoHitSharingMap is populated for all mc primaries, even if no pfos are associated to it.  This resolves an unknown exception being thrown in downstream logic if m_printAllToScreen is true.

This change opts to add in the null entry into mcToPfoHitSharingMap early on rather than check the MCParticle is present in the map downstream because this mirrors what is done in the interpreted matching where a null entry is added if no good match can be made.  

I'm also open to other suggestions for changes instead, just let me know what you think.
Cheers
Steve 