### PR TITLE
Recursive PFO Mop Up

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -93,6 +93,7 @@
 #include "larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ClearLongitudinalTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/MatchedEndPointsTool.h"
 
+#include "larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.h"
@@ -229,6 +230,7 @@
     d("LArUnattachedDeltaRays",                 UnattachedDeltaRaysAlgorithm)                                                   \
     d("LArThreeDHitCreation",                   ThreeDHitCreationAlgorithm)                                                     \
     d("LArThreeDLongitudinalTracks",            ThreeViewLongitudinalTracksAlgorithm)                                           \
+    d("LArRecursivePfoMopUp",                   RecursivePfoMopUpAlgorithm)                                                     \
     d("LArSlidingConePfoMopUp",                 SlidingConePfoMopUpAlgorithm)                                                   \
     d("LArShowerPfoMopUp",                      ShowerPfoMopUpAlgorithm)                                                        \
     d("LArVertexBasedPfoMopUp",                 VertexBasedPfoMopUpAlgorithm)                                                   \

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.cc
@@ -50,16 +50,19 @@ std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> RecursivePfoMopUpAlgorith
     for (PfoList::const_iterator pIter = pPfoList->begin(), pIterEnd = pPfoList->end(); pIter != pIterEnd; ++pIter) {
       const ParticleFlowObject* const pPfo = *pIter;
 
-      unsigned int pfoHits(0);
+      std::vector<unsigned int> pfoHits;
       ClusterList clusterList;
       LArPfoHelper::GetTwoDClusterList(pPfo, clusterList);
       for (auto const& cluster : clusterList) {
-        pfoHits += cluster->GetNCaloHits();
+        pfoHits.push_back(cluster->GetNCaloHits());
       }
-      // TODO get TrackScore Metadata
-      float trackScore(-1.f);
 
-      pfoMergeStatsVec.push_back(RecursivePfoMopUpAlgorithm::pfoMergeStats{ pfoHits, clusterList.size(), trackScore });
+      const PropertiesMap pfoMeta(pPfo->GetPropertiesMap());
+
+      const auto& trackScoreIter = pfoMeta.find("TrackScore");
+      const float trackScore(trackScoreIter != pfoMeta.end() ? trackScoreIter->second : -1.f);
+
+      pfoMergeStatsVec.push_back(RecursivePfoMopUpAlgorithm::pfoMergeStats{ pfoHits, trackScore });
     }
   }
   return pfoMergeStatsVec;

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.cc
@@ -23,7 +23,6 @@ StatusCode RecursivePfoMopUpAlgorithm::Run()
 
     for (unsigned int iter = 0; iter < m_maxIterations; ++iter)
     {
-
         for (auto const &mopUpAlg : m_mopUpAlgorithms)
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RunDaughterAlgorithm(*this, mopUpAlg));
 

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.cc
@@ -1,0 +1,79 @@
+/**
+ *  @file   larpandoracontent/LArTwoDReco/LArClusterMopUp/RecursivePfoMopUpAlgorithm.h
+ *
+ *  @brief  Implementation file for the mega cluster mop up algorithm that runs other algs.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content {
+
+StatusCode RecursivePfoMopUpAlgorithm::Run()
+{
+  bool unchanged(false);
+  std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> mergeStatsVecBefore(GetPfoMergeStats());
+
+  while (!unchanged) {
+
+    for (auto const& mopUpAlg : m_mopUpAlgorithms) {
+      PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RunDaughterAlgorithm(*this, mopUpAlg));
+    }
+
+    std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> mergeStatsVecAfter(GetPfoMergeStats());
+
+    unchanged = std::equal(mergeStatsVecBefore.cbegin(), mergeStatsVecBefore.cend(), mergeStatsVecAfter.cbegin(), mergeStatsVecAfter.cend(), RecursivePfoMopUpAlgorithm::pfoMergeStatsComp);
+
+    mergeStatsVecBefore = std::move(mergeStatsVecAfter);
+  }
+
+  return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> RecursivePfoMopUpAlgorithm::GetPfoMergeStats()
+{
+  std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> pfoMergeStatsVec;
+
+  for (StringVector::const_iterator sIter = m_pfoListNames.begin(), sIterEnd = m_pfoListNames.end(); sIter != sIterEnd; ++sIter) {
+    const PfoList* pPfoList = NULL;
+    if (STATUS_CODE_SUCCESS != PandoraContentApi::GetList(*this, *sIter, pPfoList))
+      continue;
+
+    for (PfoList::const_iterator pIter = pPfoList->begin(), pIterEnd = pPfoList->end(); pIter != pIterEnd; ++pIter) {
+      const ParticleFlowObject* const pPfo = *pIter;
+
+      unsigned int pfoHits(0);
+      ClusterList clusterList;
+      LArPfoHelper::GetTwoDClusterList(pPfo, clusterList);
+      for (auto const& cluster : clusterList) {
+        pfoHits += cluster->GetNCaloHits();
+      }
+      // TODO get TrackScore Metadata
+      float trackScore(-1.f);
+
+      pfoMergeStatsVec.push_back(RecursivePfoMopUpAlgorithm::pfoMergeStats{ pfoHits, clusterList.size(), trackScore });
+    }
+  }
+  return pfoMergeStatsVec;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode RecursivePfoMopUpAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle)
+{
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmList(*this, xmlHandle, "MopUpAlgorithms", m_mopUpAlgorithms));
+
+  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
+
+  return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.cc
@@ -13,75 +13,74 @@
 
 using namespace pandora;
 
-namespace lar_content {
+namespace lar_content
+{
 
 StatusCode RecursivePfoMopUpAlgorithm::Run()
 {
-  std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> mergeStatsVecBefore(GetPfoMergeStats());
+    std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> mergeStatsVecBefore(GetPfoMergeStats());
 
-  for (unsigned int iter = 0; iter < m_maxIterations; ++iter) {
+    for (unsigned int iter = 0; iter < m_maxIterations; ++iter)
+    {
 
-    for (auto const& mopUpAlg : m_mopUpAlgorithms) {
-      PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RunDaughterAlgorithm(*this, mopUpAlg));
-    }
+        for (auto const &mopUpAlg : m_mopUpAlgorithms)
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RunDaughterAlgorithm(*this, mopUpAlg));
 
-    std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> mergeStatsVecAfter(GetPfoMergeStats());
+        std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> mergeStatsVecAfter(GetPfoMergeStats());
 
-    if (std::equal(mergeStatsVecBefore.cbegin(), mergeStatsVecBefore.cend(), mergeStatsVecAfter.cbegin(), mergeStatsVecAfter.cend(),
-            RecursivePfoMopUpAlgorithm::pfoMergeStatsComp))
-      break;
+        if (std::equal(mergeStatsVecBefore.cbegin(), mergeStatsVecBefore.cend(), mergeStatsVecAfter.cbegin(), mergeStatsVecAfter.cend(),
+                RecursivePfoMopUpAlgorithm::pfoMergeStatsComp))
+            break;
 
-    mergeStatsVecBefore = std::move(mergeStatsVecAfter);
-  } // while !unchanged
+        mergeStatsVecBefore = std::move(mergeStatsVecAfter);
+    } // iter
 
-  return STATUS_CODE_SUCCESS;
+    return STATUS_CODE_SUCCESS;
 } // Run
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> RecursivePfoMopUpAlgorithm::GetPfoMergeStats() const
 {
-  std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> pfoMergeStatsVec;
+    std::vector<RecursivePfoMopUpAlgorithm::pfoMergeStats> pfoMergeStatsVec;
 
-  for (auto const& pfoListName : m_pfoListNames) {
+    for (auto const &pfoListName : m_pfoListNames)
+    {
+        const PfoList *pPfoList = NULL;
+        if (STATUS_CODE_SUCCESS != PandoraContentApi::GetList(*this, pfoListName, pPfoList))
+            continue;
 
-    const PfoList* pPfoList = NULL;
-    if (STATUS_CODE_SUCCESS != PandoraContentApi::GetList(*this, pfoListName, pPfoList))
-      continue;
+        for (const ParticleFlowObject *const pPfo : *pPfoList)
+        {
+            std::vector<unsigned int> pfoHits;
+            ClusterList clusterList;
+            LArPfoHelper::GetTwoDClusterList(pPfo, clusterList);
+            for (auto const &cluster : clusterList)
+            {
+                pfoHits.push_back(cluster->GetNCaloHits());
+            }
 
-    for (const ParticleFlowObject* const pPfo : *pPfoList) {
+            const PropertiesMap &pfoMeta(pPfo->GetPropertiesMap());
+            const auto &trackScoreIter(pfoMeta.find("TrackScore"));
+            const float trackScore(trackScoreIter != pfoMeta.end() ? trackScoreIter->second : -1.f);
 
-      std::vector<unsigned int> pfoHits;
-      ClusterList clusterList;
-      LArPfoHelper::GetTwoDClusterList(pPfo, clusterList);
-      for (auto const& cluster : clusterList) {
-        pfoHits.push_back(cluster->GetNCaloHits());
-      }
-
-      const PropertiesMap& pfoMeta(pPfo->GetPropertiesMap());
-      const auto& trackScoreIter(pfoMeta.find("TrackScore"));
-      const float trackScore(trackScoreIter != pfoMeta.end() ? trackScoreIter->second : -1.f);
-
-      pfoMergeStatsVec.emplace_back(RecursivePfoMopUpAlgorithm::pfoMergeStats{ pfoHits, trackScore });
-    } // pPfo : pPfoList
-  }   // pfoListName : m_pfoListNames
-  return pfoMergeStatsVec;
+            pfoMergeStatsVec.emplace_back(RecursivePfoMopUpAlgorithm::pfoMergeStats{pfoHits, trackScore});
+        } // pPfo : pPfoList
+    }     // pfoListName : m_pfoListNames
+    return pfoMergeStatsVec;
 } // GetPfoMergeStats
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode RecursivePfoMopUpAlgorithm::ReadSettings(const pandora::TiXmlHandle xmlHandle)
 {
-  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-      XmlHelper::ProcessAlgorithmList(*this, xmlHandle, "MopUpAlgorithms", m_mopUpAlgorithms));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmList(*this, xmlHandle, "MopUpAlgorithms", m_mopUpAlgorithms));
 
-  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-      XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
 
-  PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
-      XmlHelper::ReadValue(xmlHandle, "MaxIterations", m_maxIterations));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MaxIterations", m_maxIterations));
 
-  return STATUS_CODE_SUCCESS;
+    return STATUS_CODE_SUCCESS;
 } // ReadSettings
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -1,7 +1,8 @@
 /**
  *  @file   larpandoracontent/LArTwoDReco/LArClusterMopUp/RecursivePfoMopUpAlgorithm.h
  *
- *  @brief  Header file for the mega cluster mop up algorithm that runs other algs.
+ *  @brief  Header file for the recursive pfo mop up algorithm that runs other algs:
+ *          Recusively loop over a series of algortihms until no more changes are made
  *
  *  $Log: $
  */
