### PR TITLE
PR_CRP_CheckForDP

### DIFF
--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -670,6 +670,7 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *c
     // ATTN Parent of calo hit in worker is corresponding calo hit in master
     parameters.m_pParentAddress = static_cast<const void*>(pCaloHit);
     parameters.m_larTPCVolumeId = pLArCaloHit->GetLArTPCVolumeId();
+    parameters.m_daughterVolumeId = pLArCaloHit->GetDaughterVolumeId();
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::CaloHit::Create(*pPandora, parameters, m_larCaloHitFactory));
 

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -7,6 +7,7 @@
  */
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
 
 #include <algorithm>
 #include <cmath>
@@ -585,6 +586,27 @@ void LArClusterHelper::GetCaloHitListInBoundingBox(const pandora::Cluster *const
     caloHitList.sort(LArClusterHelper::SortHitsByPosition);
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+std::set<unsigned int> LArClusterHelper::GetDaughterVolumeIDs(const Cluster *const pCluster)
+{
+    std::set<unsigned int> daughterVolumeIds;
+    const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
+
+    for (OrderedCaloHitList::const_iterator ochIter = orderedCaloHitList.begin(), ochIterEnd = orderedCaloHitList.end(); ochIter != ochIterEnd; ++ochIter)
+    {
+        for (CaloHitList::const_iterator hIter = ochIter->second->begin(), hIterEnd = ochIter->second->end(); hIter != hIterEnd; ++hIter)
+        {
+            const CaloHit *const pCaloHit = *hIter;
+            const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit*>(pCaloHit));
+
+            if (pLArCaloHit) 
+                daughterVolumeIds.insert(pLArCaloHit->GetDaughterVolumeId());
+        }
+    }
+    
+    return daughterVolumeIds;
+}
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 bool LArClusterHelper::SortByNOccupiedLayers(const Cluster *const pLhs, const Cluster *const pRhs)

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -588,9 +588,8 @@ void LArClusterHelper::GetCaloHitListInBoundingBox(const pandora::Cluster *const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-std::set<unsigned int> LArClusterHelper::GetDaughterVolumeIDs(const Cluster *const pCluster)
+void LArClusterHelper::GetDaughterVolumeIDs(const Cluster *const pCluster, UIntSet &daughterVolumeIds)
 {
-    std::set<unsigned int> daughterVolumeIds;
     const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
 
     for (OrderedCaloHitList::const_iterator ochIter = orderedCaloHitList.begin(), ochIterEnd = orderedCaloHitList.end(); ochIter != ochIterEnd; ++ochIter)
@@ -604,8 +603,6 @@ std::set<unsigned int> LArClusterHelper::GetDaughterVolumeIDs(const Cluster *con
                 daughterVolumeIds.insert(pLArCaloHit->GetDaughterVolumeId());
         }
     }
-    
-    return daughterVolumeIds;
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -596,7 +596,7 @@ void LArClusterHelper::GetDaughterVolumeIDs(const Cluster *const pCluster, UIntS
     {
         for (CaloHitList::const_iterator hIter = ochIter->second->begin(), hIterEnd = ochIter->second->end(); hIter != hIterEnd; ++hIter)
         {
-            const CaloHit *const pCaloHit = *hIter;
+            const CaloHit *const pCaloHit(*hIter);
             const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit*>(pCaloHit));
 
             if (pLArCaloHit) 

--- a/larpandoracontent/LArHelpers/LArClusterHelper.h
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.h
@@ -255,6 +255,15 @@ public:
         const pandora::CartesianVector &upperBound, pandora::CaloHitList &caloHitList);
 
     /**
+     *  @brief  Get the set of the daughter volumes that contains the cluster
+     *
+     *  @param  pCluster1 address of the cluster
+     *
+     *  @return the set of daughter volumes
+     */
+    static std::set<unsigned int> GetDaughterVolumeIDs(const pandora::Cluster *const pCluster);
+
+    /**
      *  @brief  Get average Z positions of the calo hits in a cluster in range xmin to xmax
      *
      *  @param  pCluster address of the cluster

--- a/larpandoracontent/LArHelpers/LArClusterHelper.h
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.h
@@ -19,6 +19,9 @@ namespace lar_content
 class LArClusterHelper
 {
 public:
+
+    typedef std::set<unsigned int> UIntSet;
+
     /**
      *  @brief  Get the hit type associated with a two dimensional cluster
      *
@@ -257,11 +260,12 @@ public:
     /**
      *  @brief  Get the set of the daughter volumes that contains the cluster
      *
+     *  @param  daughterVolumeIds set of daughter volume Ids pCluster lives in
      *  @param  pCluster1 address of the cluster
      *
      *  @return the set of daughter volumes
      */
-    static std::set<unsigned int> GetDaughterVolumeIDs(const pandora::Cluster *const pCluster);
+    static void GetDaughterVolumeIDs(const pandora::Cluster *const pCluster, UIntSet &daughterVolumeIds);
 
     /**
      *  @brief  Get average Z positions of the calo hits in a cluster in range xmin to xmax

--- a/larpandoracontent/LArHelpers/LArClusterHelper.h
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.h
@@ -260,10 +260,8 @@ public:
     /**
      *  @brief  Get the set of the daughter volumes that contains the cluster
      *
-     *  @param  daughterVolumeIds set of daughter volume Ids pCluster lives in
-     *  @param  pCluster1 address of the cluster
-     *
-     *  @return the set of daughter volumes
+     *  @param  pCluster address of the cluster
+     *  @param  daughterVolumeIds output variable
      */
     static void GetDaughterVolumeIDs(const pandora::Cluster *const pCluster, UIntSet &daughterVolumeIds);
 

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -400,17 +400,15 @@ CartesianVector LArGeometryHelper::GetWireAxis(const Pandora &pandora, const Hit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-std::set<unsigned int> LArGeometryHelper::GetCommonDaughterVolumes(const Cluster *const pCluster1, const Cluster *const pCluster2)
+void LArGeometryHelper::GetCommonDaughterVolumes(const Cluster *const pCluster1, const Cluster *const pCluster2, UIntSet &intersect)
 {
-    std::set<unsigned int> intersect;
+    UIntSet daughterVolumeIds1, daughterVolumeIds2;
 
-    const std::set<unsigned int> daughterVolumeIds1(LArClusterHelper::GetDaughterVolumeIDs(pCluster1)), 
-        daughterVolumeIds2(LArClusterHelper::GetDaughterVolumeIDs(pCluster2));
+    LArClusterHelper::GetDaughterVolumeIDs(pCluster1, daughterVolumeIds1);
+    LArClusterHelper::GetDaughterVolumeIDs(pCluster2, daughterVolumeIds2);
 
     std::set_intersection(daughterVolumeIds1.begin(), daughterVolumeIds1.end(), daughterVolumeIds2.begin(), daughterVolumeIds2.end(), 
                           std::inserter(intersect, intersect.begin())); 
-
-    return intersect;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -400,6 +400,21 @@ CartesianVector LArGeometryHelper::GetWireAxis(const Pandora &pandora, const Hit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+std::set<unsigned int> LArGeometryHelper::GetCommonDaughterVolumes(const Cluster *const pCluster1, const Cluster *const pCluster2)
+{
+    std::set<unsigned int> intersect;
+
+    const std::set<unsigned int> daughterVolumeIds1(LArClusterHelper::GetDaughterVolumeIDs(pCluster1)), 
+        daughterVolumeIds2(LArClusterHelper::GetDaughterVolumeIDs(pCluster2));
+
+    std::set_intersection(daughterVolumeIds1.begin(), daughterVolumeIds1.end(), daughterVolumeIds2.begin(), daughterVolumeIds2.end(), 
+                          std::inserter(intersect, intersect.begin())); 
+
+    return intersect;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 bool LArGeometryHelper::IsInGap(const Pandora &pandora, const CartesianVector &testPoint2D, const HitType hitType, const float gapTolerance)
 {
     // ATTN: input test point MUST be a 2D position vector

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -198,6 +198,14 @@ public:
     static pandora::CartesianVector GetWireAxis(const pandora::Pandora &pandora, const pandora::HitType view);
 
     /**
+     *  @brief  Return the set of common daughter volumes between two 2D clusters
+     *
+     *  @param  Cluster 1
+     *  @param  Cluster 2
+     */
+    static std::set<unsigned int> GetCommonDaughterVolumes (const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2);
+ 
+    /**
      *  @brief  Whether a 2D test point lies in a registered gap with the associated hit type
      *
      *  @param  pandora the associated pandora instance

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -199,15 +199,6 @@ public:
      *  @param  view the 2D projection
      */
     static pandora::CartesianVector GetWireAxis(const pandora::Pandora &pandora, const pandora::HitType view);
-
-    /**
-     *  @brief  Return the set of common daughter volumes between two 2D clusters
-     *
-     *  @param  intersect the set of shared daughter volumes
-     *  @param  pCluster1 the first cluster
-     *  @param  pCluster2 the second cluster
-     */
-    static void GetCommonDaughterVolumes (const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, UIntSet &intersect);
  
     /**
      *  @brief  Whether a 2D test point lies in a registered gap with the associated hit type
@@ -265,8 +256,16 @@ public:
      *  @param  maxSigmaDiscrepancy maximum allowed discrepancy between lar tpc sigmaUVW values
      */
     static float GetSigmaUVW(const pandora::Pandora &pandora, const float maxSigmaDiscrepancy = 0.01);
-};
 
+    /**
+     *  @brief  Return the set of common daughter volumes between two 2D clusters
+     *
+     *  @param  intersect the set of shared daughter volumes
+     *  @param  pCluster1 the first cluster
+     *  @param  pCluster2 the second cluster
+     */
+    static void GetCommonDaughterVolumes (const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, UIntSet &intersect);
+};
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline float LArGeometryHelper::GetWireZPitch(const pandora::Pandora &pandora, const float maxWirePitchWDiscrepancy)

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -28,6 +28,9 @@ class TwoDSlidingFitResult;
 class LArGeometryHelper
 {
 public:
+
+    typedef std::set<unsigned int> UIntSet;
+
     /**
      *  @brief  Merge two views (U,V) to give a third view (Z).
      *
@@ -200,10 +203,11 @@ public:
     /**
      *  @brief  Return the set of common daughter volumes between two 2D clusters
      *
-     *  @param  Cluster 1
-     *  @param  Cluster 2
+     *  @param  intersect the set of shared daughter volumes
+     *  @param  pCluster1 the first cluster
+     *  @param  pCluster2 the second cluster
      */
-    static std::set<unsigned int> GetCommonDaughterVolumes (const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2);
+    static void GetCommonDaughterVolumes (const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, UIntSet &intersect);
  
     /**
      *  @brief  Whether a 2D test point lies in a registered gap with the associated hit type

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.cc
@@ -11,6 +11,7 @@
 #include "larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.h"
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 using namespace pandora;
 
@@ -96,7 +97,10 @@ void CosmicRayBaseMatchingAlgorithm::MatchClusters(const ClusterVector &clusterV
         {
             if (this->MatchClusters(pCluster1, pCluster2))
             {
-                matchedClusters12[pCluster1].push_back(pCluster2);
+                const std::set daughterVolumeIntersection(LArGeometryHelper::GetCommonDaughterVolumes(pCluster1, pCluster2));
+
+                if (!daughterVolumeIntersection.empty())
+                    matchedClusters12[pCluster1].push_back(pCluster2);
             }
         }
     }

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.cc
@@ -97,7 +97,8 @@ void CosmicRayBaseMatchingAlgorithm::MatchClusters(const ClusterVector &clusterV
         {
             if (this->MatchClusters(pCluster1, pCluster2))
             {
-                const std::set daughterVolumeIntersection(LArGeometryHelper::GetCommonDaughterVolumes(pCluster1, pCluster2));
+                UIntSet daughterVolumeIntersection;
+                LArGeometryHelper::GetCommonDaughterVolumes(pCluster1, pCluster2, daughterVolumeIntersection);
 
                 if (!daughterVolumeIntersection.empty())
                     matchedClusters12[pCluster1].push_back(pCluster2);

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.h
@@ -47,6 +47,7 @@ protected:
 
     typedef std::vector<Particle> ParticleList;
     typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterAssociationMap;
+    typedef std::set<unsigned int> UIntSet;
 
     /**
      *  @brief Select a set of clusters judged to be clean

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
@@ -202,7 +202,6 @@ void CosmicRayTrackRecoveryAlgorithm::MatchClusters(const Cluster* const pSeedCl
         if (daughterVolumeIntersection.empty())
             continue;
 
-
         if (LArClusterHelper::GetClusterHitType(pSeedCluster) == LArClusterHelper::GetClusterHitType(pTargetCluster))
             throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
@@ -196,7 +196,9 @@ void CosmicRayTrackRecoveryAlgorithm::MatchClusters(const Cluster* const pSeedCl
     {
         const Cluster *const pTargetCluster = *tIter;
 
-        const std::set daughterVolumeIntersection(LArGeometryHelper::GetCommonDaughterVolumes(pSeedCluster, pTargetCluster));
+        UIntSet daughterVolumeIntersection;
+        LArGeometryHelper::GetCommonDaughterVolumes(pSeedCluster, pTargetCluster, daughterVolumeIntersection);
+
         if (daughterVolumeIntersection.empty())
             continue;
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
@@ -196,6 +196,11 @@ void CosmicRayTrackRecoveryAlgorithm::MatchClusters(const Cluster* const pSeedCl
     {
         const Cluster *const pTargetCluster = *tIter;
 
+        const std::set daughterVolumeIntersection(LArGeometryHelper::GetCommonDaughterVolumes(pSeedCluster, pTargetCluster));
+        if (daughterVolumeIntersection.empty())
+            continue;
+
+
         if (LArClusterHelper::GetClusterHitType(pSeedCluster) == LArClusterHelper::GetClusterHitType(pTargetCluster))
             throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.h
@@ -42,6 +42,7 @@ private:
 
     typedef std::vector<Particle> ParticleList;
     typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterAssociationMap;
+    typedef std::set<unsigned int> UIntSet;
 
     /**
      *  @brief Get a vector of available clusters

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.cc
@@ -52,8 +52,9 @@ void TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *con
 pandora::StatusCode TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *const pCluster1,
     const Cluster *const pCluster2, TwoViewTransverseOverlapResult &overlapResult)
 {
-    const std::set daughterVolumeIntersection(LArGeometryHelper::GetCommonDaughterVolumes(pCluster1, pCluster2));
-    
+    UIntSet daughterVolumeIntersection;
+    LArGeometryHelper::GetCommonDaughterVolumes(pCluster1, pCluster2, daughterVolumeIntersection);
+
     if (daughterVolumeIntersection.empty())
         return STATUS_CODE_NOT_FOUND;
     

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.cc
@@ -52,6 +52,11 @@ void TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *con
 pandora::StatusCode TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *const pCluster1,
     const Cluster *const pCluster2, TwoViewTransverseOverlapResult &overlapResult)
 {
+    const std::set daughterVolumeIntersection(LArGeometryHelper::GetCommonDaughterVolumes(pCluster1, pCluster2));
+    
+    if (daughterVolumeIntersection.empty())
+        return STATUS_CODE_NOT_FOUND;
+    
     if (this->GetPrimaryAxisDotDriftAxis(pCluster1) > m_maxDotProduct || this->GetPrimaryAxisDotDriftAxis(pCluster2) > m_maxDotProduct)
         return STATUS_CODE_NOT_FOUND;
 

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h
@@ -33,6 +33,7 @@ class TwoViewTransverseTracksAlgorithm : public NViewTrackMatchingAlgorithm<TwoV
 {
 public:
     typedef NViewTrackMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult> > BaseAlgorithm;
+    typedef std::set<unsigned int> UIntSet;
 
     /**
      *  @brief  Default constructor


### PR DESCRIPTION
The DP team added a sanity check verifying that only 2D clusters that have hits, at least partially, in a common daughter volume should be matched.

We added some Geometry and Cluster helper functions to perform the check.

It is done in three algorithms : 1) TwoViewTransverseTrack 2)CosmicRayTrackRecovery**(this one actually touches Single-Phase)** 3)CosmicRayBaseMatching **(this one also touches Single-Phase)**

A small addition was also made in the MasterAlgorithm.cc in order to initialize properly the new LArCaloHit object that now have a new member variable called m_daughterVolumeId.

A parallel pull request https://github.com/PandoraPFA/larpandora/pull/9 has been issued for larpandora repository regarding the implementation of daughter volumes for DP and the addition of the new member variable in LArCaloHit.