### PR TITLE
Feature/event validation cosmetics

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -44,7 +44,7 @@
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 #include "larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.h"
-#include "larpandoracontent/LArMonitoring/EventValidationAlgorithm.h"
+#include "larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h"
@@ -179,7 +179,7 @@
 #include "larpandoracontent/LArContent.h"
 
 #define LAR_ALGORITHM_LIST(d)                                                                                                   \
-    d("LArEventValidation",                     EventValidationAlgorithm)                                                       \
+    d("LArNeutrinoEventValidation",             NeutrinoEventValidationAlgorithm)                                               \
     d("LArTestBeamEventValidation",             TestBeamEventValidationAlgorithm)                                               \
     d("LArTestBeamHierarchyEventValidation",    TestBeamHierarchyEventValidationAlgorithm)                                      \
     d("LArPfoValidation",                       PfoValidationAlgorithm)                                                         \

--- a/larpandoracontent/LArMonitoring/EventValidationBaseAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventValidationBaseAlgorithm.h
@@ -26,7 +26,7 @@ namespace lar_content
  */
 class EventValidationBaseAlgorithm: public pandora::Algorithm
 {
-public:
+protected:
     /**
      *  @brief  Default constructor
      */

--- a/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
@@ -1,7 +1,7 @@
 /**
- *  @file   larpandoracontent/LArMonitoring/EventValidationAlgorithm.cc
+ *  @file   larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
  *
- *  @brief  Implementation of the event validation algorithm.
+ *  @brief  Implementation of the neutrino event validation algorithm.
  *
  *  $Log: $
  */
@@ -12,7 +12,7 @@
 #include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
-#include "larpandoracontent/LArMonitoring/EventValidationAlgorithm.h"
+#include "larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h"
 
 #include <sstream>
 
@@ -21,20 +21,20 @@ using namespace pandora;
 namespace lar_content
 {
 
-EventValidationAlgorithm::EventValidationAlgorithm() :
+NeutrinoEventValidationAlgorithm::NeutrinoEventValidationAlgorithm() :
     m_useTrueNeutrinosOnly(false)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-EventValidationAlgorithm::~EventValidationAlgorithm()
+NeutrinoEventValidationAlgorithm::~NeutrinoEventValidationAlgorithm()
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pMCParticleList, const CaloHitList *const pCaloHitList,
+void NeutrinoEventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pMCParticleList, const CaloHitList *const pCaloHitList,
     const PfoList *const pPfoList, ValidationInfo &validationInfo) const
 {
     if (pMCParticleList && pCaloHitList)
@@ -102,7 +102,7 @@ void EventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pM
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const
+void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const
 {
     if (printToScreen && useInterpretedMatching) std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
     else if (printToScreen) std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
@@ -431,7 +431,7 @@ void EventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInf
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode EventValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+StatusCode NeutrinoEventValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "UseTrueNeutrinosOnly", m_useTrueNeutrinosOnly));

--- a/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h
@@ -1,12 +1,12 @@
 /**
- *  @file   larpandoracontent/LArMonitoring/EventValidationAlgorithm.h
+ *  @file   larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h
  *
- *  @brief  Header file for the event validation algorithm.
+ *  @brief  Header file for the neutrino event validation algorithm.
  *
  *  $Log: $
  */
-#ifndef LAR_EVENT_VALIDATION_ALGORITHM_H
-#define LAR_EVENT_VALIDATION_ALGORITHM_H 1
+#ifndef LAR_NEUTRINO_EVENT_VALIDATION_ALGORITHM_H
+#define LAR_NEUTRINO_EVENT_VALIDATION_ALGORITHM_H 1
 
 #include "Pandora/Algorithm.h"
 
@@ -24,20 +24,20 @@ namespace lar_content
 {
 
 /**
- *  @brief  EventValidationAlgorithm class
+ *  @brief  NeutrinoEventValidationAlgorithm class
  */
-class EventValidationAlgorithm: public EventValidationBaseAlgorithm
+class NeutrinoEventValidationAlgorithm: public EventValidationBaseAlgorithm
 {
 public:
     /**
      *  @brief  Default constructor
      */
-    EventValidationAlgorithm();
+    NeutrinoEventValidationAlgorithm();
 
     /**
      *  @brief  Destructor
      */
-    ~EventValidationAlgorithm();
+    ~NeutrinoEventValidationAlgorithm();
 
 private:
     /**
@@ -72,4 +72,4 @@ private:
 
 } // namespace lar_content
 
-#endif // LAR_EVENT_VALIDATION_ALGORITHM_H
+#endif // LAR_NEUTRINO_EVENT_VALIDATION_ALGORITHM_H


### PR DESCRIPTION
Alter the name of the EventValidationAlgorithm to NeutrinoEventValidationAlgorithm and protect the constructor and destructor of the base event validation algorithm.  A PR of LArReco will be required to go alongside this to reflect the algorithm name change.