@@ -17,19 +18,18 @@ namespace lar_content {
  */
 class RecursivePfoMopUpAlgorithm : public pandora::Algorithm {
   private:
-  // Struct to determine if a pfo has been merged
-  struct pfoMergeStats {
-    const std::vector<unsigned int> mNumHits;
-    const float mTrackScore;
+  struct pfoMergeStats {                      ///< Object to compare PFO before/after merging algs have run to see if anything changed
+    const std::vector<unsigned int> mNumHits; ///< Vector filled with number of hits in each of the PFO's clusters
+    const float mTrackScore;                  ///< MVA "Track Score" for the PFO
   };
 
-  static bool pfoMergeStatsComp(const pfoMergeStats& lhs, const pfoMergeStats& rhs)
+  static bool pfoMergeStatsComp(const pfoMergeStats& lhs, const pfoMergeStats& rhs) ///< Comparitor  for pfoMergeStats
   {
-    return ((lhs.mNumHits == rhs.mNumHits) && ((lhs.mTrackScore - rhs.mTrackScore) < std::numeric_limits<float>::epsilon()));
+    return ((lhs.mNumHits == rhs.mNumHits) && (std::abs(lhs.mTrackScore - rhs.mTrackScore) < std::numeric_limits<float>::epsilon()));
   };
 
   pandora::StatusCode Run();
-  std::vector<pfoMergeStats> GetPfoMergeStats();
+  std::vector<pfoMergeStats> GetPfoMergeStats() const; ///< Vector filled with pfoMergeStats for each PFP in m_pfoListNames
   pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
   pandora::StringVector m_pfoListNames;    ///< The list of pfo list names

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -20,7 +20,10 @@ namespace lar_content
 class RecursivePfoMopUpAlgorithm : public pandora::Algorithm
 {
 public:
-    RecursivePfoMopUpAlgorithm() : m_maxIterations(10){};
+    /**
+     *  @brief  Default constructor
+     */
+    RecursivePfoMopUpAlgorithm();
 
 private:
     typedef std::vector<unsigned int> ClusterNumHitsList;
@@ -37,7 +40,7 @@ private:
          *  @param  Vector filled with number of hits in each of the PFO's clusters
          *  @param  MVA "Track Score" for the PFO
          */
-        PfoMergeStats(const ClusterNumHitsList numClusterHits, const float trackScore);
+        PfoMergeStats(const ClusterNumHitsList &numClusterHits, const float trackScore);
 
         const ClusterNumHitsList m_numClusterHits; ///< Vector filled with number of hits in each of the PFO's clusters
         const float m_trackScore;                  ///< MVA "Track Score" for the PFO
@@ -46,12 +49,12 @@ private:
     typedef std::vector<PfoMergeStats> PfoMergeStatsList;
 
     /**
-     *  @brief  Equality comparator for two lists of PfoMergeStats
+     *  @brief  Equality comparator for two PfoMergeStats
      *
-     *  @param  lhs PFOMergeStats for comparison
-     *  @param  rhs PFOMergeStats for comparison
+     *  @param  lhs PfoMergeStats for comparison
+     *  @param  rhs PfoMergeStats for comparison
      *
-     *  @return boolian if the lhs and rhs are the same
+     *  @return boolean if the lhs and rhs are the same
      */
     static bool PfoMergeStatsComp(const PfoMergeStats &lhs, const PfoMergeStats &rhs);
 
@@ -70,11 +73,21 @@ private:
     pandora::StringVector m_mopUpAlgorithms; ///< Ordered list of mop up algorithms to run
 };
 
-inline RecursivePfoMopUpAlgorithm::PfoMergeStats::PfoMergeStats(const ClusterNumHitsList numClusterHits, const float trackScore) :
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline RecursivePfoMopUpAlgorithm::RecursivePfoMopUpAlgorithm() : m_maxIterations(10)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline RecursivePfoMopUpAlgorithm::PfoMergeStats::PfoMergeStats(const ClusterNumHitsList &numClusterHits, const float trackScore) :
     m_numClusterHits(numClusterHits),
     m_trackScore(trackScore)
 {
 }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
 
 inline bool RecursivePfoMopUpAlgorithm::PfoMergeStatsComp(
     const RecursivePfoMopUpAlgorithm::PfoMergeStats &lhs, const RecursivePfoMopUpAlgorithm::PfoMergeStats &rhs)

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -24,16 +24,43 @@ public:
 
 private:
     typedef std::vector<unsigned int> ClusterNumHitsList;
-    struct PfoMergeStats ///< Object to compare PFO before/after merging algs have run to see if anything changed
+
+    /**
+     *  @brief  PfoMergeStats class: Object to compare PFO before/after merging algs have run to see if anything changed
+     */
+    struct PfoMergeStats
     {
+    public:
+        /**
+         *  @brief  Constructor
+         *
+         *  @param  Vector filled with number of hits in each of the PFO's clusters
+         *  @param  MVA "Track Score" for the PFO
+         */
+        PfoMergeStats(const ClusterNumHitsList numClusterHits, const float trackScore);
+
         const ClusterNumHitsList m_numClusterHits; ///< Vector filled with number of hits in each of the PFO's clusters
         const float m_trackScore;                  ///< MVA "Track Score" for the PFO
     };
+
     typedef std::vector<PfoMergeStats> PfoMergeStatsList;
 
-    static bool PfoMergeStatsComp(const PfoMergeStats &lhs, const PfoMergeStats &rhs); ///< Comparator  for PfoMergeStats
+    /**
+     *  @brief  Equality comparator for two lists of PfoMergeStats
+     *
+     *  @param  lhs PFOMergeStats for comparison
+     *  @param  rhs PFOMergeStats for comparison
+     *
+     *  @return boolian if the lhs and rhs are the same
+     */
+    static bool PfoMergeStatsComp(const PfoMergeStats &lhs, const PfoMergeStats &rhs);
 
-    PfoMergeStatsList GetPfoMergeStats() const; ///< Vector filled with PfoMergeStats for each PFP in m_pfoListNames
+    /**
+     *  @brief  Get the PfoMergeStats for all of the particles in the event from m_pfoListNames
+     *
+     *  @return List of PfoMergeStats for each Pfo
+     */
+    PfoMergeStatsList GetPfoMergeStats() const;
 
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -42,6 +69,12 @@ private:
     pandora::StringVector m_pfoListNames;    ///< The list of pfo list names
     pandora::StringVector m_mopUpAlgorithms; ///< Ordered list of mop up algorithms to run
 };
+
+inline RecursivePfoMopUpAlgorithm::PfoMergeStats::PfoMergeStats(const ClusterNumHitsList numClusterHits, const float trackScore) :
+    m_numClusterHits(numClusterHits),
+    m_trackScore(trackScore)
+{
+}
 
 inline bool RecursivePfoMopUpAlgorithm::PfoMergeStatsComp(
     const RecursivePfoMopUpAlgorithm::PfoMergeStats &lhs, const RecursivePfoMopUpAlgorithm::PfoMergeStats &rhs)

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -19,14 +19,13 @@ class RecursivePfoMopUpAlgorithm : public pandora::Algorithm {
   private:
   // Struct to determine if a pfo has been merged
   struct pfoMergeStats {
-    const unsigned int mNumHits;
-    const long unsigned int mNumClusters;
+    const std::vector<unsigned int> mNumHits;
     const float mTrackScore;
   };
 
   static bool pfoMergeStatsComp(const pfoMergeStats& lhs, const pfoMergeStats& rhs)
   {
-    return ((lhs.mNumClusters == rhs.mNumClusters) && (lhs.mNumHits == rhs.mNumHits) && ((lhs.mTrackScore - rhs.mTrackScore) < std::numeric_limits<float>::epsilon()));
+    return ((lhs.mNumHits == rhs.mNumHits) && ((lhs.mTrackScore - rhs.mTrackScore) < std::numeric_limits<float>::epsilon()));
   };
 
   pandora::StatusCode Run();

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -11,30 +11,33 @@
 
 #include "Pandora/Algorithm.h"
 
-namespace lar_content {
+namespace lar_content
+{
 
 /**
  *  @brief  RecursivePfoMopUpAlgorithm class
  */
-class RecursivePfoMopUpAlgorithm : public pandora::Algorithm {
-  private:
-  struct pfoMergeStats {                      ///< Object to compare PFO before/after merging algs have run to see if anything changed
-    const std::vector<unsigned int> mNumHits; ///< Vector filled with number of hits in each of the PFO's clusters
-    const float mTrackScore;                  ///< MVA "Track Score" for the PFO
-  };
+class RecursivePfoMopUpAlgorithm : public pandora::Algorithm
+{
+private:
+    struct pfoMergeStats
+    {                                             ///< Object to compare PFO before/after merging algs have run to see if anything changed
+        const std::vector<unsigned int> mNumHits; ///< Vector filled with number of hits in each of the PFO's clusters
+        const float mTrackScore;                  ///< MVA "Track Score" for the PFO
+    };
 
-  static bool pfoMergeStatsComp(const pfoMergeStats& lhs, const pfoMergeStats& rhs) ///< Comparitor  for pfoMergeStats
-  {
-    return ((lhs.mNumHits == rhs.mNumHits) && (std::abs(lhs.mTrackScore - rhs.mTrackScore) < std::numeric_limits<float>::epsilon()));
-  };
+    static bool pfoMergeStatsComp(const pfoMergeStats &lhs, const pfoMergeStats &rhs) ///< Comparitor  for pfoMergeStats
+    {
+        return ((lhs.mNumHits == rhs.mNumHits) && (std::abs(lhs.mTrackScore - rhs.mTrackScore) < std::numeric_limits<float>::epsilon()));
+    };
 
-  pandora::StatusCode Run();
-  std::vector<pfoMergeStats> GetPfoMergeStats() const; ///< Vector filled with pfoMergeStats for each PFP in m_pfoListNames
-  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+    pandora::StatusCode Run();
+    std::vector<pfoMergeStats> GetPfoMergeStats() const; ///< Vector filled with pfoMergeStats for each PFP in m_pfoListNames
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-  unsigned int m_maxIterations;            ///< Maximum number of iterations
-  pandora::StringVector m_pfoListNames;    ///< The list of pfo list names
-  pandora::StringVector m_mopUpAlgorithms; ///< Ordered list of mop up algorithms to run
+    unsigned int m_maxIterations;            ///< Maximum number of iterations
+    pandora::StringVector m_pfoListNames;    ///< The list of pfo list names
+    pandora::StringVector m_mopUpAlgorithms; ///< Ordered list of mop up algorithms to run
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -1,0 +1,42 @@
+/**
+ *  @file   larpandoracontent/LArTwoDReco/LArClusterMopUp/RecursivePfoMopUpAlgorithm.h
+ *
+ *  @brief  Header file for the mega cluster mop up algorithm that runs other algs.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_RECURSIVE_PFO_MOP_UP_ALGORITHM_H
+#define LAR_RECURSIVE_PFO_MOP_UP_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content {
+
+/**
+ *  @brief  RecursivePfoMopUpAlgorithm class
+ */
+class RecursivePfoMopUpAlgorithm : public pandora::Algorithm {
+  private:
+  // Struct to determine if a pfo has been merged
+  struct pfoMergeStats {
+    const unsigned int mNumHits;
+    const long unsigned int mNumClusters;
+    const float mTrackScore;
+  };
+
+  static bool pfoMergeStatsComp(const pfoMergeStats& lhs, const pfoMergeStats& rhs)
+  {
+    return ((lhs.mNumClusters == rhs.mNumClusters) && (lhs.mNumHits == rhs.mNumHits) && ((lhs.mTrackScore - rhs.mTrackScore) < std::numeric_limits<float>::epsilon()));
+  };
+
+  pandora::StatusCode Run();
+  std::vector<pfoMergeStats> GetPfoMergeStats();
+  pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+  pandora::StringVector m_pfoListNames;    ///< The list of pfo list names
+  pandora::StringVector m_mopUpAlgorithms; ///< Ordered list of mop up algorithms to run
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_RECURSIVE_PFO_MOP_UP_ALGORITHM_H

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -2,7 +2,7 @@
  *  @file   larpandoracontent/LArTwoDReco/LArClusterMopUp/RecursivePfoMopUpAlgorithm.h
  *
  *  @brief  Header file for the recursive pfo mop up algorithm that runs other algs:
- *          Recusively loop over a series of algortihms until no more changes are made
+ *          Recusively loop over a series of algorithms until no more changes are made
  *
  *  $Log: $
  */
@@ -19,26 +19,35 @@ namespace lar_content
  */
 class RecursivePfoMopUpAlgorithm : public pandora::Algorithm
 {
-private:
-    struct pfoMergeStats
-    {                                             ///< Object to compare PFO before/after merging algs have run to see if anything changed
-        const std::vector<unsigned int> mNumHits; ///< Vector filled with number of hits in each of the PFO's clusters
-        const float mTrackScore;                  ///< MVA "Track Score" for the PFO
-    };
+public:
+    RecursivePfoMopUpAlgorithm() : m_maxIterations(10){};
 
-    static bool pfoMergeStatsComp(const pfoMergeStats &lhs, const pfoMergeStats &rhs) ///< Comparitor  for pfoMergeStats
+private:
+    typedef std::vector<unsigned int> ClusterNumHitsList;
+    struct PfoMergeStats ///< Object to compare PFO before/after merging algs have run to see if anything changed
     {
-        return ((lhs.mNumHits == rhs.mNumHits) && (std::abs(lhs.mTrackScore - rhs.mTrackScore) < std::numeric_limits<float>::epsilon()));
+        const ClusterNumHitsList m_numClusterHits; ///< Vector filled with number of hits in each of the PFO's clusters
+        const float m_trackScore;                  ///< MVA "Track Score" for the PFO
     };
+    typedef std::vector<PfoMergeStats> PfoMergeStatsList;
+
+    static bool PfoMergeStatsComp(const PfoMergeStats &lhs, const PfoMergeStats &rhs); ///< Comparator  for PfoMergeStats
+
+    PfoMergeStatsList GetPfoMergeStats() const; ///< Vector filled with PfoMergeStats for each PFP in m_pfoListNames
 
     pandora::StatusCode Run();
-    std::vector<pfoMergeStats> GetPfoMergeStats() const; ///< Vector filled with pfoMergeStats for each PFP in m_pfoListNames
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     unsigned int m_maxIterations;            ///< Maximum number of iterations
     pandora::StringVector m_pfoListNames;    ///< The list of pfo list names
     pandora::StringVector m_mopUpAlgorithms; ///< Ordered list of mop up algorithms to run
 };
+
+inline bool RecursivePfoMopUpAlgorithm::PfoMergeStatsComp(
+    const RecursivePfoMopUpAlgorithm::PfoMergeStats &lhs, const RecursivePfoMopUpAlgorithm::PfoMergeStats &rhs)
+{
+    return ((lhs.m_numClusterHits == rhs.m_numClusterHits) && (std::abs(lhs.m_trackScore - rhs.m_trackScore) < std::numeric_limits<float>::epsilon()));
+}
 
 } // namespace lar_content
 

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h
@@ -32,6 +32,7 @@ class RecursivePfoMopUpAlgorithm : public pandora::Algorithm {
   std::vector<pfoMergeStats> GetPfoMergeStats() const; ///< Vector filled with pfoMergeStats for each PFP in m_pfoListNames
   pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
+  unsigned int m_maxIterations;            ///< Maximum number of iterations
   pandora::StringVector m_pfoListNames;    ///< The list of pfo list names
   pandora::StringVector m_mopUpAlgorithms; ///< Ordered list of mop up algorithms to run
 };


### PR DESCRIPTION
Add RecursivePFOMopUp algorithm that loops over an input set of algorithms (defined in XML) repeatedly until no more changes to the PFO, and it's associated clusters, are made or it reaches the maximum allowed number of iterations. 