### PR TITLE
Return Type Check

### DIFF
--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
@@ -61,7 +61,8 @@ float ShowerAsymmetryFeatureTool::GetShowerAsymmetryForView(const CartesianVecto
             showerFit.GetLocalPosition(vertexPosition2D, rL, rT);
 
             CartesianVector showerDirection(0.f, 0.f, 0.f);
-            showerFit.GetGlobalFitDirection(rL, showerDirection);
+            if (STATUS_CODE_SUCCESS != showerFit.GetGlobalFitDirection(rL, showerDirection))
+                continue;
 
             const float projectedVtxPosition = vertexPosition2D.GetDotProduct(showerDirection);
 


### PR DESCRIPTION
Check return type of GetGlobalFitDirection function in shower asymmetry feature tool in response to Coverity highlighted issue.

If the fit direction cannot be found the loop continues in search of another shower like cluster to base the calculation of the asymmetry score around.  In case of no matching clusters the default asymmetry score, 1.f, is used.  Previously, in the case of an unsuccessful fit, a null fit direction (0,0,0) was used to calculate the asymmetry score, which is not desired behaviour.

I looked into throwing an exception too, but there are no try-catch blocks higher up in the calling hierarchy that would work nicely for that approach.  Therefore, as this tool just calculates a single variable for the ML vertexing approach and it's still possible to proceed with the reconstruction even if this one variables isn't set properly, I decided to go with persisting the default value.