### PR TITLE
Feature/AdjustVertexPosition

### DIFF
--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.cc
@@ -33,7 +33,7 @@ BranchAssociatedPfosTool::BranchAssociatedPfosTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BranchAssociatedPfosTool::Run(NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
+void BranchAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.h
@@ -24,7 +24,7 @@ public:
      */
     BranchAssociatedPfosTool();
 
-    void Run(NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
+    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.cc
@@ -35,7 +35,7 @@ EndAssociatedPfosTool::EndAssociatedPfosTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EndAssociatedPfosTool::Run(NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
+void EndAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.h
@@ -26,7 +26,7 @@ public:
      */
     EndAssociatedPfosTool();
 
-    void Run(NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
+    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
 
 private:
     /**

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.cc
@@ -236,8 +236,9 @@ void NeutrinoHierarchyAlgorithm::AdjustVertexAndPfoInfo(const ParticleFlowObject
     LArPfoHelper::GetThreeDClusterList(candidateDaughterPfoVector.front(), daughterClusterList3D);
     daughterClusterList3D.sort(LArClusterHelper::SortByNHits);
 
+    // If no 3D hits, must leave vertex where it was
     if (daughterClusterList3D.empty())
-        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        return;
 
     const Vertex *pOldNeutrinoVertex(LArPfoHelper::GetVertex(pNeutrinoPfo));
     const CartesianVector newVertexPosition(LArClusterHelper::GetClosestPosition(pOldNeutrinoVertex->GetPosition(), daughterClusterList3D.front()));

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.cc
@@ -234,6 +234,7 @@ void NeutrinoHierarchyAlgorithm::AdjustVertexAndPfoInfo(const ParticleFlowObject
 
     ClusterList daughterClusterList3D;
     LArPfoHelper::GetThreeDClusterList(candidateDaughterPfoVector.front(), daughterClusterList3D);
+    daughterClusterList3D.sort(LArClusterHelper::SortByNHits);
 
     if (daughterClusterList3D.empty())
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h
@@ -240,6 +240,8 @@ private:
     std::string                     m_neutrinoPfoListName;      ///< The neutrino pfo list name
     pandora::StringVector           m_daughterPfoListNames;     ///< The list of daughter pfo list names
 
+    std::string                     m_neutrinoVertexListName;   ///< The neutrino vertex list name - if not specified will assume current list
+
     unsigned int                    m_halfWindowLayers;         ///< The number of layers to use for half-window of sliding fit
     bool                            m_displayPfoInfoMap;        ///< Whether to display the pfo info map (if monitoring is enabled)
 };

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h
@@ -209,9 +209,10 @@ private:
      *  @param  pNeutrinoPfo the address of the (original) parent neutrino pfo
      *  @param  candidateDaughterPfoList the list of candidate daughter pfos
      *  @param  pfoInfoMap the pfo info map
+     *  @param  callDepth depth of callstack for this function, tracking recursive use
      */
     void ProcessPfoInfoMap(const pandora::ParticleFlowObject *const pNeutrinoPfo, const pandora::PfoList &candidateDaughterPfoList,
-        const PfoInfoMap &pfoInfoMap) const;
+        PfoInfoMap &pfoInfoMap, const unsigned int callDepth = 0) const;
 
     /**
      *  @brief  Display the information in a pfo info map, visualising pfo parent/daughter links
@@ -248,7 +249,7 @@ public:
      *  @param  pNeutrinoVertex the address of the three dimensional neutrino interaction vertex
      *  @param  pfoInfoMap mapping from pfos to three dimensional clusters, sliding fits, vertices, etc.
      */
-    virtual void Run(NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap) = 0;
+    virtual void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap) = 0;
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h
@@ -215,6 +215,16 @@ private:
         PfoInfoMap &pfoInfoMap, const unsigned int callDepth = 0) const;
 
     /**
+     *  @brief  Adjust neutrino vertex to ensure agreement with at least one pfo (first in sorted input list)
+     *
+     *  @param  pNeutrinoPfo the address of the (original) parent neutrino pfo
+     *  @param  candidateDaughterPfoList the list of candidate daughter pfos
+     *  @param  pfoInfoMap the pfo info map
+     */
+    void AdjustVertexAndPfoInfo(const pandora::ParticleFlowObject *const pNeutrinoPfo, const pandora::PfoList &candidateDaughterPfoList,
+        PfoInfoMap &pfoInfoMap) const;
+
+    /**
      *  @brief  Display the information in a pfo info map, visualising pfo parent/daughter links
      *
      *  @param  pNeutrinoPfo the address of the (original) parent neutrino pfo

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.cc
@@ -34,7 +34,7 @@ VertexAssociatedPfosTool::VertexAssociatedPfosTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void VertexAssociatedPfosTool::Run(NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
+void VertexAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.h
@@ -24,7 +24,7 @@ public:
      */
     VertexAssociatedPfosTool();
 
-    void Run(NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
+    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);


### PR DESCRIPTION
This feature should not be triggered often, but responds to some MicroBooNE events in each of which there was a large cosmic-ray remnant in one view of the slice. The remnants were located a significant distance from the neutrino interaction in the same slice (and, importantly at lower z), but there are sufficient connecting hits (and basically nowhere else for the cosmic remnants to go), so it's understandable that they ended up in the same slice.

The cosmic remnant, plus sufficient random hits in other views, creates vertex candidates at low z, and then one of these candidates is selected (the low z leads to a favourable beam score, and the significant remnant cluster is a major factor in driving a good candidate score).

Now we get to the key part: because the remnant only features in one view, it doesn't get make into a Pfo, but the downstream neutrino interaction does. We therefore end up with a neutrino interaction vertex displaced from the reconstructed daughter Pfos.

This PR involves the NeutrinoHierarchy algorithm. If found that there are no vertex-associated Pfos, the neutrino interaction vertex is relocated, using a simple scheme for now: the closest 3D position in the largest (most hits) daughter Pfo. This fixes all known problem events so far, but sophistication could be improved in the longer term.

E.g. VHits in slice 1, note cosmic remnant present only in one view in this slice (wire position up page; drift position across page):

![VHitsSlice1_7004_237_11854](https://user-images.githubusercontent.com/13437413/66653156-4793d700-ec2f-11e9-8490-fd860a30abb9.png)

E.g. WHits and old vertex position, with significant offset:

![WHitsAndOldVertex_7004_237_11854](https://user-images.githubusercontent.com/13437413/66653200-63977880-ec2f-11e9-9687-2e2d92a3fca7.png)

E.g. Whits and new vertex position, no issue:

![WHitsAndNewVertex_7004_237_11854](https://user-images.githubusercontent.com/13437413/66653231-727e2b00-ec2f-11e9-88a9-c27c48f980d7.png)

Obviously some soak testing will be required before this can be merged too. Expected impact at ProtoDUNE is negligible, but this should also be tested via e.g. observing unchanged vertex resolution plots.

Thanks!