### PR TITLE
Fix for V-shaped events in ClusterAssociationAlgorithm

### DIFF
--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.cc
@@ -106,6 +106,7 @@ void ClusterAssociationAlgorithm::UnambiguousPropagation(const Cluster *const pC
         return;
 
     this->UpdateForUnambiguousMerge(pClusterToEnlarge, pClusterToDelete, isForward, clusterAssociationMap);
+
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pClusterToEnlarge, pClusterToDelete));
     m_mergeMade = true;
 
@@ -147,11 +148,14 @@ void ClusterAssociationAlgorithm::AmbiguousPropagation(const Cluster *const pClu
 
     for (ClusterVector::iterator dIter = daughterClusterVector.begin(), dIterEnd = daughterClusterVector.end(); dIter != dIterEnd; ++dIter)
     {
-        this->UpdateForAmbiguousMerge(pCluster, *dIter, isForward, clusterAssociationMap);
+        this->UpdateForAmbiguousMerge(*dIter, clusterAssociationMap);
+
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pCluster, *dIter));
         m_mergeMade = true;
         *dIter = NULL;
     }
+
+    this->UpdateForAmbiguousMerge(pCluster, clusterAssociationMap);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -194,69 +198,29 @@ void ClusterAssociationAlgorithm::UpdateForUnambiguousMerge(const Cluster *const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClusterAssociationAlgorithm::UpdateForAmbiguousMerge(const Cluster *const pClusterToEnlarge, const Cluster *const pClusterToDelete, const bool isForwardMerge,
-    ClusterAssociationMap &clusterAssociationMap) const
+void ClusterAssociationAlgorithm::UpdateForAmbiguousMerge(const Cluster *const pCluster, ClusterAssociationMap &clusterAssociationMap) const
 {
-    ClusterAssociationMap::iterator iterEnlarge = clusterAssociationMap.find(pClusterToEnlarge);
-    ClusterAssociationMap::iterator iterDelete = clusterAssociationMap.find(pClusterToDelete);
+    ClusterAssociationMap::iterator cIter = clusterAssociationMap.find(pCluster);
 
-    if ((clusterAssociationMap.end() == iterEnlarge) || (clusterAssociationMap.end() == iterDelete))
+    if (clusterAssociationMap.end() == cIter)
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
-    ClusterSet &clusterSetEnlarge(isForwardMerge ? iterEnlarge->second.m_forwardAssociations : iterEnlarge->second.m_backwardAssociations);
-    ClusterSet &clusterSetDelete(isForwardMerge ? iterDelete->second.m_backwardAssociations : iterDelete->second.m_forwardAssociations);
-
-    for (ClusterSet::iterator iter = clusterSetEnlarge.begin(); iter != clusterSetEnlarge.end();)
+    for (ClusterAssociationMap::iterator mIter = clusterAssociationMap.begin(), mIterEnd = clusterAssociationMap.end(); mIter != mIterEnd; ++mIter)
     {
-        if ((*iter) != pClusterToDelete)
-        {
-            ClusterAssociationMap::iterator iterAssociation = clusterAssociationMap.find(*iter);
+        ClusterSet &forwardClusters = mIter->second.m_forwardAssociations;
+        ClusterSet &backwardClusters = mIter->second.m_backwardAssociations;
 
-            if (clusterAssociationMap.end() == iterAssociation)
-                throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        ClusterSet::iterator fIter = forwardClusters.find(pCluster);
+        ClusterSet::iterator bIter = backwardClusters.find(pCluster);
 
-            ClusterSet &associatedClusterSet(isForwardMerge ? iterAssociation->second.m_backwardAssociations : iterAssociation->second.m_forwardAssociations);
+        if (forwardClusters.end() != fIter)
+            forwardClusters.erase(fIter);
 
-            ClusterSet::iterator enlargeIter = associatedClusterSet.find(pClusterToEnlarge);
-
-            if (associatedClusterSet.end() == enlargeIter)
-                throw StatusCodeException(STATUS_CODE_NOT_FOUND);
-
-            associatedClusterSet.erase(enlargeIter);
-            clusterSetEnlarge.erase(iter++);
-        }
-        else
-        {
-            ++iter;
-        }
+        if (backwardClusters.end() != bIter)
+            backwardClusters.erase(bIter);
     }
 
-    for (ClusterSet::iterator iter = clusterSetDelete.begin(); iter != clusterSetDelete.end();)
-    {
-        if ((*iter) != pClusterToEnlarge)
-        {
-            ClusterAssociationMap::iterator iterAssociation = clusterAssociationMap.find(*iter);
-
-            if (clusterAssociationMap.end() == iterAssociation)
-                throw StatusCodeException(STATUS_CODE_NOT_FOUND);
-
-            ClusterSet &associatedClusterSet(isForwardMerge ? iterAssociation->second.m_forwardAssociations : iterAssociation->second.m_backwardAssociations);
-
-            ClusterSet::iterator deleteIter = associatedClusterSet.find(pClusterToDelete);
-
-            if (associatedClusterSet.end() == deleteIter)
-                throw StatusCodeException(STATUS_CODE_NOT_FOUND);
-
-            associatedClusterSet.erase(deleteIter);
-            clusterSetDelete.erase(iter++);
-        }
-        else
-        {
-            ++iter;
-        }
-    }
-
-    return this->UpdateForUnambiguousMerge(pClusterToEnlarge, pClusterToDelete, isForwardMerge, clusterAssociationMap);
+    clusterAssociationMap.erase(pCluster);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.h
@@ -102,13 +102,10 @@ private:
     /**
      *  @brief  Update cluster association map to reflect an ambiguous cluster merge
      *
-     *  @param  pClusterToEnlarge address of the cluster to be enlarged
-     *  @param  pClusterToDelete address of the cluster to be deleted
-     *  @param  isForwardMerge whether merge is forward (pClusterToEnlarge is forward-associated with pClusterToDelete)
+     *  @param  pCluster address of the cluster to be cleared
      *  @param  clusterAssociationMap the cluster association map
      */
-    void UpdateForAmbiguousMerge(const pandora::Cluster *const pClusterToEnlarge, const pandora::Cluster *const pClusterToDelete, const bool isForwardMerge,
-        ClusterAssociationMap &clusterAssociationMap) const;
+    void UpdateForAmbiguousMerge(const pandora::Cluster *const pCluster, ClusterAssociationMap &clusterAssociationMap) const;
 
     /**
      *  @brief  Navigate along cluster associations, from specified cluster, in specified direction


### PR DESCRIPTION
I've simplified the ClusterAssociationAlgorithm::UpdateForAmbiguousMerge(...) method so that ambiguously-merged clusters are entirely removed from the cluster association map.

Previously, the UpdateForAmbiguousMerge(...) method was more elaborate and also called the UpdateForUnambiguousMerge(...) method. I think this last part was the cause of our V-shaped events.

Although the previous implementation was more elaborate, I think the net effect was to simply remove the clusters-to-be-merged from the cluster association map. So, I've coded this in a simpler way - but I worry that I've missed something!
