### PR TITLE
Allow gcc 7 to compile an unused structured binding

### DIFF
--- a/larpandoracontent/LArCheating/CheatingSliceSelectionTool.cc
+++ b/larpandoracontent/LArCheating/CheatingSliceSelectionTool.cc
@@ -113,6 +113,7 @@ void CheatingSliceSelectionTool::SelectSlices(const pandora::Algorithm *const /*
     int i = 0;
     for (const auto [ cutVariable, index ] : reducedSliceVarIndexMap)
     {   // ATTN: Map is sorted on cut variable from max to min
+        (void)cutVariable;  // GCC 7 support, versions 8+ do not need this
         reducedSliceIndices.push_back(index);
         outputSliceVector.push_back(inputSliceVector[index]);
         if (++i == m_maxSlices)


### PR DESCRIPTION
Unlike later versions of GCC, in GCC 7.3 the structured binding feature generates a warning if any of the bindings are unused. This single commit allows the older compiler to successfully build with an unused binding.