### PR TITLE
Pandora development area

### DIFF
--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -78,7 +78,7 @@ public:
     void StitchPfos(const pandora::ParticleFlowObject *const pPfoToEnlarge, const pandora::ParticleFlowObject *const pPfoToDelete,
         PfoToLArTPCMap &pfoToLArTPCMap) const;
 
-private:
+protected:
     /**
      *  @brief  LArTPCHitList class
      */

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -3,7 +3,7 @@
 # The *parent* line must the first non-commented line and defines this product and version
 # The version should be of the form vxx_yy_zz (e.g. v01_02_03)
 # ATTN This package supports two build systems; please ensure version is specified here *and* in non-cetbuildtools section of CMakeLists.txt
-parent larpandoracontent v03_15_01
+parent larpandoracontent v03_15_02
 defaultqual e17
 
 # larpandoracontent has no fcl files


### PR DESCRIPTION
Facilitate experiment-specific development. Example use-case in feature/PandoraDevelopmentArea of [ubreco](https://cdcvs.fnal.gov/redmine/projects/ubreco/repository?utf8=%E2%9C%93&rev=feature%2FPandoraDevelopmentArea), also requiring feature/PandoraDevelopmentArea of [larpandora](https://cdcvs.fnal.gov/redmine/projects/larpandora/repository?utf8=%E2%9C%93&rev=feature%2FPandoraDevelopmentArea).

Note one of the commits picked up here, is because Redmine is a commit ahead of GitHub. If I resync, it might disappear from the diff associated with this PR.