### PR TITLE
Feature/test beam vertex persistence

### DIFF
--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -477,7 +477,7 @@ const Vertex *LArPfoHelper::GetVertex(const ParticleFlowObject *const pPfo)
     // ATTN : Test beam parent pfos contain an interaction and start vertex
     if (LArPfoHelper::IsTestBeam(pPfo) && pPfo->GetParentPfoList().empty())
     {
-        pVertex = LArPfoHelper::GetVertexType(pPfo->GetVertexList(), VERTEX_START);
+        pVertex = LArPfoHelper::GetVertexWithLabel(pPfo->GetVertexList(), VERTEX_START);
     }
     else
     {
@@ -498,9 +498,9 @@ const Vertex *LArPfoHelper::GetVertex(const ParticleFlowObject *const pPfo)
 const Vertex *LArPfoHelper::GetTestBeamInteractionVertex(const ParticleFlowObject *const pPfo)
 {
     if (pPfo->GetVertexList().empty() || !pPfo->GetParentPfoList().empty() || !LArPfoHelper::IsTestBeam(pPfo))
-        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-    const Vertex *pInteractionVertex(LArPfoHelper::GetVertexType(pPfo->GetVertexList(), VERTEX_INTERACTION));
+    const Vertex *pInteractionVertex(LArPfoHelper::GetVertexWithLabel(pPfo->GetVertexList(), VERTEX_INTERACTION));
 
     if (VERTEX_3D != pInteractionVertex->GetVertexType())
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -510,7 +510,7 @@ const Vertex *LArPfoHelper::GetTestBeamInteractionVertex(const ParticleFlowObjec
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const Vertex *LArPfoHelper::GetVertexType(const VertexList &vertexList, const VertexLabel &vertexLabel)
+const Vertex *LArPfoHelper::GetVertexWithLabel(const VertexList &vertexList, const VertexLabel vertexLabel)
 {
     const Vertex *pTargetVertex(nullptr);
 

--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -472,15 +472,67 @@ const Vertex *LArPfoHelper::GetVertex(const ParticleFlowObject *const pPfo)
     if (pPfo->GetVertexList().empty())
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
-    if (pPfo->GetVertexList().size() != 1)
-        throw StatusCodeException(STATUS_CODE_FAILURE);
+    const Vertex *pVertex(nullptr);
 
-    const Vertex *const pVertex = *(pPfo->GetVertexList().begin());
+    // ATTN : Test beam parent pfos contain an interaction and start vertex
+    if (LArPfoHelper::IsTestBeam(pPfo) && pPfo->GetParentPfoList().empty())
+    {
+        pVertex = LArPfoHelper::GetVertexType(pPfo->GetVertexList(), VERTEX_START);
+    }
+    else
+    {
+        if (pPfo->GetVertexList().size() != 1)
+            throw StatusCodeException(STATUS_CODE_FAILURE);
+
+        pVertex = *(pPfo->GetVertexList().begin());
+    }
 
     if (VERTEX_3D != pVertex->GetVertexType())
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
     return pVertex;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const Vertex *LArPfoHelper::GetTestBeamInteractionVertex(const ParticleFlowObject *const pPfo)
+{
+    if (pPfo->GetVertexList().empty() || !pPfo->GetParentPfoList().empty() || !LArPfoHelper::IsTestBeam(pPfo))
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+    const Vertex *pInteractionVertex(LArPfoHelper::GetVertexType(pPfo->GetVertexList(), VERTEX_INTERACTION));
+
+    if (VERTEX_3D != pInteractionVertex->GetVertexType())
+        throw StatusCodeException(STATUS_CODE_FAILURE);
+
+    return pInteractionVertex;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const Vertex *LArPfoHelper::GetVertexType(const VertexList &vertexList, const VertexLabel &vertexLabel)
+{
+    const Vertex *pTargetVertex(nullptr);
+
+    for (const Vertex *pCandidateVertex : vertexList)
+    {
+        if (pCandidateVertex->GetVertexLabel() == vertexLabel)
+        {
+            if (!pTargetVertex)
+            {
+                pTargetVertex = pCandidateVertex;
+            }
+            else
+            {
+                throw StatusCodeException(STATUS_CODE_FAILURE);
+            }
+        }
+    }
+
+    if (!pTargetVertex)
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+    return pTargetVertex;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -312,6 +312,25 @@ public:
     static const pandora::Vertex *GetVertex(const pandora::ParticleFlowObject *const pPfo);
 
     /**
+     *  @brief  Get the pfo test beam interaction vertex
+     *
+     *  @param  pPfo the address of the Pfo
+     *
+     *  @return address of pfo vertex
+     */
+    static const pandora::Vertex *GetTestBeamInteractionVertex(const pandora::ParticleFlowObject *const pPfo);
+
+    /**
+     *  @brief  Get the vertex with a specific vertex label in a given vertex list
+     *
+     *  @param  vertexList vertex list
+     *  @param  vertexLabel target vertex label type
+     *
+     *  @return address of the desired vertex
+     */
+    static const pandora::Vertex *GetVertexType(const pandora::VertexList &vertexList, const pandora::VertexLabel &vertexLabel);
+
+    /**
      *  @brief  Apply 3D sliding fit to a set of 3D points and return track trajectory
      *
      *  @param  pointVector  the input list of 3D positions

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -328,7 +328,7 @@ public:
      *
      *  @return address of the desired vertex
      */
-    static const pandora::Vertex *GetVertexType(const pandora::VertexList &vertexList, const pandora::VertexLabel &vertexLabel);
+    static const pandora::Vertex *GetVertexWithLabel(const pandora::VertexList &vertexList, const pandora::VertexLabel vertexLabel);
 
     /**
      *  @brief  Apply 3D sliding fit to a set of 3D points and return track trajectory

--- a/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.cc
@@ -211,7 +211,7 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
 #ifdef MONITORING
                 try
                 {
-                    const Vertex *const pRecoVertex(LArPfoHelper::GetVertex(pfoToSharedHits.first));
+                    const Vertex *const pRecoVertex(isRecoTestBeam ? LArPfoHelper::GetTestBeamInteractionVertex(pfoToSharedHits.first) : LArPfoHelper::GetVertex(pfoToSharedHits.first));
                     recoVertexX = pRecoVertex->GetPosition().GetX();
                     recoVertexY = pRecoVertex->GetPosition().GetY();
                     recoVertexZ = pRecoVertex->GetPosition().GetZ();

--- a/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
@@ -272,7 +272,7 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
             const CaloHitList &pfoHitList(validationInfo.GetPfoToHitsMap().at(pfoToSharedHits.first));
 
             const bool isRecoTestBeam(LArPfoHelper::IsTestBeam(pfoToSharedHits.first));
-            const bool isRecoTestBeamHierarchy(LArPfoHelper::IsTestBeam(LArPfoHelper::GetParentPfo(pfoToSharedHits.first)));
+            const bool isRecoTestBeamHierarchy(LArPfoHelper::IsTestBeamFinalState(pfoToSharedHits.first));
             const bool isGoodMatch(this->IsGoodMatch(mcPrimaryHitList, pfoHitList, sharedHitList));
 
             // Tier (0) : Primary, (1) : Daughter, (2) : Granddaughter etc...  Note that the tier only increases for visible particle
@@ -299,7 +299,7 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
 #ifdef MONITORING
                 try
                 {
-                    const Vertex *const pRecoVertex(LArPfoHelper::GetVertex(pfoToSharedHits.first));
+                    const Vertex *const pRecoVertex(isRecoTestBeamHierarchy ? LArPfoHelper::GetTestBeamInteractionVertex(LArPfoHelper::GetParentPfo(pfoToSharedHits.first)) : LArPfoHelper::GetVertex(pfoToSharedHits.first));
                     recoVertexX = pRecoVertex->GetPosition().GetX();
                     recoVertexY = pRecoVertex->GetPosition().GetY();
                     recoVertexZ = pRecoVertex->GetPosition().GetZ();

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h
@@ -18,12 +18,6 @@ namespace lar_content
  */
 class TestBeamParticleCreationAlgorithm : public pandora::Algorithm
 {
-public:
-    /**
-     *  @brief  Constructor
-     */
-    TestBeamParticleCreationAlgorithm();
-
 private:
     pandora::StatusCode Run();
 
@@ -57,9 +51,6 @@ private:
 
     std::string    m_parentVertexListName;      ///< The parent vertex list name
     std::string    m_daughterVertexListName;    ///< The daughter vertex list name
-
-    bool           m_keepInteractionVertex;     ///< Keep the vertex for the test beam particle at the interaction point
-    bool           m_keepStartVertex;           ///< Keep the vertex for the test beam particle at the position of hit at minimum z
 };
 
 } // namespace lar_content

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -3,7 +3,7 @@
 # The *parent* line must the first non-commented line and defines this product and version
 # The version should be of the form vxx_yy_zz (e.g. v01_02_03)
 # ATTN This package supports two build systems; please ensure version is specified here *and* in non-cetbuildtools section of CMakeLists.txt
-parent larpandoracontent v03_15_03
+parent larpandoracontent v03_15_04
 defaultqual e17
 
 # larpandoracontent has no fcl files


### PR DESCRIPTION
These changes set both the interaction and start vertices for the parent test beam pfo.  The alterations to the GetVertex function account for this fact and ensure default behaviour is retained for all other particles.  In the case of the parent test beam pfo, the default vertex returned by GetVertex is the start vertex as this is needed for fitting for directions downstream and this behaviour should be retained.  There is now also a GetTestBeamInteraction vertex function that returns the interaction vertex and this will be used in a modification to LArPandora to save this vertex in a separate collection.

This PR will be tested shortly and results added but the conceptual review can begin immediately.  Cheers, Steve 