### PR TITLE
Feature/unfolding mc particle hierarchy

### DIFF
--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -34,7 +34,7 @@ LArMCParticleHelper::PrimaryParameters::PrimaryParameters() :
     m_minPrimaryGoodViews(2),
     m_selectInputHits(true),
     m_maxPhotonPropagation(2.5f),
-    m_minHitSharingFraction(0.9f), 
+    m_minHitSharingFraction(0.9f),
     m_foldBackHierarchy(true)
 {
 }

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -49,10 +49,9 @@ bool LArMCParticleHelper::IsBeamNeutrinoFinalState(const MCParticle *const pMCPa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-
 bool LArMCParticleHelper::IsTriggeredBeamParticle(const MCParticle *const pMCParticle)
 {
-    const int nuance(LArMCParticleHelper::GetNuanceCode(pMCParticle)); 
+    const int nuance(LArMCParticleHelper::GetNuanceCode(pMCParticle));
     return (LArMCParticleHelper::IsPrimary(pMCParticle) && (nuance == 2001));
 }
 
@@ -356,7 +355,7 @@ void LArMCParticleHelper::GetMCToSelfMap(const MCParticleList *const pMCParticle
     for(const MCParticle *const pMCParticle : *pMCParticleList)
     {
         mcToSelfMap[pMCParticle] = pMCParticle;
-    }    
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -406,14 +405,13 @@ void LArMCParticleHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const
             const MCParticle *const pHitParticle(MCParticleHelper::GetMainMCParticle(pCaloHit));
             const MCParticle *pTargetParticle(pHitParticle);
 
-            // ATTN Do not map back to target mc if mc to primary mc map or mc to self map not provided
+            // ATTN Do not map back to target if mc to primary mc map or mc to self map not provided
             if (!mcToTargetMCMap.empty())
             {
                 MCRelationMap::const_iterator mcIter = mcToTargetMCMap.find(pHitParticle);
 
                 if (mcToTargetMCMap.end() == mcIter)
                     continue;
-		
 
                 pTargetParticle = mcIter->second;
             }
@@ -434,14 +432,13 @@ void LArMCParticleHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const
 void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
     std::function<bool(const MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap)
 {
-
-    // Obtain map [MC particle -> primary mc particle] 
+    // Obtain map: [mc particle -> primary mc particle]
     LArMCParticleHelper::MCRelationMap mcToPrimaryMCMap;
     LArMCParticleHelper::GetMCPrimaryMap(pMCParticleList, mcToPrimaryMCMap);
 
     // Remove non-reconstructable hits, e.g. those downstream of a neutron
     CaloHitList selectedCaloHitList;
-    LArMCParticleHelper::SelectCaloHits(pCaloHitList, mcToPrimaryMCMap, selectedCaloHitList, parameters.m_selectInputHits, parameters.m_maxPhotonPropagation); 
+    LArMCParticleHelper::SelectCaloHits(pCaloHitList, mcToPrimaryMCMap, selectedCaloHitList, parameters.m_selectInputHits, parameters.m_maxPhotonPropagation);
 
     // Obtain maps: [hit -> primary mc particle], [primary mc particle -> list of hits]
     CaloHitToMCMap hitToPrimaryMCMap;
@@ -455,10 +452,9 @@ void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList 
     // Select MCParticles matching criteria
     MCParticleVector candidateTargets;
     LArMCParticleHelper::SelectParticlesMatchingCriteria(mcPrimaryVector, fCriteria, candidateTargets);
-    
+
     // Ensure the MCParticles have enough "good" hits to be reconstructed
     LArMCParticleHelper::SelectParticlesByHitCount(candidateTargets, mcToTrueHitListMap, mcToPrimaryMCMap, parameters, selectedMCParticlesToHitsMap);
-
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -466,31 +462,27 @@ void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList 
 void LArMCParticleHelper::SelectUnfoldedReconstructableMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
     MCContributionMap &mcToRecoHitsMap)
 {
-
     // Obtain map: [MC particle -> self] (to prevent folding to primary MC particle)
     MCRelationMap mcToSelfMap;
-    GetMCToSelfMap(pMCParticleList, mcToSelfMap);
+    LArMCParticleHelper::GetMCToSelfMap(pMCParticleList, mcToSelfMap);
 
-    //REMOVED NEUTRON AND PHOTON CONSIDERATION
+    // ATTN REMOVED NEUTRON AND PHOTON CONSIDERATION
+    // ATTN REMOVED WHETHER PARTICLE MATCHES SOME CRITERIA (e.g whether downstream of neutrino) - not needed for created neutrino events
 
     // Obtain maps: [hits -> MC particle], [MC particle -> list of hits]
     CaloHitToMCMap trueHitToTargetMCMap;
     MCContributionMap targetMCToTrueHitListMap;
-    GetMCParticleToCaloHitMatches(pCaloHitList, mcToSelfMap, trueHitToTargetMCMap, targetMCToTrueHitListMap);
+    LArMCParticleHelper::GetMCParticleToCaloHitMatches(pCaloHitList, mcToSelfMap, trueHitToTargetMCMap, targetMCToTrueHitListMap);
 
     // Obtain vector of all mc particles as SelectParticlesByHitCount method takes a vector, not a list, as argument
     MCParticleVector targetMCVector;
     std::copy(pMCParticleList->begin(), pMCParticleList->end(), std::back_inserter(targetMCVector));
-  
-    //REMOVED WHETHER PARTICLE MATCHES SOME CRITERIA (e.g whether downstream of neutrino) - not needed for created neutrino events
 
     // Remove hits that do not meet minimum hit count and share criteria
-    SelectParticlesByHitCount(targetMCVector, targetMCToTrueHitListMap, mcToSelfMap, parameters, mcToRecoHitsMap);
-
+    LArMCParticleHelper::SelectParticlesByHitCount(targetMCVector, targetMCToTrueHitListMap, mcToSelfMap, parameters, mcToRecoHitsMap);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
-
 
 void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
     std::function<bool(const MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap)
@@ -530,7 +522,6 @@ void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(cons
         {
             CaloHitList caloHitList;
             selectedMCParticlesToHitsMap.insert(MCContributionMap::value_type(pParentMCParticle, caloHitList));
-
         }
     }
 }
@@ -540,7 +531,7 @@ void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(cons
 void LArMCParticleHelper::GetUnfoldedPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
     PfoContributionMap &pfoToReconstructable2DHitsMap)
 {
-    for(const ParticleFlowObject *const pPfo : pfoList) 
+    for (const ParticleFlowObject *const pPfo : pfoList)
     {
         CaloHitList pfoHitList;
         LArMCParticleHelper::CollectReconstructable2DHits(PfoList{pPfo}, {selectedMCParticleToHitsMap}, pfoHitList);
@@ -705,7 +696,7 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const PfoList &pfoList, c
     {
         bool isTargetHit(false);
         for (const MCContributionMap &mcParticleToHitsMap : selectedMCParticleToHitsMaps)
-        { 
+        {
             // ATTN This map is unordered, but this does not impact search for specific target hit
             for (const MCContributionMap::value_type &mapEntry : mcParticleToHitsMap)
             {
@@ -744,7 +735,6 @@ void LArMCParticleHelper::SelectCaloHits(const CaloHitList *const pCaloHitList, 
 
             if (mcToPrimaryMCMap.end() == mcIter)
                 continue;
-	    
 
             const MCParticle *const pPrimaryParticle = mcIter->second;
 
@@ -754,45 +744,6 @@ void LArMCParticleHelper::SelectCaloHits(const CaloHitList *const pCaloHitList, 
         catch (const StatusCodeException &)
         {
         }
-    }
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-  void LArMCParticleHelper::GetMCToPfoCompletenessPurityMaps(const MCContributionMap& mcParticleToHitsMap, const PfoContributionMap& pfoToHitsMap, const MCParticleToPfoHitSharingMap& mcParticleToPfoHitSharingMap, MCParticleToPfoCompletenessPurityMap& mcParticleToPfoCompletenessMap, MCParticleToPfoCompletenessPurityMap& mcParticleToPfoPurityMap) 
-{
-
-    for(const MCParticleToPfoHitSharingMap::value_type &entry : mcParticleToPfoHitSharingMap)
-    {
-        const PfoToSharedHitsVector pfoToSharedHitsVector(entry.second);
-
-        PfoToCompletenessPurityVector pfoToCompletenessVector;
-        PfoToCompletenessPurityVector pfoToPurityVector;
-
-        if(mcParticleToHitsMap.find(entry.first) == mcParticleToHitsMap.end()) 
-            continue;
-
-        const unsigned int totMCParticleHits(mcParticleToHitsMap.at(entry.first).size());
-
-        for(const PfoCaloHitListPair &pfoSharedHits : pfoToSharedHitsVector) 
-        {
-
-            if(pfoToHitsMap.find(pfoSharedHits.first) == pfoToHitsMap.end()) 
-                continue;
-
-	    const unsigned int sharedHits(pfoSharedHits.second.size());
-	    const unsigned int totPfoHits(pfoToHitsMap.at(pfoSharedHits.first).size()); 
-
-	    const double completeness(static_cast<double>(sharedHits)/static_cast<double>(totMCParticleHits));
-	    const double purity(static_cast<double>(sharedHits)/static_cast<double>(totPfoHits));
-
-	    pfoToCompletenessVector.push_back({pfoSharedHits.first, completeness});
-	    pfoToPurityVector.push_back({pfoSharedHits.first, purity});
-	}
-
-        mcParticleToPfoCompletenessMap[entry.first] = pfoToCompletenessVector;
-        mcParticleToPfoPurityMap[entry.first] = pfoToPurityVector;
-
     }
 }
 
@@ -867,7 +818,7 @@ void LArMCParticleHelper::SelectParticlesMatchingCriteria(const MCParticleVector
 void LArMCParticleHelper::SelectParticlesByHitCount(const MCParticleVector &candidateTargets, const MCContributionMap &mcToTrueHitListMap,
     const MCRelationMap &mcToTargetMCMap, const PrimaryParameters &parameters, MCContributionMap &selectedMCParticlesToHitsMap)
 {
-    // Apply restrictions on the number of good hits associated with the MC Particles
+    // Apply restrictions on the number of good hits associated with the MCParticles
     for (const MCParticle * const pMCTarget : candidateTargets)
     {
         MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCTarget);
@@ -906,13 +857,13 @@ void LArMCParticleHelper::SelectParticlesByHitCount(const MCParticleVector &cand
 bool LArMCParticleHelper::PassMCParticleChecks(const MCParticle *const pOriginalPrimary, const MCParticle *const pThisMCParticle,
     const MCParticle *const pHitMCParticle, const float maxPhotonPropagation)
 {
-  if (NEUTRON == std::abs(pThisMCParticle->GetParticleId()))
-    return false;
+    if (NEUTRON == std::abs(pThisMCParticle->GetParticleId()))
+        return false;
 
-  if ((PHOTON == pThisMCParticle->GetParticleId()) && (PHOTON != GetPrimaryMCParticle(pThisMCParticle)->GetParticleId()) && (E_MINUS != std::abs(GetPrimaryMCParticle(pThisMCParticle)->GetParticleId())))
+    if ((PHOTON == pThisMCParticle->GetParticleId()) && (PHOTON != GetPrimaryMCParticle(pThisMCParticle)->GetParticleId()) && (E_MINUS != std::abs(GetPrimaryMCParticle(pThisMCParticle)->GetParticleId())))
     {
-      if ((pThisMCParticle->GetEndpoint() - pThisMCParticle->GetVertex()).GetMagnitude() > maxPhotonPropagation)
-	return false;
+        if ((pThisMCParticle->GetEndpoint() - pThisMCParticle->GetVertex()).GetMagnitude() > maxPhotonPropagation)
+            return false;
     }
 
     if (pThisMCParticle == pHitMCParticle)

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -49,6 +49,7 @@ bool LArMCParticleHelper::IsBeamNeutrinoFinalState(const MCParticle *const pMCPa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+
 bool LArMCParticleHelper::IsTriggeredBeamParticle(const MCParticle *const pMCParticle)
 {
     const int nuance(LArMCParticleHelper::GetNuanceCode(pMCParticle)); 
@@ -350,6 +351,16 @@ void LArMCParticleHelper::GetMCLeadingMap(const MCParticleList *const pMCParticl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void LArMCParticleHelper::GetMCToSelfMap(const MCParticleList *const pMCParticleList, MCRelationMap &mcToSelfMap)
+{
+    for(const MCParticle *const pMCParticle : *pMCParticleList)
+    {
+        mcToSelfMap[pMCParticle] = pMCParticle;
+    }    
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 const MCParticle *LArMCParticleHelper::GetMainMCParticle(const ParticleFlowObject *const pPfo)
 {
     ClusterList clusterList;
@@ -385,7 +396,7 @@ bool LArMCParticleHelper::SortByMomentum(const MCParticle *const pLhs, const MCP
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
+void LArMCParticleHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const pCaloHitList, const MCRelationMap &mcToTargetMCMap,
     CaloHitToMCMap &hitToMCMap, MCContributionMap &mcToTrueHitListMap)
 {
     for (const CaloHit *const pCaloHit : *pCaloHitList)
@@ -393,21 +404,22 @@ void LArMCParticleHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const
         try
         {
             const MCParticle *const pHitParticle(MCParticleHelper::GetMainMCParticle(pCaloHit));
-            const MCParticle *pPrimaryParticle(pHitParticle);
+            const MCParticle *pTargetParticle(pHitParticle);
 
-            // ATTN Do not map back to mc primaries if mc to primary mc map not provided
-            if (!mcToPrimaryMCMap.empty())
+            // ATTN Do not map back to target mc if mc to primary mc map or mc to self map not provided
+            if (!mcToTargetMCMap.empty())
             {
-                MCRelationMap::const_iterator mcIter = mcToPrimaryMCMap.find(pHitParticle);
+                MCRelationMap::const_iterator mcIter = mcToTargetMCMap.find(pHitParticle);
 
-                if (mcToPrimaryMCMap.end() == mcIter)
+                if (mcToTargetMCMap.end() == mcIter)
                     continue;
+		
 
-                pPrimaryParticle = mcIter->second;
+                pTargetParticle = mcIter->second;
             }
 
-            mcToTrueHitListMap[pPrimaryParticle].push_back(pCaloHit);
-            hitToMCMap[pCaloHit] = pPrimaryParticle;
+            mcToTrueHitListMap[pTargetParticle].push_back(pCaloHit);
+            hitToMCMap[pCaloHit] = pTargetParticle;
         }
         catch (StatusCodeException &statusCodeException)
         {
@@ -422,13 +434,14 @@ void LArMCParticleHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const
 void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
     std::function<bool(const MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap)
 {
-    // Obtain map: [mc particle -> primary mc particle]
+
+    // Obtain map [MC particle -> primary mc particle] 
     LArMCParticleHelper::MCRelationMap mcToPrimaryMCMap;
     LArMCParticleHelper::GetMCPrimaryMap(pMCParticleList, mcToPrimaryMCMap);
 
     // Remove non-reconstructable hits, e.g. those downstream of a neutron
     CaloHitList selectedCaloHitList;
-    LArMCParticleHelper::SelectCaloHits(pCaloHitList, mcToPrimaryMCMap, selectedCaloHitList, parameters.m_selectInputHits, parameters.m_maxPhotonPropagation);
+    LArMCParticleHelper::SelectCaloHits(pCaloHitList, mcToPrimaryMCMap, selectedCaloHitList, parameters.m_selectInputHits, parameters.m_maxPhotonPropagation); 
 
     // Obtain maps: [hit -> primary mc particle], [primary mc particle -> list of hits]
     CaloHitToMCMap hitToPrimaryMCMap;
@@ -442,12 +455,42 @@ void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList 
     // Select MCParticles matching criteria
     MCParticleVector candidateTargets;
     LArMCParticleHelper::SelectParticlesMatchingCriteria(mcPrimaryVector, fCriteria, candidateTargets);
-
+    
     // Ensure the MCParticles have enough "good" hits to be reconstructed
     LArMCParticleHelper::SelectParticlesByHitCount(candidateTargets, mcToTrueHitListMap, mcToPrimaryMCMap, parameters, selectedMCParticlesToHitsMap);
+
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArMCParticleHelper::SelectUnfoldedReconstructableMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
+    MCContributionMap &mcToRecoHitsMap)
+{
+
+    // Obtain map: [MC particle -> self] (to prevent folding to primary MC particle)
+    MCRelationMap mcToSelfMap;
+    GetMCToSelfMap(pMCParticleList, mcToSelfMap);
+
+    //REMOVED NEUTRON AND PHOTON CONSIDERATION
+
+    // Obtain maps: [hits -> MC particle], [MC particle -> list of hits]
+    CaloHitToMCMap trueHitToTargetMCMap;
+    MCContributionMap targetMCToTrueHitListMap;
+    GetMCParticleToCaloHitMatches(pCaloHitList, mcToSelfMap, trueHitToTargetMCMap, targetMCToTrueHitListMap);
+
+    // Obtain vector of all mc particles as SelectParticlesByHitCount method takes a vector, not a list, as argument
+    MCParticleVector targetMCVector;
+    std::copy(pMCParticleList->begin(), pMCParticleList->end(), std::back_inserter(targetMCVector));
+  
+    //REMOVED WHETHER PARTICLE MATCHES SOME CRITERIA (e.g whether downstream of neutrino) - not needed for created neutrino events
+
+    // Remove hits that do not meet minimum hit count and share criteria
+    SelectParticlesByHitCount(targetMCVector, targetMCToTrueHitListMap, mcToSelfMap, parameters, mcToRecoHitsMap);
+
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 
 void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
     std::function<bool(const MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap)
@@ -487,7 +530,23 @@ void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(cons
         {
             CaloHitList caloHitList;
             selectedMCParticlesToHitsMap.insert(MCContributionMap::value_type(pParentMCParticle, caloHitList));
+
         }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArMCParticleHelper::GetUnfoldedPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
+    PfoContributionMap &pfoToReconstructable2DHitsMap)
+{
+    for(const ParticleFlowObject *const pPfo : pfoList) 
+    {
+        CaloHitList pfoHitList;
+        LArMCParticleHelper::CollectReconstructable2DHits(PfoList{pPfo}, {selectedMCParticleToHitsMap}, pfoHitList);
+
+        if (!pfoToReconstructable2DHitsMap.insert(PfoContributionMap::value_type(pPfo, pfoHitList)).second)
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
     }
 }
 
@@ -646,7 +705,7 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const PfoList &pfoList, c
     {
         bool isTargetHit(false);
         for (const MCContributionMap &mcParticleToHitsMap : selectedMCParticleToHitsMaps)
-        {
+        { 
             // ATTN This map is unordered, but this does not impact search for specific target hit
             for (const MCContributionMap::value_type &mapEntry : mcParticleToHitsMap)
             {
@@ -685,6 +744,7 @@ void LArMCParticleHelper::SelectCaloHits(const CaloHitList *const pCaloHitList, 
 
             if (mcToPrimaryMCMap.end() == mcIter)
                 continue;
+	    
 
             const MCParticle *const pPrimaryParticle = mcIter->second;
 
@@ -699,7 +759,46 @@ void LArMCParticleHelper::SelectCaloHits(const CaloHitList *const pCaloHitList, 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::SelectGoodCaloHits(const CaloHitList *const pSelectedCaloHitList, const LArMCParticleHelper::MCRelationMap &mcToPrimaryMCMap,
+  void LArMCParticleHelper::GetMCToPfoCompletenessPurityMaps(const MCContributionMap& mcParticleToHitsMap, const PfoContributionMap& pfoToHitsMap, const MCParticleToPfoHitSharingMap& mcParticleToPfoHitSharingMap, MCParticleToPfoCompletenessPurityMap& mcParticleToPfoCompletenessMap, MCParticleToPfoCompletenessPurityMap& mcParticleToPfoPurityMap) 
+{
+
+    for(const MCParticleToPfoHitSharingMap::value_type &entry : mcParticleToPfoHitSharingMap)
+    {
+        const PfoToSharedHitsVector pfoToSharedHitsVector(entry.second);
+
+        PfoToCompletenessPurityVector pfoToCompletenessVector;
+        PfoToCompletenessPurityVector pfoToPurityVector;
+
+        if(mcParticleToHitsMap.find(entry.first) == mcParticleToHitsMap.end()) 
+            continue;
+
+        const unsigned int totMCParticleHits(mcParticleToHitsMap.at(entry.first).size());
+
+        for(const PfoCaloHitListPair &pfoSharedHits : pfoToSharedHitsVector) 
+        {
+
+            if(pfoToHitsMap.find(pfoSharedHits.first) == pfoToHitsMap.end()) 
+                continue;
+
+	    const unsigned int sharedHits(pfoSharedHits.second.size());
+	    const unsigned int totPfoHits(pfoToHitsMap.at(pfoSharedHits.first).size()); 
+
+	    const double completeness(static_cast<double>(sharedHits)/static_cast<double>(totMCParticleHits));
+	    const double purity(static_cast<double>(sharedHits)/static_cast<double>(totPfoHits));
+
+	    pfoToCompletenessVector.push_back({pfoSharedHits.first, completeness});
+	    pfoToPurityVector.push_back({pfoSharedHits.first, purity});
+	}
+
+        mcParticleToPfoCompletenessMap[entry.first] = pfoToCompletenessVector;
+        mcParticleToPfoPurityMap[entry.first] = pfoToPurityVector;
+
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArMCParticleHelper::SelectGoodCaloHits(const CaloHitList *const pSelectedCaloHitList, const LArMCParticleHelper::MCRelationMap &mcToTargetMCMap,
     CaloHitList &selectedGoodCaloHitList, const bool selectInputHits, const float minHitSharingFraction)
 {
     if (!selectInputHits)
@@ -714,37 +813,37 @@ void LArMCParticleHelper::SelectGoodCaloHits(const CaloHitList *const pSelectedC
         for (const auto &mapEntry : pCaloHit->GetMCParticleWeightMap()) mcParticleVector.push_back(mapEntry.first);
         std::sort(mcParticleVector.begin(), mcParticleVector.end(), PointerLessThan<MCParticle>());
 
-        MCParticleWeightMap primaryWeightMap;
+        MCParticleWeightMap targetWeightMap;
 
         for (const MCParticle *const pMCParticle : mcParticleVector)
         {
             const float weight(pCaloHit->GetMCParticleWeightMap().at(pMCParticle));
-            LArMCParticleHelper::MCRelationMap::const_iterator mcIter = mcToPrimaryMCMap.find(pMCParticle);
+            LArMCParticleHelper::MCRelationMap::const_iterator mcIter = mcToTargetMCMap.find(pMCParticle);
 
-            if (mcToPrimaryMCMap.end() != mcIter)
-                primaryWeightMap[mcIter->second] += weight;
+            if (mcToTargetMCMap.end() != mcIter)
+                targetWeightMap[mcIter->second] += weight;
         }
 
-        MCParticleVector mcPrimaryVector;
-        for (const auto &mapEntry : primaryWeightMap) mcPrimaryVector.push_back(mapEntry.first);
-        std::sort(mcPrimaryVector.begin(), mcPrimaryVector.end(), PointerLessThan<MCParticle>());
+        MCParticleVector mcTargetVector;
+        for (const auto &mapEntry : targetWeightMap) mcTargetVector.push_back(mapEntry.first);
+        std::sort(mcTargetVector.begin(), mcTargetVector.end(), PointerLessThan<MCParticle>());
 
-        const MCParticle *pBestPrimaryParticle(nullptr);
-        float bestPrimaryWeight(0.f), primaryWeightSum(0.f);
+        const MCParticle *pBestTargetParticle(nullptr);
+        float bestTargetWeight(0.f), targetWeightSum(0.f);
 
-        for (const MCParticle *const pPrimaryMCParticle : mcPrimaryVector)
+        for (const MCParticle *const pTargetMCParticle : mcTargetVector)
         {
-            const float primaryWeight(primaryWeightMap.at(pPrimaryMCParticle));
-            primaryWeightSum += primaryWeight;
+            const float targetWeight(targetWeightMap.at(pTargetMCParticle));
+            targetWeightSum += targetWeight;
 
-            if (primaryWeight > bestPrimaryWeight)
+            if (targetWeight > bestTargetWeight)
             {
-                bestPrimaryWeight = primaryWeight;
-                pBestPrimaryParticle = pPrimaryMCParticle;
+                bestTargetWeight = targetWeight;
+                pBestTargetParticle = pTargetMCParticle;
             }
         }
 
-        if (!pBestPrimaryParticle || (primaryWeightSum < std::numeric_limits<float>::epsilon()) || ((bestPrimaryWeight / primaryWeightSum) < minHitSharingFraction))
+        if (!pBestTargetParticle || (targetWeightSum < std::numeric_limits<float>::epsilon()) || ((bestTargetWeight / targetWeightSum) < minHitSharingFraction))
             continue;
 
         selectedGoodCaloHitList.push_back(pCaloHit);
@@ -766,9 +865,9 @@ void LArMCParticleHelper::SelectParticlesMatchingCriteria(const MCParticleVector
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::SelectParticlesByHitCount(const MCParticleVector &candidateTargets, const MCContributionMap &mcToTrueHitListMap,
-    const MCRelationMap &mcToPrimaryMCMap, const PrimaryParameters &parameters, MCContributionMap &selectedMCParticlesToHitsMap)
+    const MCRelationMap &mcToTargetMCMap, const PrimaryParameters &parameters, MCContributionMap &selectedMCParticlesToHitsMap)
 {
-    // Apply restrictions on the number of good hits associated with the MCParticles
+    // Apply restrictions on the number of good hits associated with the MC Particles
     for (const MCParticle * const pMCTarget : candidateTargets)
     {
         MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCTarget);
@@ -779,7 +878,7 @@ void LArMCParticleHelper::SelectParticlesByHitCount(const MCParticleVector &cand
 
         // Remove shared hits where target particle deposits below threshold energy fraction
         CaloHitList goodCaloHitList;
-        LArMCParticleHelper::SelectGoodCaloHits(&caloHitList, mcToPrimaryMCMap, goodCaloHitList, parameters.m_selectInputHits, parameters.m_minHitSharingFraction);
+        LArMCParticleHelper::SelectGoodCaloHits(&caloHitList, mcToTargetMCMap, goodCaloHitList, parameters.m_selectInputHits, parameters.m_minHitSharingFraction);
 
         if (goodCaloHitList.size() < parameters.m_minPrimaryGoodHits)
             continue;
@@ -807,13 +906,13 @@ void LArMCParticleHelper::SelectParticlesByHitCount(const MCParticleVector &cand
 bool LArMCParticleHelper::PassMCParticleChecks(const MCParticle *const pOriginalPrimary, const MCParticle *const pThisMCParticle,
     const MCParticle *const pHitMCParticle, const float maxPhotonPropagation)
 {
-    if (NEUTRON == std::abs(pThisMCParticle->GetParticleId()))
-        return false;
+  if (NEUTRON == std::abs(pThisMCParticle->GetParticleId()))
+    return false;
 
-    if ((PHOTON == pThisMCParticle->GetParticleId()) && (PHOTON != pOriginalPrimary->GetParticleId()) && (E_MINUS != std::abs(pOriginalPrimary->GetParticleId())))
+  if ((PHOTON == pThisMCParticle->GetParticleId()) && (PHOTON != GetPrimaryMCParticle(pThisMCParticle)->GetParticleId()) && (E_MINUS != std::abs(GetPrimaryMCParticle(pThisMCParticle)->GetParticleId())))
     {
-        if ((pThisMCParticle->GetEndpoint() - pThisMCParticle->GetVertex()).GetMagnitude() > maxPhotonPropagation)
-            return false;
+      if ((pThisMCParticle->GetEndpoint() - pThisMCParticle->GetVertex()).GetMagnitude() > maxPhotonPropagation)
+	return false;
     }
 
     if (pThisMCParticle == pHitMCParticle)

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -681,7 +681,6 @@ void LArMCParticleHelper::CollectReconstructableTestBeamHierarchy2DHits(const Pa
     PfoList pfoList;
     // If foldBackHierarchy collect all 2D calo hits in pfo hierarchy
     // else collect hits directly belonging to pfo
-
     if (foldBackHierarchy)
     {
         // ATTN: Only collect downstream pfos for daughter test beam particles & cosmics

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -488,7 +488,7 @@ void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList 
 
     // Select MCParticles matching criteria
     MCParticleVector candidateTargets;
-    LArMCParticleHelper::SelectParticlesMatchingCriteria(targetMCVector, fCriteria, candidateTargets, parameters.m_foldBackHierarchy, false);
+    LArMCParticleHelper::SelectParticlesMatchingCriteria(targetMCVector, fCriteria, candidateTargets, parameters, false);
 
     // Ensure the MCParticles have enough "good" hits to be reconstructed
     LArMCParticleHelper::SelectParticlesByHitCount(candidateTargets, targetMCToTrueHitListMap, mcToTargetMCMap, parameters, selectedMCParticlesToHitsMap);
@@ -526,7 +526,7 @@ void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(cons
 
     // Select MCParticles matching criteria
     MCParticleVector candidateTargets;
-    LArMCParticleHelper::SelectParticlesMatchingCriteria(targetMCVector, fCriteria, candidateTargets, parameters.m_foldBackHierarchy, true);
+    LArMCParticleHelper::SelectParticlesMatchingCriteria(targetMCVector, fCriteria, candidateTargets, parameters, true);
 
     // Ensure the MCParticles have enough "good" hits to be reconstructed
     LArMCParticleHelper::SelectParticlesByHitCount(candidateTargets, targetMCToTrueHitListMap, mcToTargetMCMap, parameters, selectedMCParticlesToHitsMap);
@@ -549,15 +549,15 @@ void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(cons
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-    PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy)
+    PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
 {
-    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(pfoList, MCContributionMapVector({selectedMCParticleToHitsMap}), pfoToReconstructable2DHitsMap, foldBackHierachy);
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(pfoList, MCContributionMapVector({selectedMCParticleToHitsMap}), pfoToReconstructable2DHitsMap, foldBackHierarchy);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-    PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierarchy)
+    PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
 {
     LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(pfoList, MCContributionMapVector({selectedMCParticleToHitsMap}), pfoToReconstructable2DHitsMap, foldBackHierarchy);
 }
@@ -565,12 +565,12 @@ void LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(cons
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy)
+    PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
 {
     for (const ParticleFlowObject *const pPfo : pfoList)
     {
         CaloHitList pfoHitList;
-        LArMCParticleHelper::CollectReconstructable2DHits(pPfo, selectedMCParticleToHitsMaps, pfoHitList, foldBackHierachy);
+        LArMCParticleHelper::CollectReconstructable2DHits(pPfo, selectedMCParticleToHitsMaps, pfoHitList, foldBackHierarchy);
 
         if (!pfoToReconstructable2DHitsMap.insert(PfoContributionMap::value_type(pPfo, pfoHitList)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
@@ -580,12 +580,12 @@ void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoLis
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy)
+    PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
 {
     for (const ParticleFlowObject *const pPfo : pfoList)
     {
         CaloHitList pfoHitList;
-        LArMCParticleHelper::CollectReconstructableTestBeamHierarchy2DHits(pPfo, selectedMCParticleToHitsMaps, pfoHitList, foldBackHierachy);
+        LArMCParticleHelper::CollectReconstructableTestBeamHierarchy2DHits(pPfo, selectedMCParticleToHitsMaps, pfoHitList, foldBackHierarchy);
 
         if (!pfoToReconstructable2DHitsMap.insert(PfoContributionMap::value_type(pPfo, pfoHitList)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
@@ -653,7 +653,7 @@ void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const PfoContributionMa
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    pandora::CaloHitList &reconstructableCaloHitList2D, bool foldBackHierarchy)
+    pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy)
 {
 
     PfoList pfoList;
@@ -675,7 +675,7 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::CollectReconstructableTestBeamHierarchy2DHits(const ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    pandora::CaloHitList &reconstructableCaloHitList2D, bool foldBackHierarchy)
+    pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy)
 {
 
     PfoList pfoList;
@@ -760,6 +760,7 @@ void LArMCParticleHelper::SelectCaloHits(const CaloHitList *const pCaloHitList, 
             if (mcToTargetMCMap.end() == mcIter)
                 continue;
 
+            // ATTN With folding on or off, still require primary particle to review hierarchy details
             const MCParticle *const pPrimaryParticle = LArMCParticleHelper::GetPrimaryMCParticle(pHitParticle);
 
             if (PassMCParticleChecks(pPrimaryParticle, pPrimaryParticle, pHitParticle, maxPhotonPropagation))
@@ -828,18 +829,18 @@ void LArMCParticleHelper::SelectGoodCaloHits(const CaloHitList *const pSelectedC
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArMCParticleHelper::SelectParticlesMatchingCriteria(const MCParticleVector &inputMCParticles, std::function<bool(const MCParticle *const)> fCriteria,
-    MCParticleVector &selectedParticles, const bool foldBackHierarchy, bool isTestBeam)
+    MCParticleVector &selectedParticles, const PrimaryParameters &parameters, const bool isTestBeam)
 {
     for (const MCParticle *const pMCParticle : inputMCParticles)
     {
-        if (foldBackHierarchy)
+        if (parameters.m_foldBackHierarchy)
         {
             if (!fCriteria(pMCParticle))
                 continue;
         }
         else
         {
-            if(isTestBeam)
+            if (isTestBeam)
             {
                 if (!LArMCParticleHelper::DoesLeadingMeetCriteria(pMCParticle, fCriteria))
                     continue;
@@ -852,7 +853,7 @@ void LArMCParticleHelper::SelectParticlesMatchingCriteria(const MCParticleVector
         }
         selectedParticles.push_back(pMCParticle);
     }
-}   
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -52,7 +52,6 @@ bool LArMCParticleHelper::DoesPrimaryMeetCriteria(const MCParticle *const pMCPar
     catch (const StatusCodeException &) {}
 
     return false;
-    
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -67,7 +66,6 @@ bool LArMCParticleHelper::DoesLeadingMeetCriteria(const MCParticle *const pMCPar
     catch (const StatusCodeException &) {}
 
     return false;
-
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -485,7 +483,7 @@ void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList 
     }
     else
     {
-        (void) std::copy(pMCParticleList->begin(), pMCParticleList->end(), std::back_inserter(targetMCVector));
+        std::copy(pMCParticleList->begin(), pMCParticleList->end(), std::back_inserter(targetMCVector));
     }
 
     // Select MCParticles matching criteria
@@ -523,7 +521,7 @@ void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(cons
     }
     else
     {
-        (void) std::copy(pMCParticleList->begin(), pMCParticleList->end(), std::back_inserter(targetMCVector));
+        std::copy(pMCParticleList->begin(), pMCParticleList->end(), std::back_inserter(targetMCVector));
     }
 
     // Select MCParticles matching criteria
@@ -664,11 +662,11 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject 
     // else collect hits directly belonging to pfo
     if (foldBackHierarchy)
     {
-	LArPfoHelper::GetAllDownstreamPfos(pPfo, pfoList);
+        LArPfoHelper::GetAllDownstreamPfos(pPfo, pfoList);
     }
     else
     {
-	pfoList.push_back(pPfo);
+        pfoList.push_back(pPfo);
     }
 
     LArMCParticleHelper::CollectReconstructable2DHits(pfoList, selectedMCParticleToHitsMaps, reconstructableCaloHitList2D);
@@ -836,26 +834,25 @@ void LArMCParticleHelper::SelectParticlesMatchingCriteria(const MCParticleVector
     {
         if (foldBackHierarchy)
         {
-	    if (!fCriteria(pMCParticle))
-	        continue;
-	}
-	else
-	{
-	    if(isTestBeam)
-	    {
-	        if (!LArMCParticleHelper::DoesLeadingMeetCriteria(pMCParticle, fCriteria))
-		    continue;
-	    }
-	    else
-	    {
-	        if (!LArMCParticleHelper::DoesPrimaryMeetCriteria(pMCParticle, fCriteria))
-		    continue;
-	    }
-	}
-	
+            if (!fCriteria(pMCParticle))
+                continue;
+        }
+        else
+        {
+            if(isTestBeam)
+            {
+                if (!LArMCParticleHelper::DoesLeadingMeetCriteria(pMCParticle, fCriteria))
+                    continue;
+            }
+            else
+            {
+                if (!LArMCParticleHelper::DoesPrimaryMeetCriteria(pMCParticle, fCriteria))
+                    continue;
+            }
+        }
         selectedParticles.push_back(pMCParticle);
     }
-}
+}   
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -903,8 +900,6 @@ bool LArMCParticleHelper::PassMCParticleChecks(const MCParticle *const pOriginal
 {
     if (NEUTRON == std::abs(pThisMCParticle->GetParticleId()))
         return false;
-
-    
 
     if ((PHOTON == pThisMCParticle->GetParticleId()) && (PHOTON != pOriginalPrimary->GetParticleId()) && (E_MINUS != std::abs(pOriginalPrimary->GetParticleId())))
     {

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -47,6 +47,10 @@ public:
     typedef std::map<const pandora::ParticleFlowObject*, MCParticleToSharedHitsVector> PfoToMCParticleHitSharingMap;
     typedef std::map<const pandora::MCParticle*, PfoToSharedHitsVector> MCParticleToPfoHitSharingMap;
 
+    typedef std::pair<const pandora::ParticleFlowObject*, double> PfoCompletenessPurityPair;
+    typedef std::vector<PfoCompletenessPurityPair> PfoToCompletenessPurityVector;
+    typedef std::map<const pandora::MCParticle*, PfoToCompletenessPurityVector> MCParticleToPfoCompletenessPurityMap;
+
     /**
      *  @brief   PrimaryParameters class
      */
@@ -167,7 +171,7 @@ public:
     static const pandora::MCParticle *GetPrimaryMCParticle(const pandora::MCParticle *const pMCParticle);
 
     /**
-     *  @brief  Get the leasding particle in the hierarchy, for use at ProtoDUNE
+     *  @brief  Get the leading particle in the hierarchy, for use at ProtoDUNE
      *
      *  @param  pMCParticle the input mc particle
      *
@@ -217,6 +221,14 @@ public:
     static void GetMCLeadingMap(const pandora::MCParticleList *const pMCParticleList, MCRelationMap &mcLeadingMap);
 
     /**
+     *  @brief  Get mapping from individual mc particles (in a provided list) to themselves (to be used when not folding particles to their primaries)
+     *
+     *  @param  pMCParticleList the input mc particle list
+     *  @param  mcToSelfMap the output mapping between mc particles and themselves
+     */
+    static void GetMCToSelfMap(const pandora::MCParticleList *const pMCParticleList, MCRelationMap &mcToSelfMap);
+
+    /**
      *  @brief  Find the mc particle making the largest contribution to 2D clusters in a specified pfo
      *
      *  @param  pPfo address of the pfo to examine
@@ -237,11 +249,11 @@ public:
      *  @brief  Match calo hits to their parent particles
      *
      *  @param  pCaloHitList the input list of calo hits
-     *  @param  mcToPrimaryMCMap input mapping between mc particles and their primaries
-     *  @param  hitToPrimaryMCMap output mapping between calo hits and their main MC particle (primary MC particle if mcToPrimaryMCMap provided)
+     *  @param  mcToTargetMCMap input mapping between mc particles and their primaries OR mc particles and themselves
+     *  @param  hitToMCMap output mapping between calo hits and their main MC particle
      *  @param  mcToTrueHitListMap output mapping between MC particles and their associated hits
      */
-    static void GetMCParticleToCaloHitMatches(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
+    static void GetMCParticleToCaloHitMatches(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToTargetMCMap,
         CaloHitToMCMap &hitToMCMap, MCContributionMap &mcToTrueHitListMap);
 
     /**
@@ -257,6 +269,16 @@ public:
         const PrimaryParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap);
 
     /**
+     * @brief Select reconstructable mc particles that match given criteria
+     *
+     *  @param  pMCParticleList the address of the list of MCParticles
+     *  @param  pCaloHitList the address of the list of CaloHits
+     *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
+     *  @param  mcToRecoHitsMap the output mapping from selected mcparticles to their hits
+     */     
+    static void SelectUnfoldedReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList,                                                                 const PrimaryParameters &parameters, MCContributionMap &mcToRecoHitsMap);
+
+    /**
      *  @brief  Select leading, reconstructable mc particles in the relevant hierarchy that match given criteria.
      *
      *  @param  pMCParticleList the address of the list of MCParticles
@@ -267,6 +289,16 @@ public:
      */
     static void SelectReconstructableTestBeamHierarchyMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList,
         const PrimaryParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap);
+
+    /**
+     *  @brief  Get unfolded mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
+     *
+     *  @param  pfoList the input list of Pfos
+     *  @param  selectedMCParticleToHitsMap the input mapping from selected reconstructable MCParticles to their hits
+     *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
+     */
+    static void GetUnfoldedPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap, 
+        PfoContributionMap &pfoToReconstructable2DHitsMap);
 
     /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
@@ -334,6 +366,19 @@ public:
     static void SelectCaloHits(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
         pandora::CaloHitList &selectedCaloHitList, const bool selectInputHits, const float maxPhotonPropagation);
 
+    /**
+     *  @brief Get the map [MC particle -> vector of matched pairs (pfo MC particle matched to, completeness and purity of match)]
+     *
+     *  @param mcParticleToHitsMap the input mapping from MC particles to reconstructable hits
+     *  @param pfoToHitsMap the input mapping from pfos to reconstructable hits
+     *  @param mcParticleToPfoHitSharingMap the input mapping from selected reconstructable MC particles to pfos and the number hits shared
+     *  @param mcParticleToPfoCompletenessMap the output mapping from MC particles to vectors of matched pairs (pfo MC particle matched to, completeness of match) 
+     *  @param mcParticleToPfoPurityMap the output mapping from MC particles to vectors of matched pairs (pfo MC particle matched to, purity of match)
+     */
+    static void GetMCToPfoCompletenessPurityMaps(const MCContributionMap& mcParticleToHitsMap, const PfoContributionMap& pfoToHitsMap,
+        const MCParticleToPfoHitSharingMap& mcParticleToPfoHitSharingMap, MCParticleToPfoCompletenessPurityMap& mcParticleToPfoCompletenessMap,
+        MCParticleToPfoCompletenessPurityMap& mcParticleToPfoPurityMap);
+
 private:
     /**
      *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -371,12 +416,12 @@ private:
      *          a target mc particle is reconstructable.
      *
      *  @param  pSelectedCaloHitList the address of the calo hit list (typically already been through some selection procedure)
-     *  @param  mcToPrimaryMCMap the mc particle to primary mc particle map
+     *  @param  mcToTargetMCMap the mc particle to primary mc particle map OR mc to self map
      *  @param  selectedGoodCaloHitList to receive the populated good selected calo hit list
      *  @param  selectInputHits whether to select input hits
      *  @param  minHitSharingFraction the minimum Hit sharing fraction
      */
-    static void SelectGoodCaloHits(const pandora::CaloHitList *const pSelectedCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
+    static void SelectGoodCaloHits(const pandora::CaloHitList *const pSelectedCaloHitList, const MCRelationMap &mcToTargetMCMap,
         pandora::CaloHitList &selectedGoodCaloHitList, const bool selectInputHits, const float minHitSharingFraction);
 
     /**
@@ -392,14 +437,14 @@ private:
     /**
      *  @brief  Filter an input vector of MCParticles to ensure they have sufficient good hits to be reconstructable
      *
-     *  @param  candidateTargets candidate recontructable MCParticles
+     *  @param  candidateTargets candidate recontructable MC Particles
      *  @param  mcToTrueHitListMap mapping from candidates reconstructable MCParticles to their true hits
-     *  @param  mcToPrimaryMCMap the mc particle to primary mc particle map
-     *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
+     *  @param  mcToTargetMCMap the mc particle to target mc particle map (primary or the mc particle)
+     *  @param  parameters validation parameters to decide when an MC Particle is considered reconstructable
      *  @param  selectedMCParticlesToHitsMap the output mapping from selected mcparticles to their hits
      */
     static void SelectParticlesByHitCount(const pandora::MCParticleVector &candidateTargets, const MCContributionMap &mcToTrueHitListMap,
-        const MCRelationMap &mcToPrimaryMCMap, const PrimaryParameters &parameters, MCContributionMap &selectedMCParticlesToHitsMap);
+        const MCRelationMap &mcToTargetMCMap, const PrimaryParameters &parameters, MCContributionMap &selectedMCParticlesToHitsMap);
 
     /**
      *  @brief  Whether it is possible to navigate from a primary mc particle to a downstream mc particle without "passing through" a neutron
@@ -423,8 +468,10 @@ private:
      *  @return The hits that are found in both hitListA and hitListB
      */
     static pandora::CaloHitList GetSharedHits(const pandora::CaloHitList &hitListA, const pandora::CaloHitList &hitListB);
+
 };
 
 } // namespace lar_content
 
 #endif // #ifndef LAR_MC_PARTICLE_HELPER_H
+

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -64,7 +64,7 @@ public:
         bool          m_selectInputHits;          ///< whether to select input hits
         float         m_maxPhotonPropagation;     ///< the maximum photon propagation length
         float         m_minHitSharingFraction;    ///< the minimum Hit sharing fraction
-	bool          m_foldBackHierarchy;        ///< whether to fold the hierarchy back to the primary (neutrino) or leading particles (test beam)
+        bool          m_foldBackHierarchy;        ///< whether to fold the hierarchy back to the primary (neutrino) or leading particles (test beam)
     };
 
     /**
@@ -262,7 +262,7 @@ public:
      *  @brief  Match calo hits to their parent particles
      *
      *  @param  pCaloHitList the input list of calo hits
-     *  @param  mcToTargetMCMap input mapping between mc particles and their primaries OR mc particles and themselves
+     *  @param  mcToTargetMCMap the mc particle to target (primary or self) mc particle map
      *  @param  hitToMCMap output mapping between calo hits and their main MC particle
      *  @param  mcToTrueHitListMap output mapping between MC particles and their associated hits
      */
@@ -270,7 +270,7 @@ public:
         CaloHitToMCMap &hitToMCMap, MCContributionMap &mcToTrueHitListMap);
 
     /**
-     *  @brief  Select primary, reconstructable mc particles that match given criteria.
+     *  @brief  Select target, reconstructable mc particles that match given criteria.
      *
      *  @param  pMCParticleList the address of the list of MCParticles
      *  @param  pCaloHitList the address of the list of CaloHits
@@ -282,7 +282,7 @@ public:
         const PrimaryParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap);
 
     /**
-     *  @brief  Select leading, reconstructable mc particles in the relevant hierarchy that match given criteria.
+     *  @brief  Select target, reconstructable mc particles in the relevant hierarchy that match given criteria.
      *
      *  @param  pMCParticleList the address of the list of MCParticles
      *  @param  pCaloHitList the address of the list of CaloHits
@@ -299,10 +299,10 @@ public:
      *  @param  pfoList the input list of Pfos
      *  @param  selectedMCParticleToHitsMap the input mapping from selected reconstructable MCParticles to their hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
-     *  @param  foldToPrimaries whether to fold the particle hierarchy back to primaries
+     *  @param  foldBackHierarchy whether to fold the particle hierarchy back to the primaries
      */
     static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-	PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy);
+        PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy);
 
     /**
      *  @brief  Get mapping from Pfo in reconstructed test beam hierarchy to reconstructable 2D hits (=good hits belonging to a selected
@@ -311,9 +311,10 @@ public:
      *  @param  pfoList the input list of Pfos
      *  @param  selectedMCParticleToHitsMap the input mapping from selected reconstructable MCParticles to their hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
+     *  @param  foldBackHierarchy whether to fold the particle hierarchy back to the leading particles
      */
     static void GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-	PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy);
+        PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy);
 
     /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
@@ -321,10 +322,10 @@ public:
      *  @param  pfoList the input list of Pfos
      *  @param  selectedMCParticleToHitsMaps the input vector of mappings from selected reconstructable MCParticles to their hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
-     *  @param  foldToPrimaries whether to fold the particle hierarchy back to primaries
+     *  @param  foldToHierarchy whether to fold the particle hierarchy back to the primaries
      */
     static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy);
+        PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy);
 
     /**
      *  @brief  Get mapping from Pfo in reconstructed test beam hierarchy to reconstructable 2D hits (=good hits belonging to a selected
@@ -333,13 +334,14 @@ public:
      *  @param  pfoList the input list of Pfos
      *  @param  selectedMCParticleToHitsMaps the input vector of mappings from selected reconstructable MCParticles to their hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
+     *  @param  foldBackHierarchy whether to fold the particle hierarchy back to the leading particles
      */
     static void GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-	PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy);
+        PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy);
 
     /**
      *  @brief  Get the mappings from Pfo -> pair (reconstructable MCparticles, number of reconstructable 2D hits shared with Pfo)
-     *                                reconstructable MCParticle -> pair (Pfo, number of reconstructable 2D hits shared with MCParticle)
+     *          reconstructable MCParticle -> pair (Pfo, number of reconstructable 2D hits shared with MCParticle)
      *
      *  @param  pfoToReconstructable2DHitsMap the input mapping from Pfos to reconstructable 2D hits
      *  @param  selectedMCParticleToHitsMaps the input mappings from selected reconstructable MCParticles to hits
@@ -353,12 +355,12 @@ public:
      *  @brief  Select a subset of calo hits representing those that represent "reconstructable" regions of the event
      *
      *  @param  pCaloHitList the address of the input calo hit list
-     *  @param  mcToPrimaryMCMap the mc particle to primary mc particle map
+     *  @param  mcToTargetMCMap the mc particle to target (primary or self) mc particle map
      *  @param  selectedCaloHitList to receive the populated selected calo hit list
      *  @param  selectInputHits whether to select input hits
      *  @param  maxPhotonPropagation the maximum photon propagation length
      */
-    static void SelectCaloHits(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
+    static void SelectCaloHits(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToTargetMCMap,
         pandora::CaloHitList &selectedCaloHitList, const bool selectInputHits, const float maxPhotonPropagation);
 
 private:
@@ -368,10 +370,10 @@ private:
      *  @param  pPfo the input pfo
      *  @param  selectedMCParticleToHitsMaps the input mappings from selected reconstructable MCParticles to hits
      *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
-     *  @param  foldToPrimaries whether to fold the particle hierarchy back to primaries
+     *  @param  foldBackHierarchy whether to fold the particle hierarchy back to primaries
      */
     static void CollectReconstructable2DHits(const pandora::ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-	pandora::CaloHitList &reconstructableCaloHitList2D, bool foldBackHierachy);
+        pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy);
 
     /**
      *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -380,9 +382,10 @@ private:
      *  @param  pPfo the input pfo
      *  @param  selectedMCParticleToHitsMaps the input mappings from selected reconstructable MCParticles to hits
      *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
+     *  @param  foldBackHierarchy whether to fold the particle hierarchy back to leading particles
      */
     static void CollectReconstructableTestBeamHierarchy2DHits(const pandora::ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-	pandora::CaloHitList &reconstructableCaloHitList2D, bool foldBackHierachy);
+        pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy);
 
     /**
      *  @brief  For a given Pfo list, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -399,7 +402,7 @@ private:
      *          a target mc particle is reconstructable.
      *
      *  @param  pSelectedCaloHitList the address of the calo hit list (typically already been through some selection procedure)
-     *  @param  mcToTargetMCMap the mc particle to primary mc particle map OR mc to self map
+     *  @param  mcToTargetMCMap the mc particle to target (primary or self) mc particle map
      *  @param  selectedGoodCaloHitList to receive the populated good selected calo hit list
      *  @param  selectInputHits whether to select input hits
      *  @param  minHitSharingFraction the minimum Hit sharing fraction
@@ -413,16 +416,18 @@ private:
      *  @param  inputMCParticles input vector of MCParticles
      *  @param  fCriteria a function which returns a bool (= shouldSelect) for a given input MCParticle
      *  @param  selectedParticles the output vector of particles selected
+     *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
+     *  @param  isTestBeam whether the mc particles correspond to the test beam case or the neutrino case
      */
     static void SelectParticlesMatchingCriteria(const pandora::MCParticleVector &inputMCParticles, std::function<bool(const pandora::MCParticle *const)> fCriteria,
-        pandora::MCParticleVector &selectedParticles, const bool foldBackHierachy, bool isTestBeam);
+        pandora::MCParticleVector &selectedParticles, const PrimaryParameters &parameters, const bool isTestBeam);
 
     /**
      *  @brief  Filter an input vector of MCParticles to ensure they have sufficient good hits to be reconstructable
      *
      *  @param  candidateTargets candidate reconstructable MCParticles
      *  @param  mcToTrueHitListMap mapping from candidates reconstructable MCParticles to their true hits
-     *  @param  mcToTargetMCMap the mc particle to target mc particle map (primary or the mc particle)
+     *  @param  mcToTargetMCMap the mc particle to target (primary or self) mc particle map
      *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
      *  @param  selectedMCParticlesToHitsMap the output mapping from selected mcparticles to their hits
      */

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -64,7 +64,24 @@ public:
         bool          m_selectInputHits;          ///< whether to select input hits
         float         m_maxPhotonPropagation;     ///< the maximum photon propagation length
         float         m_minHitSharingFraction;    ///< the minimum Hit sharing fraction
+	bool          m_foldBackHierarchy;        ///< whether to fold the hierarchy back to the primary (neutrino) or leading particles (test beam)
     };
+
+    /**
+     *  @brief  Returns true if passed particle whose primary meets the passed criteria
+     *
+     *  @param  pMCParticle the input mc particle
+     *  @param  fCriteria the given criteria
+     */
+    static bool DoesPrimaryMeetCriteria(const pandora::MCParticle *const pMCParticle, std::function<bool(const pandora::MCParticle *const)> fCriteria);
+
+    /**
+     *  @brief  Returns true if passed particle whose leading meets the passed criteria
+     *
+     *  @param  pMCParticle the input mc particle
+     *  @param  fCriteria the given criteria
+     */
+    static bool DoesLeadingMeetCriteria(const pandora::MCParticle *const pMCParticle, std::function<bool(const pandora::MCParticle *const)> fCriteria);
 
     /**
      *  @brief  Returns true if passed a primary neutrino final state MCParticle
@@ -265,17 +282,6 @@ public:
         const PrimaryParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap);
 
     /**
-     * @brief Select reconstructable mc particles that match given criteria
-     *
-     *  @param  pMCParticleList the address of the list of MCParticles
-     *  @param  pCaloHitList the address of the list of CaloHits
-     *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
-     *  @param  mcToRecoHitsMap the output mapping from selected mcparticles to their hits
-     */
-    static void SelectUnfoldedReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList,
-        const PrimaryParameters &parameters, MCContributionMap &mcToRecoHitsMap);
-
-    /**
      *  @brief  Select leading, reconstructable mc particles in the relevant hierarchy that match given criteria.
      *
      *  @param  pMCParticleList the address of the list of MCParticles
@@ -288,24 +294,15 @@ public:
         const PrimaryParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap);
 
     /**
-     *  @brief  Get unfolded mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
-     *
-     *  @param  pfoList the input list of Pfos
-     *  @param  selectedMCParticleToHitsMap the input mapping from selected reconstructable MCParticles to their hits
-     *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
-     */
-    static void GetUnfoldedPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-        PfoContributionMap &pfoToReconstructable2DHitsMap);
-
-    /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
      *
      *  @param  pfoList the input list of Pfos
      *  @param  selectedMCParticleToHitsMap the input mapping from selected reconstructable MCParticles to their hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
+     *  @param  foldToPrimaries whether to fold the particle hierarchy back to primaries
      */
     static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-        PfoContributionMap &pfoToReconstructable2DHitsMap);
+	PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy);
 
     /**
      *  @brief  Get mapping from Pfo in reconstructed test beam hierarchy to reconstructable 2D hits (=good hits belonging to a selected
@@ -316,7 +313,7 @@ public:
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      */
     static void GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-        PfoContributionMap &pfoToReconstructable2DHitsMap);
+	PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy);
 
     /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
@@ -324,9 +321,10 @@ public:
      *  @param  pfoList the input list of Pfos
      *  @param  selectedMCParticleToHitsMaps the input vector of mappings from selected reconstructable MCParticles to their hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
+     *  @param  foldToPrimaries whether to fold the particle hierarchy back to primaries
      */
     static void GetPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        PfoContributionMap &pfoToReconstructable2DHitsMap);
+        PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy);
 
     /**
      *  @brief  Get mapping from Pfo in reconstructed test beam hierarchy to reconstructable 2D hits (=good hits belonging to a selected
@@ -337,7 +335,7 @@ public:
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      */
     static void GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        PfoContributionMap &pfoToReconstructable2DHitsMap);
+	PfoContributionMap &pfoToReconstructable2DHitsMap, bool foldBackHierachy);
 
     /**
      *  @brief  Get the mappings from Pfo -> pair (reconstructable MCparticles, number of reconstructable 2D hits shared with Pfo)
@@ -370,9 +368,10 @@ private:
      *  @param  pPfo the input pfo
      *  @param  selectedMCParticleToHitsMaps the input mappings from selected reconstructable MCParticles to hits
      *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
+     *  @param  foldToPrimaries whether to fold the particle hierarchy back to primaries
      */
     static void CollectReconstructable2DHits(const pandora::ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        pandora::CaloHitList &reconstructableCaloHitList2D);
+	pandora::CaloHitList &reconstructableCaloHitList2D, bool foldBackHierachy);
 
     /**
      *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -383,7 +382,7 @@ private:
      *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
      */
     static void CollectReconstructableTestBeamHierarchy2DHits(const pandora::ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        pandora::CaloHitList &reconstructableCaloHitList2D);
+	pandora::CaloHitList &reconstructableCaloHitList2D, bool foldBackHierachy);
 
     /**
      *  @brief  For a given Pfo list, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -416,7 +415,7 @@ private:
      *  @param  selectedParticles the output vector of particles selected
      */
     static void SelectParticlesMatchingCriteria(const pandora::MCParticleVector &inputMCParticles, std::function<bool(const pandora::MCParticle *const)> fCriteria,
-        pandora::MCParticleVector &selectedParticles);
+        pandora::MCParticleVector &selectedParticles, const bool foldBackHierachy, bool isTestBeam);
 
     /**
      *  @brief  Filter an input vector of MCParticles to ensure they have sufficient good hits to be reconstructable

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -47,10 +47,6 @@ public:
     typedef std::map<const pandora::ParticleFlowObject*, MCParticleToSharedHitsVector> PfoToMCParticleHitSharingMap;
     typedef std::map<const pandora::MCParticle*, PfoToSharedHitsVector> MCParticleToPfoHitSharingMap;
 
-    typedef std::pair<const pandora::ParticleFlowObject*, double> PfoCompletenessPurityPair;
-    typedef std::vector<PfoCompletenessPurityPair> PfoToCompletenessPurityVector;
-    typedef std::map<const pandora::MCParticle*, PfoToCompletenessPurityVector> MCParticleToPfoCompletenessPurityMap;
-
     /**
      *  @brief   PrimaryParameters class
      */
@@ -275,8 +271,9 @@ public:
      *  @param  pCaloHitList the address of the list of CaloHits
      *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
      *  @param  mcToRecoHitsMap the output mapping from selected mcparticles to their hits
-     */     
-    static void SelectUnfoldedReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList,                                                                 const PrimaryParameters &parameters, MCContributionMap &mcToRecoHitsMap);
+     */
+    static void SelectUnfoldedReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList,
+        const PrimaryParameters &parameters, MCContributionMap &mcToRecoHitsMap);
 
     /**
      *  @brief  Select leading, reconstructable mc particles in the relevant hierarchy that match given criteria.
@@ -297,7 +294,7 @@ public:
      *  @param  selectedMCParticleToHitsMap the input mapping from selected reconstructable MCParticles to their hits
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      */
-    static void GetUnfoldedPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap, 
+    static void GetUnfoldedPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
         PfoContributionMap &pfoToReconstructable2DHitsMap);
 
     /**
@@ -366,19 +363,6 @@ public:
     static void SelectCaloHits(const pandora::CaloHitList *const pCaloHitList, const MCRelationMap &mcToPrimaryMCMap,
         pandora::CaloHitList &selectedCaloHitList, const bool selectInputHits, const float maxPhotonPropagation);
 
-    /**
-     *  @brief Get the map [MC particle -> vector of matched pairs (pfo MC particle matched to, completeness and purity of match)]
-     *
-     *  @param mcParticleToHitsMap the input mapping from MC particles to reconstructable hits
-     *  @param pfoToHitsMap the input mapping from pfos to reconstructable hits
-     *  @param mcParticleToPfoHitSharingMap the input mapping from selected reconstructable MC particles to pfos and the number hits shared
-     *  @param mcParticleToPfoCompletenessMap the output mapping from MC particles to vectors of matched pairs (pfo MC particle matched to, completeness of match) 
-     *  @param mcParticleToPfoPurityMap the output mapping from MC particles to vectors of matched pairs (pfo MC particle matched to, purity of match)
-     */
-    static void GetMCToPfoCompletenessPurityMaps(const MCContributionMap& mcParticleToHitsMap, const PfoContributionMap& pfoToHitsMap,
-        const MCParticleToPfoHitSharingMap& mcParticleToPfoHitSharingMap, MCParticleToPfoCompletenessPurityMap& mcParticleToPfoCompletenessMap,
-        MCParticleToPfoCompletenessPurityMap& mcParticleToPfoPurityMap);
-
 private:
     /**
      *  @brief  For a given Pfo, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -437,10 +421,10 @@ private:
     /**
      *  @brief  Filter an input vector of MCParticles to ensure they have sufficient good hits to be reconstructable
      *
-     *  @param  candidateTargets candidate recontructable MC Particles
+     *  @param  candidateTargets candidate reconstructable MCParticles
      *  @param  mcToTrueHitListMap mapping from candidates reconstructable MCParticles to their true hits
      *  @param  mcToTargetMCMap the mc particle to target mc particle map (primary or the mc particle)
-     *  @param  parameters validation parameters to decide when an MC Particle is considered reconstructable
+     *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
      *  @param  selectedMCParticlesToHitsMap the output mapping from selected mcparticles to their hits
      */
     static void SelectParticlesByHitCount(const pandora::MCParticleVector &candidateTargets, const MCContributionMap &mcToTrueHitListMap,
@@ -468,10 +452,8 @@ private:
      *  @return The hits that are found in both hitListA and hitListB
      */
     static pandora::CaloHitList GetSharedHits(const pandora::CaloHitList &hitListA, const pandora::CaloHitList &hitListB);
-
 };
 
 } // namespace lar_content
 
 #endif // #ifndef LAR_MC_PARTICLE_HELPER_H
-

--- a/larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.cc
+++ b/larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.cc
@@ -55,7 +55,7 @@ void CosmicRayTaggingMonitoringTool::FindAmbiguousPfos(const PfoList &parentCosm
     LArMCParticleHelper::MCContributionMapVector mcParticlesToGoodHitsMaps({nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap, crMCParticlesToGoodHitsMap});
 
     LArMCParticleHelper::PfoContributionMap pfoToReconstructable2DHitsMap;
-    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(parentCosmicRayPfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap);
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(parentCosmicRayPfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap, m_parameters.m_foldBackHierarchy);
 
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCParticleHitSharingMap;
     LArMCParticleHelper::MCParticleToPfoHitSharingMap mcParticleToPfoHitSharingMap;

--- a/larpandoracontent/LArMonitoring/EventValidationBaseAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventValidationBaseAlgorithm.cc
@@ -228,6 +228,9 @@ StatusCode EventValidationBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
         "MaxPhotonPropagation", m_primaryParameters.m_maxPhotonPropagation));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "FoldToPrimaries", m_primaryParameters.m_foldBackHierarchy));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
         "PrintAllToScreen", m_printAllToScreen));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,

--- a/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
@@ -68,7 +68,7 @@ void NeutrinoEventValidationAlgorithm::FillValidationInfo(const MCParticleList *
         }
 
         LArMCParticleHelper::PfoContributionMap pfoToHitsMap;
-        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap);
+        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
 
         validationInfo.SetPfoToHitsMap(pfoToHitsMap);
     }

--- a/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
@@ -59,7 +59,7 @@ StatusCode PfoValidationAlgorithm::Run()
     }
 
     LArMCParticleHelper::PfoContributionMap pfoToReconstructable2DHitsMap;
-    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap);
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap, m_parameters.m_foldBackHierarchy);
 
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCParticleHitSharingMap;
     LArMCParticleHelper::MCParticleToPfoHitSharingMap mcParticleToPfoHitSharingMap;

--- a/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.cc
@@ -67,7 +67,7 @@ void TestBeamEventValidationAlgorithm::FillValidationInfo(const MCParticleList *
         }
 
         LArMCParticleHelper::PfoContributionMap pfoToHitsMap;
-        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap);
+        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
 
         validationInfo.SetPfoToHitsMap(pfoToHitsMap);
     }

--- a/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
@@ -77,7 +77,7 @@ void TestBeamHierarchyEventValidationAlgorithm::FillValidationInfo(const MCParti
         }
 
         LArMCParticleHelper::PfoContributionMap pfoToHitsMap;
-        LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap);
+        LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
         validationInfo.SetPfoToHitsMap(pfoToHitsMap);
     }
 


### PR DESCRIPTION
Some Comments:

1) I had removed the photon and neutron considerations remain but  can easily be switched off by setting m_selectInputHits to false in the xml. 
 2) As per the current implementation the user has to do some of the unfolding or folding on the pfo side themselves. This is because they have to pass the function a list of pfos and they get a pfo->hits map for those pfos. So for the unfolded version they would have to pass in the whole pfo list and for the folded version they would have to pass in the list of primaries. I thought this was a bit annoying but I didn't change it since I think in the case of the test beam the pfos you want to select isn't as simple as those two cases, also one could chose to look at cosmics only etc...
3) I have pretty much done the same thing for the test beam as the neutrino case since the functions have a very similar structure. The only difference is that there is some code in the test beam case that i think says  'if the parent particle of the any of the MCParticles in the mc->hits map is not itself in the map (because it wasn't deemed reconstructable) then add it in but with an empty calo hit list associated to it' I thought this was independent of the folding so left it in.