### PR TITLE
Move semantics

### DIFF
--- a/larpandoracontent/LArObjects/LArTrackOverlapResult.cc
+++ b/larpandoracontent/LArObjects/LArTrackOverlapResult.cc
@@ -165,6 +165,16 @@ TransverseOverlapResult &TransverseOverlapResult::operator=(const TransverseOver
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
+
+TransverseOverlapResult &TransverseOverlapResult::operator=(TransverseOverlapResult &&rhs)
+{
+    this->TrackOverlapResult::operator=(rhs);
+    m_xOverlap = std::move(rhs.m_xOverlap);
+
+    return *this;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 TransverseOverlapResult operator+(const TransverseOverlapResult &lhs, const TransverseOverlapResult &rhs)
@@ -289,6 +299,17 @@ FragmentOverlapResult &FragmentOverlapResult::operator=(const FragmentOverlapRes
     this->TrackOverlapResult::operator=(rhs);
     m_caloHitList = rhs.GetFragmentCaloHitList();
     m_clusterList = rhs.GetFragmentClusterList();
+
+    return *this;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+FragmentOverlapResult &FragmentOverlapResult::operator=(FragmentOverlapResult &&rhs)
+{
+    this->TrackOverlapResult::operator=(rhs);
+    m_caloHitList = std::move(rhs.m_caloHitList);
+    m_clusterList = std::move(rhs.m_clusterList);
 
     return *this;
 }

--- a/larpandoracontent/LArObjects/LArTrackOverlapResult.h
+++ b/larpandoracontent/LArObjects/LArTrackOverlapResult.h
@@ -173,6 +173,13 @@ public:
      */
     TransverseOverlapResult &operator=(const TransverseOverlapResult &rhs);
 
+    /**
+     *  @brief Move assignment operator
+     *
+     *  @param  rhs the object to be moved
+     */
+    TransverseOverlapResult &operator=(TransverseOverlapResult &&rhs);
+
 private:
     XOverlap        m_xOverlap;                     ///< The x overlap object
 };
@@ -335,6 +342,13 @@ public:
      *  @param  rhs the track overlap result to assign
      */
     FragmentOverlapResult &operator=(const FragmentOverlapResult &rhs);
+
+    /**
+     *  @brief Move assignment operator
+     *
+     *  @param  rhs the object to be moved
+     */
+    FragmentOverlapResult &operator=(FragmentOverlapResult &&rhs);
 
 private:
     pandora::CaloHitList    m_caloHitList;      ///< The list of fragment-associated hits

--- a/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.cc
+++ b/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.cc
@@ -198,4 +198,17 @@ TwoViewTransverseOverlapResult &TwoViewTransverseOverlapResult::operator=(const 
     return *this;
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+TwoViewTransverseOverlapResult &TwoViewTransverseOverlapResult::operator=(TwoViewTransverseOverlapResult &&rhs)
+{
+    m_downsamplingFactor = rhs.m_downsamplingFactor;
+    m_nSamplingPoints = rhs.m_nSamplingPoints;
+    m_nMatchedSamplingPoints = rhs.m_nMatchedSamplingPoints;
+    m_correlationCoefficient = rhs.m_correlationCoefficient;
+    m_twoViewXOverlap = std::move(rhs.m_twoViewXOverlap);
+
+    return *this;
+}
+
 } // namespace lar_content

--- a/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.h
+++ b/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.h
@@ -188,6 +188,13 @@ public:
      */
     TwoViewTransverseOverlapResult &operator=(const TwoViewTransverseOverlapResult &rhs);
 
+    /**
+     *  @brief Move assignment operator
+     *
+     *  @param  rhs the object to be moved
+     */
+    TwoViewTransverseOverlapResult &operator=(TwoViewTransverseOverlapResult &&rhs);
+
 private:
     float                  m_downsamplingFactor;                  ///< The downsampling factor
     unsigned int           m_nSamplingPoints;                     ///< The number of sampling points


### PR DESCRIPTION
Add move assignment operators to increase efficiency where move can replace copy.