### PR TITLE
Apply ClangFormat

### DIFF
--- a/larpandoracontent/LArCheating/CheatingBeamParticleIdTool.cc
+++ b/larpandoracontent/LArCheating/CheatingBeamParticleIdTool.cc
@@ -18,14 +18,14 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingBeamParticleIdTool::CheatingBeamParticleIdTool() :
-    m_minWeightFraction(0.5f)
+CheatingBeamParticleIdTool::CheatingBeamParticleIdTool() : m_minWeightFraction(0.5f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *const /*pAlgorithm*/, const SliceHypotheses &testBeamSliceHypotheses, const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
+void CheatingBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *const /*pAlgorithm*/,
+    const SliceHypotheses &testBeamSliceHypotheses, const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
 {
     if (testBeamSliceHypotheses.size() != crSliceHypotheses.size())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -50,7 +50,7 @@ void CheatingBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *cons
             totalWeight += thisTotalWeight;
         }
 
-        const float beamWeightFraction(totalWeight < std::numeric_limits<float>::epsilon() ? 0.f : beamParticleWeight/totalWeight);
+        const float beamWeightFraction(totalWeight < std::numeric_limits<float>::epsilon() ? 0.f : beamParticleWeight / totalWeight);
 
         if (beamWeightFraction > m_minWeightFraction)
         {

--- a/larpandoracontent/LArCheating/CheatingBeamParticleIdTool.h
+++ b/larpandoracontent/LArCheating/CheatingBeamParticleIdTool.h
@@ -8,8 +8,8 @@
 #ifndef LAR_CHEATING_BEAM_PARTICLE_ID_TOOL_H
 #define LAR_CHEATING_BEAM_PARTICLE_ID_TOOL_H 1
 
-#include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
 #include "larpandoracontent/LArCheating/CheatingSliceIdBaseTool.h"
+#include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
 
 namespace lar_content
 {
@@ -25,12 +25,13 @@ public:
      */
     CheatingBeamParticleIdTool();
 
-    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
+    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float     m_minWeightFraction;     ///< The minimum weight fraction for identifying a slice as a beam particle
+    float m_minWeightFraction; ///< The minimum weight fraction for identifying a slice as a beam particle
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingBeamParticleSliceSelectionTool.h
+++ b/larpandoracontent/LArCheating/CheatingBeamParticleSliceSelectionTool.h
@@ -33,4 +33,3 @@ private:
 } // namespace lar_content
 
 #endif // #ifndef LAR_CHEATING_BEAM_PARTICLE_SLICE_SELECTION_TOOL_H
-

--- a/larpandoracontent/LArCheating/CheatingClusterCharacterisationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingClusterCharacterisationAlgorithm.cc
@@ -27,7 +27,9 @@ bool CheatingClusterCharacterisationAlgorithm::IsClearTrack(const Cluster *const
         if ((PHOTON != pMCParticle->GetParticleId()) && (E_MINUS != std::abs(pMCParticle->GetParticleId())))
             return true;
     }
-    catch (const StatusCodeException &) {}
+    catch (const StatusCodeException &)
+    {
+    }
 
     return false;
 }

--- a/larpandoracontent/LArCheating/CheatingClusterCreationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingClusterCreationAlgorithm.cc
@@ -15,8 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingClusterCreationAlgorithm::CheatingClusterCreationAlgorithm() :
-    m_collapseToPrimaryMCParticles(false)
+CheatingClusterCreationAlgorithm::CheatingClusterCreationAlgorithm() : m_collapseToPrimaryMCParticles(false)
 {
 }
 
@@ -57,14 +56,16 @@ void CheatingClusterCreationAlgorithm::GetMCParticleToHitListMap(MCParticleToHit
 
             this->SimpleMCParticleCollection(pCaloHit, mcPrimaryMap, mcParticleToHitListMap);
         }
-        catch (const StatusCodeException &) {}
+        catch (const StatusCodeException &)
+        {
+        }
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingClusterCreationAlgorithm::SimpleMCParticleCollection(const CaloHit *const pCaloHit, const LArMCParticleHelper::MCRelationMap &mcPrimaryMap,
-    MCParticleToHitListMap &mcParticleToHitListMap) const
+void CheatingClusterCreationAlgorithm::SimpleMCParticleCollection(const CaloHit *const pCaloHit,
+    const LArMCParticleHelper::MCRelationMap &mcPrimaryMap, MCParticleToHitListMap &mcParticleToHitListMap) const
 {
     const MCParticle *pMCParticle(MCParticleHelper::GetMainMCParticle(pCaloHit));
 
@@ -105,7 +106,8 @@ bool CheatingClusterCreationAlgorithm::SelectMCParticlesForClustering(const MCPa
 void CheatingClusterCreationAlgorithm::CreateClusters(const MCParticleToHitListMap &mcParticleToHitListMap) const
 {
     MCParticleVector mcParticleVector;
-    for (const auto &mapEntry : mcParticleToHitListMap) mcParticleVector.push_back(mapEntry.first);
+    for (const auto &mapEntry : mcParticleToHitListMap)
+        mcParticleVector.push_back(mapEntry.first);
     std::sort(mcParticleVector.begin(), mcParticleVector.end(), LArMCParticleHelper::SortByMomentum);
 
     for (const MCParticle *const pMCParticle : mcParticleVector)
@@ -124,15 +126,15 @@ void CheatingClusterCreationAlgorithm::CreateClusters(const MCParticleToHitListM
 
         switch (pMCParticle->GetParticleId())
         {
-        case PHOTON:
-        case E_PLUS:
-        case E_MINUS:
-        case MU_PLUS:
-        case MU_MINUS:
-            metadata.m_particleId = pMCParticle->GetParticleId();
-            break;
-        default:
-            break;
+            case PHOTON:
+            case E_PLUS:
+            case E_MINUS:
+            case MU_PLUS:
+            case MU_MINUS:
+                metadata.m_particleId = pMCParticle->GetParticleId();
+                break;
+            default:
+                break;
         }
 
         if (metadata.m_particleId.IsInitialized())
@@ -144,17 +146,16 @@ void CheatingClusterCreationAlgorithm::CreateClusters(const MCParticleToHitListM
 
 StatusCode CheatingClusterCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CollapseToPrimaryMCParticles", m_collapseToPrimaryMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CollapseToPrimaryMCParticles", m_collapseToPrimaryMCParticles));
 
     if (m_collapseToPrimaryMCParticles)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "MCParticleListName", m_mcParticleListName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "ParticleIdList", m_particleIdList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ParticleIdList", m_particleIdList));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingClusterCreationAlgorithm.h
+++ b/larpandoracontent/LArCheating/CheatingClusterCreationAlgorithm.h
@@ -32,7 +32,7 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::MCParticle*, pandora::CaloHitList> MCParticleToHitListMap;
+    typedef std::unordered_map<const pandora::MCParticle *, pandora::CaloHitList> MCParticleToHitListMap;
 
     /**
      *  @brief  Create map between each (primary) MC particle and associated calo hits
@@ -67,10 +67,10 @@ private:
      */
     void CreateClusters(const MCParticleToHitListMap &mcParticleToHitListMap) const;
 
-    bool                m_collapseToPrimaryMCParticles; ///< Whether to collapse mc particle hierarchies to primary particles
-    std::string         m_mcParticleListName;           ///< The mc particle list name, required if want to collapse mc particle hierarchy
+    bool m_collapseToPrimaryMCParticles; ///< Whether to collapse mc particle hierarchies to primary particles
+    std::string m_mcParticleListName;    ///< The mc particle list name, required if want to collapse mc particle hierarchy
 
-    pandora::IntVector  m_particleIdList;               ///< list of particle ids of MCPFOs to be selected
+    pandora::IntVector m_particleIdList; ///< list of particle ids of MCPFOs to be selected
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingCosmicRayIdentificationAlg.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayIdentificationAlg.cc
@@ -19,8 +19,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingCosmicRayIdentificationAlg::CheatingCosmicRayIdentificationAlg() :
-    m_maxNeutrinoFraction(0.5f)
+CheatingCosmicRayIdentificationAlg::CheatingCosmicRayIdentificationAlg() : m_maxNeutrinoFraction(0.5f)
 {
 }
 
@@ -29,7 +28,8 @@ CheatingCosmicRayIdentificationAlg::CheatingCosmicRayIdentificationAlg() :
 StatusCode CheatingCosmicRayIdentificationAlg::Run()
 {
     const PfoList *pPfoList(nullptr);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
 
     if (!pPfoList)
     {
@@ -61,7 +61,8 @@ StatusCode CheatingCosmicRayIdentificationAlg::Run()
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, m_inputPfoListName, m_outputPfoListName, outputPfoList));
 
         if (!outputDaughterPfoList.empty())
-            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, m_inputDaughterPfoListName, m_outputDaughterPfoListName, outputDaughterPfoList));
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::SaveList(*this, m_inputDaughterPfoListName, m_outputDaughterPfoListName, outputDaughterPfoList));
     }
 
     return STATUS_CODE_SUCCESS;
@@ -71,22 +72,20 @@ StatusCode CheatingCosmicRayIdentificationAlg::Run()
 
 StatusCode CheatingCosmicRayIdentificationAlg::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputPfoListName", m_inputPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputPfoListName", m_inputPfoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputPfoListName", m_outputPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputPfoListName", m_outputPfoListName));
 
     m_inputDaughterPfoListName = m_inputPfoListName;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputDaughterPfoListName", m_inputDaughterPfoListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "InputDaughterPfoListName", m_inputDaughterPfoListName));
 
     m_outputDaughterPfoListName = m_outputPfoListName;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputDaughterPfoListName", m_outputDaughterPfoListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "OutputDaughterPfoListName", m_outputDaughterPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxNeutrinoFraction", m_maxNeutrinoFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxNeutrinoFraction", m_maxNeutrinoFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingCosmicRayIdentificationAlg.h
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayIdentificationAlg.h
@@ -28,11 +28,11 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string     m_inputPfoListName;             ///< The input pfo list name
-    std::string     m_outputPfoListName;            ///< The output pfo list name
-    std::string     m_inputDaughterPfoListName;     ///< The input daughter pfo list name (if not specified, will assume same as main input list)
-    std::string     m_outputDaughterPfoListName;    ///< The output daughter pfo list name (if not specified, will assume same as main output list)
-    float           m_maxNeutrinoFraction;          ///< The maximum true neutrino fraction in a particle to be labelled as a cosmic ray
+    std::string m_inputPfoListName;          ///< The input pfo list name
+    std::string m_outputPfoListName;         ///< The output pfo list name
+    std::string m_inputDaughterPfoListName;  ///< The input daughter pfo list name (if not specified, will assume same as main input list)
+    std::string m_outputDaughterPfoListName; ///< The output daughter pfo list name (if not specified, will assume same as main output list)
+    float m_maxNeutrinoFraction;             ///< The maximum true neutrino fraction in a particle to be labelled as a cosmic ray
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingCosmicRayRemovalAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayRemovalAlgorithm.cc
@@ -6,8 +6,8 @@
  *  $Log: $
  */
 
-#include "Pandora/AlgorithmHeaders.h"
 #include "Helpers/MCParticleHelper.h"
+#include "Pandora/AlgorithmHeaders.h"
 
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 
@@ -38,7 +38,8 @@ StatusCode CheatingCosmicRayRemovalAlgorithm::Run()
         }
         catch (const StatusCodeException &)
         {
-            std::cout << "CheatingCosmicRayRemovalAlgorithm::Run - Unable to determine MCParticle origin for an input CaloHit, which will be skipped." << std::endl;
+            std::cout << "CheatingCosmicRayRemovalAlgorithm::Run - Unable to determine MCParticle origin for an input CaloHit, which will be skipped."
+                      << std::endl;
             continue;
         }
     }

--- a/larpandoracontent/LArCheating/CheatingCosmicRayRemovalAlgorithm.h
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayRemovalAlgorithm.h
@@ -29,9 +29,9 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string m_inputCaloHitListName;     ///< Input calo hit list name
-    std::string m_outputCaloHitListName;    ///< Output calo hit list name
-    std::string m_mcParticleListName;       ///< MC Particle list name
+    std::string m_inputCaloHitListName;  ///< Input calo hit list name
+    std::string m_outputCaloHitListName; ///< Output calo hit list name
+    std::string m_mcParticleListName;    ///< MC Particle list name
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingCosmicRayShowerMatchingAlg.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayShowerMatchingAlg.cc
@@ -27,7 +27,7 @@ StatusCode CheatingCosmicRayShowerMatchingAlg::Run()
     const PfoList *pPfoList(nullptr);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
 
-    for (const ParticleFlowObject *const pPfo  : *pPfoList)
+    for (const ParticleFlowObject *const pPfo : *pPfoList)
     {
         ClusterList twoDClusters;
         LArPfoHelper::GetTwoDClusterList(pPfo, twoDClusters);
@@ -59,8 +59,8 @@ void CheatingCosmicRayShowerMatchingAlg::GetCandidateClusters(ClusterList &candi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingCosmicRayShowerMatchingAlg::CosmicRayShowerMatching(const ParticleFlowObject *const pPfo, const Cluster *const pPfoCluster,
-    const ClusterList &candidateClusterList) const
+void CheatingCosmicRayShowerMatchingAlg::CosmicRayShowerMatching(
+    const ParticleFlowObject *const pPfo, const Cluster *const pPfoCluster, const ClusterList &candidateClusterList) const
 {
     try
     {
@@ -87,21 +87,23 @@ void CheatingCosmicRayShowerMatchingAlg::CosmicRayShowerMatching(const ParticleF
                 if (!LArMCParticleHelper::IsNeutrino(pParentMCParticle) && (pPfoParentMCParticle == pParentMCParticle))
                     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToPfo(*this, pPfo, pCandidateCluster));
             }
-            catch (const StatusCodeException &) {}
+            catch (const StatusCodeException &)
+            {
+            }
         }
     }
-    catch (const StatusCodeException &) {}
+    catch (const StatusCodeException &)
+    {
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode CheatingCosmicRayShowerMatchingAlg::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputPfoListName", m_inputPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputPfoListName", m_inputPfoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputClusterListNames", m_inputClusterListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingCosmicRayShowerMatchingAlg.h
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayShowerMatchingAlg.h
@@ -40,8 +40,8 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string             m_inputPfoListName;           ///< The input pfo list name
-    pandora::StringVector   m_inputClusterListNames;      ///< The input cluster list names
+    std::string m_inputPfoListName;                ///< The input pfo list name
+    pandora::StringVector m_inputClusterListNames; ///< The input cluster list names
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.cc
@@ -19,8 +19,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingCosmicRayTaggingTool::CheatingCosmicRayTaggingTool() :
-    m_maxCosmicRayFraction(0.25f)
+CheatingCosmicRayTaggingTool::CheatingCosmicRayTaggingTool() : m_maxCosmicRayFraction(0.25f)
 {
 }
 
@@ -52,8 +51,8 @@ void CheatingCosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmic
 
 StatusCode CheatingCosmicRayTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCosmicRayFraction", m_maxCosmicRayFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCosmicRayFraction", m_maxCosmicRayFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.h
+++ b/larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.h
@@ -29,7 +29,7 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float   m_maxCosmicRayFraction;        ///< The maximum cosmic ray fraction for a pfo to be declared an ambiguous cosmic ray
+    float m_maxCosmicRayFraction; ///< The maximum cosmic ray fraction for a pfo to be declared an ambiguous cosmic ray
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingEventSlicingTool.cc
+++ b/larpandoracontent/LArCheating/CheatingEventSlicingTool.cc
@@ -24,10 +24,10 @@ typedef SlicingAlgorithm::Slice Slice;
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void CheatingEventSlicingTool::RunSlicing(const Algorithm *const pAlgorithm, const HitTypeToNameMap &caloHitListNames,
-    const HitTypeToNameMap &/*clusterListNames*/, SliceList &sliceList)
+    const HitTypeToNameMap & /*clusterListNames*/, SliceList &sliceList)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     MCParticleToSliceMap mcParticleToSliceMap;
     this->InitializeMCParticleToSliceMap(pAlgorithm, caloHitListNames, mcParticleToSliceMap);
@@ -37,7 +37,8 @@ void CheatingEventSlicingTool::RunSlicing(const Algorithm *const pAlgorithm, con
     this->FillSlices(pAlgorithm, TPC_VIEW_W, caloHitListNames, mcParticleToSliceMap);
 
     MCParticleVector mcParticleVector;
-    for (const auto &mapEntry : mcParticleToSliceMap) mcParticleVector.push_back(mapEntry.first);
+    for (const auto &mapEntry : mcParticleToSliceMap)
+        mcParticleVector.push_back(mapEntry.first);
     std::sort(mcParticleVector.begin(), mcParticleVector.end(), LArMCParticleHelper::SortByMomentum);
 
     for (const MCParticle *const pMCParticle : mcParticleVector)
@@ -51,8 +52,8 @@ void CheatingEventSlicingTool::RunSlicing(const Algorithm *const pAlgorithm, con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingEventSlicingTool::InitializeMCParticleToSliceMap(const Algorithm *const pAlgorithm, const HitTypeToNameMap &caloHitListNames,
-    MCParticleToSliceMap &mcParticleToSliceMap) const
+void CheatingEventSlicingTool::InitializeMCParticleToSliceMap(
+    const Algorithm *const pAlgorithm, const HitTypeToNameMap &caloHitListNames, MCParticleToSliceMap &mcParticleToSliceMap) const
 {
     for (const auto &mapEntry : caloHitListNames)
     {
@@ -62,7 +63,8 @@ void CheatingEventSlicingTool::InitializeMCParticleToSliceMap(const Algorithm *c
         for (const CaloHit *const pCaloHit : *pCaloHitList)
         {
             MCParticleVector mcParticleVector;
-            for (const auto &weightMapEntry : pCaloHit->GetMCParticleWeightMap()) mcParticleVector.push_back(weightMapEntry.first);
+            for (const auto &weightMapEntry : pCaloHit->GetMCParticleWeightMap())
+                mcParticleVector.push_back(weightMapEntry.first);
             std::sort(mcParticleVector.begin(), mcParticleVector.end(), LArMCParticleHelper::SortByMomentum);
 
             for (const MCParticle *const pMCParticle : mcParticleVector)
@@ -81,8 +83,8 @@ void CheatingEventSlicingTool::InitializeMCParticleToSliceMap(const Algorithm *c
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingEventSlicingTool::FillSlices(const Algorithm *const pAlgorithm, const HitType hitType, const HitTypeToNameMap &caloHitListNames,
-    MCParticleToSliceMap &mcParticleToSliceMap) const
+void CheatingEventSlicingTool::FillSlices(const Algorithm *const pAlgorithm, const HitType hitType,
+    const HitTypeToNameMap &caloHitListNames, MCParticleToSliceMap &mcParticleToSliceMap) const
 {
     if ((TPC_VIEW_U != hitType) && (TPC_VIEW_V != hitType) && (TPC_VIEW_W != hitType))
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoracontent/LArCheating/CheatingEventSlicingTool.h
+++ b/larpandoracontent/LArCheating/CheatingEventSlicingTool.h
@@ -27,7 +27,7 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::MCParticle*, SlicingAlgorithm::Slice> MCParticleToSliceMap;
+    typedef std::unordered_map<const pandora::MCParticle *, SlicingAlgorithm::Slice> MCParticleToSliceMap;
 
     /**
      *  @brief  Initialize the map from parent mc particles to slice objects
@@ -36,8 +36,8 @@ private:
      *  @param  caloHitListNames the hit type to calo hit list name map
      *  @param  mcParticleToSliceMap to receive the parent mc particle to slice map
      */
-    void InitializeMCParticleToSliceMap(const pandora::Algorithm *const pAlgorithm, const SlicingAlgorithm::HitTypeToNameMap &caloHitListNames,
-        MCParticleToSliceMap &mcParticleToSliceMap) const;
+    void InitializeMCParticleToSliceMap(const pandora::Algorithm *const pAlgorithm,
+        const SlicingAlgorithm::HitTypeToNameMap &caloHitListNames, MCParticleToSliceMap &mcParticleToSliceMap) const;
 
     /**
      *  @brief  Fill slices using hits from a specified view
@@ -47,8 +47,8 @@ private:
      *  @param  caloHitListNames the hit type to calo hit list name map
      *  @param  mcParticleToSliceMap to receive the parent mc particle to slice map
      */
-    void FillSlices(const pandora::Algorithm *const pAlgorithm, const pandora::HitType hitType, const SlicingAlgorithm::HitTypeToNameMap &caloHitListNames,
-        MCParticleToSliceMap &mcParticleToSliceMap) const;
+    void FillSlices(const pandora::Algorithm *const pAlgorithm, const pandora::HitType hitType,
+        const SlicingAlgorithm::HitTypeToNameMap &caloHitListNames, MCParticleToSliceMap &mcParticleToSliceMap) const;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingNeutrinoCreationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoCreationAlgorithm.cc
@@ -18,9 +18,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingNeutrinoCreationAlgorithm::CheatingNeutrinoCreationAlgorithm() :
-    m_collapseToPrimaryMCParticles(false),
-    m_vertexTolerance(0.5f)
+CheatingNeutrinoCreationAlgorithm::CheatingNeutrinoCreationAlgorithm() : m_collapseToPrimaryMCParticles(false), m_vertexTolerance(0.5f)
 {
 }
 
@@ -112,7 +110,8 @@ void CheatingNeutrinoCreationAlgorithm::AddNeutrinoVertex(const MCParticle *cons
         }
     }
 
-    if (!pNeutrinoVertex || (VERTEX_3D != pNeutrinoVertex->GetVertexType()) || ((pNeutrinoVertex->GetPosition() - pMCNeutrino->GetEndpoint()).GetMagnitude() > m_vertexTolerance))
+    if (!pNeutrinoVertex || (VERTEX_3D != pNeutrinoVertex->GetVertexType()) ||
+        ((pNeutrinoVertex->GetPosition() - pMCNeutrino->GetEndpoint()).GetMagnitude() > m_vertexTolerance))
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToPfo(*this, pNeutrinoPfo, pNeutrinoVertex));
@@ -166,8 +165,8 @@ void CheatingNeutrinoCreationAlgorithm::GetMCParticleToDaughterPfoMap(MCParticle
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingNeutrinoCreationAlgorithm::CreatePfoHierarchy(const MCParticle *const pParentMCParticle, const ParticleFlowObject *const pParentPfo,
-    const MCParticleToPfoMap &mcParticleToPfoMap) const
+void CheatingNeutrinoCreationAlgorithm::CreatePfoHierarchy(const MCParticle *const pParentMCParticle,
+    const ParticleFlowObject *const pParentPfo, const MCParticleToPfoMap &mcParticleToPfoMap) const
 {
     for (const MCParticle *const pDaughterMCParticle : pParentMCParticle->GetDaughterList())
     {
@@ -189,23 +188,18 @@ void CheatingNeutrinoCreationAlgorithm::CreatePfoHierarchy(const MCParticle *con
 
 StatusCode CheatingNeutrinoCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CollapseToPrimaryMCParticles", m_collapseToPrimaryMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CollapseToPrimaryMCParticles", m_collapseToPrimaryMCParticles));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "MCParticleListName", m_mcParticleListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "NeutrinoPfoListName", m_neutrinoPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "NeutrinoPfoListName", m_neutrinoPfoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexListName", m_vertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "VertexListName", m_vertexListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "DaughterPfoListNames", m_daughterPfoListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "DaughterPfoListNames", m_daughterPfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexTolerance", m_vertexTolerance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexTolerance", m_vertexTolerance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingNeutrinoCreationAlgorithm.h
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoCreationAlgorithm.h
@@ -54,7 +54,7 @@ private:
      */
     void AddNeutrinoVertex(const pandora::MCParticle *const pMCNeutrino, const pandora::ParticleFlowObject *const pNeutrinoPfo) const;
 
-    typedef std::unordered_map<const pandora::MCParticle*, const pandora::ParticleFlowObject*> MCParticleToPfoMap;
+    typedef std::unordered_map<const pandora::MCParticle *, const pandora::ParticleFlowObject *> MCParticleToPfoMap;
 
     /**
      *  @brief  Extract candidate daughter pfos from external lists and populate a map from main mc particle (or primary) to pfo
@@ -75,15 +75,15 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    bool                    m_collapseToPrimaryMCParticles; ///< Whether to collapse mc particle hierarchies to primary particles
+    bool m_collapseToPrimaryMCParticles; ///< Whether to collapse mc particle hierarchies to primary particles
 
-    std::string             m_mcParticleListName;           ///< The name of the three d mc particle list name
-    std::string             m_neutrinoPfoListName;          ///< The name of the neutrino pfo list
+    std::string m_mcParticleListName;  ///< The name of the three d mc particle list name
+    std::string m_neutrinoPfoListName; ///< The name of the neutrino pfo list
 
-    std::string             m_vertexListName;               ///< The name of the neutrino vertex list
-    pandora::StringVector   m_daughterPfoListNames;         ///< The list of daughter pfo list names
+    std::string m_vertexListName;                 ///< The name of the neutrino vertex list
+    pandora::StringVector m_daughterPfoListNames; ///< The list of daughter pfo list names
 
-    float                   m_vertexTolerance;              ///< Tolerance, 3d displacement, allowed between reco neutrino vertex and mc neutrino endpoint
+    float m_vertexTolerance; ///< Tolerance, 3d displacement, allowed between reco neutrino vertex and mc neutrino endpoint
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingNeutrinoDaughterVerticesAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoDaughterVerticesAlgorithm.cc
@@ -17,8 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingNeutrinoDaughterVerticesAlgorithm::CheatingNeutrinoDaughterVerticesAlgorithm() :
-    m_collapseToPrimaryMCParticles(false)
+CheatingNeutrinoDaughterVerticesAlgorithm::CheatingNeutrinoDaughterVerticesAlgorithm() : m_collapseToPrimaryMCParticles(false)
 {
 }
 
@@ -63,8 +62,7 @@ void CheatingNeutrinoDaughterVerticesAlgorithm::GetMCPrimaryMap(LArMCParticleHel
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingNeutrinoDaughterVerticesAlgorithm::ProcessRecoNeutrinos(const PfoList &neutrinoPfos,
-    const LArMCParticleHelper::MCRelationMap &mcPrimaryMap) const
+void CheatingNeutrinoDaughterVerticesAlgorithm::ProcessRecoNeutrinos(const PfoList &neutrinoPfos, const LArMCParticleHelper::MCRelationMap &mcPrimaryMap) const
 {
     for (const ParticleFlowObject *const pNeutrinoPfo : neutrinoPfos)
     {
@@ -82,15 +80,17 @@ void CheatingNeutrinoDaughterVerticesAlgorithm::ProcessRecoNeutrinos(const PfoLi
             {
                 this->ProcessDaughterPfo(pDaughterPfo, mcPrimaryMap);
             }
-            catch (const StatusCodeException &) {}
+            catch (const StatusCodeException &)
+            {
+            }
         }
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingNeutrinoDaughterVerticesAlgorithm::ProcessDaughterPfo(const ParticleFlowObject *const pDaughterPfo,
-    const LArMCParticleHelper::MCRelationMap &mcPrimaryMap) const
+void CheatingNeutrinoDaughterVerticesAlgorithm::ProcessDaughterPfo(
+    const ParticleFlowObject *const pDaughterPfo, const LArMCParticleHelper::MCRelationMap &mcPrimaryMap) const
 {
     const MCParticle *pMCParticle(LArMCParticleHelper::GetMainMCParticle(pDaughterPfo));
 
@@ -104,7 +104,8 @@ void CheatingNeutrinoDaughterVerticesAlgorithm::ProcessDaughterPfo(const Particl
         pMCParticle = primaryIter->second;
     }
 
-    const VertexList *pVertexList(nullptr); std::string vertexListName;
+    const VertexList *pVertexList(nullptr);
+    std::string vertexListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pVertexList, vertexListName));
 
     PandoraContentApi::Vertex::Parameters parameters;
@@ -126,20 +127,17 @@ void CheatingNeutrinoDaughterVerticesAlgorithm::ProcessDaughterPfo(const Particl
 
 StatusCode CheatingNeutrinoDaughterVerticesAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CollapseToPrimaryMCParticles", m_collapseToPrimaryMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CollapseToPrimaryMCParticles", m_collapseToPrimaryMCParticles));
 
     if (m_collapseToPrimaryMCParticles)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "MCParticleListName", m_mcParticleListName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
     }
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "NeutrinoPfoListName", m_neutrinoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "NeutrinoPfoListName", m_neutrinoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputVertexListName", m_vertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_vertexListName));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingNeutrinoDaughterVerticesAlgorithm.h
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoDaughterVerticesAlgorithm.h
@@ -54,11 +54,11 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    bool                m_collapseToPrimaryMCParticles; ///< Whether to collapse mc particle hierarchies to primary particles
-    std::string         m_mcParticleListName;           ///< The mc particle list name, required if want to collapse mc particle hierarchy
+    bool m_collapseToPrimaryMCParticles; ///< Whether to collapse mc particle hierarchies to primary particles
+    std::string m_mcParticleListName;    ///< The mc particle list name, required if want to collapse mc particle hierarchy
 
-    std::string         m_neutrinoListName;             ///< The input list of pfo list names
-    std::string         m_vertexListName;               ///< The name of the output cosmic-ray vertex list
+    std::string m_neutrinoListName; ///< The input list of pfo list names
+    std::string m_vertexListName;   ///< The name of the output cosmic-ray vertex list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingNeutrinoIdTool.cc
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoIdTool.cc
@@ -18,7 +18,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-void CheatingNeutrinoIdTool::SelectOutputPfos(const pandora::Algorithm *const /*pAlgorithm*/, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
+void CheatingNeutrinoIdTool::SelectOutputPfos(const pandora::Algorithm *const /*pAlgorithm*/, const SliceHypotheses &nuSliceHypotheses,
+    const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
 {
     if (nuSliceHypotheses.size() != crSliceHypotheses.size())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoracontent/LArCheating/CheatingNeutrinoIdTool.h
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoIdTool.h
@@ -20,7 +20,8 @@ namespace lar_content
 class CheatingNeutrinoIdTool : public CheatingSliceIdBaseTool
 {
 public:
-    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
+    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);

--- a/larpandoracontent/LArCheating/CheatingNeutrinoSliceSelectionTool.h
+++ b/larpandoracontent/LArCheating/CheatingNeutrinoSliceSelectionTool.h
@@ -33,4 +33,3 @@ private:
 } // namespace lar_content
 
 #endif // #ifndef LAR_CHEATING_NEUTRINO_SLICE_SELECTION_TOOL_H
-

--- a/larpandoracontent/LArCheating/CheatingPfoCharacterisationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingPfoCharacterisationAlgorithm.cc
@@ -37,7 +37,8 @@ bool CheatingPfoCharacterisationAlgorithm::IsClearTrack(const ParticleFlowObject
     const MCParticle *pBestMCParticle(nullptr);
 
     MCParticleList mcParticleList;
-    for (const auto &mapEntry : mcParticleWeightMap) mcParticleList.push_back(mapEntry.first);
+    for (const auto &mapEntry : mcParticleWeightMap)
+        mcParticleList.push_back(mapEntry.first);
     mcParticleList.sort(LArMCParticleHelper::SortByMomentum);
 
     for (const MCParticle *const pMCParticle : mcParticleList)

--- a/larpandoracontent/LArCheating/CheatingPfoCreationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingPfoCreationAlgorithm.cc
@@ -64,8 +64,8 @@ StatusCode CheatingPfoCreationAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingPfoCreationAlgorithm::GetMCParticleToClusterListMap(const ClusterList *const pClusterList, const LArMCParticleHelper::MCRelationMap &mcPrimaryMap,
-    MCParticleToClusterListMap &mcParticleToClusterListMap) const
+void CheatingPfoCreationAlgorithm::GetMCParticleToClusterListMap(const ClusterList *const pClusterList,
+    const LArMCParticleHelper::MCRelationMap &mcPrimaryMap, MCParticleToClusterListMap &mcParticleToClusterListMap) const
 {
     for (const Cluster *const pCluster : *pClusterList)
     {
@@ -91,7 +91,9 @@ void CheatingPfoCreationAlgorithm::GetMCParticleToClusterListMap(const ClusterLi
 
             mcParticleToClusterListMap[pMCParticle].push_back(pCluster);
         }
-        catch (const StatusCodeException &) {}
+        catch (const StatusCodeException &)
+        {
+        }
     }
 }
 
@@ -102,14 +104,17 @@ void CheatingPfoCreationAlgorithm::CreatePfos(const MCParticleToClusterListMap &
     if (mcParticleToClusterListMap.empty())
         return;
 
-    const PfoList *pPfoList(nullptr); std::string pfoListName;
+    const PfoList *pPfoList(nullptr);
+    std::string pfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
-    const VertexList *pVertexList(nullptr); std::string vertexListName;
+    const VertexList *pVertexList(nullptr);
+    std::string vertexListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pVertexList, vertexListName));
 
     MCParticleVector mcParticleVector;
-    for (const auto &mapEntry : mcParticleToClusterListMap) mcParticleVector.push_back(mapEntry.first);
+    for (const auto &mapEntry : mcParticleToClusterListMap)
+        mcParticleVector.push_back(mapEntry.first);
     std::sort(mcParticleVector.begin(), mcParticleVector.end(), LArMCParticleHelper::SortByMomentum);
 
     for (const MCParticle *const pMCParticle : mcParticleVector)
@@ -149,7 +154,8 @@ void CheatingPfoCreationAlgorithm::CreatePfos(const MCParticleToClusterListMap &
         }
         catch (const StatusCodeException &)
         {
-            std::cout << "CheatingPfoCreationAlgorithm: Could not create PFO for MCParticle with pdg code " << pMCParticle->GetParticleId() << std::endl;
+            std::cout << "CheatingPfoCreationAlgorithm: Could not create PFO for MCParticle with pdg code " << pMCParticle->GetParticleId()
+                      << std::endl;
         }
     }
 
@@ -194,47 +200,41 @@ unsigned int CheatingPfoCreationAlgorithm::GetNHitTypesAboveThreshold(const Clus
 
 StatusCode CheatingPfoCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputClusterListNames", m_inputClusterListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputPfoListName", m_outputPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputPfoListName", m_outputPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CollapseToPrimaryMCParticles", m_collapseToPrimaryMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CollapseToPrimaryMCParticles", m_collapseToPrimaryMCParticles));
 
     if (m_collapseToPrimaryMCParticles)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "MCParticleListName", m_mcParticleListName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseOnlyAvailableClusters", m_useOnlyAvailableClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseOnlyAvailableClusters", m_useOnlyAvailableClusters));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "AddVertices", m_addVertices));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "AddVertices", m_addVertices));
 
     if (m_addVertices)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "OutputVertexListName", m_outputVertexListName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_outputVertexListName));
 
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-            "ReplaceCurrentVertexList", m_replaceCurrentVertexList));
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+            XmlHelper::ReadValue(xmlHandle, "ReplaceCurrentVertexList", m_replaceCurrentVertexList));
     }
 
     IntVector particleIdVector;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "ParticleIdList", particleIdVector));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ParticleIdList", particleIdVector));
 
     m_particleIdList.insert(particleIdVector.begin(), particleIdVector.end());
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinGoodHitTypes", m_minGoodHitTypes));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinGoodHitTypes", m_minGoodHitTypes));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NHitsForGoodHitType", m_nHitsForGoodHitType));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NHitsForGoodHitType", m_nHitsForGoodHitType));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingPfoCreationAlgorithm.h
+++ b/larpandoracontent/LArCheating/CheatingPfoCreationAlgorithm.h
@@ -32,7 +32,7 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::MCParticle*, pandora::ClusterList> MCParticleToClusterListMap;
+    typedef std::unordered_map<const pandora::MCParticle *, pandora::ClusterList> MCParticleToClusterListMap;
 
     /**
      *  @brief  Get a map relating mc particles to a list of daughter clusters
@@ -41,15 +41,15 @@ private:
      *  @param  mcPrimaryMap the mapping between mc particles and their parents
      *  @param  mcParticleToClusterListMap to receive the populated mc particle to cluster list map
      */
-    void GetMCParticleToClusterListMap(const pandora::ClusterList *const pClusterList, const LArMCParticleHelper::MCRelationMap &mcPrimaryMap,
-        MCParticleToClusterListMap &mcParticleToClusterListMap) const;
+    void GetMCParticleToClusterListMap(const pandora::ClusterList *const pClusterList,
+        const LArMCParticleHelper::MCRelationMap &mcPrimaryMap, MCParticleToClusterListMap &mcParticleToClusterListMap) const;
 
     /**
      *  @brief  Create pfos corresponding to the details in a provided mc particle to cluster list map
      *
      *  @param  mcParticleToClusterListMap the mc particle to cluster list map
      */
-    void CreatePfos(const  MCParticleToClusterListMap &mcParticleToClusterListMap) const;
+    void CreatePfos(const MCParticleToClusterListMap &mcParticleToClusterListMap) const;
 
     /**
      *  @brief  Get the number of hit types containing more than a specified number of hits
@@ -64,19 +64,19 @@ private:
     typedef std::map<pandora::HitType, unsigned int> HitTypeMap;
     typedef std::set<int> ParticleIdList;
 
-    pandora::StringVector   m_inputClusterListNames;        ///< The names of the input cluster lists
-    std::string             m_outputPfoListName;            ///< The output pfo list name
-    std::string             m_outputVertexListName;         ///< The output vertex list name
+    pandora::StringVector m_inputClusterListNames; ///< The names of the input cluster lists
+    std::string m_outputPfoListName;               ///< The output pfo list name
+    std::string m_outputVertexListName;            ///< The output vertex list name
 
-    bool                    m_collapseToPrimaryMCParticles; ///< Whether to collapse mc particle hierarchies to primary particles
-    std::string             m_mcParticleListName;           ///< The mc particle list name
+    bool m_collapseToPrimaryMCParticles; ///< Whether to collapse mc particle hierarchies to primary particles
+    std::string m_mcParticleListName;    ///< The mc particle list name
 
-    bool                    m_useOnlyAvailableClusters;     ///< Whether to consider unavailable clusters when identifying cheated pfos
-    bool                    m_addVertices;                  ///< Whether to add the start vertex to the cheated pfo
-    bool                    m_replaceCurrentVertexList;     ///< Whether to replace current vertex list
-    unsigned int            m_minGoodHitTypes;              ///< The min number of good hit types in the clusters collected for a given mc particle
-    unsigned int            m_nHitsForGoodHitType;          ///< The min number of hits of a particular hit type in order to declare the hit type is good
-    ParticleIdList          m_particleIdList;               ///< The list of particle ids to consider for pfo creation; will consider all ids if empty
+    bool m_useOnlyAvailableClusters;    ///< Whether to consider unavailable clusters when identifying cheated pfos
+    bool m_addVertices;                 ///< Whether to add the start vertex to the cheated pfo
+    bool m_replaceCurrentVertexList;    ///< Whether to replace current vertex list
+    unsigned int m_minGoodHitTypes;     ///< The min number of good hit types in the clusters collected for a given mc particle
+    unsigned int m_nHitsForGoodHitType; ///< The min number of hits of a particular hit type in order to declare the hit type is good
+    ParticleIdList m_particleIdList;    ///< The list of particle ids to consider for pfo creation; will consider all ids if empty
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingSliceIdBaseTool.cc
+++ b/larpandoracontent/LArCheating/CheatingSliceIdBaseTool.cc
@@ -19,9 +19,11 @@ using namespace pandora;
 namespace lar_content
 {
 
-void CheatingSliceIdBaseTool::GetTargetParticleWeight(const PfoList *const pPfoList, float &targetParticleWeight, float &totalWeight, std::function<bool(const MCParticle *const)> fCriteria)
+void CheatingSliceIdBaseTool::GetTargetParticleWeight(
+    const PfoList *const pPfoList, float &targetParticleWeight, float &totalWeight, std::function<bool(const MCParticle *const)> fCriteria)
 {
-    targetParticleWeight = 0.f; totalWeight = 0.f;
+    targetParticleWeight = 0.f;
+    totalWeight = 0.f;
 
     for (const ParticleFlowObject *const pPfo : *pPfoList)
     {
@@ -53,16 +55,19 @@ void CheatingSliceIdBaseTool::GetTargetParticleWeight(const PfoList *const pPfoL
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingSliceIdBaseTool::GetTargetParticleWeight(const CaloHit *const pCaloHit, float &targetParticleWeight, float &totalWeight, std::function<bool(const MCParticle *const)> fCriteria)
+void CheatingSliceIdBaseTool::GetTargetParticleWeight(
+    const CaloHit *const pCaloHit, float &targetParticleWeight, float &totalWeight, std::function<bool(const MCParticle *const)> fCriteria)
 {
-    targetParticleWeight = 0.f; totalWeight = 0.f;
+    targetParticleWeight = 0.f;
+    totalWeight = 0.f;
     const MCParticleWeightMap &hitMCParticleWeightMap(pCaloHit->GetMCParticleWeightMap());
 
     if (hitMCParticleWeightMap.empty())
         return;
 
     MCParticleList mcParticleList;
-    for (const auto &mapEntry : hitMCParticleWeightMap) mcParticleList.push_back(mapEntry.first);
+    for (const auto &mapEntry : hitMCParticleWeightMap)
+        mcParticleList.push_back(mapEntry.first);
     mcParticleList.sort(LArMCParticleHelper::SortByMomentum);
 
     for (const MCParticle *const pMCParticle : mcParticleList)

--- a/larpandoracontent/LArCheating/CheatingSliceIdBaseTool.h
+++ b/larpandoracontent/LArCheating/CheatingSliceIdBaseTool.h
@@ -21,7 +21,8 @@ namespace lar_content
 class CheatingSliceIdBaseTool : public SliceIdBaseTool
 {
 public:
-    virtual void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos) = 0;
+    virtual void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos) = 0;
 
     /**
      *  @brief  Get the target particle weight in a list of pfos
@@ -31,7 +32,8 @@ public:
      *  @param  totalWeight the total weight
      *  @param  fCriteria a function which returns a bool (= shouldSelect) for a given input MCParticle
      */
-    static void GetTargetParticleWeight(const pandora::PfoList *const pPfoList, float &targetParticleWeight, float &totalWeight, std::function<bool(const pandora::MCParticle *const)> fCriteria);
+    static void GetTargetParticleWeight(const pandora::PfoList *const pPfoList, float &targetParticleWeight, float &totalWeight,
+        std::function<bool(const pandora::MCParticle *const)> fCriteria);
 
     /**
      *  @brief  Get the target particle weight for a calo hit
@@ -41,7 +43,8 @@ public:
      *  @param  totalWeight the total weight
      *  @param  fCriteria a function which returns a bool (= shouldSelect) for a given input MCParticle
      */
-    static void GetTargetParticleWeight(const pandora::CaloHit *const pCaloHit, float &targetParticleWeight, float &totalWeight, std::function<bool(const pandora::MCParticle *const)> fCriteria);
+    static void GetTargetParticleWeight(const pandora::CaloHit *const pCaloHit, float &targetParticleWeight, float &totalWeight,
+        std::function<bool(const pandora::MCParticle *const)> fCriteria);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);

--- a/larpandoracontent/LArCheating/CheatingSliceSelectionTool.cc
+++ b/larpandoracontent/LArCheating/CheatingSliceSelectionTool.cc
@@ -17,17 +17,13 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingSliceSelectionTool::CheatingSliceSelectionTool() :
-    m_maxSlices{1},
-    m_threshold{-1.f},
-    m_cutVariable{"completeness"}
+CheatingSliceSelectionTool::CheatingSliceSelectionTool() : m_maxSlices{1}, m_threshold{-1.f}, m_cutVariable{"completeness"}
 {
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 
-void CheatingSliceSelectionTool::SelectSlices(const pandora::Algorithm *const /*pAlgorithm*/, const SliceVector &inputSliceVector,
-    SliceVector &outputSliceVector)
+void CheatingSliceSelectionTool::SelectSlices(const pandora::Algorithm *const /*pAlgorithm*/, const SliceVector &inputSliceVector, SliceVector &outputSliceVector)
 {
     // ATTN Ensure this only runs if slicing enabled
     unsigned int sliceCounter{0};
@@ -42,7 +38,7 @@ void CheatingSliceSelectionTool::SelectSlices(const pandora::Algorithm *const /*
         CaloHitList localHitList{};
         // ATTN Must ensure we copy the hit actually owned by master instance; access differs with/without slicing enabled
         for (const CaloHit *const pSliceCaloHit : sliceHits)
-            localHitList.push_back(static_cast<const CaloHit*>(pSliceCaloHit->GetParentAddress()));
+            localHitList.push_back(static_cast<const CaloHit *>(pSliceCaloHit->GetParentAddress()));
 
         for (const CaloHit *const pCaloHit : localHitList)
         {
@@ -111,9 +107,9 @@ void CheatingSliceSelectionTool::SelectSlices(const pandora::Algorithm *const /*
     // Select the best m_maxSlices slices - prefix increment ensures all slices retained if m_maxSlices == 0
     std::vector<int> reducedSliceIndices{};
     int i = 0;
-    for (const auto [ cutVariable, index ] : reducedSliceVarIndexMap)
-    {   // ATTN: Map is sorted on cut variable from max to min
-        (void)cutVariable;  // GCC 7 support, versions 8+ do not need this
+    for (const auto [cutVariable, index] : reducedSliceVarIndexMap)
+    {                      // ATTN: Map is sorted on cut variable from max to min
+        (void)cutVariable; // GCC 7 support, versions 8+ do not need this
         reducedSliceIndices.push_back(index);
         outputSliceVector.push_back(inputSliceVector[index]);
         if (++i == m_maxSlices)
@@ -125,14 +121,11 @@ void CheatingSliceSelectionTool::SelectSlices(const pandora::Algorithm *const /*
 
 StatusCode CheatingSliceSelectionTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxSlices", m_maxSlices));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "Threshold", m_threshold));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxSlices", m_maxSlices));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "Threshold", m_threshold));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CutVariable", m_cutVariable));
-    std::transform(m_cutVariable.begin(), m_cutVariable.end(), m_cutVariable.begin(), [](unsigned char c){ return std::tolower(c); });
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CutVariable", m_cutVariable));
+    std::transform(m_cutVariable.begin(), m_cutVariable.end(), m_cutVariable.begin(), [](unsigned char c) { return std::tolower(c); });
     if (m_cutVariable != "completeness" && m_cutVariable != "purity")
     {
         std::cout << "CheatingSliceSelectionTool::ReadSettings: Unknown cut variable \'" << m_cutVariable << "\'" << std::endl;

--- a/larpandoracontent/LArCheating/CheatingSliceSelectionTool.h
+++ b/larpandoracontent/LArCheating/CheatingSliceSelectionTool.h
@@ -31,8 +31,7 @@ public:
      *  @param  inputSliceVector the initial slice vector
      *  @param  outputSliceVector the output slice vector
      */
-    void SelectSlices(const pandora::Algorithm *const pAlgorithm, const SliceVector &inputSliceVector,
-        SliceVector &outputSliceVector);
+    void SelectSlices(const pandora::Algorithm *const pAlgorithm, const SliceVector &inputSliceVector, SliceVector &outputSliceVector);
 
     typedef std::map<float, int, std::greater<float>> MetricSliceIndexMap;
 
@@ -47,12 +46,11 @@ protected:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
 protected:
-    int             m_maxSlices;                ///< The maximum number of slices to retain (0 to retain all) - default 0
-    float           m_threshold;                ///< The minimum cut threshold to retain a slice (< 0 for no threshold) - default -1
-    std::string     m_cutVariable;              ///< The variable to cut on ("purity" or "completeness") - default "completeness"
+    int m_maxSlices;           ///< The maximum number of slices to retain (0 to retain all) - default 0
+    float m_threshold;         ///< The minimum cut threshold to retain a slice (< 0 for no threshold) - default -1
+    std::string m_cutVariable; ///< The variable to cut on ("purity" or "completeness") - default "completeness"
 };
 
 } // namespace lar_content
 
 #endif // #ifndef LAR_CHEATING_SLICE_SELECTION_TOOL_H
-

--- a/larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.cc
@@ -18,9 +18,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-CheatingVertexCreationAlgorithm::CheatingVertexCreationAlgorithm() :
-    m_replaceCurrentVertexList(true),
-    m_vertexXCorrection(0.f)
+CheatingVertexCreationAlgorithm::CheatingVertexCreationAlgorithm() : m_replaceCurrentVertexList(true), m_vertexXCorrection(0.f)
 {
 }
 
@@ -31,7 +29,8 @@ StatusCode CheatingVertexCreationAlgorithm::Run()
     const MCParticleList *pMCParticleList(nullptr);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pMCParticleList));
 
-    const VertexList *pVertexList(nullptr); std::string temporaryListName;
+    const VertexList *pVertexList(nullptr);
+    std::string temporaryListName;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pVertexList, temporaryListName));
 
     for (const MCParticle *const pMCParticle : *pMCParticleList)
@@ -40,7 +39,8 @@ StatusCode CheatingVertexCreationAlgorithm::Run()
             continue;
 
         PandoraContentApi::Vertex::Parameters parameters;
-        parameters.m_position = CartesianVector(pMCParticle->GetEndpoint().GetX() + m_vertexXCorrection, pMCParticle->GetEndpoint().GetY(), pMCParticle->GetEndpoint().GetZ());
+        parameters.m_position = CartesianVector(
+            pMCParticle->GetEndpoint().GetX() + m_vertexXCorrection, pMCParticle->GetEndpoint().GetY(), pMCParticle->GetEndpoint().GetZ());
         parameters.m_vertexLabel = VERTEX_INTERACTION;
         parameters.m_vertexType = VERTEX_3D;
 
@@ -63,14 +63,13 @@ StatusCode CheatingVertexCreationAlgorithm::Run()
 
 StatusCode CheatingVertexCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputVertexListName", m_outputVertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_outputVertexListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ReplaceCurrentVertexList", m_replaceCurrentVertexList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ReplaceCurrentVertexList", m_replaceCurrentVertexList));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexXCorrection", m_vertexXCorrection));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexXCorrection", m_vertexXCorrection));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.h
+++ b/larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.h
@@ -28,9 +28,9 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string     m_outputVertexListName;         ///< The name under which to save the output vertex list
-    bool            m_replaceCurrentVertexList;     ///< Whether to replace the current vertex list with the output list
-    float           m_vertexXCorrection;            ///< The vertex x correction, added to reported mc neutrino endpoint x value, in cm
+    std::string m_outputVertexListName; ///< The name under which to save the output vertex list
+    bool m_replaceCurrentVertexList;    ///< Whether to replace the current vertex list with the output list
+    float m_vertexXCorrection;          ///< The vertex x correction, added to reported mc neutrino endpoint x value, in cm
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCheating/CheatingVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArCheating/CheatingVertexSelectionAlgorithm.cc
@@ -15,8 +15,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-void CheatingVertexSelectionAlgorithm::GetVertexScoreList(const VertexVector &vertexVector, const BeamConstants &/*beamConstants*/,
-    HitKDTree2D &/*kdTreeU*/, HitKDTree2D &/*kdTreeV*/, HitKDTree2D &/*kdTreeW*/, VertexScoreList &vertexScoreList) const
+void CheatingVertexSelectionAlgorithm::GetVertexScoreList(const VertexVector &vertexVector, const BeamConstants & /*beamConstants*/,
+    HitKDTree2D & /*kdTreeU*/, HitKDTree2D & /*kdTreeV*/, HitKDTree2D & /*kdTreeW*/, VertexScoreList &vertexScoreList) const
 {
     const Vertex *pBestVertex(nullptr);
     float bestVertexDr(std::numeric_limits<float>::max());

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -17,6 +17,7 @@
 #include "larpandoracontent/LArCheating/CheatingClusterCharacterisationAlgorithm.h"
 #include "larpandoracontent/LArCheating/CheatingClusterCreationAlgorithm.h"
 #include "larpandoracontent/LArCheating/CheatingCosmicRayIdentificationAlg.h"
+#include "larpandoracontent/LArCheating/CheatingCosmicRayRemovalAlgorithm.h"
 #include "larpandoracontent/LArCheating/CheatingCosmicRayShowerMatchingAlg.h"
 #include "larpandoracontent/LArCheating/CheatingCosmicRayTaggingTool.h"
 #include "larpandoracontent/LArCheating/CheatingEventSlicingTool.h"
@@ -26,7 +27,6 @@
 #include "larpandoracontent/LArCheating/CheatingNeutrinoSliceSelectionTool.h"
 #include "larpandoracontent/LArCheating/CheatingPfoCharacterisationAlgorithm.h"
 #include "larpandoracontent/LArCheating/CheatingPfoCreationAlgorithm.h"
-#include "larpandoracontent/LArCheating/CheatingCosmicRayRemovalAlgorithm.h"
 #include "larpandoracontent/LArCheating/CheatingVertexCreationAlgorithm.h"
 #include "larpandoracontent/LArCheating/CheatingVertexSelectionAlgorithm.h"
 
@@ -35,9 +35,9 @@
 #include "larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h"
 #include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
 #include "larpandoracontent/LArControlFlow/NeutrinoIdTool.h"
-#include "larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.h"
 #include "larpandoracontent/LArControlFlow/PostProcessingAlgorithm.h"
 #include "larpandoracontent/LArControlFlow/PreProcessingAlgorithm.h"
+#include "larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.h"
 #include "larpandoracontent/LArControlFlow/SlicingAlgorithm.h"
 #include "larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h"
 
@@ -47,16 +47,16 @@
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 #include "larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.h"
-#include "larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.h"
-#include "larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h"
-#include "larpandoracontent/LArMonitoring/VisualParticleMonitoringAlgorithm.h"
+#include "larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/ShowerTensorVisualizationTool.h"
 #include "larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/TransverseMatrixVisualizationTool.h"
 #include "larpandoracontent/LArMonitoring/TransverseTensorVisualizationTool.h"
+#include "larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h"
+#include "larpandoracontent/LArMonitoring/VisualParticleMonitoringAlgorithm.h"
 
 #include "larpandoracontent/LArPersistency/EventReadingAlgorithm.h"
 #include "larpandoracontent/LArPersistency/EventWritingAlgorithm.h"
@@ -86,49 +86,49 @@
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/DeltaRayShowerHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedLongitudinalTrackHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedTransverseTrackHitsTool.h"
-#include "larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/TwoViewShowerHitsTool.h"
 
-#include "larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ClearLongitudinalTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/MatchedEndPointsTool.h"
+#include "larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h"
-#include "larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.h"
 
-#include "larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArShowerFragments/ClearRemnantsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArShowerFragments/ConnectedRemnantsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArShowerFragments/MopUpRemnantsTool.h"
+#include "larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.h"
 
-#include "larpandoracontent/LArThreeDReco/LArShowerMatching/ThreeViewShowersAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArShowerMatching/ClearShowersTool.h"
 #include "larpandoracontent/LArThreeDReco/LArShowerMatching/SimpleShowersTool.h"
 #include "larpandoracontent/LArThreeDReco/LArShowerMatching/SplitShowersTool.h"
+#include "larpandoracontent/LArThreeDReco/LArShowerMatching/ThreeViewShowersAlgorithm.h"
 
-#include "larpandoracontent/LArThreeDReco/LArTrackFragments/ThreeViewTrackFragmentsAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArTrackFragments/ClearTrackFragmentsTool.h"
+#include "larpandoracontent/LArThreeDReco/LArTrackFragments/ThreeViewTrackFragmentsAlgorithm.h"
 
-#include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ClearTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/LongTracksTool.h"
-#include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackSegmentTool.h"
+#include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/OvershootTracksTool.h"
-#include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.h"
+#include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TrackSplittingTool.h"
+#include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/UndershootTracksTool.h"
 
-#include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewClearTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewLongTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.h"
+#include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
 
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
 #include "larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h"
@@ -138,8 +138,8 @@
 
 #include "larpandoracontent/LArTrackShowerId/CutClusterCharacterisationAlgorithm.h"
 #include "larpandoracontent/LArTrackShowerId/CutPfoCharacterisationAlgorithm.h"
-#include "larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.h"
 #include "larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.h"
+#include "larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.h"
 #include "larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h"
 
 #include "larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.h"
@@ -152,9 +152,9 @@
 #include "larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseAssociationAlgorithm.h"
 #include "larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseExtensionAlgorithm.h"
 
+#include "larpandoracontent/LArTwoDReco/LArClusterCreation/ClusteringParentAlgorithm.h"
 #include "larpandoracontent/LArTwoDReco/LArClusterCreation/SimpleClusterCreationAlgorithm.h"
 #include "larpandoracontent/LArTwoDReco/LArClusterCreation/TrackClusterCreationAlgorithm.h"
-#include "larpandoracontent/LArTwoDReco/LArClusterCreation/ClusteringParentAlgorithm.h"
 
 #include "larpandoracontent/LArTwoDReco/LArClusterMopUp/BoundedClusterMopUpAlgorithm.h"
 #include "larpandoracontent/LArTwoDReco/LArClusterMopUp/ConeClusterMopUpAlgorithm.h"
@@ -191,6 +191,7 @@
 
 #include "larpandoracontent/LArContent.h"
 
+// clang-format off
 #define LAR_ALGORITHM_LIST(d)                                                                                                   \
     d("LArNeutrinoEventValidation",             NeutrinoEventValidationAlgorithm)                                               \
     d("LArTestBeamEventValidation",             TestBeamEventValidationAlgorithm)                                               \
@@ -423,3 +424,4 @@ pandora::StatusCode LArContent::RegisterBasicPlugins(const pandora::Pandora &pan
     LAR_PARTICLE_ID_LIST(LAR_CONTENT_REGISTER_PARTICLE_ID);
     return pandora::STATUS_CODE_SUCCESS;
 }
+// clang-format on

--- a/larpandoracontent/LArContent.h
+++ b/larpandoracontent/LArContent.h
@@ -8,7 +8,10 @@
 #ifndef LAR_CONTENT_H
 #define LAR_CONTENT_H 1
 
-namespace pandora { class Pandora; }
+namespace pandora
+{
+class Pandora;
+}
 
 /**
  *  @brief  LArContent class

--- a/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.cc
+++ b/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.cc
@@ -73,13 +73,15 @@ StatusCode BdtBeamParticleIdTool::Initialize()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BdtBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
+void BdtBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+    const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
 {
     if (nuSliceHypotheses.size() != crSliceHypotheses.size())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     const unsigned int nSlices(nuSliceHypotheses.size());
-    if (nSlices == 0) return;
+    if (nSlices == 0)
+        return;
 
     SliceFeaturesVector sliceFeaturesVector;
     this->GetSliceFeatures(nuSliceHypotheses, crSliceHypotheses, sliceFeaturesVector);
@@ -95,7 +97,8 @@ void BdtBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *const pAl
         for (unsigned int sliceIndex = 0; sliceIndex < nSlices; ++sliceIndex)
         {
             const SliceFeatures &features(sliceFeaturesVector.at(sliceIndex));
-            if (!features.IsFeatureVectorAvailable()) continue;
+            if (!features.IsFeatureVectorAvailable())
+                continue;
 
             LArMvaHelper::MvaFeatureVector featureVector;
 
@@ -124,7 +127,8 @@ void BdtBeamParticleIdTool::SelectOutputPfos(const pandora::Algorithm *const pAl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BdtBeamParticleIdTool::GetSliceFeatures(const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const
+void BdtBeamParticleIdTool::GetSliceFeatures(
+    const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const
 {
     for (unsigned int sliceIndex = 0, nSlices = nuSliceHypotheses.size(); sliceIndex < nSlices; ++sliceIndex)
         sliceFeaturesVector.push_back(SliceFeatures(nuSliceHypotheses.at(sliceIndex), crSliceHypotheses.at(sliceIndex), m_sliceFeatureParameters));
@@ -156,7 +160,8 @@ void BdtBeamParticleIdTool::SelectPfos(const PfoList &pfos, PfoList &selectedPfo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BdtBeamParticleIdTool::GetBestMCSliceIndices(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::IntVector &bestSliceIndices) const
+void BdtBeamParticleIdTool::GetBestMCSliceIndices(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+    const SliceHypotheses &crSliceHypotheses, pandora::IntVector &bestSliceIndices) const
 {
     // Get all hits in all slices to find true number of mc hits
     const CaloHitList *pAllReconstructedCaloHitList(nullptr);
@@ -172,7 +177,8 @@ void BdtBeamParticleIdTool::GetBestMCSliceIndices(const pandora::Algorithm *cons
     // Remove non-reconstructable hits, e.g. those downstream of a neutron
     CaloHitList reconstructableCaloHitList;
     LArMCParticleHelper::PrimaryParameters parameters;
-    LArMCParticleHelper::SelectCaloHits(pAllReconstructedCaloHitList, mcToPrimaryMCMap, reconstructableCaloHitList, parameters.m_selectInputHits, parameters.m_maxPhotonPropagation);
+    LArMCParticleHelper::SelectCaloHits(pAllReconstructedCaloHitList, mcToPrimaryMCMap, reconstructableCaloHitList,
+        parameters.m_selectInputHits, parameters.m_maxPhotonPropagation);
 
     MCParticleToIntMap mcParticleToReconstructableHitsMap;
     this->PopulateMCParticleToHitsMap(mcParticleToReconstructableHitsMap, reconstructableCaloHitList);
@@ -282,14 +288,16 @@ void BdtBeamParticleIdTool::Collect2DHits(const PfoList &pfos, CaloHitList &reco
 
 bool BdtBeamParticleIdTool::PassesQualityCuts(const float purity, const float completeness) const
 {
-    if ((purity < m_minPurity) || (completeness < m_minCompleteness)) return false;
+    if ((purity < m_minPurity) || (completeness < m_minCompleteness))
+        return false;
 
     return true;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BdtBeamParticleIdTool::SelectPfosByAdaBDTScore(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, PfoList &selectedPfos) const
+void BdtBeamParticleIdTool::SelectPfosByAdaBDTScore(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+    const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, PfoList &selectedPfos) const
 {
     // Calculate the probability of each slice that passes the minimum probability cut
     std::vector<UintFloatPair> sliceIndexAdaBDTScorePairs;
@@ -321,10 +329,8 @@ void BdtBeamParticleIdTool::SelectPfosByAdaBDTScore(const pandora::Algorithm *co
     }
 
     // Sort the slices by probability
-    std::sort(sliceIndexAdaBDTScorePairs.begin(), sliceIndexAdaBDTScorePairs.end(), [] (const UintFloatPair &a, const UintFloatPair &b)
-    {
-        return (a.second > b.second);
-    });
+    std::sort(sliceIndexAdaBDTScorePairs.begin(), sliceIndexAdaBDTScorePairs.end(),
+        [](const UintFloatPair &a, const UintFloatPair &b) { return (a.second > b.second); });
 
     // Select the first m_maxNeutrinos as neutrinos, and the rest as cosmic
     unsigned int nNuSlices(0);
@@ -396,7 +402,8 @@ BdtBeamParticleIdTool::SliceFeatureParameters::SliceFeatureParameters() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BdtBeamParticleIdTool::SliceFeatureParameters::Initialize(const float larTPCMinX, const float larTPCMaxX, const float larTPCMinY, const float larTPCMaxY, const float larTPCMinZ, const float larTPCMaxZ)
+void BdtBeamParticleIdTool::SliceFeatureParameters::Initialize(const float larTPCMinX, const float larTPCMaxX, const float larTPCMinY,
+    const float larTPCMaxY, const float larTPCMinZ, const float larTPCMaxZ)
 {
     m_larTPCMinX = larTPCMinX;
     m_larTPCMaxX = larTPCMaxX;
@@ -429,8 +436,10 @@ BdtBeamParticleIdTool::SliceFeatures::SliceFeatures(const PfoList &pfosNu, const
 {
     try
     {
-        double closestDistanceNu(std::numeric_limits<double>::max()), closestDistanceCr(std::numeric_limits<double>::max()), supplementaryAngleToBeamNu(std::numeric_limits<double>::max()),
-               supplementaryAngleToBeamCr(std::numeric_limits<double>::max()), separationNu(std::numeric_limits<double>::max()), separationCr(std::numeric_limits<double>::max());;
+        double closestDistanceNu(std::numeric_limits<double>::max()), closestDistanceCr(std::numeric_limits<double>::max()),
+            supplementaryAngleToBeamNu(std::numeric_limits<double>::max()), supplementaryAngleToBeamCr(std::numeric_limits<double>::max()),
+            separationNu(std::numeric_limits<double>::max()), separationCr(std::numeric_limits<double>::max());
+        ;
         CaloHitList caloHitList3DNu, caloHitList3DCr, selectedCaloHitListNu, selectedCaloHitListCr;
         PfoList allConnectedPfoListNu, allConnectedPfoListCr;
         LArPcaHelper::EigenValues eigenValuesNu(0.f, 0.f, 0.f);
@@ -447,7 +456,8 @@ BdtBeamParticleIdTool::SliceFeatures::SliceFeatures(const PfoList &pfosNu, const
         if (!selectedCaloHitListNu.empty() && !selectedCaloHitListCr.empty())
         {
             float maxYNu(-std::numeric_limits<float>::max()), maxYCr(-std::numeric_limits<float>::max());
-            CartesianVector centroidNu(0.f, 0.f, 0.f), interceptOneNu(0.f, 0.f, 0.f), interceptTwoNu(0.f, 0.f, 0.f), centroidCr(0.f, 0.f, 0.f), interceptOneCr(0.f, 0.f, 0.f), interceptTwoCr(0.f, 0.f, 0.f);
+            CartesianVector centroidNu(0.f, 0.f, 0.f), interceptOneNu(0.f, 0.f, 0.f), interceptTwoNu(0.f, 0.f, 0.f),
+                centroidCr(0.f, 0.f, 0.f), interceptOneCr(0.f, 0.f, 0.f), interceptTwoCr(0.f, 0.f, 0.f);
 
             // Beam
             LArPcaHelper::EigenVectors eigenVecsNu;
@@ -512,8 +522,8 @@ BdtBeamParticleIdTool::SliceFeatures::SliceFeatures(const PfoList &pfosNu, const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BdtBeamParticleIdTool::SliceFeatures::GetLeadingCaloHits(const CaloHitList &inputCaloHitList, CaloHitList &outputCaloHitList,
-    double &closestHitToFaceDistance) const
+void BdtBeamParticleIdTool::SliceFeatures::GetLeadingCaloHits(
+    const CaloHitList &inputCaloHitList, CaloHitList &outputCaloHitList, double &closestHitToFaceDistance) const
 {
     if (inputCaloHitList.empty())
     {
@@ -521,14 +531,16 @@ void BdtBeamParticleIdTool::SliceFeatures::GetLeadingCaloHits(const CaloHitList 
         throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
     }
 
-    typedef std::pair<const CaloHit*, float> HitDistancePair;
+    typedef std::pair<const CaloHit *, float> HitDistancePair;
     typedef std::vector<HitDistancePair> HitDistanceVector;
     HitDistanceVector hitDistanceVector;
 
     for (const CaloHit *const pCaloHit : inputCaloHitList)
-        hitDistanceVector.emplace_back(pCaloHit, (pCaloHit->GetPositionVector() - m_sliceFeatureParameters.GetBeamLArTPCIntersection()).GetMagnitudeSquared());
+        hitDistanceVector.emplace_back(
+            pCaloHit, (pCaloHit->GetPositionVector() - m_sliceFeatureParameters.GetBeamLArTPCIntersection()).GetMagnitudeSquared());
 
-    std::sort(hitDistanceVector.begin(), hitDistanceVector.end(), [](const HitDistancePair &lhs, const HitDistancePair &rhs) -> bool {return (lhs.second < rhs.second);});
+    std::sort(hitDistanceVector.begin(), hitDistanceVector.end(),
+        [](const HitDistancePair &lhs, const HitDistancePair &rhs) -> bool { return (lhs.second < rhs.second); });
 
     if (hitDistanceVector.front().second < 0.f)
     {
@@ -539,8 +551,10 @@ void BdtBeamParticleIdTool::SliceFeatures::GetLeadingCaloHits(const CaloHitList 
     closestHitToFaceDistance = std::sqrt(hitDistanceVector.front().second);
 
     const unsigned int nInputHits(inputCaloHitList.size());
-    const unsigned int nSelectedCaloHits(nInputHits < m_sliceFeatureParameters.GetNSelectedHits() ? nInputHits :
-        static_cast<unsigned int>(std::ceil(static_cast<float>(nInputHits) * m_sliceFeatureParameters.GetSelectedFraction() / 100.f)));
+    const unsigned int nSelectedCaloHits(
+        nInputHits < m_sliceFeatureParameters.GetNSelectedHits()
+            ? nInputHits
+            : static_cast<unsigned int>(std::ceil(static_cast<float>(nInputHits) * m_sliceFeatureParameters.GetSelectedFraction() / 100.f)));
 
     for (const HitDistancePair &hitDistancePair : hitDistanceVector)
     {
@@ -553,8 +567,8 @@ void BdtBeamParticleIdTool::SliceFeatures::GetLeadingCaloHits(const CaloHitList 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts(const CartesianVector &a0, const CartesianVector &lineDirection,
-    CartesianVector &interceptOne, CartesianVector &interceptTwo) const
+void BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts(
+    const CartesianVector &a0, const CartesianVector &lineDirection, CartesianVector &interceptOne, CartesianVector &interceptTwo) const
 {
     CartesianPointVector intercepts;
     CartesianVector lineUnitVector(0.f, 0.f, 0.f);
@@ -602,13 +616,15 @@ void BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts(const CartesianVe
 
         if (!interceptsSet)
         {
-            std::cout << "BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts - unable to set the intercepts between a line and the LArTPC" << std::endl;
+            std::cout << "BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts - unable to set the intercepts between a line and the LArTPC"
+                      << std::endl;
             throw StatusCodeException(STATUS_CODE_NOT_ALLOWED);
         }
     }
     else
     {
-        std::cout << "BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts - inconsistent number of intercepts between a line and the LArTPC" << std::endl;
+        std::cout << "BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts - inconsistent number of intercepts between a line and the LArTPC"
+                  << std::endl;
         throw StatusCodeException(STATUS_CODE_NOT_ALLOWED);
     }
 }
@@ -617,9 +633,12 @@ void BdtBeamParticleIdTool::SliceFeatures::GetLArTPCIntercepts(const CartesianVe
 
 bool BdtBeamParticleIdTool::SliceFeatures::IsContained(const CartesianVector &spacePoint, const float limit) const
 {
-    if ((m_sliceFeatureParameters.GetLArTPCMinX() - spacePoint.GetX() > limit) || (spacePoint.GetX() - m_sliceFeatureParameters.GetLArTPCMaxX() > limit) ||
-        (m_sliceFeatureParameters.GetLArTPCMinY() - spacePoint.GetY() > limit) || (spacePoint.GetY() - m_sliceFeatureParameters.GetLArTPCMaxY() > limit) ||
-        (m_sliceFeatureParameters.GetLArTPCMinZ() - spacePoint.GetZ() > limit) || (spacePoint.GetZ() - m_sliceFeatureParameters.GetLArTPCMaxZ() > limit))
+    if ((m_sliceFeatureParameters.GetLArTPCMinX() - spacePoint.GetX() > limit) ||
+        (spacePoint.GetX() - m_sliceFeatureParameters.GetLArTPCMaxX() > limit) ||
+        (m_sliceFeatureParameters.GetLArTPCMinY() - spacePoint.GetY() > limit) ||
+        (spacePoint.GetY() - m_sliceFeatureParameters.GetLArTPCMaxY() > limit) ||
+        (m_sliceFeatureParameters.GetLArTPCMinZ() - spacePoint.GetZ() > limit) ||
+        (spacePoint.GetZ() - m_sliceFeatureParameters.GetLArTPCMaxZ() > limit))
     {
         return false;
     }
@@ -649,7 +668,8 @@ float BdtBeamParticleIdTool::SliceFeatures::GetAdaBoostDecisionTreeScore(const A
 {
     // ATTN if one or more of the features can not be calculated, then default to calling the slice a cosmic ray.  -1.f is the minimum score
     // possible for a weighted bdt.
-    if (!this->IsFeatureVectorAvailable()) return -1.f;
+    if (!this->IsFeatureVectorAvailable())
+        return -1.f;
 
     LArMvaHelper::MvaFeatureVector featureVector;
 
@@ -672,32 +692,25 @@ float BdtBeamParticleIdTool::SliceFeatures::GetAdaBoostDecisionTreeScore(const A
 StatusCode BdtBeamParticleIdTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
     // BDT Settings
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseTrainingMode", m_useTrainingMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseTrainingMode", m_useTrainingMode));
 
     if (m_useTrainingMode)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "TrainingOutputFileName", m_trainingOutputFile));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "TrainingOutputFileName", m_trainingOutputFile));
 
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "CaloHitListName", m_caloHitListName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
 
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "MCParticleListName", m_mcParticleListName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
     }
     else
     {
         std::string bdtName;
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "BdtName", bdtName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "BdtName", bdtName));
 
         std::string bdtFileName;
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "BdtFileName", bdtFileName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "BdtFileName", bdtFileName));
 
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "MinAdaBDTScore", m_minAdaBDTScore));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MinAdaBDTScore", m_minAdaBDTScore));
 
         const std::string fullBdtFileName(LArFileHelper::FindFileInPath(bdtFileName, m_filePathEnvironmentVariable));
         const StatusCode statusCode(m_adaBoostDecisionTree.Initialize(fullBdtFileName, bdtName));
@@ -709,26 +722,25 @@ StatusCode BdtBeamParticleIdTool::ReadSettings(const TiXmlHandle xmlHandle)
         }
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinimumPurity", m_minPurity));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumPurity", m_minPurity));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinimumCompleteness", m_minCompleteness));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumCompleteness", m_minCompleteness));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaximumNeutrinos", m_maxNeutrinos));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumNeutrinos", m_maxNeutrinos));
 
     // Geometry Information for training
     FloatVector beamLArTPCIntersection;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "BeamTPCIntersection", beamLArTPCIntersection));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "BeamTPCIntersection", beamLArTPCIntersection));
 
     if (3 == beamLArTPCIntersection.size())
     {
-        pandora::CartesianVector beamLArTPCIntersectionCartesianVector(beamLArTPCIntersection.at(0), beamLArTPCIntersection.at(1), beamLArTPCIntersection.at(2));
+        pandora::CartesianVector beamLArTPCIntersectionCartesianVector(
+            beamLArTPCIntersection.at(0), beamLArTPCIntersection.at(1), beamLArTPCIntersection.at(2));
         m_sliceFeatureParameters.SetBeamLArTPCIntersection(beamLArTPCIntersectionCartesianVector);
     }
     else if (!beamLArTPCIntersection.empty())
@@ -744,8 +756,8 @@ StatusCode BdtBeamParticleIdTool::ReadSettings(const TiXmlHandle xmlHandle)
     }
 
     FloatVector beamDirection;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "BeamDirection", beamDirection));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "BeamDirection", beamDirection));
 
     if (3 == beamDirection.size())
     {
@@ -767,24 +779,21 @@ StatusCode BdtBeamParticleIdTool::ReadSettings(const TiXmlHandle xmlHandle)
 
     float selectedFraction(0.f);
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectedFraction", selectedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SelectedFraction", selectedFraction));
 
     if (selectedFraction > std::numeric_limits<float>::epsilon())
         m_sliceFeatureParameters.SetSelectedFraction(selectedFraction);
 
     unsigned int nSelectedHits(0);
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NSelectedHits", nSelectedHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NSelectedHits", nSelectedHits));
 
     if (nSelectedHits > 0)
         m_sliceFeatureParameters.SetNSelectedHits(nSelectedHits);
 
     float containmentLimit(0.f);
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ContainmentLimit", containmentLimit));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ContainmentLimit", containmentLimit));
 
     if (containmentLimit < 0.f)
     {

--- a/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h
+++ b/larpandoracontent/LArControlFlow/BdtBeamParticleIdTool.h
@@ -33,21 +33,22 @@ public:
      *
      *  @param  BdtBeamParticleIdTool to copy
      */
-    BdtBeamParticleIdTool(const BdtBeamParticleIdTool&) = default;
+    BdtBeamParticleIdTool(const BdtBeamParticleIdTool &) = default;
 
     /**
      *  @brief  Assignment operator
      *
      *  @param  The BdtBeamParticleIdTool to assign
      */
-    BdtBeamParticleIdTool &operator=(const BdtBeamParticleIdTool&) = default;
+    BdtBeamParticleIdTool &operator=(const BdtBeamParticleIdTool &) = default;
 
     /**
      *  @brief  Destructor
      */
     ~BdtBeamParticleIdTool() = default;
 
-    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &beamSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
+    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &beamSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
 
 private:
     /**
@@ -73,9 +74,9 @@ private:
         pandora::CartesianVector GetLineIntersection(const pandora::CartesianVector &point, const pandora::CartesianVector &direction) const;
 
     private:
-        pandora::CartesianVector      m_unitNormal;                         ///< Unit normal to plane
-        pandora::CartesianVector      m_point;                              ///< A point on the plane
-        double                        m_d;                                  ///< Parameter defining a plane
+        pandora::CartesianVector m_unitNormal; ///< Unit normal to plane
+        pandora::CartesianVector m_point;      ///< A point on the plane
+        double m_d;                            ///< Parameter defining a plane
     };
 
     typedef std::vector<Plane> PlaneVector;
@@ -101,116 +102,117 @@ private:
          *  @param  larTPCMinZ the global LArTPC volume minimum z extent
          *  @param  larTPCMaxZ the global LArTPC volume maximum z extent
          */
-       void Initialize(const float larTPCMinX, const float larTPCMaxX, const float larTPCMinY, const float larTPCMaxY, const float larTPCMinZ, const float larTPCMaxZ);
+        void Initialize(const float larTPCMinX, const float larTPCMaxX, const float larTPCMinY, const float larTPCMaxY,
+            const float larTPCMinZ, const float larTPCMaxZ);
 
-       /**
-        *  @brief  Set m_beamLArTPCIntersection
-        *
-        *  @param  beamLArTPCIntersection intersection of beam and TPC
-        */
-       void SetBeamLArTPCIntersection(const pandora::CartesianVector &beamLArTPCIntersection);
+        /**
+         *  @brief  Set m_beamLArTPCIntersection
+         *
+         *  @param  beamLArTPCIntersection intersection of beam and TPC
+         */
+        void SetBeamLArTPCIntersection(const pandora::CartesianVector &beamLArTPCIntersection);
 
-       /**
-        *  @brief  Set m_beamDirection
-        *
-        *  @param  beamDirection direction of beam
-        */
-       void SetBeamDirection(const pandora::CartesianVector &beamDirection);
+        /**
+         *  @brief  Set m_beamDirection
+         *
+         *  @param  beamDirection direction of beam
+         */
+        void SetBeamDirection(const pandora::CartesianVector &beamDirection);
 
-       /**
-        *  @brief  Set m_selectedFraction
-        *
-        *  @param  selectedFraction fraction of hits to use in 3D cluster fits
-        */
-       void SetSelectedFraction(const float selectedFraction);
+        /**
+         *  @brief  Set m_selectedFraction
+         *
+         *  @param  selectedFraction fraction of hits to use in 3D cluster fits
+         */
+        void SetSelectedFraction(const float selectedFraction);
 
-       /**
-        *  @brief  Set m_nSelectedHits
-        *
-        *  @param  nSelectedHits minimum number of hits to use in 3D cluster fits
-        */
-       void SetNSelectedHits(const unsigned int nSelectedHits);
+        /**
+         *  @brief  Set m_nSelectedHits
+         *
+         *  @param  nSelectedHits minimum number of hits to use in 3D cluster fits
+         */
+        void SetNSelectedHits(const unsigned int nSelectedHits);
 
-       /**
-        *  @brief  Set m_containmentLimit
-        *
-        *  @param  containmentLimit limit used in is contained definition
-        */
-       void SetContainmentLimit(const float containmentLimit);
+        /**
+         *  @brief  Set m_containmentLimit
+         *
+         *  @param  containmentLimit limit used in is contained definition
+         */
+        void SetContainmentLimit(const float containmentLimit);
 
-       /**
-        *  @brief  Get m_larTPCMinX
-        */
-       float GetLArTPCMinX() const;
+        /**
+         *  @brief  Get m_larTPCMinX
+         */
+        float GetLArTPCMinX() const;
 
-       /**
-        *  @brief  Get m_larTPCMaxX
-        */
-       float GetLArTPCMaxX() const;
+        /**
+         *  @brief  Get m_larTPCMaxX
+         */
+        float GetLArTPCMaxX() const;
 
-       /**
-        *  @brief  Get m_larTPCMinY
-        */
-       float GetLArTPCMinY() const;
+        /**
+         *  @brief  Get m_larTPCMinY
+         */
+        float GetLArTPCMinY() const;
 
-       /**
-        *  @brief  Get m_larTPCMaxY
-        */
-       float GetLArTPCMaxY() const;
+        /**
+         *  @brief  Get m_larTPCMaxY
+         */
+        float GetLArTPCMaxY() const;
 
-       /**
-        *  @brief  Get m_larTPCMinZ
-        */
-       float GetLArTPCMinZ() const;
+        /**
+         *  @brief  Get m_larTPCMinZ
+         */
+        float GetLArTPCMinZ() const;
 
-       /**
-        *  @brief  Get m_larTPCMaxZ
-        */
-       float GetLArTPCMaxZ() const;
+        /**
+         *  @brief  Get m_larTPCMaxZ
+         */
+        float GetLArTPCMaxZ() const;
 
-       /**
-        *  @brief  Get vector of planes
-        */
-       const PlaneVector &GetPlanes() const;
+        /**
+         *  @brief  Get vector of planes
+         */
+        const PlaneVector &GetPlanes() const;
 
-       /**
-        *  @brief  Get the beam LArTPC intersection
-        */
-       const pandora::CartesianVector &GetBeamLArTPCIntersection() const;
+        /**
+         *  @brief  Get the beam LArTPC intersection
+         */
+        const pandora::CartesianVector &GetBeamLArTPCIntersection() const;
 
-       /**
-        *  @brief  Get the beam direction
-        */
-       const pandora::CartesianVector &GetBeamDirection() const;
+        /**
+         *  @brief  Get the beam direction
+         */
+        const pandora::CartesianVector &GetBeamDirection() const;
 
-       /**
-        *  @brief  Get m_selectedFraction
-        */
-       float GetSelectedFraction() const;
+        /**
+         *  @brief  Get m_selectedFraction
+         */
+        float GetSelectedFraction() const;
 
-       /**
-        *  @brief  Get m_nSelectedHits
-        */
-       unsigned int GetNSelectedHits() const;
+        /**
+         *  @brief  Get m_nSelectedHits
+         */
+        unsigned int GetNSelectedHits() const;
 
-       /**
-        *  @brief  Get m_containmentLimit
-        */
-       float GetContainmentLimit() const;
+        /**
+         *  @brief  Get m_containmentLimit
+         */
+        float GetContainmentLimit() const;
 
     private:
-        float                       m_larTPCMinX;             ///< Global LArTPC volume minimum x extent
-        float                       m_larTPCMaxX;             ///< Global LArTPC volume maximum x extent
-        float                       m_larTPCMinY;             ///< Global LArTPC volume minimum y extent
-        float                       m_larTPCMaxY;             ///< Global LArTPC volume maximum y extent
-        float                       m_larTPCMinZ;             ///< Global LArTPC volume minimum z extent
-        float                       m_larTPCMaxZ;             ///< Global LArTPC volume maximum z extent
-        PlaneVector                 m_larTPCPlanes;           ///< Vector of all planes making up global LArTPC volume
-        pandora::CartesianVector    m_beamLArTPCIntersection; ///< Intersection of beam and global LArTPC volume
-        pandora::CartesianVector    m_beamDirection;          ///< Beam direction
-        float                       m_selectedFraction;       ///< Fraction of hits to use in 3D cluster fits
-        unsigned int                m_nSelectedHits;          ///< Minimum number of hits to use in 3D cluster fits
-        float                       m_containmentLimit;       ///< Limit applied in is contained definition
+        float m_larTPCMinX;                                ///< Global LArTPC volume minimum x extent
+        float m_larTPCMaxX;                                ///< Global LArTPC volume maximum x extent
+        float m_larTPCMinY;                                ///< Global LArTPC volume minimum y extent
+        float m_larTPCMaxY;                                ///< Global LArTPC volume maximum y extent
+        float m_larTPCMinZ;                                ///< Global LArTPC volume minimum z extent
+        float m_larTPCMaxZ;                                ///< Global LArTPC volume maximum z extent
+        PlaneVector m_larTPCPlanes;                        ///< Vector of all planes making up global LArTPC volume
+        pandora::CartesianVector m_beamLArTPCIntersection; ///< Intersection of beam and global LArTPC volume
+        pandora::CartesianVector m_beamDirection;          ///< Beam direction
+        float m_selectedFraction;                          ///< Fraction of hits to use in 3D cluster fits
+        unsigned int m_nSelectedHits;                      ///< Minimum number of hits to use in 3D cluster fits
+        float m_containmentLimit;                          ///< Limit applied in is contained definition
     };
 
     /**
@@ -226,14 +228,14 @@ private:
          *  @param  crPfos input list of Pfos reconstructed under the cosmic ray hypothesis
          *  @param  geometryInfo geometry information block
          */
-         SliceFeatures(const pandora::PfoList &nuPfos, const pandora::PfoList &crPfos, const SliceFeatureParameters &sliceFeatureParameters);
+        SliceFeatures(const pandora::PfoList &nuPfos, const pandora::PfoList &crPfos, const SliceFeatureParameters &sliceFeatureParameters);
 
         /**
          *  @brief  Copy constructor
          *
          *  @param  The SliceFeatures to copy
          */
-        SliceFeatures(const SliceFeatures&) = default;
+        SliceFeatures(const SliceFeatures &) = default;
 
         /**
          *  @brief  Destructor
@@ -271,8 +273,8 @@ private:
          *  @param  outputCaloHitList to receive the list of selected calo hits
          *  @param  closestHitToFaceDistance to receive the distance of closest hit to beam spot
          */
-        void GetLeadingCaloHits(const pandora::CaloHitList &inputCaloHitList, pandora::CaloHitList &outputCaloHitList,
-            double &closestHitToFaceDistance) const;
+        void GetLeadingCaloHits(
+            const pandora::CaloHitList &inputCaloHitList, pandora::CaloHitList &outputCaloHitList, double &closestHitToFaceDistance) const;
 
         /**
          *  @brief  Find the intercepts of a line with the protoDUNE detector
@@ -292,14 +294,14 @@ private:
          */
         bool IsContained(const pandora::CartesianVector &spacePoint, const float limit) const;
 
-        bool                            m_isAvailable;               ///< Is the feature vector available
-        const SliceFeatureParameters    m_sliceFeatureParameters;    ///< Geometry information block
-        LArMvaHelper::MvaFeatureVector  m_featureVector;             ///< The MVA feature vector
+        bool m_isAvailable;                                    ///< Is the feature vector available
+        const SliceFeatureParameters m_sliceFeatureParameters; ///< Geometry information block
+        LArMvaHelper::MvaFeatureVector m_featureVector;        ///< The MVA feature vector
     };
 
     typedef std::vector<SliceFeatures> SliceFeaturesVector;
     typedef std::pair<unsigned int, float> UintFloatPair;
-    typedef std::unordered_map<const pandora::MCParticle*, int> MCParticleToIntMap;
+    typedef std::unordered_map<const pandora::MCParticle *, int> MCParticleToIntMap;
 
     pandora::StatusCode Initialize();
 
@@ -310,7 +312,8 @@ private:
      *  @param  crSliceHypotheses the input cosmic slice hypotheses
      *  @param  sliceFeaturesVector vector to hold the slice features
      */
-    void GetSliceFeatures(const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const;
+    void GetSliceFeatures(
+        const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const;
 
     /**
      *  @brief  Select all pfos under the same hypothesis
@@ -337,7 +340,8 @@ private:
      *  @param  crSliceHypotheses the input cosmic slice hypotheses
      *  @param  bestSliceIndices vector of slice indices passing quality cuts
      */
-    void GetBestMCSliceIndices(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::IntVector &bestSliceIndices) const;
+    void GetBestMCSliceIndices(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::IntVector &bestSliceIndices) const;
 
     /**
      *  @brief  Fill mc particle to nHits map from calo hit list
@@ -375,24 +379,25 @@ private:
      *  @param  sliceFeaturesVector vector holding the slice features
      *  @param  selectedPfos the list of pfos to populate
      */
-    void SelectPfosByAdaBDTScore(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, pandora::PfoList &selectedPfos) const;
+    void SelectPfosByAdaBDTScore(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, pandora::PfoList &selectedPfos) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     // Training
-    bool                            m_useTrainingMode;                      ///< Should use training mode. If true, training examples will be written to the output file
-    std::string                     m_trainingOutputFile;                   ///< Output file name for training examples
-    std::string                     m_caloHitListName;                      ///< Name of input calo hit list
-    std::string                     m_mcParticleListName;                   ///< Name of input MC particle list
-    float                           m_minPurity;                            ///< Minimum purity of the best slice to use event for training
-    float                           m_minCompleteness;                      ///< Minimum completeness of the best slice to use event for training
+    bool m_useTrainingMode;           ///< Should use training mode. If true, training examples will be written to the output file
+    std::string m_trainingOutputFile; ///< Output file name for training examples
+    std::string m_caloHitListName;    ///< Name of input calo hit list
+    std::string m_mcParticleListName; ///< Name of input MC particle list
+    float m_minPurity;                ///< Minimum purity of the best slice to use event for training
+    float m_minCompleteness;          ///< Minimum completeness of the best slice to use event for training
 
     // Classification
-    AdaBoostDecisionTree            m_adaBoostDecisionTree;                 ///< The adaptive boost decision tree
-    std::string                     m_filePathEnvironmentVariable;          ///< The environment variable providing a list of paths to bdt files
-    unsigned int                    m_maxNeutrinos;                         ///< The maximum number of neutrinos to select in any one event
-    float                           m_minAdaBDTScore;                       ///< Minimum score required to classify a slice as a beam particle
-    SliceFeatureParameters          m_sliceFeatureParameters;               ///< Geometry information block
+    AdaBoostDecisionTree m_adaBoostDecisionTree;     ///< The adaptive boost decision tree
+    std::string m_filePathEnvironmentVariable;       ///< The environment variable providing a list of paths to bdt files
+    unsigned int m_maxNeutrinos;                     ///< The maximum number of neutrinos to select in any one event
+    float m_minAdaBDTScore;                          ///< Minimum score required to classify a slice as a beam particle
+    SliceFeatureParameters m_sliceFeatureParameters; ///< Geometry information block
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/BeamParticleIdTool.cc
+++ b/larpandoracontent/LArControlFlow/BeamParticleIdTool.cc
@@ -39,7 +39,8 @@ BeamParticleIdTool::BeamParticleIdTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, const SliceHypotheses &beamSliceHypotheses, const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
+void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, const SliceHypotheses &beamSliceHypotheses,
+    const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
 {
     if (beamSliceHypotheses.size() != crSliceHypotheses.size())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -49,8 +50,9 @@ void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, con
     {
         for (unsigned int sliceIndex = 0, nSlices = beamSliceHypotheses.size(); sliceIndex < nSlices; ++sliceIndex)
         {
-            const PfoList &sliceOutput((m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex))) ?
-                beamSliceHypotheses.at(sliceIndex) : crSliceHypotheses.at(sliceIndex));
+            const PfoList &sliceOutput((m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex)))
+                                           ? beamSliceHypotheses.at(sliceIndex)
+                                           : crSliceHypotheses.at(sliceIndex));
 
             const float score(m_selectAllBeamParticles || (m_selectOnlyFirstSliceBeamParticles && (0 == sliceIndex)) ? 1.f : -1.f);
 
@@ -100,8 +102,8 @@ void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, con
                 const float separationOne((interceptOne - m_beamTPCIntersection).GetMagnitude());
                 const float separationTwo((interceptTwo - m_beamTPCIntersection).GetMagnitude());
 
-                if ((std::min(separationOne, separationTwo) < m_projectionIntersectionCut) &&
-                    (closestDistance < m_closestDistanceCut) && (supplementaryAngleToBeam > m_angleToBeamCut))
+                if ((std::min(separationOne, separationTwo) < m_projectionIntersectionCut) && (closestDistance < m_closestDistanceCut) &&
+                    (supplementaryAngleToBeam > m_angleToBeamCut))
                 {
                     usebeamHypothesis = true;
                 }
@@ -109,7 +111,7 @@ void BeamParticleIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, con
         }
         catch (const StatusCodeException &)
         {
-             usebeamHypothesis = false;
+            usebeamHypothesis = false;
         }
 
         const PfoList &sliceOutput(usebeamHypothesis ? beamSliceHypotheses.at(sliceIndex) : crSliceHypotheses.at(sliceIndex));
@@ -175,25 +177,26 @@ StatusCode BeamParticleIdTool::Initialize()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BeamParticleIdTool::GetSelectedCaloHits(const CaloHitList &inputCaloHitList, CaloHitList &outputCaloHitList,
-    float &closestHitToFaceDistance) const
+void BeamParticleIdTool::GetSelectedCaloHits(const CaloHitList &inputCaloHitList, CaloHitList &outputCaloHitList, float &closestHitToFaceDistance) const
 {
     if (inputCaloHitList.empty())
         throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
 
-    typedef std::pair<const CaloHit*, float> HitDistancePair;
+    typedef std::pair<const CaloHit *, float> HitDistancePair;
     typedef std::vector<HitDistancePair> HitDistanceVector;
     HitDistanceVector hitDistanceVector;
 
     for (const CaloHit *const pCaloHit : inputCaloHitList)
         hitDistanceVector.emplace_back(pCaloHit, (pCaloHit->GetPositionVector() - m_beamTPCIntersection).GetMagnitudeSquared());
 
-    std::sort(hitDistanceVector.begin(), hitDistanceVector.end(), [](const HitDistancePair &lhs, const HitDistancePair &rhs) -> bool {return (lhs.second < rhs.second);});
+    std::sort(hitDistanceVector.begin(), hitDistanceVector.end(),
+        [](const HitDistancePair &lhs, const HitDistancePair &rhs) -> bool { return (lhs.second < rhs.second); });
     closestHitToFaceDistance = std::sqrt(hitDistanceVector.front().second);
 
     const unsigned int nInputHits(inputCaloHitList.size());
-    const unsigned int nSelectedCaloHits(nInputHits < m_nSelectedHits ? nInputHits :
-        static_cast<unsigned int>(std::round(static_cast<float>(nInputHits) * m_selectedFraction / 100.f + 0.5f)));
+    const unsigned int nSelectedCaloHits(
+        nInputHits < m_nSelectedHits ? nInputHits
+                                     : static_cast<unsigned int>(std::round(static_cast<float>(nInputHits) * m_selectedFraction / 100.f + 0.5f)));
 
     for (const HitDistancePair &hitDistancePair : hitDistanceVector)
     {
@@ -206,8 +209,8 @@ void BeamParticleIdTool::GetSelectedCaloHits(const CaloHitList &inputCaloHitList
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BeamParticleIdTool::GetTPCIntercepts(const CartesianVector &a0, const CartesianVector &lineDirection,
-    CartesianVector &interceptOne, CartesianVector &interceptTwo) const
+void BeamParticleIdTool::GetTPCIntercepts(
+    const CartesianVector &a0, const CartesianVector &lineDirection, CartesianVector &interceptOne, CartesianVector &interceptTwo) const
 {
     CartesianPointVector intercepts;
     const CartesianVector lineUnitVector(lineDirection.GetUnitVector());
@@ -235,9 +238,12 @@ void BeamParticleIdTool::GetTPCIntercepts(const CartesianVector &a0, const Carte
 
 bool BeamParticleIdTool::IsContained(const CartesianVector &spacePoint) const
 {
-    if ((m_tpcMinX - spacePoint.GetX() > std::numeric_limits<float>::epsilon()) || (spacePoint.GetX() - m_tpcMaxX > std::numeric_limits<float>::epsilon()) ||
-        (m_tpcMinY - spacePoint.GetY() > std::numeric_limits<float>::epsilon()) || (spacePoint.GetY() - m_tpcMaxY > std::numeric_limits<float>::epsilon()) ||
-        (m_tpcMinZ - spacePoint.GetZ() > std::numeric_limits<float>::epsilon()) || (spacePoint.GetZ() - m_tpcMaxZ > std::numeric_limits<float>::epsilon()))
+    if ((m_tpcMinX - spacePoint.GetX() > std::numeric_limits<float>::epsilon()) ||
+        (spacePoint.GetX() - m_tpcMaxX > std::numeric_limits<float>::epsilon()) ||
+        (m_tpcMinY - spacePoint.GetY() > std::numeric_limits<float>::epsilon()) ||
+        (spacePoint.GetY() - m_tpcMaxY > std::numeric_limits<float>::epsilon()) ||
+        (m_tpcMinZ - spacePoint.GetZ() > std::numeric_limits<float>::epsilon()) ||
+        (spacePoint.GetZ() - m_tpcMaxZ > std::numeric_limits<float>::epsilon()))
     {
         return false;
     }
@@ -276,21 +282,22 @@ CartesianVector BeamParticleIdTool::Plane::GetLineIntersection(const CartesianVe
 
 StatusCode BeamParticleIdTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectAllBeamParticles", m_selectAllBeamParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SelectAllBeamParticles", m_selectAllBeamParticles));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectOnlyFirstSliceBeamParticles", m_selectOnlyFirstSliceBeamParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "SelectOnlyFirstSliceBeamParticles", m_selectOnlyFirstSliceBeamParticles));
 
     if (m_selectAllBeamParticles && m_selectOnlyFirstSliceBeamParticles)
     {
-        std::cout << "BeamParticleIdTool::ReadSettings - cannot use both SelectAllBeamParticles and SelectOnlyFirstSliceBeamParticles simultaneously" << std::endl;
+        std::cout << "BeamParticleIdTool::ReadSettings - cannot use both SelectAllBeamParticles and SelectOnlyFirstSliceBeamParticles simultaneously"
+                  << std::endl;
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
     FloatVector beamTPCIntersection;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "BeamTPCIntersection", beamTPCIntersection));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "BeamTPCIntersection", beamTPCIntersection));
 
     if (3 == beamTPCIntersection.size())
     {
@@ -308,8 +315,8 @@ StatusCode BeamParticleIdTool::ReadSettings(const TiXmlHandle xmlHandle)
     }
 
     FloatVector beamDirection;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "BeamDirection", beamDirection));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "BeamDirection", beamDirection));
 
     if (3 == beamDirection.size())
     {
@@ -327,20 +334,18 @@ StatusCode BeamParticleIdTool::ReadSettings(const TiXmlHandle xmlHandle)
         m_beamDirection.SetValues(std::sin(thetaXZ0), 0, std::cos(thetaXZ0));
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ProjectionIntersectionCut", m_projectionIntersectionCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ProjectionIntersectionCut", m_projectionIntersectionCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClosestDistanceCut", m_closestDistanceCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClosestDistanceCut", m_closestDistanceCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "AngleToBeamCut", m_angleToBeamCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "AngleToBeamCut", m_angleToBeamCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectedFraction", m_selectedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SelectedFraction", m_selectedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NSelectedHits", m_nSelectedHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NSelectedHits", m_nSelectedHits));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArControlFlow/BeamParticleIdTool.h
+++ b/larpandoracontent/LArControlFlow/BeamParticleIdTool.h
@@ -24,7 +24,8 @@ public:
      */
     BeamParticleIdTool();
 
-    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &beamSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
+    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &beamSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
 
 private:
     /**
@@ -50,9 +51,9 @@ private:
         pandora::CartesianVector GetLineIntersection(const pandora::CartesianVector &a0, const pandora::CartesianVector &a) const;
 
     private:
-        pandora::CartesianVector      m_unitNormal;                         ///< Unit normal to plane
-        pandora::CartesianVector      m_point;                              ///< A point on the plane
-        float                         m_d;                                  ///< Parameter defining a plane
+        pandora::CartesianVector m_unitNormal; ///< Unit normal to plane
+        pandora::CartesianVector m_point;      ///< A point on the plane
+        float m_d;                             ///< Parameter defining a plane
     };
 
     pandora::StatusCode Initialize();
@@ -64,8 +65,7 @@ private:
      *  @param  outputCaloHitList to receive the list of selected calo hits
      *  @param  closestHitToFaceDistance to receive the distance of closest hit to beam spot
      */
-    void GetSelectedCaloHits(const pandora::CaloHitList &inputCaloHitList, pandora::CaloHitList &outputCaloHitList,
-        float &closestHitToFaceDistance) const;
+    void GetSelectedCaloHits(const pandora::CaloHitList &inputCaloHitList, pandora::CaloHitList &outputCaloHitList, float &closestHitToFaceDistance) const;
 
     /**
      *  @brief  Find the intercepts of a line with the protoDUNE detector
@@ -89,23 +89,23 @@ private:
 
     typedef std::vector<Plane> PlaneVector;
 
-    bool                            m_selectAllBeamParticles;               ///< First approach: select all beam particles, as opposed to selecting all cosmics
-    bool                            m_selectOnlyFirstSliceBeamParticles;    ///< First approach: select first slice beam particles, cosmics for all subsequent slices
-    float                           m_tpcMinX;                              ///< Global TPC volume minimum x extent
-    float                           m_tpcMaxX;                              ///< Global TPC volume maximum x extent
-    float                           m_tpcMinY;                              ///< Global TPC volume minimum y extent
-    float                           m_tpcMaxY;                              ///< Global TPC volume maximum y extent
-    float                           m_tpcMinZ;                              ///< Global TPC volume minimum z extent
-    float                           m_tpcMaxZ;                              ///< Global TPC volume maximum z extent
-    pandora::CartesianVector        m_beamTPCIntersection;                  ///< Intersection of beam and global TPC volume
-    pandora::CartesianVector        m_beamDirection;                        ///< Beam direction
-    PlaneVector                     m_tpcPlanes;                            ///< Vector of all planes making up global TPC volume
+    bool m_selectAllBeamParticles;            ///< First approach: select all beam particles, as opposed to selecting all cosmics
+    bool m_selectOnlyFirstSliceBeamParticles; ///< First approach: select first slice beam particles, cosmics for all subsequent slices
+    float m_tpcMinX;                          ///< Global TPC volume minimum x extent
+    float m_tpcMaxX;                          ///< Global TPC volume maximum x extent
+    float m_tpcMinY;                          ///< Global TPC volume minimum y extent
+    float m_tpcMaxY;                          ///< Global TPC volume maximum y extent
+    float m_tpcMinZ;                          ///< Global TPC volume minimum z extent
+    float m_tpcMaxZ;                          ///< Global TPC volume maximum z extent
+    pandora::CartesianVector m_beamTPCIntersection; ///< Intersection of beam and global TPC volume
+    pandora::CartesianVector m_beamDirection;       ///< Beam direction
+    PlaneVector m_tpcPlanes;                        ///< Vector of all planes making up global TPC volume
 
-    float                           m_projectionIntersectionCut;            ///< Projection intersection distance cut, used in beam event selection
-    float                           m_closestDistanceCut;                   ///< Closest distance (of hit to beam spot), used in beam event selection
-    float                           m_angleToBeamCut;                       ///< Angle between major axis and beam direction, used in beam event selection
-    float                           m_selectedFraction;                     ///< Fraction of hits to use in 3D cluster fits
-    unsigned int                    m_nSelectedHits;                        ///< Minimum number of hits to use in 3D cluster fits
+    float m_projectionIntersectionCut; ///< Projection intersection distance cut, used in beam event selection
+    float m_closestDistanceCut;        ///< Closest distance (of hit to beam spot), used in beam event selection
+    float m_angleToBeamCut;            ///< Angle between major axis and beam direction, used in beam event selection
+    float m_selectedFraction;          ///< Fraction of hits to use in 3D cluster fits
+    unsigned int m_nSelectedHits;      ///< Minimum number of hits to use in 3D cluster fits
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
@@ -118,7 +118,7 @@ void CosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos,
     this->CheckIfInTime(candidates, pfoToInTimeMap);
 
     PfoToBoolMap pfoToIsContainedMap;
-    this->CheckIfContained(candidates, pfoToIsContainedMap );
+    this->CheckIfContained(candidates, pfoToIsContainedMap);
 
     PfoToBoolMap pfoToIsTopToBottomMap;
     this->CheckIfTopToBottom(candidates, pfoToIsTopToBottomMap);
@@ -168,8 +168,8 @@ void CosmicRayTaggingTool::GetPfoAssociations(const PfoList &parentCosmicRayPfos
         if (!this->GetValid3DCluster(pPfo, pCluster) || !pCluster)
             continue;
 
-        (void) pfoToSlidingFitsMap.insert(PfoToSlidingFitsMap::value_type(pPfo, std::make_pair(
-            ThreeDSlidingFitResult(pCluster, 5, layerPitch), ThreeDSlidingFitResult(pCluster, 100, layerPitch)))); // TODO Configurable
+        (void)pfoToSlidingFitsMap.insert(PfoToSlidingFitsMap::value_type(pPfo,
+            std::make_pair(ThreeDSlidingFitResult(pCluster, 5, layerPitch), ThreeDSlidingFitResult(pCluster, 100, layerPitch)))); // TODO Configurable
     }
 
     for (const ParticleFlowObject *const pPfo1 : parentCosmicRayPfos)
@@ -192,10 +192,14 @@ void CosmicRayTaggingTool::GetPfoAssociations(const PfoList &parentCosmicRayPfos
             const ThreeDSlidingFitResult &fitPos2(iter2->second.first), &fitDir2(iter2->second.second);
 
             // TODO Use existing LArPointingClusters and IsEmission/IsNode logic, for consistency
-            if (!(this->CheckAssociation(fitPos1.GetGlobalMinLayerPosition(), fitDir1.GetGlobalMinLayerDirection() * -1.f, fitPos2.GetGlobalMinLayerPosition(), fitDir2.GetGlobalMinLayerDirection() * -1.f) ||
-                this->CheckAssociation(fitPos1.GetGlobalMinLayerPosition(), fitDir1.GetGlobalMinLayerDirection() * -1.f, fitPos2.GetGlobalMaxLayerPosition(), fitDir2.GetGlobalMaxLayerDirection()) ||
-                this->CheckAssociation(fitPos1.GetGlobalMaxLayerPosition(), fitDir1.GetGlobalMaxLayerDirection(), fitPos2.GetGlobalMinLayerPosition(), fitDir2.GetGlobalMinLayerDirection() * -1.f) ||
-                this->CheckAssociation(fitPos1.GetGlobalMaxLayerPosition(), fitDir1.GetGlobalMaxLayerDirection(), fitPos2.GetGlobalMaxLayerPosition(), fitDir2.GetGlobalMaxLayerDirection())))
+            if (!(this->CheckAssociation(fitPos1.GetGlobalMinLayerPosition(), fitDir1.GetGlobalMinLayerDirection() * -1.f,
+                      fitPos2.GetGlobalMinLayerPosition(), fitDir2.GetGlobalMinLayerDirection() * -1.f) ||
+                    this->CheckAssociation(fitPos1.GetGlobalMinLayerPosition(), fitDir1.GetGlobalMinLayerDirection() * -1.f,
+                        fitPos2.GetGlobalMaxLayerPosition(), fitDir2.GetGlobalMaxLayerDirection()) ||
+                    this->CheckAssociation(fitPos1.GetGlobalMaxLayerPosition(), fitDir1.GetGlobalMaxLayerDirection(),
+                        fitPos2.GetGlobalMinLayerPosition(), fitDir2.GetGlobalMinLayerDirection() * -1.f) ||
+                    this->CheckAssociation(fitPos1.GetGlobalMaxLayerPosition(), fitDir1.GetGlobalMaxLayerDirection(),
+                        fitPos2.GetGlobalMaxLayerPosition(), fitDir2.GetGlobalMaxLayerDirection())))
             {
                 continue;
             }
@@ -213,8 +217,8 @@ void CosmicRayTaggingTool::GetPfoAssociations(const PfoList &parentCosmicRayPfos
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool CosmicRayTaggingTool::CheckAssociation(const CartesianVector &endPoint1, const CartesianVector &endDir1, const CartesianVector &endPoint2,
-    const CartesianVector &endDir2) const
+bool CosmicRayTaggingTool::CheckAssociation(
+    const CartesianVector &endPoint1, const CartesianVector &endDir1, const CartesianVector &endPoint2, const CartesianVector &endDir2) const
 {
     // TODO This function needs significant tidying and checks (variable names must be self describing, check deltaTheta, etc.)
     const CartesianVector n(endDir1.GetUnitVector());
@@ -237,8 +241,8 @@ bool CosmicRayTaggingTool::CheckAssociation(const CartesianVector &endPoint1, co
     const float maxVertexUncertainty(m_maxAssociationDist * std::sin(deltaTheta) + m_positionalUncertainty);
 
     // Ensure that the distances to the point of closest approch are within the limits
-    if ((lambda < -maxVertexUncertainty) || (mu < -maxVertexUncertainty) ||
-        (lambda > m_maxAssociationDist + maxVertexUncertainty) || (mu > m_maxAssociationDist + maxVertexUncertainty))
+    if ((lambda < -maxVertexUncertainty) || (mu < -maxVertexUncertainty) || (lambda > m_maxAssociationDist + maxVertexUncertainty) ||
+        (mu > m_maxAssociationDist + maxVertexUncertainty))
     {
         return false;
     }
@@ -368,7 +372,9 @@ void CosmicRayTaggingTool::CheckIfInTime(const CRCandidateList &candidates, PfoT
                 if (std::fabs(LArPfoHelper::GetVertex(candidate.m_pPfo)->GetX0()) > m_inTimeMaxX0)
                     isInTime = false;
             }
-            catch (const StatusCodeException &) {}
+            catch (const StatusCodeException &)
+            {
+            }
         }
 
         // Cosmic-ray muons extending outside of (any individual) physical volume if given t0 is that of the beam particle
@@ -385,7 +391,7 @@ void CosmicRayTaggingTool::CheckIfInTime(const CRCandidateList &candidates, PfoT
 
             for (const CaloHit *const pCaloHit : caloHitList)
             {
-                const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit*>(pCaloHit));
+                const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
 
                 if (!pLArCaloHit)
                     continue;
@@ -425,16 +431,19 @@ void CosmicRayTaggingTool::CheckIfContained(const CRCandidateList &candidates, P
 {
     for (const CRCandidate &candidate : candidates)
     {
-        const float upperY((candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
-        const float lowerY((candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+        const float upperY(
+            (candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+        const float lowerY(
+            (candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
 
-        const float zAtUpperY((candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetZ() : candidate.m_endPoint2.GetZ());
-        const float zAtLowerY((candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetZ() : candidate.m_endPoint2.GetZ());
+        const float zAtUpperY(
+            (candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetZ() : candidate.m_endPoint2.GetZ());
+        const float zAtLowerY(
+            (candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetZ() : candidate.m_endPoint2.GetZ());
 
-        const bool isContained((upperY < m_face_Yt - m_marginY) && (upperY > m_face_Yb + m_marginY) &&
-            (lowerY < m_face_Yt - m_marginY) && (lowerY > m_face_Yb + m_marginY) &&
-            (zAtUpperY < m_face_Zd - m_marginZ) && (zAtUpperY > m_face_Zu + m_marginZ) &&
-            (zAtLowerY < m_face_Zd - m_marginZ) && (zAtLowerY > m_face_Zu + m_marginZ));
+        const bool isContained((upperY < m_face_Yt - m_marginY) && (upperY > m_face_Yb + m_marginY) && (lowerY < m_face_Yt - m_marginY) &&
+                               (lowerY > m_face_Yb + m_marginY) && (zAtUpperY < m_face_Zd - m_marginZ) && (zAtUpperY > m_face_Zu + m_marginZ) &&
+                               (zAtLowerY < m_face_Zd - m_marginZ) && (zAtLowerY > m_face_Zu + m_marginZ));
 
         if (!pfoToIsContainedMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, isContained)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
@@ -447,8 +456,10 @@ void CosmicRayTaggingTool::CheckIfTopToBottom(const CRCandidateList &candidates,
 {
     for (const CRCandidate &candidate : candidates)
     {
-        const float upperY((candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
-        const float lowerY((candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+        const float upperY(
+            (candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+        const float lowerY(
+            (candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
 
         const bool isTopToBottom((upperY > m_face_Yt - m_marginY) && (lowerY < m_face_Yb + m_marginY));
 
@@ -459,8 +470,8 @@ void CosmicRayTaggingTool::CheckIfTopToBottom(const CRCandidateList &candidates,
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsContainedMap,
-    UIntSet &neutrinoSliceSet) const
+void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap,
+    const PfoToBoolMap &pfoToIsContainedMap, UIntSet &neutrinoSliceSet) const
 {
     IntBoolMap sliceIdToIsInTimeMap;
 
@@ -479,22 +490,25 @@ void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, 
             continue;
 
         const bool likelyNeutrino(candidate.m_canFit && sliceIdToIsInTimeMap.at(candidate.m_sliceId) &&
-            (candidate.m_theta < m_maxNeutrinoCosTheta || pfoToIsContainedMap.at(candidate.m_pPfo)));
+                                  (candidate.m_theta < m_maxNeutrinoCosTheta || pfoToIsContainedMap.at(candidate.m_pPfo)));
 
         if (likelyNeutrino)
-            (void) neutrinoSliceSet.insert(candidate.m_sliceId);
+            (void)neutrinoSliceSet.insert(candidate.m_sliceId);
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsTopToBottomMap,
-    const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const
+void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap,
+    const PfoToBoolMap &pfoToIsTopToBottomMap, const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const
 {
     for (const CRCandidate &candidate : candidates)
     {
-        const bool likelyCRMuon(!neutrinoSliceSet.count(candidate.m_sliceId) && (!pfoToInTimeMap.at(candidate.m_pPfo) || (candidate.m_canFit &&
-            (pfoToIsTopToBottomMap.at(candidate.m_pPfo) || ((candidate.m_theta > m_minCosmicCosTheta) && (candidate.m_curvature < m_maxCosmicCurvature)))) ));
+        const bool likelyCRMuon(
+            !neutrinoSliceSet.count(candidate.m_sliceId) &&
+            (!pfoToInTimeMap.at(candidate.m_pPfo) ||
+                (candidate.m_canFit && (pfoToIsTopToBottomMap.at(candidate.m_pPfo) ||
+                                           ((candidate.m_theta > m_minCosmicCosTheta) && (candidate.m_curvature < m_maxCosmicCurvature))))));
 
         if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyCRMuon)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
@@ -566,42 +580,36 @@ void CosmicRayTaggingTool::CRCandidate::CalculateFitVariables(const ThreeDSlidin
 
 StatusCode CosmicRayTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CutMode", m_cutMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CutMode", m_cutMode));
     std::transform(m_cutMode.begin(), m_cutMode.end(), m_cutMode.begin(), ::tolower);
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "AngularUncertainty", m_angularUncertainty ));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "AngularUncertainty", m_angularUncertainty));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PositionalUncertainty", m_positionalUncertainty ));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PositionalUncertainty", m_positionalUncertainty));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAssociationDist", m_maxAssociationDist));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAssociationDist", m_maxAssociationDist));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HitThreshold", m_minimumHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitThreshold", m_minimumHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "InTimeMargin", m_inTimeMargin));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMargin", m_inTimeMargin));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "InTimeMaxX0", m_inTimeMaxX0));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMaxX0", m_inTimeMaxX0));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MarginY", m_marginY));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginY", m_marginY));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MarginZ", m_marginZ));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginZ", m_marginZ));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxNeutrinoCosTheta", m_maxNeutrinoCosTheta));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxNeutrinoCosTheta", m_maxNeutrinoCosTheta));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCosmicCosTheta", m_minCosmicCosTheta));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosmicCosTheta", m_minCosmicCosTheta));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCosmicCurvature", m_maxCosmicCurvature));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCosmicCurvature", m_maxCosmicCurvature));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
@@ -47,14 +47,14 @@ private:
          */
         CRCandidate(const pandora::Pandora &pandora, const pandora::ParticleFlowObject *const pPfo, const unsigned int sliceId);
 
-        const pandora::ParticleFlowObject * const m_pPfo;         ///< Address of the candidate Pfo
-        unsigned int                              m_sliceId;      ///< Slice ID
-        bool                                      m_canFit;       ///< If there are a sufficient number of 3D hits to perform a fitting
-        pandora::CartesianVector                  m_endPoint1;    ///< First fitted end point in 3D
-        pandora::CartesianVector                  m_endPoint2;    ///< Second fitted end point in 3D
-        double                                    m_length;       ///< Straight line length of the linear fit
-        double                                    m_curvature;    ///< Measure of the curvature of the track
-        double                                    m_theta;        ///< Direction made with vertical
+        const pandora::ParticleFlowObject *const m_pPfo; ///< Address of the candidate Pfo
+        unsigned int m_sliceId;                          ///< Slice ID
+        bool m_canFit;                                   ///< If there are a sufficient number of 3D hits to perform a fitting
+        pandora::CartesianVector m_endPoint1;            ///< First fitted end point in 3D
+        pandora::CartesianVector m_endPoint2;            ///< Second fitted end point in 3D
+        double m_length;                                 ///< Straight line length of the linear fit
+        double m_curvature;                              ///< Measure of the curvature of the track
+        double m_theta;                                  ///< Direction made with vertical
 
     private:
         /**
@@ -97,8 +97,8 @@ private:
      *
      *  @return whether the Pfos are associated
      */
-    bool CheckAssociation(const pandora::CartesianVector &endPoint1, const pandora::CartesianVector &endDir1, const pandora::CartesianVector &endPoint2,
-        const pandora::CartesianVector &endDir2) const;
+    bool CheckAssociation(const pandora::CartesianVector &endPoint1, const pandora::CartesianVector &endDir1,
+        const pandora::CartesianVector &endPoint2, const pandora::CartesianVector &endDir2) const;
 
     typedef std::unordered_map<const pandora::ParticleFlowObject *, unsigned int> PfoToSliceIdMap;
 
@@ -192,28 +192,28 @@ private:
      *          "nominal" = optimised to maximise CR removal whilst preserving neutrinos
      *          "aggressive" = remove CR muons and allow more neutrinos to be tagged
      */
-    std::string     m_cutMode;
+    std::string m_cutMode;
 
-    float           m_angularUncertainty;       ///< The uncertainty in degrees for the angle of a Pfo
-    float           m_positionalUncertainty;    ///< The uncertainty in cm for the position of Pfo endpoint in 3D
-    float           m_maxAssociationDist;       ///< The maximum distance from endpoint to point of closest approach, typically a multiple of LAr radiation length
+    float m_angularUncertainty;    ///< The uncertainty in degrees for the angle of a Pfo
+    float m_positionalUncertainty; ///< The uncertainty in cm for the position of Pfo endpoint in 3D
+    float m_maxAssociationDist; ///< The maximum distance from endpoint to point of closest approach, typically a multiple of LAr radiation length
 
-    unsigned int    m_minimumHits;              ///< The minimum number of hits for a Pfo to be considered
+    unsigned int m_minimumHits; ///< The minimum number of hits for a Pfo to be considered
 
-    float           m_inTimeMargin;             ///< The maximum distance outside of the physical detector volume that a Pfo may be to still be considered in time
-    float           m_inTimeMaxX0;              ///< The maximum pfo x0 (determined from shifted vertex) to allow pfo to still be considered in time
-    float           m_marginY;                  ///< The minimum distance from a detector Y-face for a Pfo to be associated
-    float           m_marginZ;                  ///< The minimum distance from a detector Z-face for a Pfo to be associated
-    float           m_maxNeutrinoCosTheta;      ///< The maximum cos(theta) that a Pfo can have to be classified as a likely neutrino
-    float           m_minCosmicCosTheta;        ///< The minimum cos(theta) that a Pfo can have to be classified as a likely CR muon
-    float           m_maxCosmicCurvature;       ///< The maximum curvature that a Pfo can have to be classified as a likely CR muon
+    float m_inTimeMargin; ///< The maximum distance outside of the physical detector volume that a Pfo may be to still be considered in time
+    float m_inTimeMaxX0;  ///< The maximum pfo x0 (determined from shifted vertex) to allow pfo to still be considered in time
+    float m_marginY;      ///< The minimum distance from a detector Y-face for a Pfo to be associated
+    float m_marginZ;      ///< The minimum distance from a detector Z-face for a Pfo to be associated
+    float m_maxNeutrinoCosTheta; ///< The maximum cos(theta) that a Pfo can have to be classified as a likely neutrino
+    float m_minCosmicCosTheta;   ///< The minimum cos(theta) that a Pfo can have to be classified as a likely CR muon
+    float m_maxCosmicCurvature;  ///< The maximum curvature that a Pfo can have to be classified as a likely CR muon
 
-    float           m_face_Xa;                  ///< Anode      X face
-    float           m_face_Xc;                  ///< Cathode    X face
-    float           m_face_Yb;                  ///< Bottom     Y face
-    float           m_face_Yt;                  ///< Top        Y face
-    float           m_face_Zu;                  ///< Upstream   Z face
-    float           m_face_Zd;                  ///< Downstream Z face
+    float m_face_Xa; ///< Anode      X face
+    float m_face_Xc; ///< Cathode    X face
+    float m_face_Yb; ///< Bottom     Y face
+    float m_face_Yt; ///< Top        Y face
+    float m_face_Zu; ///< Upstream   Z face
+    float m_face_Zd; ///< Downstream Z face
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -109,8 +109,8 @@ void MasterAlgorithm::ShiftPfoHierarchy(const ParticleFlowObject *const pParentP
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MasterAlgorithm::StitchPfos(const ParticleFlowObject *const pPfoToEnlarge, const ParticleFlowObject *const pPfoToDelete,
-    PfoToLArTPCMap &pfoToLArTPCMap) const
+void MasterAlgorithm::StitchPfos(
+    const ParticleFlowObject *const pPfoToEnlarge, const ParticleFlowObject *const pPfoToDelete, PfoToLArTPCMap &pfoToLArTPCMap) const
 {
     if (pPfoToEnlarge == pPfoToDelete)
         throw StatusCodeException(STATUS_CODE_NOT_ALLOWED);
@@ -128,7 +128,7 @@ void MasterAlgorithm::StitchPfos(const ParticleFlowObject *const pPfoToEnlarge, 
     for (const ParticleFlowObject *const pDaughterPfo : daughterPfos)
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPfoToEnlarge, pDaughterPfo));
 
-    for (const  Vertex *const pDaughterVertex : daughterVertices)
+    for (const Vertex *const pDaughterVertex : daughterVertices)
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete(*this, pDaughterVertex, m_recreatedVertexListName));
 
     for (const Cluster *const pDaughterCluster : daughterClusters)
@@ -138,8 +138,8 @@ void MasterAlgorithm::StitchPfos(const ParticleFlowObject *const pPfoToEnlarge, 
 
         if (pParentCluster)
         {
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pDaughterCluster,
-                m_recreatedClusterListName, m_recreatedClusterListName));
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pDaughterCluster, m_recreatedClusterListName, m_recreatedClusterListName));
         }
         else
         {
@@ -211,7 +211,8 @@ StatusCode MasterAlgorithm::InitializeWorkerInstances()
         for (const LArTPCMap::value_type &mapEntry : larTPCMap)
         {
             const unsigned int volumeId(mapEntry.second->GetLArTPCVolumeId());
-            m_crWorkerInstances.push_back(this->CreateWorkerInstance(*(mapEntry.second), gapList, m_crSettingsFile, "CRWorkerInstance" + std::to_string(volumeId)));
+            m_crWorkerInstances.push_back(
+                this->CreateWorkerInstance(*(mapEntry.second), gapList, m_crSettingsFile, "CRWorkerInstance" + std::to_string(volumeId)));
         }
 
         if (m_shouldRunSlicing)
@@ -241,9 +242,12 @@ StatusCode MasterAlgorithm::CopyMCParticles() const
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputMCParticleListName, pMCParticleList));
 
     PandoraInstanceList pandoraWorkerInstances(m_crWorkerInstances);
-    if (m_pSlicingWorkerInstance) pandoraWorkerInstances.push_back(m_pSlicingWorkerInstance);
-    if (m_pSliceNuWorkerInstance) pandoraWorkerInstances.push_back(m_pSliceNuWorkerInstance);
-    if (m_pSliceCRWorkerInstance) pandoraWorkerInstances.push_back(m_pSliceCRWorkerInstance);
+    if (m_pSlicingWorkerInstance)
+        pandoraWorkerInstances.push_back(m_pSlicingWorkerInstance);
+    if (m_pSliceNuWorkerInstance)
+        pandoraWorkerInstances.push_back(m_pSliceNuWorkerInstance);
+    if (m_pSliceCRWorkerInstance)
+        pandoraWorkerInstances.push_back(m_pSliceCRWorkerInstance);
 
     LArMCParticleFactory mcParticleFactory;
 
@@ -268,7 +272,7 @@ StatusCode MasterAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &volume
 
     for (const CaloHit *const pCaloHit : *pCaloHitList)
     {
-        const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit*>(pCaloHit));
+        const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
 
         if (!pLArCaloHit && (1 != nLArTPCs))
             return STATUS_CODE_INVALID_PARAMETER;
@@ -280,7 +284,7 @@ StatusCode MasterAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &volume
         larTPCHitList.m_allHitList.push_back(pCaloHit);
 
         if (((pCaloHit->GetPositionVector().GetX() >= (pLArTPC->GetCenterX() - 0.5f * pLArTPC->GetWidthX())) &&
-            (pCaloHit->GetPositionVector().GetX() <= (pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX()))))
+                (pCaloHit->GetPositionVector().GetX() <= (pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX()))))
         {
             larTPCHitList.m_truncatedHitList.push_back(pCaloHit);
         }
@@ -389,7 +393,7 @@ StatusCode MasterAlgorithm::TagCosmicRayPfos(const PfoToFloatMap &stitchedPfosTo
 
         if (isClearCosmic)
             clearCosmicRayPfos.push_back(pPfo);
-   }
+    }
 
     for (const Pfo *const pPfo : *pRecreatedCRPfos)
     {
@@ -469,7 +473,8 @@ StatusCode MasterAlgorithm::RunSlicing(const VolumeIdToHitListMap &volumeIdToHit
             }
             else
             {
-                if (sliceVector.empty()) sliceVector.push_back(CaloHitList());
+                if (sliceVector.empty())
+                    sliceVector.push_back(CaloHitList());
                 sliceVector.back().push_back(pCaloHit);
             }
         }
@@ -531,7 +536,7 @@ StatusCode MasterAlgorithm::RunSliceReconstruction(SliceVector &sliceVector, Sli
         for (const CaloHit *const pSliceCaloHit : sliceHits)
         {
             // ATTN Must ensure we copy the hit actually owned by master instance; access differs with/without slicing enabled
-            const CaloHit *const pCaloHitInMaster(m_shouldRunSlicing ? static_cast<const CaloHit*>(pSliceCaloHit->GetParentAddress()) : pSliceCaloHit);
+            const CaloHit *const pCaloHitInMaster(m_shouldRunSlicing ? static_cast<const CaloHit *>(pSliceCaloHit->GetParentAddress()) : pSliceCaloHit);
 
             if (m_shouldRunNeutrinoRecoOption)
                 PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Copy(m_pSliceNuWorkerInstance, pCaloHitInMaster));
@@ -641,7 +646,7 @@ StatusCode MasterAlgorithm::Reset()
 
 StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *const pCaloHit) const
 {
-    const LArCaloHit *const pLArCaloHit{dynamic_cast<const LArCaloHit*>(pCaloHit)};
+    const LArCaloHit *const pLArCaloHit{dynamic_cast<const LArCaloHit *>(pCaloHit)};
     if (pLArCaloHit == nullptr)
     {
         std::cout << "MasterAlgorithm: Could not cast CaloHit to LArCaloHit" << std::endl;
@@ -668,7 +673,7 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *c
     parameters.m_layer = pCaloHit->GetLayer();
     parameters.m_isInOuterSamplingLayer = pCaloHit->IsInOuterSamplingLayer();
     // ATTN Parent of calo hit in worker is corresponding calo hit in master
-    parameters.m_pParentAddress = static_cast<const void*>(pCaloHit);
+    parameters.m_pParentAddress = static_cast<const void *>(pCaloHit);
     parameters.m_larTPCVolumeId = pLArCaloHit->GetLArTPCVolumeId();
     parameters.m_daughterVolumeId = (m_larCaloHitVersion > 1) ? pLArCaloHit->GetDaughterVolumeId() : 0;
 
@@ -683,8 +688,8 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *c
 
         for (const MCParticle *const pMCParticle : mcParticleVector)
         {
-            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetCaloHitToMCParticleRelationship(
-                *pPandora, pLArCaloHit, pMCParticle, pLArCaloHit->GetMCParticleWeightMap().at(pMCParticle)));
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraApi::SetCaloHitToMCParticleRelationship(*pPandora, pLArCaloHit, pMCParticle, pLArCaloHit->GetMCParticleWeightMap().at(pMCParticle)));
         }
     }
 
@@ -696,7 +701,7 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *c
 StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const MCParticle *const pMCParticle, const LArMCParticleFactory *const pMCParticleFactory) const
 {
     LArMCParticleParameters parameters;
-    const LArMCParticle *const pLArMCParticle = dynamic_cast<const LArMCParticle*>(pMCParticle);
+    const LArMCParticle *const pLArMCParticle = dynamic_cast<const LArMCParticle *>(pMCParticle);
 
     if (!pLArMCParticle)
     {
@@ -712,7 +717,7 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const MCParticle
     parameters.m_particleId = pMCParticle->GetParticleId();
     parameters.m_mcParticleType = pMCParticle->GetMCParticleType();
     // ATTN Parent of mc particle in worker is corresponding mc particle in master
-    parameters.m_pParentAddress = static_cast<const void*>(pMCParticle);
+    parameters.m_pParentAddress = static_cast<const void *>(pMCParticle);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::MCParticle::Create(*pPandora, parameters, *pMCParticleFactory));
 
     for (const MCParticle *const pDaughterMCParticle : pMCParticle->GetDaughterList())
@@ -786,10 +791,10 @@ StatusCode MasterAlgorithm::Recreate(const ParticleFlowObject *const pInputPfo, 
         pInputCluster->GetOrderedCaloHitList().FillCaloHitList(inputCaloHitList);
 
         for (const CaloHit *const pInputCaloHit : inputCaloHitList)
-            newCaloHitList.push_back(static_cast<const CaloHit*>(pInputCaloHit->GetParentAddress()));
+            newCaloHitList.push_back(static_cast<const CaloHit *>(pInputCaloHit->GetParentAddress()));
 
         for (const CaloHit *const pInputCaloHit : pInputCluster->GetIsolatedCaloHitList())
-            newIsolatedCaloHitList.push_back(static_cast<const CaloHit*>(pInputCaloHit->GetParentAddress()));
+            newIsolatedCaloHitList.push_back(static_cast<const CaloHit *>(pInputCaloHit->GetParentAddress()));
 
         if (!newCaloHitList.empty())
             newClusterList.push_back(this->CreateCluster(pInputCluster, newCaloHitList, newIsolatedCaloHitList));
@@ -802,15 +807,15 @@ StatusCode MasterAlgorithm::Recreate(const ParticleFlowObject *const pInputPfo, 
 
         for (const CaloHit *const pInputCaloHit : inputCaloHitList)
         {
-            const CaloHit *const pWorkerParentCaloHit(static_cast<const CaloHit*>(pInputCaloHit->GetParentAddress()));
-            const CaloHit *const pMasterParentCaloHit(static_cast<const CaloHit*>(pWorkerParentCaloHit->GetParentAddress()));
+            const CaloHit *const pWorkerParentCaloHit(static_cast<const CaloHit *>(pInputCaloHit->GetParentAddress()));
+            const CaloHit *const pMasterParentCaloHit(static_cast<const CaloHit *>(pWorkerParentCaloHit->GetParentAddress()));
             newCaloHitList.push_back(this->CreateCaloHit(pInputCaloHit, pMasterParentCaloHit));
         }
 
         for (const CaloHit *const pInputCaloHit : pInputCluster->GetIsolatedCaloHitList())
         {
-            const CaloHit *const pWorkerParentCaloHit(static_cast<const CaloHit*>(pInputCaloHit->GetParentAddress()));
-            const CaloHit *const pMasterParentCaloHit(static_cast<const CaloHit*>(pWorkerParentCaloHit->GetParentAddress()));
+            const CaloHit *const pWorkerParentCaloHit(static_cast<const CaloHit *>(pInputCaloHit->GetParentAddress()));
+            const CaloHit *const pMasterParentCaloHit(static_cast<const CaloHit *>(pWorkerParentCaloHit->GetParentAddress()));
             newIsolatedCaloHitList.push_back(this->CreateCaloHit(pInputCaloHit, pMasterParentCaloHit));
         }
 
@@ -859,7 +864,7 @@ const CaloHit *MasterAlgorithm::CreateCaloHit(const CaloHit *const pInputCaloHit
     parameters.m_hitRegion = pInputCaloHit->GetHitRegion();
     parameters.m_layer = pInputCaloHit->GetLayer();
     parameters.m_isInOuterSamplingLayer = pInputCaloHit->IsInOuterSamplingLayer();
-    parameters.m_pParentAddress = static_cast<const void*>(pParentCaloHit);
+    parameters.m_pParentAddress = static_cast<const void *>(pParentCaloHit);
 
     const CaloHit *pNewCaloHit(nullptr);
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pNewCaloHit));
@@ -874,8 +879,8 @@ const CaloHit *MasterAlgorithm::CreateCaloHit(const CaloHit *const pInputCaloHit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const Cluster *MasterAlgorithm::CreateCluster(const Cluster *const pInputCluster, const CaloHitList &newCaloHitList,
-    const CaloHitList &newIsolatedCaloHitList) const
+const Cluster *MasterAlgorithm::CreateCluster(
+    const Cluster *const pInputCluster, const CaloHitList &newCaloHitList, const CaloHitList &newIsolatedCaloHitList) const
 {
     PandoraContentApi::Cluster::Parameters parameters;
     parameters.m_caloHitList = newCaloHitList;
@@ -908,8 +913,8 @@ const Vertex *MasterAlgorithm::CreateVertex(const Vertex *const pInputVertex) co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const ParticleFlowObject *MasterAlgorithm::CreatePfo(const ParticleFlowObject *const pInputPfo, const ClusterList &newClusterList,
-    const VertexList &newVertexList) const
+const ParticleFlowObject *MasterAlgorithm::CreatePfo(
+    const ParticleFlowObject *const pInputPfo, const ClusterList &newClusterList, const VertexList &newVertexList) const
 {
     PandoraContentApi::ParticleFlowObject::Parameters parameters;
     parameters.m_particleId = pInputPfo->GetParticleId();
@@ -930,14 +935,16 @@ const ParticleFlowObject *MasterAlgorithm::CreatePfo(const ParticleFlowObject *c
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPC &larTPC, const DetectorGapList &gapList, const std::string &settingsFile, const std::string &name) const
+const Pandora *MasterAlgorithm::CreateWorkerInstance(
+    const LArTPC &larTPC, const DetectorGapList &gapList, const std::string &settingsFile, const std::string &name) const
 {
     // The Pandora instance
     const Pandora *const pPandora(new Pandora(name));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, LArContent::RegisterAlgorithms(*pPandora));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, LArContent::RegisterBasicPlugins(*pPandora));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetPseudoLayerPlugin(*pPandora, new lar_content::LArPseudoLayerPlugin));
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetLArTransformationPlugin(*pPandora, new lar_content::LArRotationalTransformationPlugin));
+    PANDORA_THROW_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, PandoraApi::SetLArTransformationPlugin(*pPandora, new lar_content::LArRotationalTransformationPlugin));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RegisterCustomContent(pPandora));
     MultiPandoraApi::AddDaughterPandoraInstance(&(this->GetPandora()), pPandora);
 
@@ -965,10 +972,10 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPC &larTPC, const
     // The Gaps
     for (const DetectorGap *const pGap : gapList)
     {
-        const LineGap *const pLineGap(dynamic_cast<const LineGap*>(pGap));
+        const LineGap *const pLineGap(dynamic_cast<const LineGap *>(pGap));
 
         if (pLineGap && (((pLineGap->GetLineEndX() >= tpcMinX) && (pLineGap->GetLineEndX() <= tpcMaxX)) ||
-            ((pLineGap->GetLineStartX() >= tpcMinX) && (pLineGap->GetLineStartX() <= tpcMaxX))) )
+                            ((pLineGap->GetLineStartX() >= tpcMinX) && (pLineGap->GetLineStartX() <= tpcMaxX))))
         {
             PandoraApi::Geometry::LineGap::Parameters lineGapParameters;
             const LineGapType lineGapType(pLineGap->GetLineGapType());
@@ -976,7 +983,8 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPC &larTPC, const
             lineGapParameters.m_lineStartX = pLineGap->GetLineStartX();
             lineGapParameters.m_lineEndX = pLineGap->GetLineEndX();
 
-            if (m_fullWidthCRWorkerWireGaps && ((lineGapType == TPC_WIRE_GAP_VIEW_U) || (lineGapType == TPC_WIRE_GAP_VIEW_V) || (lineGapType == TPC_WIRE_GAP_VIEW_W)))
+            if (m_fullWidthCRWorkerWireGaps &&
+                ((lineGapType == TPC_WIRE_GAP_VIEW_U) || (lineGapType == TPC_WIRE_GAP_VIEW_V) || (lineGapType == TPC_WIRE_GAP_VIEW_W)))
             {
                 lineGapParameters.m_lineStartX = -std::numeric_limits<float>::max();
                 lineGapParameters.m_lineEndX = std::numeric_limits<float>::max();
@@ -995,7 +1003,8 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPC &larTPC, const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPCMap &larTPCMap, const DetectorGapList &gapList, const std::string &settingsFile, const std::string &name) const
+const Pandora *MasterAlgorithm::CreateWorkerInstance(
+    const LArTPCMap &larTPCMap, const DetectorGapList &gapList, const std::string &settingsFile, const std::string &name) const
 {
     if (larTPCMap.empty())
     {
@@ -1008,7 +1017,8 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPCMap &larTPCMap,
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, LArContent::RegisterAlgorithms(*pPandora));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, LArContent::RegisterBasicPlugins(*pPandora));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetPseudoLayerPlugin(*pPandora, new lar_content::LArPseudoLayerPlugin));
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::SetLArTransformationPlugin(*pPandora, new lar_content::LArRotationalTransformationPlugin));
+    PANDORA_THROW_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, PandoraApi::SetLArTransformationPlugin(*pPandora, new lar_content::LArRotationalTransformationPlugin));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RegisterCustomContent(pPandora));
     MultiPandoraApi::AddDaughterPandoraInstance(&(this->GetPandora()), pPandora);
 
@@ -1053,7 +1063,7 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(const LArTPCMap &larTPCMap,
     // The Gaps
     for (const DetectorGap *const pGap : gapList)
     {
-        const LineGap *const pLineGap(dynamic_cast<const LineGap*>(pGap));
+        const LineGap *const pLineGap(dynamic_cast<const LineGap *>(pGap));
 
         if (pLineGap)
         {
@@ -1087,28 +1097,32 @@ StatusCode MasterAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 
     if (this->ExternalParametersPresent())
     {
-        pExternalParameters = dynamic_cast<ExternalSteeringParameters*>(this->GetExternalParameters());
-        if (!pExternalParameters) return STATUS_CODE_FAILURE;
+        pExternalParameters = dynamic_cast<ExternalSteeringParameters *>(this->GetExternalParameters());
+        if (!pExternalParameters)
+            return STATUS_CODE_FAILURE;
     }
 
     {
         AlgorithmToolVector algorithmToolVector;
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "SliceSelectionTools",
-            algorithmToolVector));
+        PANDORA_RETURN_RESULT_IF(
+            STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "SliceSelectionTools", algorithmToolVector));
 
         for (AlgorithmTool *const pAlgorithmTool : algorithmToolVector)
         {
-            SliceSelectionBaseTool *const pSliceSelectionTool(dynamic_cast<SliceSelectionBaseTool*>(pAlgorithmTool));
-            if (!pSliceSelectionTool) return STATUS_CODE_INVALID_PARAMETER;
+            SliceSelectionBaseTool *const pSliceSelectionTool(dynamic_cast<SliceSelectionBaseTool *>(pAlgorithmTool));
+            if (!pSliceSelectionTool)
+                return STATUS_CODE_INVALID_PARAMETER;
             m_sliceSelectionToolVector.push_back(pSliceSelectionTool);
         }
     }
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() :
-        pExternalParameters->m_shouldRunAllHitsCosmicReco, xmlHandle, "ShouldRunAllHitsCosmicReco", m_shouldRunAllHitsCosmicReco));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() : pExternalParameters->m_shouldRunAllHitsCosmicReco,
+            xmlHandle, "ShouldRunAllHitsCosmicReco", m_shouldRunAllHitsCosmicReco));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() :
-        pExternalParameters->m_shouldRunStitching, xmlHandle, "ShouldRunStitching", m_shouldRunStitching));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() : pExternalParameters->m_shouldRunStitching,
+            xmlHandle, "ShouldRunStitching", m_shouldRunStitching));
 
     if (m_shouldRunStitching && !m_shouldRunAllHitsCosmicReco)
     {
@@ -1123,14 +1137,16 @@ StatusCode MasterAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 
         for (AlgorithmTool *const pAlgorithmTool : algorithmToolVector)
         {
-            StitchingBaseTool *const pStitchingTool(dynamic_cast<StitchingBaseTool*>(pAlgorithmTool));
-            if (!pStitchingTool) return STATUS_CODE_INVALID_PARAMETER;
+            StitchingBaseTool *const pStitchingTool(dynamic_cast<StitchingBaseTool *>(pAlgorithmTool));
+            if (!pStitchingTool)
+                return STATUS_CODE_INVALID_PARAMETER;
             m_stitchingToolVector.push_back(pStitchingTool);
         }
     }
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() :
-        pExternalParameters->m_shouldRunCosmicHitRemoval, xmlHandle, "ShouldRunCosmicHitRemoval", m_shouldRunCosmicHitRemoval));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() : pExternalParameters->m_shouldRunCosmicHitRemoval,
+            xmlHandle, "ShouldRunCosmicHitRemoval", m_shouldRunCosmicHitRemoval));
 
     if (m_shouldRunCosmicHitRemoval && !m_shouldRunAllHitsCosmicReco)
     {
@@ -1141,31 +1157,38 @@ StatusCode MasterAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     if (m_shouldRunCosmicHitRemoval)
     {
         AlgorithmToolVector algorithmToolVector;
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "CosmicRayTaggingTools", algorithmToolVector));
+        PANDORA_RETURN_RESULT_IF(
+            STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "CosmicRayTaggingTools", algorithmToolVector));
 
         for (AlgorithmTool *const pAlgorithmTool : algorithmToolVector)
         {
-            CosmicRayTaggingBaseTool *const pCosmicRayTaggingTool(dynamic_cast<CosmicRayTaggingBaseTool*>(pAlgorithmTool));
-            if (!pCosmicRayTaggingTool) return STATUS_CODE_INVALID_PARAMETER;
+            CosmicRayTaggingBaseTool *const pCosmicRayTaggingTool(dynamic_cast<CosmicRayTaggingBaseTool *>(pAlgorithmTool));
+            if (!pCosmicRayTaggingTool)
+                return STATUS_CODE_INVALID_PARAMETER;
             m_cosmicRayTaggingToolVector.push_back(pCosmicRayTaggingTool);
         }
     }
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() :
-        pExternalParameters->m_shouldRunSlicing, xmlHandle, "ShouldRunSlicing", m_shouldRunSlicing));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() : pExternalParameters->m_shouldRunSlicing,
+            xmlHandle, "ShouldRunSlicing", m_shouldRunSlicing));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() :
-        pExternalParameters->m_shouldRunNeutrinoRecoOption, xmlHandle, "ShouldRunNeutrinoRecoOption", m_shouldRunNeutrinoRecoOption));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() : pExternalParameters->m_shouldRunNeutrinoRecoOption,
+            xmlHandle, "ShouldRunNeutrinoRecoOption", m_shouldRunNeutrinoRecoOption));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() :
-        pExternalParameters->m_shouldRunCosmicRecoOption, xmlHandle, "ShouldRunCosmicRecoOption", m_shouldRunCosmicRecoOption));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() : pExternalParameters->m_shouldRunCosmicRecoOption,
+            xmlHandle, "ShouldRunCosmicRecoOption", m_shouldRunCosmicRecoOption));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() :
-        pExternalParameters->m_shouldPerformSliceId, xmlHandle, "ShouldPerformSliceId", m_shouldPerformSliceId));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() : pExternalParameters->m_shouldPerformSliceId,
+            xmlHandle, "ShouldPerformSliceId", m_shouldPerformSliceId));
 
     if (m_shouldPerformSliceId && (!m_shouldRunSlicing || !m_shouldRunNeutrinoRecoOption || !m_shouldRunCosmicRecoOption))
     {
-        std::cout << "MasterAlgorithm::ReadSettings - ShouldPerformSliceId requires ShouldRunSlicing and both neutrino and cosmic reconstruction options" << std::endl;
+        std::cout << "MasterAlgorithm::ReadSettings - ShouldPerformSliceId requires ShouldRunSlicing and both neutrino and cosmic reconstruction options"
+                  << std::endl;
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
@@ -1176,32 +1199,34 @@ StatusCode MasterAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 
         for (AlgorithmTool *const pAlgorithmTool : algorithmToolVector)
         {
-            SliceIdBaseTool *const pSliceIdIdTool(dynamic_cast<SliceIdBaseTool*>(pAlgorithmTool));
-            if (!pSliceIdIdTool) return STATUS_CODE_INVALID_PARAMETER;
+            SliceIdBaseTool *const pSliceIdIdTool(dynamic_cast<SliceIdBaseTool *>(pAlgorithmTool));
+            if (!pSliceIdIdTool)
+                return STATUS_CODE_INVALID_PARAMETER;
             m_sliceIdToolVector.push_back(pSliceIdIdTool);
         }
     }
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() :
-        pExternalParameters->m_printOverallRecoStatus, xmlHandle, "PrintOverallRecoStatus", m_printOverallRecoStatus));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        this->ReadExternalSettings(pExternalParameters, !pExternalParameters ? InputBool() : pExternalParameters->m_printOverallRecoStatus,
+            xmlHandle, "PrintOverallRecoStatus", m_printOverallRecoStatus));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VisualizeOverallRecoStatus", m_visualizeOverallRecoStatus));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "VisualizeOverallRecoStatus", m_visualizeOverallRecoStatus));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LArCaloHitVersion", m_larCaloHitVersion));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LArCaloHitVersion", m_larCaloHitVersion));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldRemoveOutOfTimeHits", m_shouldRemoveOutOfTimeHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShouldRemoveOutOfTimeHits", m_shouldRemoveOutOfTimeHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FullWidthCRWorkerWireGaps", m_fullWidthCRWorkerWireGaps));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "FullWidthCRWorkerWireGaps", m_fullWidthCRWorkerWireGaps));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PassMCParticlesToWorkerInstances", m_passMCParticlesToWorkerInstances));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "PassMCParticlesToWorkerInstances", m_passMCParticlesToWorkerInstances));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CRSettingsFile", m_crSettingsFile));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "NuSettingsFile", m_nuSettingsFile));

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -11,8 +11,8 @@
 #include "Pandora/AlgorithmTool.h"
 #include "Pandora/ExternallyConfiguredAlgorithm.h"
 
-#include "larpandoracontent/LArObjects/LArCaloHit.h"
 #include "larpandoracontent/LArControlFlow/MultiPandoraApi.h"
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
 
 #include <unordered_map>
 
@@ -27,8 +27,8 @@ class LArMCParticleFactory;
 
 typedef std::vector<pandora::CaloHitList> SliceVector;
 typedef std::vector<pandora::PfoList> SliceHypotheses;
-typedef std::unordered_map<const pandora::ParticleFlowObject*, const pandora::LArTPC*> PfoToLArTPCMap;
-typedef std::unordered_map<const pandora::ParticleFlowObject*, float> PfoToFloatMap;
+typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
+typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoToFloatMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -49,17 +49,17 @@ public:
     class ExternalSteeringParameters : public pandora::ExternalParameters
     {
     public:
-        pandora::InputBool      m_shouldRunAllHitsCosmicReco;       ///< Whether to run all hits cosmic-ray reconstruction
-        pandora::InputBool      m_shouldRunStitching;               ///< Whether to stitch cosmic-ray muons crossing between volumes
-        pandora::InputBool      m_shouldRunCosmicHitRemoval;        ///< Whether to remove hits from tagged cosmic-rays
-        pandora::InputBool      m_shouldRunSlicing;                 ///< Whether to slice events into separate regions for processing
-        pandora::InputBool      m_shouldRunNeutrinoRecoOption;      ///< Whether to run neutrino reconstruction for each slice
-        pandora::InputBool      m_shouldRunCosmicRecoOption;        ///< Whether to run cosmic-ray reconstruction for each slice
-        pandora::InputBool      m_shouldPerformSliceId;             ///< Whether to identify slices and select most appropriate pfos
-        pandora::InputBool      m_printOverallRecoStatus;           ///< Whether to print current operation status messages
+        pandora::InputBool m_shouldRunAllHitsCosmicReco;  ///< Whether to run all hits cosmic-ray reconstruction
+        pandora::InputBool m_shouldRunStitching;          ///< Whether to stitch cosmic-ray muons crossing between volumes
+        pandora::InputBool m_shouldRunCosmicHitRemoval;   ///< Whether to remove hits from tagged cosmic-rays
+        pandora::InputBool m_shouldRunSlicing;            ///< Whether to slice events into separate regions for processing
+        pandora::InputBool m_shouldRunNeutrinoRecoOption; ///< Whether to run neutrino reconstruction for each slice
+        pandora::InputBool m_shouldRunCosmicRecoOption;   ///< Whether to run cosmic-ray reconstruction for each slice
+        pandora::InputBool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
+        pandora::InputBool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
     };
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, const pandora::LArTPC*> PfoToLArTPCMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
 
     /**
      *  @brief  Shift a Pfo hierarchy by a specified x0 value
@@ -87,8 +87,8 @@ protected:
     class LArTPCHitList
     {
     public:
-        pandora::CaloHitList    m_allHitList;                       ///< The list of all hits originating from a given LArTPC
-        pandora::CaloHitList    m_truncatedHitList;                 ///< The list of hits confined within LArTPC boundaries for given beam t0 value
+        pandora::CaloHitList m_allHitList;       ///< The list of all hits originating from a given LArTPC
+        pandora::CaloHitList m_truncatedHitList; ///< The list of hits confined within LArTPC boundaries for given beam t0 value
     };
 
     typedef std::map<unsigned int, LArTPCHitList> VolumeIdToHitListMap;
@@ -141,7 +141,8 @@ protected:
      *  @param  clearCosmicRayPfos to receive the list of clear cosmic-ray pfos
      *  @param  ambiguousPfos to receive the list of ambiguous cosmic-ray pfos for further analysis
      */
-    pandora::StatusCode TagCosmicRayPfos(const PfoToFloatMap &stitchedPfosToX0Map, pandora::PfoList &clearCosmicRayPfos, pandora::PfoList &ambiguousPfos) const;
+    pandora::StatusCode TagCosmicRayPfos(
+        const PfoToFloatMap &stitchedPfosToX0Map, pandora::PfoList &clearCosmicRayPfos, pandora::PfoList &ambiguousPfos) const;
 
     /**
      *  @brief  Run cosmic-ray hit removal, freeing hits in ambiguous pfos for further processing
@@ -195,7 +196,8 @@ protected:
      *  @param  pMCParticle the address of the mc particle
      *  @param  pMCParticleFactory the address of the mc particle factory, allowing decoration of instances with information beyond that expected by sdk
      */
-    pandora::StatusCode Copy(const pandora::Pandora *const pPandora, const pandora::MCParticle *const pMCParticle, const LArMCParticleFactory *const pMCParticleFactory) const;
+    pandora::StatusCode Copy(const pandora::Pandora *const pPandora, const pandora::MCParticle *const pMCParticle,
+        const LArMCParticleFactory *const pMCParticleFactory) const;
 
     /**
      *  @brief  Recreate a specified list of pfos in the current pandora instance
@@ -255,8 +257,8 @@ protected:
      *
      *  @return the address of the new pfo
      */
-    const pandora::ParticleFlowObject *CreatePfo(const pandora::ParticleFlowObject *const pInputPfo, const pandora::ClusterList &newClusterList,
-        const pandora::VertexList &newVertexList) const;
+    const pandora::ParticleFlowObject *CreatePfo(const pandora::ParticleFlowObject *const pInputPfo,
+        const pandora::ClusterList &newClusterList, const pandora::VertexList &newVertexList) const;
 
     /**
      *  @brief  Create a pandora worker instance to handle a single LArTPC
@@ -302,55 +304,55 @@ protected:
      *  @param  xmlTag the xml tag
      *  @param  outputBool to receive the output boolean value
      */
-    pandora::StatusCode ReadExternalSettings(const ExternalSteeringParameters *const pExternalParameters, const pandora::InputBool inputBool,
-        const pandora::TiXmlHandle xmlHandle, const std::string &xmlTag, bool &outputBool);
+    pandora::StatusCode ReadExternalSettings(const ExternalSteeringParameters *const pExternalParameters,
+        const pandora::InputBool inputBool, const pandora::TiXmlHandle xmlHandle, const std::string &xmlTag, bool &outputBool);
 
-    bool                        m_workerInstancesInitialized;       ///< Whether all worker instances have been initialized
+    bool m_workerInstancesInitialized; ///< Whether all worker instances have been initialized
 
-    unsigned int                m_larCaloHitVersion;                ///< The LArCaloHit version for LArCaloHitFactory
+    unsigned int m_larCaloHitVersion; ///< The LArCaloHit version for LArCaloHitFactory
 
-    bool                        m_shouldRunAllHitsCosmicReco;       ///< Whether to run all hits cosmic-ray reconstruction
-    bool                        m_shouldRunStitching;               ///< Whether to stitch cosmic-ray muons crossing between volumes
-    bool                        m_shouldRunCosmicHitRemoval;        ///< Whether to remove hits from tagged cosmic-rays
-    bool                        m_shouldRunSlicing;                 ///< Whether to slice events into separate regions for processing
-    bool                        m_shouldRunNeutrinoRecoOption;      ///< Whether to run neutrino reconstruction for each slice
-    bool                        m_shouldRunCosmicRecoOption;        ///< Whether to run cosmic-ray reconstruction for each slice
-    bool                        m_shouldPerformSliceId;             ///< Whether to identify slices and select most appropriate pfos
-    bool                        m_printOverallRecoStatus;           ///< Whether to print current operation status messages
-    bool                        m_visualizeOverallRecoStatus;       ///< Whether to display results of current operations
-    bool                        m_shouldRemoveOutOfTimeHits;        ///< Whether to remove out of time hits
+    bool m_shouldRunAllHitsCosmicReco;  ///< Whether to run all hits cosmic-ray reconstruction
+    bool m_shouldRunStitching;          ///< Whether to stitch cosmic-ray muons crossing between volumes
+    bool m_shouldRunCosmicHitRemoval;   ///< Whether to remove hits from tagged cosmic-rays
+    bool m_shouldRunSlicing;            ///< Whether to slice events into separate regions for processing
+    bool m_shouldRunNeutrinoRecoOption; ///< Whether to run neutrino reconstruction for each slice
+    bool m_shouldRunCosmicRecoOption;   ///< Whether to run cosmic-ray reconstruction for each slice
+    bool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
+    bool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
+    bool m_visualizeOverallRecoStatus;  ///< Whether to display results of current operations
+    bool m_shouldRemoveOutOfTimeHits;   ///< Whether to remove out of time hits
 
-    PandoraInstanceList         m_crWorkerInstances;                ///< The list of cosmic-ray reconstruction worker instances
-    const pandora::Pandora     *m_pSlicingWorkerInstance;           ///< The slicing worker instance
-    const pandora::Pandora     *m_pSliceNuWorkerInstance;           ///< The per-slice neutrino reconstruction worker instance
-    const pandora::Pandora     *m_pSliceCRWorkerInstance;           ///< The per-slice cosmic-ray reconstruction worker instance
+    PandoraInstanceList m_crWorkerInstances;          ///< The list of cosmic-ray reconstruction worker instances
+    const pandora::Pandora *m_pSlicingWorkerInstance; ///< The slicing worker instance
+    const pandora::Pandora *m_pSliceNuWorkerInstance; ///< The per-slice neutrino reconstruction worker instance
+    const pandora::Pandora *m_pSliceCRWorkerInstance; ///< The per-slice cosmic-ray reconstruction worker instance
 
-    bool                        m_fullWidthCRWorkerWireGaps;        ///< Whether wire-type line gaps in cosmic-ray worker instances should cover all drift time
-    bool                        m_passMCParticlesToWorkerInstances; ///< Whether to pass mc particle details (and links to calo hits) to worker instances
+    bool m_fullWidthCRWorkerWireGaps;        ///< Whether wire-type line gaps in cosmic-ray worker instances should cover all drift time
+    bool m_passMCParticlesToWorkerInstances; ///< Whether to pass mc particle details (and links to calo hits) to worker instances
 
-    typedef std::vector<StitchingBaseTool*> StitchingToolVector;
-    typedef std::vector<CosmicRayTaggingBaseTool*> CosmicRayTaggingToolVector;
-    typedef std::vector<SliceIdBaseTool*> SliceIdToolVector;
-    typedef std::vector<SliceSelectionBaseTool*> SliceSelectionToolVector;
+    typedef std::vector<StitchingBaseTool *> StitchingToolVector;
+    typedef std::vector<CosmicRayTaggingBaseTool *> CosmicRayTaggingToolVector;
+    typedef std::vector<SliceIdBaseTool *> SliceIdToolVector;
+    typedef std::vector<SliceSelectionBaseTool *> SliceSelectionToolVector;
 
-    StitchingToolVector         m_stitchingToolVector;              ///< The stitching tool vector
-    CosmicRayTaggingToolVector  m_cosmicRayTaggingToolVector;       ///< The cosmic-ray tagging tool vector
-    SliceIdToolVector           m_sliceIdToolVector;                ///< The slice id tool vector
-    SliceSelectionToolVector    m_sliceSelectionToolVector;         ///< The slice selection tool vector
+    StitchingToolVector m_stitchingToolVector;               ///< The stitching tool vector
+    CosmicRayTaggingToolVector m_cosmicRayTaggingToolVector; ///< The cosmic-ray tagging tool vector
+    SliceIdToolVector m_sliceIdToolVector;                   ///< The slice id tool vector
+    SliceSelectionToolVector m_sliceSelectionToolVector;     ///< The slice selection tool vector
 
-    std::string                 m_filePathEnvironmentVariable;      ///< The environment variable providing a list of paths to xml files
-    std::string                 m_crSettingsFile;                   ///< The cosmic-ray reconstruction settings file
-    std::string                 m_nuSettingsFile;                   ///< The neutrino reconstruction settings file
-    std::string                 m_slicingSettingsFile;              ///< The slicing settings file
+    std::string m_filePathEnvironmentVariable; ///< The environment variable providing a list of paths to xml files
+    std::string m_crSettingsFile;              ///< The cosmic-ray reconstruction settings file
+    std::string m_nuSettingsFile;              ///< The neutrino reconstruction settings file
+    std::string m_slicingSettingsFile;         ///< The slicing settings file
 
-    std::string                 m_inputMCParticleListName;          ///< The input mc particle list name
-    std::string                 m_inputHitListName;                 ///< The input hit list name
-    std::string                 m_recreatedPfoListName;             ///< The output recreated pfo list name
-    std::string                 m_recreatedClusterListName;         ///< The output recreated cluster list name
-    std::string                 m_recreatedVertexListName;          ///< The output recreated vertex list name
+    std::string m_inputMCParticleListName;  ///< The input mc particle list name
+    std::string m_inputHitListName;         ///< The input hit list name
+    std::string m_recreatedPfoListName;     ///< The output recreated pfo list name
+    std::string m_recreatedClusterListName; ///< The output recreated cluster list name
+    std::string m_recreatedVertexListName;  ///< The output recreated vertex list name
 
-    float                       m_inTimeMaxX0;                      ///< Cut on X0 to determine whether particle is clear cosmic ray
-    LArCaloHitFactory           m_larCaloHitFactory;                ///< Factory for creating LArCaloHits during hit copying
+    float m_inTimeMaxX0;                   ///< Cut on X0 to determine whether particle is clear cosmic ray
+    LArCaloHitFactory m_larCaloHitFactory; ///< Factory for creating LArCaloHits during hit copying
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -370,7 +372,8 @@ public:
      *  @param  pfoToLArTPCMap the pfo to lar tpc map
      *  @param  stitchedPfosToX0Map a map of cosmic-ray pfos that have been stitched between lar tpcs to the X0 shift
      */
-    virtual void Run(const MasterAlgorithm *const pAlgorithm, const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) = 0;
+    virtual void Run(const MasterAlgorithm *const pAlgorithm, const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap,
+        PfoToFloatMap &stitchedPfosToX0Map) = 0;
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -389,7 +392,8 @@ public:
      *  @param  ambiguousPfos to receive the list of ambiguous pfos
      *  @param  pAlgorithm the address of this master algorithm
      */
-    virtual void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm) = 0;
+    virtual void FindAmbiguousPfos(
+        const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm) = 0;
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -409,8 +413,8 @@ public:
      *  @param  crSliceHypotheses the parent pfos representing the cosmic-ray muon outcome for each slice
      *  @param  sliceNuPfos to receive the list of selected pfos
      */
-    virtual void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses,
-        pandora::PfoList &selectedPfos) = 0;
+    virtual void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos) = 0;
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -429,8 +433,7 @@ public:
      *  @param  inputSliceVector the initial slice vector
      *  @param  outputSliceVector the output slice vector
      */
-    virtual void SelectSlices(const pandora::Algorithm *const pAlgorithm, const SliceVector &inputSliceVector,
-        SliceVector &outputSliceVector) = 0;
+    virtual void SelectSlices(const pandora::Algorithm *const pAlgorithm, const SliceVector &inputSliceVector, SliceVector &outputSliceVector) = 0;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArControlFlow/MultiPandoraApi.h
+++ b/larpandoracontent/LArControlFlow/MultiPandoraApi.h
@@ -13,9 +13,9 @@
 
 namespace pandora
 {
-    class Pandora;
-    class ParticleFlowObject;
-}
+class Pandora;
+class ParticleFlowObject;
+} // namespace pandora
 
 class MultiPandoraApiImpl;
 
@@ -107,7 +107,7 @@ public:
     static void SetVolumeId(const pandora::Pandora *const pPandora, const unsigned int volumeId);
 
 private:
-    static MultiPandoraApiImpl      m_multiPandoraApiImpl;          ///< The multi pandora api implementation
+    static MultiPandoraApiImpl m_multiPandoraApiImpl; ///< The multi pandora api implementation
 };
 
 #endif // #ifndef MULTI_PANDORA_API_H

--- a/larpandoracontent/LArControlFlow/MultiPandoraApiImpl.cc
+++ b/larpandoracontent/LArControlFlow/MultiPandoraApiImpl.cc
@@ -30,7 +30,9 @@ const pandora::Pandora *MultiPandoraApiImpl::GetPandoraInstance(const pandora::P
             if (volumeId == this->GetVolumeId(pPandora))
                 return pPandora;
         }
-        catch (const pandora::StatusCodeException &) {}
+        catch (const pandora::StatusCodeException &)
+        {
+        }
     }
 
     throw pandora::StatusCodeException(pandora::STATUS_CODE_NOT_FOUND);
@@ -135,7 +137,8 @@ void MultiPandoraApiImpl::DeletePandoraInstances(const pandora::Pandora *const p
     }
     catch (const pandora::StatusCodeException &)
     {
-        std::cout << "MultiPandoraApiImpl::DeletePandoraInstances - unable to find daughter instances associated with primary " << pPrimaryPandora << std::endl;
+        std::cout << "MultiPandoraApiImpl::DeletePandoraInstances - unable to find daughter instances associated with primary "
+                  << pPrimaryPandora << std::endl;
     }
 
     pandoraInstanceList.push_back(pPrimaryPandora);

--- a/larpandoracontent/LArControlFlow/MultiPandoraApiImpl.h
+++ b/larpandoracontent/LArControlFlow/MultiPandoraApiImpl.h
@@ -108,9 +108,9 @@ private:
     typedef std::unordered_map<const pandora::Pandora *, const pandora::Pandora *> PandoraRelationMap;
     typedef std::unordered_map<const pandora::Pandora *, unsigned int> PandoraToVolumeIdMap;
 
-    PandoraInstanceMap              m_primaryToDaughtersMap;    ///< The map from primary pandora instance to list of daughter pandora instances
-    PandoraRelationMap              m_daughterToPrimaryMap;     ///< The map from daughter pandora instance to primary pandora instance
-    PandoraToVolumeIdMap            m_pandoraToVolumeIdMap;     ///< The map from pandora instance to volume id
+    PandoraInstanceMap m_primaryToDaughtersMap;  ///< The map from primary pandora instance to list of daughter pandora instances
+    PandoraRelationMap m_daughterToPrimaryMap;   ///< The map from daughter pandora instance to primary pandora instance
+    PandoraToVolumeIdMap m_pandoraToVolumeIdMap; ///< The map from pandora instance to volume id
 
     friend class MultiPandoraApi;
 };

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -28,7 +28,7 @@ namespace lar_content
  *          If training mode is switched on, then the tool will write MVA training exmples to the specified output file. The events selected for
  *          training must pass (user configurable) slicing quality cuts. Users may also select events based on their interaction type (nuance code).
  */
-template<typename T>
+template <typename T>
 class NeutrinoIdTool : public SliceIdBaseTool
 {
 public:
@@ -37,7 +37,8 @@ public:
      */
     NeutrinoIdTool();
 
-    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
+    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
 
 private:
     /**
@@ -102,7 +103,8 @@ private:
          *
          *  @return the direction of the input spacepoints
          */
-        pandora::CartesianVector GetDirection(const pandora::CartesianPointVector &spacePoints, std::function<bool(const pandora::CartesianVector &pointA, const pandora::CartesianVector &pointB)> fShouldChooseA) const;
+        pandora::CartesianVector GetDirection(const pandora::CartesianPointVector &spacePoints,
+            std::function<bool(const pandora::CartesianVector &pointA, const pandora::CartesianVector &pointB)> fShouldChooseA) const;
 
         /**
          *  @brief  Use a sliding fit to get the direction of a collection of spacepoint near a vertex position
@@ -140,11 +142,12 @@ private:
          *  @param  radius the radius of the sphere
          *  @param  spacePointsInSphere the vector to hold the spacepoint in the sphere
          */
-        void GetPointsInSphere(const pandora::CartesianPointVector &spacePoints, const pandora::CartesianVector &vertex, const float radius, pandora::CartesianPointVector &spacePointsInSphere) const;
+        void GetPointsInSphere(const pandora::CartesianPointVector &spacePoints, const pandora::CartesianVector &vertex, const float radius,
+            pandora::CartesianPointVector &spacePointsInSphere) const;
 
-        bool                               m_isAvailable;    ///< Is the feature vector available
-        LArMvaHelper::MvaFeatureVector     m_featureVector;  ///< The MVA feature vector
-        const NeutrinoIdTool *const        m_pTool;          ///< The tool that owns this
+        bool m_isAvailable;                             ///< Is the feature vector available
+        LArMvaHelper::MvaFeatureVector m_featureVector; ///< The MVA feature vector
+        const NeutrinoIdTool *const m_pTool;            ///< The tool that owns this
     };
 
     typedef std::pair<unsigned int, float> UintFloatPair;
@@ -158,7 +161,8 @@ private:
      *  @param  crSliceHypotheses the input cosmic slice hypotheses
      *  @param  sliceFeaturesVector vector to hold the slice features
      */
-    void GetSliceFeatures(const NeutrinoIdTool *const pTool, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const;
+    void GetSliceFeatures(const NeutrinoIdTool *const pTool, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, SliceFeaturesVector &sliceFeaturesVector) const;
 
     /**
      *  @brief  Get the slice with the most neutrino induced hits using Monte-Carlo information
@@ -170,7 +174,8 @@ private:
      *
      *  @return does the best slice pass the quality cuts for training?
      */
-    bool GetBestMCSliceIndex(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, unsigned int &bestSliceIndex) const;
+    bool GetBestMCSliceIndex(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, unsigned int &bestSliceIndex) const;
 
     /**
      *  @brief  Determine if the event passes the selection cuts for training and has the required NUANCE code
@@ -190,7 +195,8 @@ private:
      *  @param  reconstructedCaloHitList output list of all 2d hits in the input pfos
      *  @param  reconstructableCaloHitSet set of reconstructable calo hits
      */
-    void Collect2DHits(const pandora::PfoList &pfos, pandora::CaloHitList &reconstructedCaloHitList, const pandora::CaloHitSet &reconstructableCaloHitSet) const;
+    void Collect2DHits(const pandora::PfoList &pfos, pandora::CaloHitList &reconstructedCaloHitList,
+        const pandora::CaloHitSet &reconstructableCaloHitSet) const;
 
     /**
      *  @brief  Count the number of neutrino induced hits in a given list using MC information
@@ -228,7 +234,8 @@ private:
      *  @param  sliceFeaturesVector vector holding the slice features
      *  @param  selectedPfos the list of pfos to populate
      */
-    void SelectPfosByProbability(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, pandora::PfoList &selectedPfos) const;
+    void SelectPfosByProbability(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, const SliceFeaturesVector &sliceFeaturesVector, pandora::PfoList &selectedPfos) const;
 
     /**
      *  @brief  Add the given pfos to the selected Pfo list
@@ -241,19 +248,19 @@ private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     // Training
-    bool                  m_useTrainingMode;              ///< Should use training mode. If true, training examples will be written to the output file
-    std::string           m_trainingOutputFile;           ///< Output file name for training examples
-    bool                  m_selectNuanceCode;             ///< Should select training events by nuance code
-    int                   m_nuance;                       ///< Nuance code to select for training
-    float                 m_minPurity;                    ///< Minimum purity of the best slice to use event for training
-    float                 m_minCompleteness;              ///< Minimum completeness of the best slice to use event for training
+    bool m_useTrainingMode;           ///< Should use training mode. If true, training examples will be written to the output file
+    std::string m_trainingOutputFile; ///< Output file name for training examples
+    bool m_selectNuanceCode;          ///< Should select training events by nuance code
+    int m_nuance;                     ///< Nuance code to select for training
+    float m_minPurity;                ///< Minimum purity of the best slice to use event for training
+    float m_minCompleteness;          ///< Minimum completeness of the best slice to use event for training
 
     // Classification
-    float                 m_minProbability;               ///< Minimum probability required to classify a slice as the neutrino
-    unsigned int          m_maxNeutrinos;                 ///< The maximum number of neutrinos to select in any one event
+    float m_minProbability;      ///< Minimum probability required to classify a slice as the neutrino
+    unsigned int m_maxNeutrinos; ///< The maximum number of neutrinos to select in any one event
 
-    T                     m_mva;                          ///< The mva
-    std::string           m_filePathEnvironmentVariable;  ///< The environment variable providing a list of paths to mva files
+    T m_mva;                                   ///< The mva
+    std::string m_filePathEnvironmentVariable; ///< The environment variable providing a list of paths to mva files
 };
 
 typedef NeutrinoIdTool<AdaBoostDecisionTree> BdtNeutrinoIdTool;

--- a/larpandoracontent/LArControlFlow/PostProcessingAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/PostProcessingAlgorithm.cc
@@ -15,8 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-PostProcessingAlgorithm::PostProcessingAlgorithm() :
-    m_listCounter(0)
+PostProcessingAlgorithm::PostProcessingAlgorithm() : m_listCounter(0)
 {
 }
 
@@ -82,24 +81,23 @@ StatusCode PostProcessingAlgorithm::RenameList(const std::string &oldListName) c
 
 StatusCode PostProcessingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "PfoListNames", m_pfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "ClusterListNames", m_clusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "VertexListNames", m_vertexListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "VertexListNames", m_vertexListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "CaloHitListNames", m_caloHitListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "CaloHitListNames", m_caloHitListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CurrentPfoListReplacement", m_currentPfoListReplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CurrentPfoListReplacement", m_currentPfoListReplacement));
 
     return STATUS_CODE_SUCCESS;
 }
-
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/PostProcessingAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/PostProcessingAlgorithm.h
@@ -38,14 +38,14 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector   m_pfoListNames;                 ///< The list of pfo list names
-    pandora::StringVector   m_clusterListNames;             ///< The list of cluster list names
-    pandora::StringVector   m_vertexListNames;              ///< The list of vertex list names
-    pandora::StringVector   m_caloHitListNames;             ///< The list of calo hit list names
+    pandora::StringVector m_pfoListNames;     ///< The list of pfo list names
+    pandora::StringVector m_clusterListNames; ///< The list of cluster list names
+    pandora::StringVector m_vertexListNames;  ///< The list of vertex list names
+    pandora::StringVector m_caloHitListNames; ///< The list of calo hit list names
 
-    std::string             m_currentPfoListReplacement;    ///< The name of the pfo list to replace the current list
+    std::string m_currentPfoListReplacement; ///< The name of the pfo list to replace the current list
 
-    unsigned int            m_listCounter;                  ///< The counter appended to output (and replacement current) list names and reset each event
+    unsigned int m_listCounter; ///< The counter appended to output (and replacement current) list names and reset each event
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArControlFlow/PreProcessingAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/PreProcessingAlgorithm.cc
@@ -66,7 +66,8 @@ StatusCode PreProcessingAlgorithm::Run()
         if (STATUS_CODE_SUCCESS != PandoraContentApi::ReplaceCurrentList<CaloHit>(*this, m_currentCaloHitListReplacement))
         {
             if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
-                std::cout << "PreProcessingAlgorithm: could not replace current calo hit list with list named: " << m_currentCaloHitListReplacement << std::endl;
+                std::cout << "PreProcessingAlgorithm: could not replace current calo hit list with list named: " << m_currentCaloHitListReplacement
+                          << std::endl;
         }
     }
 
@@ -93,7 +94,7 @@ void PreProcessingAlgorithm::ProcessCaloHits()
         if (m_processedHits.count(pCaloHit))
             continue;
 
-        (void) m_processedHits.insert(pCaloHit);
+        (void)m_processedHits.insert(pCaloHit);
 
         if (m_onlyAvailableCaloHits && !PandoraContentApi::IsAvailable(*this, pCaloHit))
             continue;
@@ -113,8 +114,8 @@ void PreProcessingAlgorithm::ProcessCaloHits()
         {
             if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
             {
-                std::cout << "PreProcessingAlgorithm: found a hit with extent " << pCaloHit->GetCellLengthScale()
-                          << ", require (" << m_minCellLengthScale << " - " << m_maxCellLengthScale << "), will remove it" << std::endl;
+                std::cout << "PreProcessingAlgorithm: found a hit with extent " << pCaloHit->GetCellLengthScale() << ", require ("
+                          << m_minCellLengthScale << " - " << m_maxCellLengthScale << "), will remove it" << std::endl;
             }
 
             continue;
@@ -216,7 +217,8 @@ void PreProcessingAlgorithm::GetFilteredCaloHitList(const CaloHitList &inputList
                 const float deltaMip(pCaloHit2->GetMipEquivalentEnergy() > pCaloHit1->GetMipEquivalentEnergy());
 
                 if ((deltaMip > std::numeric_limits<float>::epsilon()) ||
-                    ((std::fabs(deltaMip) < std::numeric_limits<float>::epsilon()) && (outputList.end() != std::find(outputList.begin(), outputList.end(), pCaloHit2))))
+                    ((std::fabs(deltaMip) < std::numeric_limits<float>::epsilon()) &&
+                        (outputList.end() != std::find(outputList.begin(), outputList.end(), pCaloHit2))))
                 {
                     isUnique = false;
                     break;
@@ -240,41 +242,34 @@ void PreProcessingAlgorithm::GetFilteredCaloHitList(const CaloHitList &inputList
 
 StatusCode PreProcessingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MipEquivalentCut", m_mipEquivalentCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MipEquivalentCut", m_mipEquivalentCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCellLengthScale", m_minCellLengthScale));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCellLengthScale", m_minCellLengthScale));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCellLengthScale", m_maxCellLengthScale));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCellLengthScale", m_maxCellLengthScale));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SearchRegion1D", m_searchRegion1D));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SearchRegion1D", m_searchRegion1D));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxEventHits", m_maxEventHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxEventHits", m_maxEventHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "OnlyAvailableCaloHits", m_onlyAvailableCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "OnlyAvailableCaloHits", m_onlyAvailableCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputCaloHitListName", m_inputCaloHitListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InputCaloHitListName", m_inputCaloHitListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputCaloHitListNameU", m_outputCaloHitListNameU));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputCaloHitListNameU", m_outputCaloHitListNameU));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputCaloHitListNameV", m_outputCaloHitListNameV));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputCaloHitListNameV", m_outputCaloHitListNameV));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputCaloHitListNameW", m_outputCaloHitListNameW));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputCaloHitListNameW", m_outputCaloHitListNameW));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "FilteredCaloHitListName", m_filteredCaloHitListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "FilteredCaloHitListName", m_filteredCaloHitListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "CurrentCaloHitListReplacement", m_currentCaloHitListReplacement));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CurrentCaloHitListReplacement", m_currentCaloHitListReplacement));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArControlFlow/PreProcessingAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/PreProcessingAlgorithm.h
@@ -13,8 +13,10 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -30,8 +32,8 @@ public:
     PreProcessingAlgorithm();
 
 private:
-    typedef KDTreeLinkerAlgo<const pandora::CaloHit*, 2> HitKDTree2D;
-    typedef KDTreeNodeInfoT<const pandora::CaloHit*, 2> HitKDNode2D;
+    typedef KDTreeLinkerAlgo<const pandora::CaloHit *, 2> HitKDTree2D;
+    typedef KDTreeNodeInfoT<const pandora::CaloHit *, 2> HitKDNode2D;
     typedef std::vector<HitKDNode2D> HitKDNode2DList;
 
     pandora::StatusCode Reset();
@@ -61,21 +63,21 @@ private:
      */
     void ProcessMCParticles();
 
-    pandora::CaloHitSet m_processedHits;                    ///< The set of all previously processed calo hits
+    pandora::CaloHitSet m_processedHits; ///< The set of all previously processed calo hits
 
-    float               m_mipEquivalentCut;                 ///< Minimum mip equivalent energy for calo hit
-    float               m_minCellLengthScale;               ///< The minimum length scale for calo hit
-    float               m_maxCellLengthScale;               ///< The maximum length scale for calo hit
-    float               m_searchRegion1D;                   ///< Search region, applied to each dimension, for look-up from kd-trees
-    unsigned int        m_maxEventHits;                     ///< The maximum number of hits in an event to proceed with the reconstruction
+    float m_mipEquivalentCut;    ///< Minimum mip equivalent energy for calo hit
+    float m_minCellLengthScale;  ///< The minimum length scale for calo hit
+    float m_maxCellLengthScale;  ///< The maximum length scale for calo hit
+    float m_searchRegion1D;      ///< Search region, applied to each dimension, for look-up from kd-trees
+    unsigned int m_maxEventHits; ///< The maximum number of hits in an event to proceed with the reconstruction
 
-    bool                m_onlyAvailableCaloHits;            ///< Whether to only include available calo hits
-    std::string         m_inputCaloHitListName;             ///< The input calo hit list name
-    std::string         m_outputCaloHitListNameU;           ///< The output calo hit list name for TPC_VIEW_U hits
-    std::string         m_outputCaloHitListNameV;           ///< The output calo hit list name for TPC_VIEW_V hits
-    std::string         m_outputCaloHitListNameW;           ///< The output calo hit list name for TPC_VIEW_W hits
-    std::string         m_filteredCaloHitListName;          ///< The output calo hit list name for all U, V and W hits
-    std::string         m_currentCaloHitListReplacement;    ///< The name of the calo hit list to replace the current list (optional)
+    bool m_onlyAvailableCaloHits;                ///< Whether to only include available calo hits
+    std::string m_inputCaloHitListName;          ///< The input calo hit list name
+    std::string m_outputCaloHitListNameU;        ///< The output calo hit list name for TPC_VIEW_U hits
+    std::string m_outputCaloHitListNameV;        ///< The output calo hit list name for TPC_VIEW_V hits
+    std::string m_outputCaloHitListNameW;        ///< The output calo hit list name for TPC_VIEW_W hits
+    std::string m_filteredCaloHitListName;       ///< The output calo hit list name for all U, V and W hits
+    std::string m_currentCaloHitListReplacement; ///< The name of the calo hit list to replace the current list (optional)
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.cc
@@ -15,23 +15,23 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleNeutrinoIdTool::SimpleNeutrinoIdTool() :
-    m_selectAllNeutrinos(true),
-    m_selectOnlyFirstSliceNeutrinos(false)
+SimpleNeutrinoIdTool::SimpleNeutrinoIdTool() : m_selectAllNeutrinos(true), m_selectOnlyFirstSliceNeutrinos(false)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void SimpleNeutrinoIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
+void SimpleNeutrinoIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+    const SliceHypotheses &crSliceHypotheses, PfoList &selectedPfos)
 {
     if (nuSliceHypotheses.size() != crSliceHypotheses.size())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     for (unsigned int sliceIndex = 0, nSlices = nuSliceHypotheses.size(); sliceIndex < nSlices; ++sliceIndex)
     {
-        const PfoList &sliceOutput((m_selectAllNeutrinos || (m_selectOnlyFirstSliceNeutrinos && (0 == sliceIndex))) ?
-            nuSliceHypotheses.at(sliceIndex) : crSliceHypotheses.at(sliceIndex));
+        const PfoList &sliceOutput((m_selectAllNeutrinos || (m_selectOnlyFirstSliceNeutrinos && (0 == sliceIndex)))
+                                       ? nuSliceHypotheses.at(sliceIndex)
+                                       : crSliceHypotheses.at(sliceIndex));
 
         const float score(m_selectAllNeutrinos || (m_selectOnlyFirstSliceNeutrinos && (0 == sliceIndex)) ? 1.f : -1.f);
 
@@ -57,15 +57,16 @@ void SimpleNeutrinoIdTool::SelectOutputPfos(const Algorithm *const pAlgorithm, c
 
 StatusCode SimpleNeutrinoIdTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectAllNeutrinos", m_selectAllNeutrinos));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SelectAllNeutrinos", m_selectAllNeutrinos));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectOnlyFirstSliceNeutrinos", m_selectOnlyFirstSliceNeutrinos));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "SelectOnlyFirstSliceNeutrinos", m_selectOnlyFirstSliceNeutrinos));
 
     if (m_selectAllNeutrinos == m_selectOnlyFirstSliceNeutrinos)
     {
-        std::cout << "SimpleNeutrinoIdTool::ReadSettings - exactly one of SelectAllNeutrinos and SelectOnlyFirstSliceNeutrinos must be true" << std::endl;
+        std::cout << "SimpleNeutrinoIdTool::ReadSettings - exactly one of SelectAllNeutrinos and SelectOnlyFirstSliceNeutrinos must be true"
+                  << std::endl;
         return STATUS_CODE_INVALID_PARAMETER;
     }
 

--- a/larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/SimpleNeutrinoIdTool.h
@@ -24,13 +24,14 @@ public:
      */
     SimpleNeutrinoIdTool();
 
-    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses, const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
+    void SelectOutputPfos(const pandora::Algorithm *const pAlgorithm, const SliceHypotheses &nuSliceHypotheses,
+        const SliceHypotheses &crSliceHypotheses, pandora::PfoList &selectedPfos);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    bool        m_selectAllNeutrinos;               ///< First approach: select all neutrinos, as opposed to selecting all cosmics
-    bool        m_selectOnlyFirstSliceNeutrinos;    ///< First approach: select first slice neutrinos, cosmics for all subsequent slices
+    bool m_selectAllNeutrinos;            ///< First approach: select all neutrinos, as opposed to selecting all cosmics
+    bool m_selectOnlyFirstSliceNeutrinos; ///< First approach: select first slice neutrinos, cosmics for all subsequent slices
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArControlFlow/SlicingAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/SlicingAlgorithm.cc
@@ -17,8 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-SlicingAlgorithm::SlicingAlgorithm() :
-    m_pEventSlicingTool(nullptr)
+SlicingAlgorithm::SlicingAlgorithm() : m_pEventSlicingTool(nullptr)
 {
 }
 
@@ -48,18 +47,24 @@ StatusCode SlicingAlgorithm::Run()
         clusterParametersU.m_caloHitList = slice.m_caloHitListU;
         clusterParametersV.m_caloHitList = slice.m_caloHitListV;
         clusterParametersW.m_caloHitList = slice.m_caloHitListW;
-        if (!clusterParametersU.m_caloHitList.empty()) PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, clusterParametersU, pClusterU));
-        if (!clusterParametersV.m_caloHitList.empty()) PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, clusterParametersV, pClusterV));
-        if (!clusterParametersW.m_caloHitList.empty()) PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, clusterParametersW, pClusterW));
+        if (!clusterParametersU.m_caloHitList.empty())
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, clusterParametersU, pClusterU));
+        if (!clusterParametersV.m_caloHitList.empty())
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, clusterParametersV, pClusterV));
+        if (!clusterParametersW.m_caloHitList.empty())
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, clusterParametersW, pClusterW));
 
         if (!pClusterU && !pClusterV && !pClusterW)
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
         const Pfo *pSlicePfo(nullptr);
         PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
-        if (pClusterU) pfoParameters.m_clusterList.push_back(pClusterU);
-        if (pClusterV) pfoParameters.m_clusterList.push_back(pClusterV);
-        if (pClusterW) pfoParameters.m_clusterList.push_back(pClusterW);
+        if (pClusterU)
+            pfoParameters.m_clusterList.push_back(pClusterU);
+        if (pClusterV)
+            pfoParameters.m_clusterList.push_back(pClusterV);
+        if (pClusterW)
+            pfoParameters.m_clusterList.push_back(pClusterW);
         pfoParameters.m_charge = 0;
         pfoParameters.m_energy = 0.f;
         pfoParameters.m_mass = 0.f;
@@ -89,12 +94,13 @@ StatusCode SlicingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     AlgorithmTool *pAlgorithmTool(nullptr);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmTool(*this, xmlHandle, "SliceCreation", pAlgorithmTool));
-    m_pEventSlicingTool = dynamic_cast<EventSlicingBaseTool*>(pAlgorithmTool);
+    m_pEventSlicingTool = dynamic_cast<EventSlicingBaseTool *>(pAlgorithmTool);
 
     if (!m_pEventSlicingTool)
         return STATUS_CODE_INVALID_PARAMETER;
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithm(*this, xmlHandle, "SlicingListDeletion", m_slicingListDeletionAlgorithm));
+    PANDORA_RETURN_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithm(*this, xmlHandle, "SlicingListDeletion", m_slicingListDeletionAlgorithm));
 
     std::string caloHitListNameU, caloHitListNameV, caloHitListNameW;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputCaloHitListNameU", caloHitListNameU));

--- a/larpandoracontent/LArControlFlow/SlicingAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/SlicingAlgorithm.h
@@ -8,8 +8,8 @@
 #ifndef LAR_SLICING_ALGORITHM_H
 #define LAR_SLICING_ALGORITHM_H 1
 
-#include "Pandora/AlgorithmTool.h"
 #include "Pandora/Algorithm.h"
+#include "Pandora/AlgorithmTool.h"
 
 namespace lar_content
 {
@@ -30,9 +30,9 @@ public:
     class Slice
     {
     public:
-        pandora::CaloHitList    m_caloHitListU;                     ///< The u calo hit list
-        pandora::CaloHitList    m_caloHitListV;                     ///< The v calo hit list
-        pandora::CaloHitList    m_caloHitListW;                     ///< The w calo hit list
+        pandora::CaloHitList m_caloHitListU; ///< The u calo hit list
+        pandora::CaloHitList m_caloHitListV; ///< The v calo hit list
+        pandora::CaloHitList m_caloHitListW; ///< The w calo hit list
     };
 
     typedef std::vector<Slice> SliceList;
@@ -47,14 +47,14 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    EventSlicingBaseTool       *m_pEventSlicingTool;                ///< The address of the event slicing tool
-    std::string                 m_slicingListDeletionAlgorithm;     ///< The name of the slicing list deletion algorithm
+    EventSlicingBaseTool *m_pEventSlicingTool;  ///< The address of the event slicing tool
+    std::string m_slicingListDeletionAlgorithm; ///< The name of the slicing list deletion algorithm
 
-    HitTypeToNameMap            m_caloHitListNames;                 ///< The hit type to calo hit list name map
-    HitTypeToNameMap            m_clusterListNames;                 ///< The hit type to cluster list name map
+    HitTypeToNameMap m_caloHitListNames; ///< The hit type to calo hit list name map
+    HitTypeToNameMap m_clusterListNames; ///< The hit type to cluster list name map
 
-    std::string                 m_sliceClusterListName;             ///< The name of the output slice cluster list
-    std::string                 m_slicePfoListName;                 ///< The name of the output slice pfo list
+    std::string m_sliceClusterListName; ///< The name of the output slice cluster list
+    std::string m_slicePfoListName;     ///< The name of the output slice pfo list
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.cc
@@ -8,10 +8,10 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
-#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
-#include "larpandoracontent/LArHelpers/LArStitchingHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArStitchingHelper.h"
 
 #include "larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h"
 
@@ -39,10 +39,11 @@ StitchingCosmicRayMergingTool::StitchingCosmicRayMergingTool() :
 {
 }
 
-void StitchingCosmicRayMergingTool::Run(const MasterAlgorithm *const pAlgorithm, const PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map)
+void StitchingCosmicRayMergingTool::Run(const MasterAlgorithm *const pAlgorithm, const PfoList *const pMultiPfoList,
+    PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     if (this->GetPandora().GetGeometry()->GetLArTPCMap().size() < 2)
         return;
@@ -94,7 +95,8 @@ void StitchingCosmicRayMergingTool::SelectPrimaryPfos(const PfoList *pInputPfoLi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void StitchingCosmicRayMergingTool::BuildPointingClusterMaps(const PfoList &inputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, ThreeDPointingClusterMap &pointingClusterMap) const
+void StitchingCosmicRayMergingTool::BuildPointingClusterMaps(
+    const PfoList &inputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, ThreeDPointingClusterMap &pointingClusterMap) const
 {
     for (const ParticleFlowObject *const pPfo : inputPfoList)
     {
@@ -114,9 +116,11 @@ void StitchingCosmicRayMergingTool::BuildPointingClusterMaps(const PfoList &inpu
                 throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
             const ThreeDSlidingFitResult slidingFitResult(clusterList.front(), m_halfWindowLayers, slidingFitPitch);
-            (void) pointingClusterMap.insert(ThreeDPointingClusterMap::value_type(pPfo, LArPointingCluster(slidingFitResult)));
+            (void)pointingClusterMap.insert(ThreeDPointingClusterMap::value_type(pPfo, LArPointingCluster(slidingFitResult)));
         }
-        catch (const StatusCodeException &) {}
+        catch (const StatusCodeException &)
+        {
+        }
     }
 }
 
@@ -135,11 +139,12 @@ void StitchingCosmicRayMergingTool::BuildTPCMaps(const PfoList &inputPfoList, co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void StitchingCosmicRayMergingTool::CreatePfoMatches(const LArTPCToPfoMap &larTPCToPfoMap, const ThreeDPointingClusterMap &pointingClusterMap,
-    PfoAssociationMatrix &pfoAssociationMatrix) const
+void StitchingCosmicRayMergingTool::CreatePfoMatches(const LArTPCToPfoMap &larTPCToPfoMap,
+    const ThreeDPointingClusterMap &pointingClusterMap, PfoAssociationMatrix &pfoAssociationMatrix) const
 {
     LArTPCVector larTPCVector;
-    for (const auto &mapEntry : larTPCToPfoMap) larTPCVector.push_back(mapEntry.first);
+    for (const auto &mapEntry : larTPCToPfoMap)
+        larTPCVector.push_back(mapEntry.first);
     std::sort(larTPCVector.begin(), larTPCVector.end(), LArStitchingHelper::SortTPCs);
 
     for (LArTPCVector::const_iterator tpcIter1 = larTPCVector.begin(), tpcIterEnd = larTPCVector.end(); tpcIter1 != tpcIterEnd; ++tpcIter1)
@@ -166,9 +171,8 @@ void StitchingCosmicRayMergingTool::CreatePfoMatches(const LArTPCToPfoMap &larTP
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void StitchingCosmicRayMergingTool::CreatePfoMatches(const LArTPC &larTPC1, const LArTPC &larTPC2,
-    const ParticleFlowObject *const pPfo1, const ParticleFlowObject *const pPfo2,
-    const ThreeDPointingClusterMap &pointingClusterMap, PfoAssociationMatrix &pfoAssociationMatrix) const
+void StitchingCosmicRayMergingTool::CreatePfoMatches(const LArTPC &larTPC1, const LArTPC &larTPC2, const ParticleFlowObject *const pPfo1,
+    const ParticleFlowObject *const pPfo2, const ThreeDPointingClusterMap &pointingClusterMap, PfoAssociationMatrix &pfoAssociationMatrix) const
 {
     // Get centre and width of boundary between tpcs
     const float boundaryCenterX(LArStitchingHelper::GetTPCBoundaryCenterX(larTPC1, larTPC2));
@@ -252,12 +256,12 @@ void StitchingCosmicRayMergingTool::CreatePfoMatches(const LArTPC &larTPC1, cons
         return;
     }
 
-    const float minL((!LArGeometryHelper::IsInGap(this->GetPandora(), pointingVertex1.GetPosition(),  TPC_3D) ||
-        !LArGeometryHelper::IsInGap(this->GetPandora(), pointingVertex2.GetPosition(),  TPC_3D)) ? -1.f : m_relaxMinLongitudinalDisplacement);
-    const float dXdL1(m_useXcoordinate ? pX1 :
-        (1.f - pX1 * pX1 > std::numeric_limits<float>::epsilon()) ? pX1 / std::sqrt(1.f - pX1 * pX1) : minL);
-    const float dXdL2(m_useXcoordinate ? pX2 :
-        (1.f - pX2 * pX2 > std::numeric_limits<float>::epsilon()) ? pX2 / std::sqrt(1.f - pX2 * pX2) : minL);
+    const float minL((!LArGeometryHelper::IsInGap(this->GetPandora(), pointingVertex1.GetPosition(), TPC_3D) ||
+                         !LArGeometryHelper::IsInGap(this->GetPandora(), pointingVertex2.GetPosition(), TPC_3D))
+                         ? -1.f
+                         : m_relaxMinLongitudinalDisplacement);
+    const float dXdL1(m_useXcoordinate ? pX1 : (1.f - pX1 * pX1 > std::numeric_limits<float>::epsilon()) ? pX1 / std::sqrt(1.f - pX1 * pX1) : minL);
+    const float dXdL2(m_useXcoordinate ? pX2 : (1.f - pX2 * pX2 > std::numeric_limits<float>::epsilon()) ? pX2 / std::sqrt(1.f - pX2 * pX2) : minL);
     const float maxL1(maxLongitudinalDisplacementX / dXdL1);
     const float maxL2(maxLongitudinalDisplacementX / dXdL2);
 
@@ -291,7 +295,8 @@ void StitchingCosmicRayMergingTool::SelectPfoMatches(const PfoAssociationMatrix 
     PfoAssociationMatrix bestAssociationMatrix;
 
     PfoVector pfoVector1;
-    for (const auto &mapEntry : pfoAssociationMatrix) pfoVector1.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoAssociationMatrix)
+        pfoVector1.push_back(mapEntry.first);
     std::sort(pfoVector1.begin(), pfoVector1.end(), LArPfoHelper::SortByNHits);
 
     for (const ParticleFlowObject *const pPfo1 : pfoVector1)
@@ -305,7 +310,8 @@ void StitchingCosmicRayMergingTool::SelectPfoMatches(const PfoAssociationMatrix 
         PfoAssociation bestAssociationOuter(PfoAssociation::UNDEFINED, PfoAssociation::UNDEFINED, 0.f);
 
         PfoVector pfoVector2;
-        for (const auto &mapEntry : pfoAssociationMap) pfoVector2.push_back(mapEntry.first);
+        for (const auto &mapEntry : pfoAssociationMap)
+            pfoVector2.push_back(mapEntry.first);
         std::sort(pfoVector2.begin(), pfoVector2.end(), LArPfoHelper::SortByNHits);
 
         for (const ParticleFlowObject *const pPfo2 : pfoVector2)
@@ -334,16 +340,17 @@ void StitchingCosmicRayMergingTool::SelectPfoMatches(const PfoAssociationMatrix 
         }
 
         if (pBestPfoInner)
-            (void) bestAssociationMatrix[pPfo1].insert(PfoAssociationMap::value_type(pBestPfoInner, bestAssociationInner));
+            (void)bestAssociationMatrix[pPfo1].insert(PfoAssociationMap::value_type(pBestPfoInner, bestAssociationInner));
 
         if (pBestPfoOuter)
-            (void) bestAssociationMatrix[pPfo1].insert(PfoAssociationMap::value_type(pBestPfoOuter, bestAssociationOuter));
+            (void)bestAssociationMatrix[pPfo1].insert(PfoAssociationMap::value_type(pBestPfoOuter, bestAssociationOuter));
     }
 
     // Second step: make the merge if A -> X and B -> Y is in fact A -> B and B -> A
     // =============================================================================
     PfoVector pfoVector3;
-    for (const auto &mapEntry : bestAssociationMatrix) pfoVector3.push_back(mapEntry.first);
+    for (const auto &mapEntry : bestAssociationMatrix)
+        pfoVector3.push_back(mapEntry.first);
     std::sort(pfoVector3.begin(), pfoVector3.end(), LArPfoHelper::SortByNHits);
 
     for (const ParticleFlowObject *const pParentPfo : pfoVector3)
@@ -351,7 +358,8 @@ void StitchingCosmicRayMergingTool::SelectPfoMatches(const PfoAssociationMatrix 
         const PfoAssociationMap &parentAssociationMap(bestAssociationMatrix.at(pParentPfo));
 
         PfoVector pfoVector4;
-        for (const auto &mapEntry : parentAssociationMap) pfoVector4.push_back(mapEntry.first);
+        for (const auto &mapEntry : parentAssociationMap)
+            pfoVector4.push_back(mapEntry.first);
         std::sort(pfoVector4.begin(), pfoVector4.end(), LArPfoHelper::SortByNHits);
 
         for (const ParticleFlowObject *const pDaughterPfo : pfoVector4)
@@ -386,7 +394,8 @@ void StitchingCosmicRayMergingTool::SelectPfoMerges(const PfoMergeMap &pfoMatche
     PfoSet vetoSet;
 
     PfoVector inputPfoVector;
-    for (const auto &mapEntry : pfoMatches) inputPfoVector.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoMatches)
+        inputPfoVector.push_back(mapEntry.first);
     std::sort(inputPfoVector.begin(), inputPfoVector.end(), LArPfoHelper::SortByNHits);
 
     for (const ParticleFlowObject *const pInputPfo : inputPfoVector)
@@ -420,8 +429,8 @@ void StitchingCosmicRayMergingTool::SelectPfoMerges(const PfoMergeMap &pfoMatche
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void StitchingCosmicRayMergingTool::CollectAssociatedPfos(const ParticleFlowObject *const pSeedPfo, const ParticleFlowObject *const pCurrentPfo,
-    const PfoMergeMap &pfoMergeMap, const PfoSet &vetoSet, PfoList &associatedList) const
+void StitchingCosmicRayMergingTool::CollectAssociatedPfos(const ParticleFlowObject *const pSeedPfo,
+    const ParticleFlowObject *const pCurrentPfo, const PfoMergeMap &pfoMergeMap, const PfoSet &vetoSet, PfoList &associatedList) const
 {
     if (vetoSet.count(pCurrentPfo))
         return;
@@ -453,7 +462,8 @@ void StitchingCosmicRayMergingTool::OrderPfoMerges(const PfoToLArTPCMap &pfoToLA
     const PfoMergeMap &inputPfoMerges, PfoMergeMap &outputPfoMerges) const
 {
     PfoVector inputPfoVector;
-    for (const auto &mapEntry : inputPfoMerges) inputPfoVector.push_back(mapEntry.first);
+    for (const auto &mapEntry : inputPfoMerges)
+        inputPfoVector.push_back(mapEntry.first);
     std::sort(inputPfoVector.begin(), inputPfoVector.end(), LArPfoHelper::SortByNHits);
 
     for (const ParticleFlowObject *const pInputPfo : inputPfoVector)
@@ -504,16 +514,20 @@ void StitchingCosmicRayMergingTool::OrderPfoMerges(const PfoToLArTPCMap &pfoToLA
                     LArPointingCluster::Vertex nearVertex1, nearVertex2;
                     LArStitchingHelper::GetClosestVertices(*pLArTPC1, *pLArTPC2, pointingCluster1, pointingCluster2, nearVertex1, nearVertex2);
 
-                    const LArPointingCluster::Vertex &farVertex1(nearVertex1.IsInnerVertex() ? pointingCluster1.GetOuterVertex() : pointingCluster1.GetInnerVertex());
-                    const LArPointingCluster::Vertex &farVertex2(nearVertex2.IsInnerVertex() ? pointingCluster2.GetOuterVertex() : pointingCluster2.GetInnerVertex());
+                    const LArPointingCluster::Vertex &farVertex1(
+                        nearVertex1.IsInnerVertex() ? pointingCluster1.GetOuterVertex() : pointingCluster1.GetInnerVertex());
+                    const LArPointingCluster::Vertex &farVertex2(
+                        nearVertex2.IsInnerVertex() ? pointingCluster2.GetOuterVertex() : pointingCluster2.GetInnerVertex());
                     const float deltaY(farVertex1.GetPosition().GetY() - farVertex2.GetPosition().GetY());
 
                     if (std::fabs(deltaY) < std::numeric_limits<float>::epsilon())
-                         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+                        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
                     pVertexPfo = ((deltaY > 0.f) ? pPfo1 : pPfo2);
                 }
-                catch (const pandora::StatusCodeException &) {}
+                catch (const pandora::StatusCodeException &)
+                {
+                }
             }
         }
 
@@ -528,7 +542,8 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
     const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) const
 {
     PfoVector pfoVectorToEnlarge;
-    for (const auto &mapEntry : pfoMerges) pfoVectorToEnlarge.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoMerges)
+        pfoVectorToEnlarge.push_back(mapEntry.first);
     std::sort(pfoVectorToEnlarge.begin(), pfoVectorToEnlarge.end(), LArPfoHelper::SortByNHits);
 
     for (const ParticleFlowObject *const pPfoToEnlarge : pfoVectorToEnlarge)
@@ -600,7 +615,9 @@ void StitchingCosmicRayMergingTool::StitchPfos(const MasterAlgorithm *const pAlg
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void StitchingCosmicRayMergingTool::ShiftPfo(const MasterAlgorithm *const pAlgorithm, const ParticleFlowObject *const pPfoToShift, const ParticleFlowObject *const pMatchedPfo, const float x0, const PfoToLArTPCMap &pfoToLArTPCMap, const PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const
+void StitchingCosmicRayMergingTool::ShiftPfo(const MasterAlgorithm *const pAlgorithm, const ParticleFlowObject *const pPfoToShift,
+    const ParticleFlowObject *const pMatchedPfo, const float x0, const PfoToLArTPCMap &pfoToLArTPCMap,
+    const PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const
 {
     // get stitching vertex for the pfo to be shifted
     const PfoToPointingVertexMatrix::const_iterator pfoToPointingVertexMatrixIter(pfoToPointingVertexMatrix.find(pPfoToShift));
@@ -678,8 +695,7 @@ bool StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
             LArPointingCluster::Vertex pointingVertex1, pointingVertex2;
             try
             {
-                LArStitchingHelper::GetClosestVertices(*pLArTPC1, *pLArTPC2, pointingCluster1, pointingCluster2,
-                    pointingVertex1, pointingVertex2);
+                LArStitchingHelper::GetClosestVertices(*pLArTPC1, *pLArTPC2, pointingCluster1, pointingCluster2, pointingVertex1, pointingVertex2);
 
                 // Record pfo1 stitching vertex for pfo1<->pfo2 match, used to determine shifting direction in later step
                 const PfoToPointingVertexMatrix::iterator pfoToPointingVertexMatrixIter1(pfoToPointingVertexMatrix.find(pPfo1));
@@ -687,7 +703,7 @@ bool StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
                 {
                     // No matches present in map, add pfo1<->pfo2 match
                     const PfoToPointingVertexMap pfoToPointingVertexMap({{pPfo2, pointingVertex1}});
-                    (void) pfoToPointingVertexMatrix.insert(PfoToPointingVertexMatrix::value_type(pPfo1, pfoToPointingVertexMap));
+                    (void)pfoToPointingVertexMatrix.insert(PfoToPointingVertexMatrix::value_type(pPfo1, pfoToPointingVertexMap));
                 }
                 else
                 {
@@ -696,11 +712,12 @@ bool StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
                     const PfoToPointingVertexMap::iterator pfoToPointingVertexMapIter(pfoToPointingVertexMap.find(pPfo2));
                     if (pfoToPointingVertexMapIter == pfoToPointingVertexMap.end())
                     {
-                        (void) pfoToPointingVertexMap.insert(PfoToPointingVertexMap::value_type(pPfo2, pointingVertex1));
+                        (void)pfoToPointingVertexMap.insert(PfoToPointingVertexMap::value_type(pPfo2, pointingVertex1));
                     }
                     else
                     {
-                        if ((pfoToPointingVertexMapIter->second.GetPosition() - pointingVertex1.GetPosition()).GetMagnitude() > std::numeric_limits<float>::epsilon())
+                        if ((pfoToPointingVertexMapIter->second.GetPosition() - pointingVertex1.GetPosition()).GetMagnitude() >
+                            std::numeric_limits<float>::epsilon())
                             throw StatusCodeException(STATUS_CODE_FAILURE);
                     }
                 }
@@ -711,7 +728,7 @@ bool StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
                 {
                     // No matches present in map, add pfo1<->pfo2 match
                     const PfoToPointingVertexMap pfoToPointingVertexMap({{pPfo1, pointingVertex2}});
-                    (void) pfoToPointingVertexMatrix.insert(PfoToPointingVertexMatrix::value_type(pPfo2, pfoToPointingVertexMap));
+                    (void)pfoToPointingVertexMatrix.insert(PfoToPointingVertexMatrix::value_type(pPfo2, pfoToPointingVertexMap));
                 }
                 else
                 {
@@ -720,11 +737,12 @@ bool StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
                     const PfoToPointingVertexMap::iterator pfoToPointingVertexMapIter(pfoToPointingVertexMap.find(pPfo1));
                     if (pfoToPointingVertexMapIter == pfoToPointingVertexMap.end())
                     {
-                        (void) pfoToPointingVertexMap.insert(PfoToPointingVertexMap::value_type(pPfo1, pointingVertex2));
+                        (void)pfoToPointingVertexMap.insert(PfoToPointingVertexMap::value_type(pPfo1, pointingVertex2));
                     }
                     else
                     {
-                        if ((pfoToPointingVertexMapIter->second.GetPosition() - pointingVertex2.GetPosition()).GetMagnitude() > std::numeric_limits<float>::epsilon())
+                        if ((pfoToPointingVertexMapIter->second.GetPosition() - pointingVertex2.GetPosition()).GetMagnitude() >
+                            std::numeric_limits<float>::epsilon())
                             throw StatusCodeException(STATUS_CODE_FAILURE);
                     }
                 }
@@ -744,7 +762,8 @@ bool StitchingCosmicRayMergingTool::CalculateX0(const PfoToLArTPCMap &pfoToLArTP
                         return false;
                 }
 
-                sumX += thisX0; sumN += 1.f;
+                sumX += thisX0;
+                sumN += 1.f;
             }
             catch (const pandora::StatusCodeException &statusCodeException)
             {
@@ -798,46 +817,44 @@ float StitchingCosmicRayMergingTool::PfoAssociation::GetFigureOfMerit() const
 
 StatusCode StitchingCosmicRayMergingTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ThreeDStitchingMode", m_useXcoordinate));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ThreeDStitchingMode", m_useXcoordinate));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "AlwaysApplyT0Calculation", m_alwaysApplyT0Calculation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "AlwaysApplyT0Calculation", m_alwaysApplyT0Calculation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HalfWindowLayers", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HalfWindowLayers", m_halfWindowLayers));
 
     float minLength(std::sqrt(m_minLengthSquared));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPfoLength", minLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinPfoLength", minLength));
     m_minLengthSquared = minLength * minLength;
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCosRelativeAngle", m_minCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosRelativeAngle", m_minCosRelativeAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "RelaxMinLongitudinalDisplacement", m_relaxMinLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "RelaxMinLongitudinalDisplacement", m_relaxMinLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalDisplacementX", m_maxLongitudinalDisplacementX));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacementX", m_maxLongitudinalDisplacementX));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LooserMinCosRelativeAngle", m_relaxCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "LooserMinCosRelativeAngle", m_relaxCosRelativeAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LooserMaxTransverseDisplacement", m_relaxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "LooserMaxTransverseDisplacement", m_relaxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinNCaloHits3D", m_minNCaloHits3D));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinNCaloHits3D", m_minNCaloHits3D));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxX0FractionalDeviation", m_maxX0FractionalDeviation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxX0FractionalDeviation", m_maxX0FractionalDeviation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "BoundaryToleranceWidth", m_boundaryToleranceWidth));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BoundaryToleranceWidth", m_boundaryToleranceWidth));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
+++ b/larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h
@@ -28,7 +28,8 @@ public:
      */
     StitchingCosmicRayMergingTool();
 
-    void Run(const MasterAlgorithm *const pAlgorithm, const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map);
+    void Run(const MasterAlgorithm *const pAlgorithm, const pandora::PfoList *const pMultiPfoList, PfoToLArTPCMap &pfoToLArTPCMap,
+        PfoToFloatMap &stitchedPfosToX0Map);
 
     /**
      *  @brief  PfoAssociation class
@@ -42,8 +43,8 @@ public:
         enum VertexType
         {
             UNDEFINED = 0,
-            INNER     = 1,
-            OUTER     = 2
+            INNER = 1,
+            OUTER = 2
         };
 
         /**
@@ -77,9 +78,9 @@ public:
         float GetFigureOfMerit() const;
 
     private:
-        VertexType      m_parent;           ///< The parent vertex type
-        VertexType      m_daughter;         ///< The daughter vertex type
-        float           m_fom;              ///< The figure of merit
+        VertexType m_parent;   ///< The parent vertex type
+        VertexType m_daughter; ///< The daughter vertex type
+        float m_fom;           ///< The figure of merit
     };
 
 private:
@@ -94,7 +95,7 @@ private:
      */
     void SelectPrimaryPfos(const pandora::PfoList *pInputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, pandora::PfoList &outputPfoList) const;
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, LArPointingCluster> ThreeDPointingClusterMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, LArPointingCluster> ThreeDPointingClusterMap;
 
     /**
      *  @brief  Build a 3D pointing cluster for each Pfo
@@ -103,9 +104,10 @@ private:
      *  @param  pfoToLArTPCMap the input mapping between Pfos and tpc
      *  @param  pointingClusterMap  the mapping between Pfos and their corresponding 3D pointing clusters
      */
-    void BuildPointingClusterMaps(const pandora::PfoList &inputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, ThreeDPointingClusterMap &pointingClusterMap) const;
+    void BuildPointingClusterMaps(
+        const pandora::PfoList &inputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, ThreeDPointingClusterMap &pointingClusterMap) const;
 
-    typedef std::unordered_map<const pandora::LArTPC*, pandora::PfoList> LArTPCToPfoMap;
+    typedef std::unordered_map<const pandora::LArTPC *, pandora::PfoList> LArTPCToPfoMap;
 
     /**
      *  @brief  Build a list of Pfos for each tpc
@@ -116,8 +118,8 @@ private:
      */
     void BuildTPCMaps(const pandora::PfoList &inputPfoList, const PfoToLArTPCMap &pfoToLArTPCMap, LArTPCToPfoMap &larTPCToPfoMap) const;
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, PfoAssociation> PfoAssociationMap;
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, PfoAssociationMap> PfoAssociationMatrix;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, PfoAssociation> PfoAssociationMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, PfoAssociationMap> PfoAssociationMatrix;
 
     /**
      *  @brief  Create associations between Pfos using 3D pointing clusters
@@ -140,9 +142,10 @@ private:
      *  @param  pfoAssociationMatrix the output matrix of associations between Pfos
      */
     void CreatePfoMatches(const pandora::LArTPC &larTPC1, const pandora::LArTPC &larTPC2, const pandora::ParticleFlowObject *const pPfo1,
-        const pandora::ParticleFlowObject *const pPfo2, const ThreeDPointingClusterMap &pointingClusterMap, PfoAssociationMatrix &pfoAssociationMatrix) const;
+        const pandora::ParticleFlowObject *const pPfo2, const ThreeDPointingClusterMap &pointingClusterMap,
+        PfoAssociationMatrix &pfoAssociationMatrix) const;
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, pandora::PfoList> PfoMergeMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, pandora::PfoList> PfoMergeMap;
 
     /**
      *  @brief  Select the best associations between Pfos; create a mapping between associated Pfos, handling any ambiguities
@@ -195,8 +198,8 @@ private:
     void StitchPfos(const MasterAlgorithm *const pAlgorithm, const ThreeDPointingClusterMap &pointingClusterMap,
         const PfoMergeMap &pfoMerges, PfoToLArTPCMap &pfoToLArTPCMap, PfoToFloatMap &stitchedPfosToX0Map) const;
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, LArPointingCluster::Vertex> PfoToPointingVertexMap;
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, PfoToPointingVertexMap> PfoToPointingVertexMatrix;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, LArPointingCluster::Vertex> PfoToPointingVertexMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, PfoToPointingVertexMap> PfoToPointingVertexMatrix;
 
     /**
      *  @brief  Shift a pfo given its pfo stitching pair
@@ -207,8 +210,9 @@ private:
      *  @param  pfoToLArTPCMap the pfo to lar tpc map
      *  @param  pfoToPointingVertexMatrix the map [pfo -> map [matched pfo -> pfo stitching vertex]]
      */
-    void ShiftPfo(const MasterAlgorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pPfoToShift, const pandora::ParticleFlowObject *const pMatchedPfo,
-        const float x0, const PfoToLArTPCMap &pfoToLArTPCMap, const PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const;
+    void ShiftPfo(const MasterAlgorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pPfoToShift,
+        const pandora::ParticleFlowObject *const pMatchedPfo, const float x0, const PfoToLArTPCMap &pfoToLArTPCMap,
+        const PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const;
 
     /**
      *  @brief  Calculate x0 shift for a group of associated Pfos
@@ -224,19 +228,19 @@ private:
     bool CalculateX0(const PfoToLArTPCMap &pfoToLArTPCMap, const ThreeDPointingClusterMap &pointingClusterMap,
         const pandora::PfoVector &pfoVector, float &x0, PfoToPointingVertexMatrix &pfoToPointingVertexMatrix) const;
 
-    bool            m_useXcoordinate;
-    bool            m_alwaysApplyT0Calculation;
-    int             m_halfWindowLayers;
-    float           m_minLengthSquared;
-    float           m_minCosRelativeAngle;
-    float           m_relaxMinLongitudinalDisplacement;   ///< The minimum value of the longitudinal impact parameter for association if both verticies fall in the detector gap
-    float           m_maxLongitudinalDisplacementX;
-    float           m_maxTransverseDisplacement;
-    float           m_relaxCosRelativeAngle;
-    float           m_relaxTransverseDisplacement;
-    unsigned int    m_minNCaloHits3D;
-    float           m_maxX0FractionalDeviation;           ///< The maximum allowed fractional difference of an X0 contribution for matches to be stitched
-    float           m_boundaryToleranceWidth;             ///< The distance from the APA/CPA boundary inside which the deviation consideration is ignored
+    bool m_useXcoordinate;
+    bool m_alwaysApplyT0Calculation;
+    int m_halfWindowLayers;
+    float m_minLengthSquared;
+    float m_minCosRelativeAngle;
+    float m_relaxMinLongitudinalDisplacement; ///< The minimum value of the longitudinal impact parameter for association if both verticies fall in the detector gap
+    float m_maxLongitudinalDisplacementX;
+    float m_maxTransverseDisplacement;
+    float m_relaxCosRelativeAngle;
+    float m_relaxTransverseDisplacement;
+    unsigned int m_minNCaloHits3D;
+    float m_maxX0FractionalDeviation; ///< The maximum allowed fractional difference of an X0 contribution for matches to be stitched
+    float m_boundaryToleranceWidth;   ///< The distance from the APA/CPA boundary inside which the deviation consideration is ignored
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCustomParticles/CustomParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArCustomParticles/CustomParticleCreationAlgorithm.cc
@@ -42,13 +42,13 @@ StatusCode CustomParticleCreationAlgorithm::Run()
     }
 
     // Create temporary lists
-    const PfoList *pTempPfoList = NULL; std::string tempPfoListName;
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pTempPfoList,
-        tempPfoListName));
+    const PfoList *pTempPfoList = NULL;
+    std::string tempPfoListName;
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pTempPfoList, tempPfoListName));
 
-    const VertexList *pTempVertexList = NULL; std::string tempVertexListName;
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pTempVertexList,
-        tempVertexListName));
+    const VertexList *pTempVertexList = NULL;
+    std::string tempVertexListName;
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pTempVertexList, tempVertexListName));
 
     // Loop over input Pfos
     PfoList pfoList(pPfoList->begin(), pPfoList->end());

--- a/larpandoracontent/LArCustomParticles/CustomParticleCreationAlgorithm.h
+++ b/larpandoracontent/LArCustomParticles/CustomParticleCreationAlgorithm.h
@@ -28,11 +28,11 @@ protected:
      *  @param  pInputPfo the address of the input Pfo
      *  @param  pOutputPfo the address of the output Pfo
      */
-    virtual void CreatePfo(const pandora::ParticleFlowObject *const pInputPfo, const pandora::ParticleFlowObject*& pOutputPfo) const = 0;
+    virtual void CreatePfo(const pandora::ParticleFlowObject *const pInputPfo, const pandora::ParticleFlowObject *&pOutputPfo) const = 0;
 
 private:
-    std::string  m_pfoListName;      ///< The name of the input pfo list
-    std::string  m_vertexListName;   ///< The name of the input vertex list
+    std::string m_pfoListName;    ///< The name of the input pfo list
+    std::string m_vertexListName; ///< The name of the input vertex list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArCustomParticles/PcaShowerParticleBuildingAlgorithm.cc
+++ b/larpandoracontent/LArCustomParticles/PcaShowerParticleBuildingAlgorithm.cc
@@ -23,14 +23,13 @@ using namespace pandora;
 namespace lar_content
 {
 
-PcaShowerParticleBuildingAlgorithm::PcaShowerParticleBuildingAlgorithm() :
-    m_layerFitHalfWindow(20)
+PcaShowerParticleBuildingAlgorithm::PcaShowerParticleBuildingAlgorithm() : m_layerFitHalfWindow(20)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PcaShowerParticleBuildingAlgorithm::CreatePfo(const ParticleFlowObject *const pInputPfo, const ParticleFlowObject*& pOutputPfo) const
+void PcaShowerParticleBuildingAlgorithm::CreatePfo(const ParticleFlowObject *const pInputPfo, const ParticleFlowObject *&pOutputPfo) const
 {
     try
     {
@@ -71,12 +70,12 @@ void PcaShowerParticleBuildingAlgorithm::CreatePfo(const ParticleFlowObject *con
         pfoParameters.m_showerTertiaryVector = showerPCA.GetTertiaryAxis();
         pfoParameters.m_showerEigenValues = showerPCA.GetEigenValues();
         pfoParameters.m_showerLength = showerPCA.GetAxisLengths();
-        pfoParameters.m_showerOpeningAngle = (showerPCA.GetPrimaryLength() > 0.f ? std::atan(showerPCA.GetSecondaryLength() / showerPCA.GetPrimaryLength()) : 0.f);
+        pfoParameters.m_showerOpeningAngle =
+            (showerPCA.GetPrimaryLength() > 0.f ? std::atan(showerPCA.GetSecondaryLength() / showerPCA.GetPrimaryLength()) : 0.f);
 
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pOutputPfo,
-            pfoFactory));
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pOutputPfo, pfoFactory));
 
-        const LArShowerPfo *const pLArPfo = dynamic_cast<const LArShowerPfo*>(pOutputPfo);
+        const LArShowerPfo *const pLArPfo = dynamic_cast<const LArShowerPfo *>(pOutputPfo);
 
         if (!pLArPfo)
             throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -103,8 +102,8 @@ void PcaShowerParticleBuildingAlgorithm::CreatePfo(const ParticleFlowObject *con
 
 StatusCode PcaShowerParticleBuildingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LayerFitHalfWindow", m_layerFitHalfWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LayerFitHalfWindow", m_layerFitHalfWindow));
 
     return CustomParticleCreationAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArCustomParticles/PcaShowerParticleBuildingAlgorithm.h
+++ b/larpandoracontent/LArCustomParticles/PcaShowerParticleBuildingAlgorithm.h
@@ -40,7 +40,7 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_layerFitHalfWindow;       ///<
+    unsigned int m_layerFitHalfWindow; ///<
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArCustomParticles/TrackParticleBuildingAlgorithm.cc
+++ b/larpandoracontent/LArCustomParticles/TrackParticleBuildingAlgorithm.cc
@@ -22,15 +22,13 @@ using namespace pandora;
 namespace lar_content
 {
 
-TrackParticleBuildingAlgorithm::TrackParticleBuildingAlgorithm() :
-    m_slidingFitHalfWindow(20)
+TrackParticleBuildingAlgorithm::TrackParticleBuildingAlgorithm() : m_slidingFitHalfWindow(20)
 {
-
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackParticleBuildingAlgorithm::CreatePfo(const ParticleFlowObject *const pInputPfo, const ParticleFlowObject*& pOutputPfo) const
+void TrackParticleBuildingAlgorithm::CreatePfo(const ParticleFlowObject *const pInputPfo, const ParticleFlowObject *&pOutputPfo) const
 {
     try
     {
@@ -74,10 +72,9 @@ void TrackParticleBuildingAlgorithm::CreatePfo(const ParticleFlowObject *const p
         pfoParameters.m_propertiesToAdd = pInputPfo->GetPropertiesMap();
         pfoParameters.m_trackStateVector = trackStateVector;
 
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pOutputPfo,
-            trackFactory));
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pOutputPfo, trackFactory));
 
-        const LArTrackPfo *const pLArPfo = dynamic_cast<const LArTrackPfo*>(pOutputPfo);
+        const LArTrackPfo *const pLArPfo = dynamic_cast<const LArTrackPfo *>(pOutputPfo);
         if (NULL == pLArPfo)
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
@@ -107,8 +104,8 @@ void TrackParticleBuildingAlgorithm::CreatePfo(const ParticleFlowObject *const p
 
 StatusCode TrackParticleBuildingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_slidingFitHalfWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_slidingFitHalfWindow));
 
     return CustomParticleCreationAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArCustomParticles/TrackParticleBuildingAlgorithm.h
+++ b/larpandoracontent/LArCustomParticles/TrackParticleBuildingAlgorithm.h
@@ -29,9 +29,9 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    void CreatePfo(const pandora::ParticleFlowObject *const pInputPfo, const pandora::ParticleFlowObject*& pOutputPfo) const;
+    void CreatePfo(const pandora::ParticleFlowObject *const pInputPfo, const pandora::ParticleFlowObject *&pOutputPfo) const;
 
-    unsigned int    m_slidingFitHalfWindow;   ///<
+    unsigned int m_slidingFitHalfWindow; ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -38,10 +38,14 @@ void LArClusterHelper::GetClustersUVW(const ClusterList &inputClusters, ClusterL
     {
         const HitType hitType(LArClusterHelper::GetClusterHitType(*iter));
 
-        if (TPC_VIEW_U == hitType) clusterListU.push_back(*iter);
-        else if (TPC_VIEW_V == hitType) clusterListV.push_back(*iter);
-        else if (TPC_VIEW_W == hitType) clusterListW.push_back(*iter);
-        else throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        if (TPC_VIEW_U == hitType)
+            clusterListU.push_back(*iter);
+        else if (TPC_VIEW_V == hitType)
+            clusterListV.push_back(*iter);
+        else if (TPC_VIEW_W == hitType)
+            clusterListW.push_back(*iter);
+        else
+            throw StatusCodeException(STATUS_CODE_NOT_FOUND);
     }
 }
 
@@ -129,7 +133,7 @@ float LArClusterHelper::GetLayerOccupancy(const Cluster *const pCluster1, const 
 {
     const unsigned int nOccupiedLayers(pCluster1->GetOrderedCaloHitList().size() + pCluster2->GetOrderedCaloHitList().size());
     const unsigned int nLayers(1 + std::max(pCluster1->GetOuterPseudoLayer(), pCluster2->GetOuterPseudoLayer()) -
-        std::min(pCluster1->GetInnerPseudoLayer(), pCluster2->GetInnerPseudoLayer()));
+                               std::min(pCluster1->GetInnerPseudoLayer(), pCluster2->GetInnerPseudoLayer()));
 
     if (nLayers > 0)
         return (static_cast<float>(nOccupiedLayers) / static_cast<float>(nLayers));
@@ -265,8 +269,8 @@ CartesianVector LArClusterHelper::GetClosestPosition(const CartesianVector &posi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArClusterHelper::GetClosestPositions(const Cluster *const pCluster1, const Cluster *const pCluster2, CartesianVector &outputPosition1,
-    CartesianVector &outputPosition2)
+void LArClusterHelper::GetClosestPositions(
+    const Cluster *const pCluster1, const Cluster *const pCluster2, CartesianVector &outputPosition1, CartesianVector &outputPosition2)
 {
     bool distanceFound(false);
     float minDistanceSquared(std::numeric_limits<float>::max());
@@ -399,13 +403,12 @@ void LArClusterHelper::GetExtremalCoordinates(const ClusterList &clusterList, Ca
 
 void LArClusterHelper::GetExtremalCoordinates(const Cluster *const pCluster, CartesianVector &innerCoordinate, CartesianVector &outerCoordinate)
 {
-  return LArClusterHelper::GetExtremalCoordinates(pCluster->GetOrderedCaloHitList(), innerCoordinate, outerCoordinate);
+    return LArClusterHelper::GetExtremalCoordinates(pCluster->GetOrderedCaloHitList(), innerCoordinate, outerCoordinate);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArClusterHelper::GetExtremalCoordinates(const OrderedCaloHitList &orderedCaloHitList, CartesianVector &innerCoordinate,
-    CartesianVector &outerCoordinate)
+void LArClusterHelper::GetExtremalCoordinates(const OrderedCaloHitList &orderedCaloHitList, CartesianVector &innerCoordinate, CartesianVector &outerCoordinate)
 {
     if (orderedCaloHitList.empty())
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
@@ -427,8 +430,7 @@ void LArClusterHelper::GetExtremalCoordinates(const OrderedCaloHitList &orderedC
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArClusterHelper::GetExtremalCoordinates(const CartesianPointVector &coordinateVector, CartesianVector &innerCoordinate,
-    CartesianVector &outerCoordinate)
+void LArClusterHelper::GetExtremalCoordinates(const CartesianPointVector &coordinateVector, CartesianVector &innerCoordinate, CartesianVector &outerCoordinate)
 {
     if (coordinateVector.empty())
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
@@ -547,7 +549,7 @@ void LArClusterHelper::GetCoordinateVector(const Cluster *const pCluster, Cartes
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArClusterHelper::GetCaloHitListInBoundingBox(const pandora::Cluster *const pCluster, const pandora::CartesianVector &lowerBound,
-        const pandora::CartesianVector &upperBound, pandora::CaloHitList &caloHitList)
+    const pandora::CartesianVector &upperBound, pandora::CaloHitList &caloHitList)
 {
     const bool useX(std::fabs(upperBound.GetX() - lowerBound.GetX()) > std::numeric_limits<float>::epsilon());
     const bool useY(std::fabs(upperBound.GetY() - lowerBound.GetY()) > std::numeric_limits<float>::epsilon());
@@ -567,18 +569,15 @@ void LArClusterHelper::GetCaloHitListInBoundingBox(const pandora::Cluster *const
         for (const CaloHit *const pCaloHit : *layerEntry.second)
         {
             const CartesianVector &hitPosition = pCaloHit->GetPositionVector();
-            if (useX &&
-                (hitPosition.GetX() < minX - std::numeric_limits<float>::epsilon() ||
-                 hitPosition.GetX() > maxX + std::numeric_limits<float>::epsilon()))
-                    continue;
-            else if (useY &&
-                (hitPosition.GetY() < minY - std::numeric_limits<float>::epsilon() ||
-                 hitPosition.GetY() > maxY + std::numeric_limits<float>::epsilon()))
-                    continue;
-            else if (useZ &&
-                (hitPosition.GetZ() < minZ - std::numeric_limits<float>::epsilon() ||
-                 hitPosition.GetZ() > maxZ + std::numeric_limits<float>::epsilon()))
-                    continue;
+            if (useX && (hitPosition.GetX() < minX - std::numeric_limits<float>::epsilon() ||
+                            hitPosition.GetX() > maxX + std::numeric_limits<float>::epsilon()))
+                continue;
+            else if (useY && (hitPosition.GetY() < minY - std::numeric_limits<float>::epsilon() ||
+                                 hitPosition.GetY() > maxY + std::numeric_limits<float>::epsilon()))
+                continue;
+            else if (useZ && (hitPosition.GetZ() < minZ - std::numeric_limits<float>::epsilon() ||
+                                 hitPosition.GetZ() > maxZ + std::numeric_limits<float>::epsilon()))
+                continue;
 
             caloHitList.push_back(pCaloHit);
         }
@@ -597,9 +596,9 @@ void LArClusterHelper::GetDaughterVolumeIDs(const Cluster *const pCluster, UIntS
         for (CaloHitList::const_iterator hIter = ochIter->second->begin(), hIterEnd = ochIter->second->end(); hIter != hIterEnd; ++hIter)
         {
             const CaloHit *const pCaloHit(*hIter);
-            const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit*>(pCaloHit));
+            const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
 
-            if (pLArCaloHit) 
+            if (pLArCaloHit)
                 daughterVolumeIds.insert(pLArCaloHit->GetDaughterVolumeId());
         }
     }
@@ -651,7 +650,7 @@ bool LArClusterHelper::SortByInnerLayer(const Cluster *const pLhs, const Cluster
     const unsigned int innerLayerRhs(pRhs->GetInnerPseudoLayer());
 
     if (innerLayerLhs != innerLayerRhs)
-      return (innerLayerLhs < innerLayerRhs);
+        return (innerLayerLhs < innerLayerRhs);
 
     return SortByPosition(pLhs, pRhs);
 }

--- a/larpandoracontent/LArHelpers/LArClusterHelper.h
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.h
@@ -19,7 +19,6 @@ namespace lar_content
 class LArClusterHelper
 {
 public:
-
     typedef std::set<unsigned int> UIntSet;
 
     /**
@@ -49,8 +48,7 @@ public:
      *  @param  hitType the specified hit type
      *  @param  clusterList to receive the clusters
      */
-    static void GetClustersByHitType(const pandora::ClusterList &inputClusters, const pandora::HitType hitType,
-        pandora::ClusterList &clusterList);
+    static void GetClustersByHitType(const pandora::ClusterList &inputClusters, const pandora::HitType hitType, pandora::ClusterList &clusterList);
 
     /**
      *  @brief  Get length squared of cluster
@@ -195,8 +193,8 @@ public:
      *  @param  the inner extremal position
      *  @param  the outer extremal position
      */
-    static void GetExtremalCoordinates(const pandora::ClusterList &clusterList, pandora::CartesianVector &innerCoordinate,
-        pandora::CartesianVector &outerCoordinate);
+    static void GetExtremalCoordinates(
+        const pandora::ClusterList &clusterList, pandora::CartesianVector &innerCoordinate, pandora::CartesianVector &outerCoordinate);
 
     /**
      *  @brief  Get positions of the two most distant calo hits in a cluster (ordered by Z)
@@ -205,8 +203,8 @@ public:
      *  @param  the inner extremal position
      *  @param  the outer extremal position
      */
-    static void GetExtremalCoordinates(const pandora::Cluster *const pCluster, pandora::CartesianVector &innerCoordinate,
-        pandora::CartesianVector &outerCoordinate);
+    static void GetExtremalCoordinates(
+        const pandora::Cluster *const pCluster, pandora::CartesianVector &innerCoordinate, pandora::CartesianVector &outerCoordinate);
 
     /**
      *  @brief  Get positions of the two most distant calo hits in an ordered calo hit list (ordered by Z)
@@ -218,7 +216,7 @@ public:
     static void GetExtremalCoordinates(const pandora::OrderedCaloHitList &orderedCaloHitList, pandora::CartesianVector &innerCoordinate,
         pandora::CartesianVector &outerCoordinate);
 
-  /**
+    /**
      *  @brief  Get positions of the two most distant points in a provided list (ordered by Z)
      *
      *  @param  coordinateVector the hit list
@@ -235,8 +233,8 @@ public:
      *  @param  the minimum positions (x,y,z)
      *  @param  the maximum positions (x,y,z)
      */
-    static void GetClusterBoundingBox(const pandora::Cluster *const pCluster, pandora::CartesianVector &minimumCoordinate,
-        pandora::CartesianVector &maximumCoordinate);
+    static void GetClusterBoundingBox(
+        const pandora::Cluster *const pCluster, pandora::CartesianVector &minimumCoordinate, pandora::CartesianVector &maximumCoordinate);
 
     /**
      *  @brief  Get vector of hit coordinates from an input cluster
@@ -254,7 +252,7 @@ public:
      *  @param  upperBound the other opposing corner of the bounding box
      *  @param  caloHitList the CaloHitList to be filled
      */
-    static void GetCaloHitListInBoundingBox(const pandora::Cluster *const pCluster, const pandora::CartesianVector &lowerBound, 
+    static void GetCaloHitListInBoundingBox(const pandora::Cluster *const pCluster, const pandora::CartesianVector &lowerBound,
         const pandora::CartesianVector &upperBound, pandora::CaloHitList &caloHitList);
 
     /**
@@ -341,7 +339,7 @@ public:
      */
     static bool SortHitsByPositionInX(const pandora::CaloHit *const pLhs, const pandora::CaloHit *const pRhs);
 
-   /**
+    /**
      *  @brief  Sort calo hits by their pulse height
      *
      *  @param  pLhs address of first calo hit

--- a/larpandoracontent/LArHelpers/LArDiscreteProbabilityHelper.cc
+++ b/larpandoracontent/LArHelpers/LArDiscreteProbabilityHelper.cc
@@ -13,8 +13,8 @@ namespace lar_content
 {
 
 template <typename T>
-float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPermutationTest(const T &t1, const T &t2, 
-    std::mt19937 &randomNumberGenerator, const unsigned int nPermutations)
+float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPermutationTest(
+    const T &t1, const T &t2, std::mt19937 &randomNumberGenerator, const unsigned int nPermutations)
 {
     if (1 > nPermutations)
         throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
@@ -28,7 +28,7 @@ float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPer
             LArDiscreteProbabilityHelper::MakeRandomisedSample(t1, randomNumberGenerator),
             LArDiscreteProbabilityHelper::MakeRandomisedSample(t2, randomNumberGenerator)));
 
-        if ((rRandomised-rNominal) > std::numeric_limits<float>::epsilon())
+        if ((rRandomised - rNominal) > std::numeric_limits<float>::epsilon())
             nExtreme++;
     }
 
@@ -38,8 +38,8 @@ float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPer
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromStudentTDistribution(const T &t1, 
-    const T &t2, const unsigned int nIntegrationSteps, const float upperLimit)
+float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromStudentTDistribution(
+    const T &t1, const T &t2, const unsigned int nIntegrationSteps, const float upperLimit)
 {
     const float correlation(LArDiscreteProbabilityHelper::CalculateCorrelationCoefficient(t1, t2));
     const float dof(static_cast<float>(LArDiscreteProbabilityHelper::GetSize(t1)) - 2.f);
@@ -47,24 +47,25 @@ float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromStu
     if (0 > dof)
         throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
 
-    const float tTestStatisticDenominator(1.f-correlation-correlation);
+    const float tTestStatisticDenominator(1.f - correlation - correlation);
 
     if (tTestStatisticDenominator < std::numeric_limits<float>::epsilon())
         throw pandora::StatusCodeException(pandora::STATUS_CODE_FAILURE);
 
-    const float tTestStatistic(correlation*std::sqrt(dof)/(std::sqrt(tTestStatisticDenominator)));
-    const float tDistCoeff(std::tgamma(0.5f*(dof + 1.f))/std::tgamma(0.5f*dof)/(std::sqrt(dof*M_PI)));
+    const float tTestStatistic(correlation * std::sqrt(dof) / (std::sqrt(tTestStatisticDenominator)));
+    const float tDistCoeff(std::tgamma(0.5f * (dof + 1.f)) / std::tgamma(0.5f * dof) / (std::sqrt(dof * M_PI)));
 
-    const float dx((upperLimit - tTestStatistic)/static_cast<float>(nIntegrationSteps));
-    float integral(tDistCoeff*std::pow(1.f + tTestStatistic*tTestStatistic/dof, -0.5f*(dof + 1.f)) + 
-            tDistCoeff*std::pow(1.f + upperLimit*upperLimit/dof, -0.5f*(dof + 1.f)));
+    const float dx((upperLimit - tTestStatistic) / static_cast<float>(nIntegrationSteps));
+    float integral(tDistCoeff * std::pow(1.f + tTestStatistic * tTestStatistic / dof, -0.5f * (dof + 1.f)) +
+                   tDistCoeff * std::pow(1.f + upperLimit * upperLimit / dof, -0.5f * (dof + 1.f)));
     for (unsigned int iStep = 1; iStep < nIntegrationSteps; ++iStep)
     {
-        integral+=2.f*tDistCoeff*std::pow( 
-            1.f + (tTestStatistic + static_cast<float>(iStep)*dx)*(tTestStatistic + static_cast<float>(iStep)*dx)/dof, -0.5f*(dof + 1.f));
+        integral += 2.f * tDistCoeff *
+                    std::pow(1.f + (tTestStatistic + static_cast<float>(iStep) * dx) * (tTestStatistic + static_cast<float>(iStep) * dx) / dof,
+                        -0.5f * (dof + 1.f));
     }
 
-    return integral*dx/2.f;
+    return integral * dx / 2.f;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -90,16 +91,16 @@ float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficient(const T &t1,
         const float diff1(LArDiscreteProbabilityHelper::GetElement(t1, iElement) - mean1);
         const float diff2(LArDiscreteProbabilityHelper::GetElement(t2, iElement) - mean2);
 
-        variance1 += diff1*diff1;
-        variance2 += diff2*diff2;
-        covariance += diff1*diff2;
+        variance1 += diff1 * diff1;
+        variance2 += diff2 * diff2;
+        covariance += diff1 * diff2;
     }
 
     if (variance1 < std::numeric_limits<float>::epsilon() || variance2 < std::numeric_limits<float>::epsilon())
         throw pandora::StatusCodeException(pandora::STATUS_CODE_FAILURE);
 
-    const float sqrtVars(std::sqrt(variance1*variance2));
-    if(sqrtVars < std::numeric_limits<float>::epsilon())
+    const float sqrtVars(std::sqrt(variance1 * variance2));
+    if (sqrtVars < std::numeric_limits<float>::epsilon())
         throw pandora::StatusCodeException(pandora::STATUS_CODE_FAILURE);
 
     return covariance / sqrtVars;
@@ -116,18 +117,22 @@ float LArDiscreteProbabilityHelper::CalculateMean(const T &t)
 
     float mean(0.f);
     for (unsigned int iElement = 0; iElement < size; ++iElement)
-        mean+=LArDiscreteProbabilityHelper::GetElement(t,iElement);
+        mean += LArDiscreteProbabilityHelper::GetElement(t, iElement);
 
     return mean / static_cast<float>(size);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPermutationTest(const DiscreteProbabilityVector &, const DiscreteProbabilityVector &, std::mt19937 &, const unsigned int);
-template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPermutationTest(const pandora::FloatVector &, const pandora::FloatVector &, std::mt19937 &, const unsigned int);
+template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPermutationTest(
+    const DiscreteProbabilityVector &, const DiscreteProbabilityVector &, std::mt19937 &, const unsigned int);
+template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPermutationTest(
+    const pandora::FloatVector &, const pandora::FloatVector &, std::mt19937 &, const unsigned int);
 
-template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromStudentTDistribution(const DiscreteProbabilityVector &, const DiscreteProbabilityVector &, const unsigned int, const float);
-template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromStudentTDistribution(const pandora::FloatVector &, const pandora::FloatVector &, const unsigned int, const float);
+template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromStudentTDistribution(
+    const DiscreteProbabilityVector &, const DiscreteProbabilityVector &, const unsigned int, const float);
+template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromStudentTDistribution(
+    const pandora::FloatVector &, const pandora::FloatVector &, const unsigned int, const float);
 
 template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficient(const DiscreteProbabilityVector &, const DiscreteProbabilityVector &);
 template float LArDiscreteProbabilityHelper::CalculateCorrelationCoefficient(const pandora::FloatVector &, const pandora::FloatVector &);

--- a/larpandoracontent/LArHelpers/LArDiscreteProbabilityHelper.h
+++ b/larpandoracontent/LArHelpers/LArDiscreteProbabilityHelper.h
@@ -33,8 +33,8 @@ public:
      *  @return the p-value
      */
     template <typename T>
-    static float CalculateCorrelationCoefficientPValueFromPermutationTest(const T &t1, const T &t2, 
-        std::mt19937 &randomNumberGenerator, const unsigned int nPermutations);
+    static float CalculateCorrelationCoefficientPValueFromPermutationTest(
+        const T &t1, const T &t2, std::mt19937 &randomNumberGenerator, const unsigned int nPermutations);
 
     /**
      *  @brief  Calculate P value for measured correlation coefficient between two datasets via a integrating the student T dist.
@@ -47,8 +47,8 @@ public:
      *  @return the p-value
      */
     template <typename T>
-    static float CalculateCorrelationCoefficientPValueFromStudentTDistribution(const T &t1, const T &t2, 
-        const unsigned int nIntegrationSteps, const float upperLimit);
+    static float CalculateCorrelationCoefficientPValueFromStudentTDistribution(
+        const T &t1, const T &t2, const unsigned int nIntegrationSteps, const float upperLimit);
 
     /**
      *  @brief  Calculate the correlation coefficient between two datasets 
@@ -149,14 +149,12 @@ inline std::vector<T> LArDiscreteProbabilityHelper::MakeRandomisedSample(const s
 }
 
 template <>
-inline DiscreteProbabilityVector LArDiscreteProbabilityHelper::MakeRandomisedSample(const DiscreteProbabilityVector &t, 
-    std::mt19937 &randomNumberGenerator)
+inline DiscreteProbabilityVector LArDiscreteProbabilityHelper::MakeRandomisedSample(const DiscreteProbabilityVector &t, std::mt19937 &randomNumberGenerator)
 {
-    return DiscreteProbabilityVector(t,randomNumberGenerator);
+    return DiscreteProbabilityVector(t, randomNumberGenerator);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
-
 
 template <typename T>
 inline unsigned int LArDiscreteProbabilityHelper::GetSize(const std::vector<T> &t)
@@ -165,21 +163,21 @@ inline unsigned int LArDiscreteProbabilityHelper::GetSize(const std::vector<T> &
 }
 
 template <>
-inline unsigned int LArDiscreteProbabilityHelper::GetSize(const DiscreteProbabilityVector& t)
+inline unsigned int LArDiscreteProbabilityHelper::GetSize(const DiscreteProbabilityVector &t)
 {
     return t.GetSize();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 inline float LArDiscreteProbabilityHelper::GetElement(const std::vector<T> &t, const unsigned int index)
 {
     return static_cast<float>(t.at(index));
 }
 
 template <>
-inline float LArDiscreteProbabilityHelper::GetElement(const DiscreteProbabilityVector& t, const unsigned int index)
+inline float LArDiscreteProbabilityHelper::GetElement(const DiscreteProbabilityVector &t, const unsigned int index)
 {
     return static_cast<float>(t.GetProbability(index));
 }

--- a/larpandoracontent/LArHelpers/LArFileHelper.cc
+++ b/larpandoracontent/LArHelpers/LArFileHelper.cc
@@ -38,7 +38,8 @@ std::string LArFileHelper::FindFileInPath(const std::string &unqualifiedFileName
             return qualifiedFileNameAttempt;
     }
 
-    std::cout << "Unable to find file  " << unqualifiedFileName << " in any path specified by environment variable " << environmentVariable << ", delimiter " << delimiter << std::endl;
+    std::cout << "Unable to find file  " << unqualifiedFileName << " in any path specified by environment variable " << environmentVariable
+              << ", delimiter " << delimiter << std::endl;
     throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 }
 

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.cc
@@ -163,7 +163,7 @@ void LArFormattingHelper::Table::PrintTableElements() const
     if (m_columnTitles.empty())
         return;
 
-    const unsigned int nRows((m_elements.size() + m_columnTitles.size() - 1)/m_columnTitles.size());
+    const unsigned int nRows((m_elements.size() + m_columnTitles.size() - 1) / m_columnTitles.size());
     const unsigned int nColumns(m_columnTitles.size());
     if (nRows * nColumns != m_elements.size())
     {
@@ -185,7 +185,8 @@ void LArFormattingHelper::Table::PrintTableCell(const std::string &value, const 
     const unsigned int column(index % m_widths.size());
 
     const std::string separator(this->IsSeparatorColumn(column) ? "" : " ");
-    std::cout << "|" << format << separator << std::setw(m_widths[column]) << std::internal << value << separator << std::resetiosflags(std::ios::adjustfield);
+    std::cout << "|" << format << separator << std::setw(m_widths[column]) << std::internal << value << separator
+              << std::resetiosflags(std::ios::adjustfield);
     LArFormattingHelper::ResetStyle();
 
     if (column == m_columnTitles.size() - 1)

--- a/larpandoracontent/LArHelpers/LArFormattingHelper.h
+++ b/larpandoracontent/LArHelpers/LArFormattingHelper.h
@@ -134,7 +134,7 @@ public:
          * @param  columnTitles the string columns titles use empty string for a separator column
          * @param  precision the number of significant figures to display for number type table elements
          */
-        Table(const pandora::StringVector &columnTitles, const unsigned int precision=3);
+        Table(const pandora::StringVector &columnTitles, const unsigned int precision = 3);
 
         /**
          * @brief  Print the table
@@ -148,8 +148,8 @@ public:
          * @param  style the style of the element
          * @param  color the color of the element
          */
-        template<typename T>
-        void AddElement(const T &value, const Style style=REGULAR, const Color color=DEFAULT);
+        template <typename T>
+        void AddElement(const T &value, const Style style = REGULAR, const Color color = DEFAULT);
 
     private:
         /**
@@ -202,18 +202,18 @@ public:
          */
         void UpdateColumnWidth();
 
-        const pandora::StringVector     m_columnTitles;     ///< The vector of columns titles in the table
-        const unsigned int              m_precision;        ///< The number of significant figures to use when displaying number types
-        pandora::StringVector           m_elements;         ///< The vector of flattened table elements
-        pandora::StringVector           m_format;           ///< The formatting of each table element
-        std::vector<unsigned int>       m_widths;           ///< The widths of each column (in units of number of characters)
-        std::stringstream               m_stringstream;     ///< The stringstream to print objects to
+        const pandora::StringVector m_columnTitles; ///< The vector of columns titles in the table
+        const unsigned int m_precision;             ///< The number of significant figures to use when displaying number types
+        pandora::StringVector m_elements;           ///< The vector of flattened table elements
+        pandora::StringVector m_format;             ///< The formatting of each table element
+        std::vector<unsigned int> m_widths;         ///< The widths of each column (in units of number of characters)
+        std::stringstream m_stringstream;           ///< The stringstream to print objects to
     };
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 inline void LArFormattingHelper::Table::AddElement(const T &value, const Style style, const Color color)
 {
     this->CheckAndSetSeparatorColumn();

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -6,8 +6,8 @@
  *  $Log: $
  */
 
-#include "Managers/PluginManager.h"
 #include "Managers/GeometryManager.h"
+#include "Managers/PluginManager.h"
 
 #include "Geometry/DetectorGap.h"
 #include "Geometry/LArTPC.h"
@@ -68,8 +68,8 @@ float LArGeometryHelper::MergeTwoPositions(const Pandora &pandora, const HitType
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-CartesianVector LArGeometryHelper::MergeTwoDirections(const Pandora &pandora, const HitType view1, const HitType view2,
-    const CartesianVector &direction1, const CartesianVector &direction2)
+CartesianVector LArGeometryHelper::MergeTwoDirections(
+    const Pandora &pandora, const HitType view1, const HitType view2, const CartesianVector &direction1, const CartesianVector &direction2)
 {
     // x components must be consistent
     if (direction1.GetX() * direction2.GetX() < 0.f)
@@ -84,32 +84,44 @@ CartesianVector LArGeometryHelper::MergeTwoDirections(const Pandora &pandora, co
 
     if ((view1 == TPC_VIEW_U) && (view2 == TPC_VIEW_V))
     {
-        pU = s1 * direction1.GetZ(); pV = s2 * direction2.GetZ(); newView = TPC_VIEW_W;
+        pU = s1 * direction1.GetZ();
+        pV = s2 * direction2.GetZ();
+        newView = TPC_VIEW_W;
     }
 
     if ((view1 == TPC_VIEW_V) && (view2 == TPC_VIEW_U))
     {
-        pV = s1 * direction1.GetZ(); pU = s2 * direction2.GetZ(); newView = TPC_VIEW_W;
+        pV = s1 * direction1.GetZ();
+        pU = s2 * direction2.GetZ();
+        newView = TPC_VIEW_W;
     }
 
     if ((view1 == TPC_VIEW_W) && (view2 == TPC_VIEW_U))
     {
-        pW = s1 * direction1.GetZ(); pU = s2 * direction2.GetZ(); newView = TPC_VIEW_V;
+        pW = s1 * direction1.GetZ();
+        pU = s2 * direction2.GetZ();
+        newView = TPC_VIEW_V;
     }
 
     if ((view1 == TPC_VIEW_U) && (view2 == TPC_VIEW_W))
     {
-        pU = s1 * direction1.GetZ(); pW = s2 * direction2.GetZ(); newView = TPC_VIEW_V;
+        pU = s1 * direction1.GetZ();
+        pW = s2 * direction2.GetZ();
+        newView = TPC_VIEW_V;
     }
 
     if ((view1 == TPC_VIEW_V) && (view2 == TPC_VIEW_W))
     {
-        pV = s1 * direction1.GetZ(); pW = s2 * direction2.GetZ(); newView = TPC_VIEW_U;
+        pV = s1 * direction1.GetZ();
+        pW = s2 * direction2.GetZ();
+        newView = TPC_VIEW_U;
     }
 
     if ((view1 == TPC_VIEW_W) && (view2 == TPC_VIEW_V))
     {
-        pW = s1 * direction1.GetZ(); pV = s2 * direction2.GetZ(); newView = TPC_VIEW_U;
+        pW = s1 * direction1.GetZ();
+        pV = s2 * direction2.GetZ();
+        newView = TPC_VIEW_U;
     }
 
     if (newView == TPC_VIEW_W)
@@ -126,13 +138,13 @@ CartesianVector LArGeometryHelper::MergeTwoDirections(const Pandora &pandora, co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArGeometryHelper::MergeTwoPositions(const Pandora &pandora, const HitType view1, const HitType view2, const CartesianVector &position1,
-    const CartesianVector &position2, CartesianVector &position3, float& chiSquared)
+void LArGeometryHelper::MergeTwoPositions(const Pandora &pandora, const HitType view1, const HitType view2,
+    const CartesianVector &position1, const CartesianVector &position2, CartesianVector &position3, float &chiSquared)
 {
     if (view1 == view2)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-    const float X3((position1.GetX() + position2.GetX() ) / 2.f);
+    const float X3((position1.GetX() + position2.GetX()) / 2.f);
     const float Z1(position1.GetZ());
     const float Z2(position2.GetZ());
     const float Z3(LArGeometryHelper::MergeTwoPositions(pandora, view1, view2, Z1, Z2));
@@ -145,7 +157,7 @@ void LArGeometryHelper::MergeTwoPositions(const Pandora &pandora, const HitType 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArGeometryHelper::MergeTwoPositions(const Pandora &pandora, const HitType view1, const HitType view2, const CartesianVector &position1,
-    const CartesianVector &position2, CartesianVector &outputU, CartesianVector &outputV, CartesianVector &outputW, float& chiSquared)
+    const CartesianVector &position2, CartesianVector &outputU, CartesianVector &outputV, CartesianVector &outputW, float &chiSquared)
 {
     if (view1 == view2)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -158,37 +170,49 @@ void LArGeometryHelper::MergeTwoPositions(const Pandora &pandora, const HitType 
 
     if ((view1 == TPC_VIEW_U) && (view2 == TPC_VIEW_V))
     {
-        aveU = Z1; aveV = Z2; aveW = Z3;
+        aveU = Z1;
+        aveV = Z2;
+        aveW = Z3;
     }
 
     if ((view1 == TPC_VIEW_V) && (view2 == TPC_VIEW_W))
     {
-        aveV = Z1; aveW = Z2; aveU = Z3;
+        aveV = Z1;
+        aveW = Z2;
+        aveU = Z3;
     }
 
     if ((view1 == TPC_VIEW_W) && (view2 == TPC_VIEW_U))
     {
-        aveW = Z1; aveU = Z2; aveV = Z3;
+        aveW = Z1;
+        aveU = Z2;
+        aveV = Z3;
     }
 
     if ((view1 == TPC_VIEW_V) && (view2 == TPC_VIEW_U))
     {
-        aveV = Z1; aveU = Z2; aveW = Z3;
+        aveV = Z1;
+        aveU = Z2;
+        aveW = Z3;
     }
 
     if ((view1 == TPC_VIEW_W) && (view2 == TPC_VIEW_V))
     {
-        aveW = Z1; aveV = Z2; aveU = Z3;
+        aveW = Z1;
+        aveV = Z2;
+        aveU = Z3;
     }
 
     if ((view1 == TPC_VIEW_U) && (view2 == TPC_VIEW_W))
     {
-        aveU = Z1; aveW = Z2; aveV = Z3;
+        aveU = Z1;
+        aveW = Z2;
+        aveV = Z3;
     }
 
-    outputU.SetValues( aveX, 0.f, aveU );
-    outputV.SetValues( aveX, 0.f, aveV );
-    outputW.SetValues( aveX, 0.f, aveW );
+    outputU.SetValues(aveX, 0.f, aveU);
+    outputV.SetValues(aveX, 0.f, aveV);
+    outputW.SetValues(aveX, 0.f, aveW);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -207,7 +231,7 @@ void LArGeometryHelper::MergeThreePositions(const Pandora &pandora, const HitTyp
 
     if ((view1 == TPC_VIEW_V) && (view2 == TPC_VIEW_W))
     {
-        return LArGeometryHelper::MergeThreePositions(pandora, position3, position1, position2, outputU, outputV, outputW, chiSquared );
+        return LArGeometryHelper::MergeThreePositions(pandora, position3, position1, position2, outputU, outputV, outputW, chiSquared);
     }
 
     if ((view1 == TPC_VIEW_W) && (view2 == TPC_VIEW_U))
@@ -262,23 +286,24 @@ void LArGeometryHelper::MergeThreePositions(const Pandora &pandora, const Cartes
 
     const float sigmaUVW(LArGeometryHelper::GetSigmaUVW(pandora));
     chiSquared = ((outputU.GetX() - positionU.GetX()) * (outputU.GetX() - positionU.GetX()) +
-        (outputV.GetX() - positionV.GetX()) * (outputV.GetX() - positionV.GetX()) +
-        (outputW.GetX() - positionW.GetX()) * (outputW.GetX() - positionW.GetX()) +
-        (outputU.GetZ() - positionU.GetZ()) * (outputU.GetZ() - positionU.GetZ()) +
-        (outputV.GetZ() - positionV.GetZ()) * (outputV.GetZ() - positionV.GetZ()) +
-        (outputW.GetZ() - positionW.GetZ()) * (outputW.GetZ() - positionW.GetZ())) / (sigmaUVW * sigmaUVW);
+                     (outputV.GetX() - positionV.GetX()) * (outputV.GetX() - positionV.GetX()) +
+                     (outputW.GetX() - positionW.GetX()) * (outputW.GetX() - positionW.GetX()) +
+                     (outputU.GetZ() - positionU.GetZ()) * (outputU.GetZ() - positionU.GetZ()) +
+                     (outputV.GetZ() - positionV.GetZ()) * (outputV.GetZ() - positionV.GetZ()) +
+                     (outputW.GetZ() - positionW.GetZ()) * (outputW.GetZ() - positionW.GetZ())) /
+                 (sigmaUVW * sigmaUVW);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArGeometryHelper::MergeTwoPositions3D(const Pandora &pandora, const HitType view1, const HitType view2, const CartesianVector &position1,
-    const CartesianVector &position2, CartesianVector &position3D, float &chiSquared)
+void LArGeometryHelper::MergeTwoPositions3D(const Pandora &pandora, const HitType view1, const HitType view2,
+    const CartesianVector &position1, const CartesianVector &position2, CartesianVector &position3D, float &chiSquared)
 {
     CartesianVector positionU(0.f, 0.f, 0.f), positionV(0.f, 0.f, 0.f), positionW(0.f, 0.f, 0.f);
     LArGeometryHelper::MergeTwoPositions(pandora, view1, view2, position1, position2, positionU, positionV, positionW, chiSquared);
 
-    position3D.SetValues(positionW.GetX(), pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoY(positionU.GetZ(),positionV.GetZ()),
-        pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoZ(positionU.GetZ(),positionV.GetZ()) );
+    position3D.SetValues(positionW.GetX(), pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoY(positionU.GetZ(), positionV.GetZ()),
+        pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoZ(positionU.GetZ(), positionV.GetZ()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -289,8 +314,8 @@ void LArGeometryHelper::MergeThreePositions3D(const Pandora &pandora, const HitT
     CartesianVector positionU(0.f, 0.f, 0.f), positionV(0.f, 0.f, 0.f), positionW(0.f, 0.f, 0.f);
     LArGeometryHelper::MergeThreePositions(pandora, view1, view2, view3, position1, position2, position3, positionU, positionV, positionW, chiSquared);
 
-    position3D.SetValues(positionW.GetX(), pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoY(positionU.GetZ(),positionV.GetZ()),
-        pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoZ(positionU.GetZ(),positionV.GetZ()));
+    position3D.SetValues(positionW.GetX(), pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoY(positionU.GetZ(), positionV.GetZ()),
+        pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoZ(positionU.GetZ(), positionV.GetZ()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -299,17 +324,20 @@ CartesianVector LArGeometryHelper::ProjectPosition(const Pandora &pandora, const
 {
     if (view == TPC_VIEW_U)
     {
-        return CartesianVector(position3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoU(position3D.GetY(), position3D.GetZ()));
+        return CartesianVector(
+            position3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoU(position3D.GetY(), position3D.GetZ()));
     }
 
     else if (view == TPC_VIEW_V)
     {
-        return CartesianVector(position3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoV(position3D.GetY(), position3D.GetZ()));
+        return CartesianVector(
+            position3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoV(position3D.GetY(), position3D.GetZ()));
     }
 
     else if (view == TPC_VIEW_W)
     {
-        return CartesianVector(position3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(position3D.GetY(), position3D.GetZ()));
+        return CartesianVector(
+            position3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(position3D.GetY(), position3D.GetZ()));
     }
 
     throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -321,17 +349,23 @@ CartesianVector LArGeometryHelper::ProjectDirection(const Pandora &pandora, cons
 {
     if (view == TPC_VIEW_U)
     {
-        return CartesianVector(direction3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoU(direction3D.GetY(), direction3D.GetZ())).GetUnitVector();
+        return CartesianVector(
+            direction3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoU(direction3D.GetY(), direction3D.GetZ()))
+            .GetUnitVector();
     }
 
     else if (view == TPC_VIEW_V)
     {
-        return CartesianVector(direction3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoV(direction3D.GetY(), direction3D.GetZ())).GetUnitVector();
+        return CartesianVector(
+            direction3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoV(direction3D.GetY(), direction3D.GetZ()))
+            .GetUnitVector();
     }
 
     else if (view == TPC_VIEW_W)
     {
-        return CartesianVector(direction3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(direction3D.GetY(), direction3D.GetZ())).GetUnitVector();
+        return CartesianVector(
+            direction3D.GetX(), 0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(direction3D.GetY(), direction3D.GetZ()))
+            .GetUnitVector();
     }
 
     throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -353,12 +387,14 @@ float LArGeometryHelper::GetWirePitch(const Pandora &pandora, const HitType view
     }
 
     const LArTPC *const pFirstLArTPC(larTPCMap.begin()->second);
-    const float wirePitch(view == TPC_VIEW_U ? pFirstLArTPC->GetWirePitchU() : (view == TPC_VIEW_V ? pFirstLArTPC->GetWirePitchV() : pFirstLArTPC->GetWirePitchW()));
+    const float wirePitch(view == TPC_VIEW_U ? pFirstLArTPC->GetWirePitchU()
+                                             : (view == TPC_VIEW_V ? pFirstLArTPC->GetWirePitchV() : pFirstLArTPC->GetWirePitchW()));
 
     for (const LArTPCMap::value_type &mapEntry : larTPCMap)
     {
         const LArTPC *const pLArTPC(mapEntry.second);
-        const float alternateWirePitch(view == TPC_VIEW_U ? pLArTPC->GetWirePitchU() : (view == TPC_VIEW_V ? pLArTPC->GetWirePitchV() : pLArTPC->GetWirePitchW()));
+        const float alternateWirePitch(
+            view == TPC_VIEW_U ? pLArTPC->GetWirePitchU() : (view == TPC_VIEW_V ? pLArTPC->GetWirePitchV() : pLArTPC->GetWirePitchW()));
 
         if (std::fabs(wirePitch - alternateWirePitch) > maxWirePitchDiscrepancy)
         {
@@ -376,22 +412,19 @@ CartesianVector LArGeometryHelper::GetWireAxis(const Pandora &pandora, const Hit
 {
     if (view == TPC_VIEW_U)
     {
-        return CartesianVector(0.f,
-            pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoU(1.f, 0.f),
+        return CartesianVector(0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoU(1.f, 0.f),
             pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoU(0.f, 1.f));
     }
 
     else if (view == TPC_VIEW_V)
     {
-        return CartesianVector(0.f,
-            pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoV(1.f, 0.f),
+        return CartesianVector(0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoV(1.f, 0.f),
             pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoV(0.f, 1.f));
     }
 
     else if (view == TPC_VIEW_W)
     {
-        return CartesianVector(0.f,
-            pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(1.f, 0.f),
+        return CartesianVector(0.f, pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(1.f, 0.f),
             pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(0.f, 1.f));
     }
 
@@ -407,8 +440,8 @@ void LArGeometryHelper::GetCommonDaughterVolumes(const Cluster *const pCluster1,
     LArClusterHelper::GetDaughterVolumeIDs(pCluster1, daughterVolumeIds1);
     LArClusterHelper::GetDaughterVolumeIDs(pCluster2, daughterVolumeIds2);
 
-    std::set_intersection(daughterVolumeIds1.begin(), daughterVolumeIds1.end(), daughterVolumeIds2.begin(), daughterVolumeIds2.end(), 
-                          std::inserter(intersect, intersect.begin())); 
+    std::set_intersection(daughterVolumeIds1.begin(), daughterVolumeIds1.end(), daughterVolumeIds2.begin(), daughterVolumeIds2.end(),
+        std::inserter(intersect, intersect.begin()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -435,8 +468,7 @@ bool LArGeometryHelper::IsInGap3D(const Pandora &pandora, const CartesianVector 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool LArGeometryHelper::IsXSamplingPointInGap(const Pandora &pandora, const float xSample, const TwoDSlidingFitResult &slidingFitResult,
-    const float gapTolerance)
+bool LArGeometryHelper::IsXSamplingPointInGap(const Pandora &pandora, const float xSample, const TwoDSlidingFitResult &slidingFitResult, const float gapTolerance)
 {
     const HitType hitType(LArClusterHelper::GetClusterHitType(slidingFitResult.GetCluster()));
     const CartesianVector minLayerPosition(slidingFitResult.GetGlobalMinLayerPosition());
@@ -454,8 +486,10 @@ bool LArGeometryHelper::IsXSamplingPointInGap(const Pandora &pandora, const floa
             return (LArGeometryHelper::IsInGap(pandora, slidingFitPosition, hitType, gapTolerance));
     }
 
-    const CartesianVector lowXDirection(minLayerIsAtLowX ? slidingFitResult.GetGlobalMinLayerDirection() : slidingFitResult.GetGlobalMaxLayerDirection());
-    const CartesianVector highXDirection(minLayerIsAtLowX ? slidingFitResult.GetGlobalMaxLayerDirection() : slidingFitResult.GetGlobalMinLayerDirection());
+    const CartesianVector lowXDirection(
+        minLayerIsAtLowX ? slidingFitResult.GetGlobalMinLayerDirection() : slidingFitResult.GetGlobalMaxLayerDirection());
+    const CartesianVector highXDirection(
+        minLayerIsAtLowX ? slidingFitResult.GetGlobalMaxLayerDirection() : slidingFitResult.GetGlobalMinLayerDirection());
 
     const bool sampleIsNearerToLowX(std::fabs(xSample - lowXCoordinate.GetX()) < std::fabs(xSample - highXCoordinate.GetX()));
     const CartesianVector &startPosition(sampleIsNearerToLowX ? lowXCoordinate : highXCoordinate);
@@ -481,16 +515,15 @@ float LArGeometryHelper::CalculateGapDeltaZ(const Pandora &pandora, const float 
 
     for (const DetectorGap *const pDetectorGap : pandora.GetGeometry()->GetDetectorGapList())
     {
-        const LineGap *const pLineGap = dynamic_cast<const LineGap*>(pDetectorGap);
+        const LineGap *const pLineGap = dynamic_cast<const LineGap *>(pDetectorGap);
 
         if (!pLineGap)
             throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
         const LineGapType lineGapType(pLineGap->GetLineGapType());
 
-        if (!(((TPC_VIEW_U == hitType) && (TPC_WIRE_GAP_VIEW_U == lineGapType)) ||
-              ((TPC_VIEW_V == hitType) && (TPC_WIRE_GAP_VIEW_V == lineGapType)) ||
-              ((TPC_VIEW_W == hitType) && (TPC_WIRE_GAP_VIEW_W == lineGapType))))
+        if (!(((TPC_VIEW_U == hitType) && (TPC_WIRE_GAP_VIEW_U == lineGapType)) || ((TPC_VIEW_V == hitType) && (TPC_WIRE_GAP_VIEW_V == lineGapType)) ||
+                ((TPC_VIEW_W == hitType) && (TPC_WIRE_GAP_VIEW_W == lineGapType))))
         {
             continue;
         }

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -13,7 +13,11 @@
 
 #include <unordered_map>
 
-namespace pandora {class CartesianVector; class Pandora;}
+namespace pandora
+{
+class CartesianVector;
+class Pandora;
+} // namespace pandora
 
 namespace lar_content
 {
@@ -28,7 +32,6 @@ class TwoDSlidingFitResult;
 class LArGeometryHelper
 {
 public:
-
     typedef std::set<unsigned int> UIntSet;
 
     /**
@@ -67,8 +70,7 @@ public:
      *  @param  chi-squared
      */
     static void MergeTwoPositions(const pandora::Pandora &pandora, const pandora::HitType view1, const pandora::HitType view2,
-        const pandora::CartesianVector &position1, const pandora::CartesianVector &position2, pandora::CartesianVector &position3,
-        float &chiSquared);
+        const pandora::CartesianVector &position1, const pandora::CartesianVector &position2, pandora::CartesianVector &position3, float &chiSquared);
 
     /**
      *  @brief  Merge 2D positions from two views to give 2D position in third view
@@ -135,8 +137,7 @@ public:
      *  @param  chi-squared
      */
     static void MergeTwoPositions3D(const pandora::Pandora &pandora, const pandora::HitType view1, const pandora::HitType view2,
-        const pandora::CartesianVector &position1, const pandora::CartesianVector &position2, pandora::CartesianVector &position3D,
-        float &chiSquared);
+        const pandora::CartesianVector &position1, const pandora::CartesianVector &position2, pandora::CartesianVector &position3D, float &chiSquared);
 
     /**
      *  @brief  Merge 2D positions from three views to give unified 3D position
@@ -162,8 +163,8 @@ public:
      *  @param  position3D the position in 3D
      *  @param  view the 2D projection
      */
-    static pandora::CartesianVector ProjectPosition(const pandora::Pandora &pandora, const pandora::CartesianVector &position3D,
-        const pandora::HitType view);
+    static pandora::CartesianVector ProjectPosition(
+        const pandora::Pandora &pandora, const pandora::CartesianVector &position3D, const pandora::HitType view);
 
     /**
      *  @brief  Project 3D direction into a given 2D view
@@ -172,8 +173,8 @@ public:
      *  @param  direction3D the direction in 3D
      *  @param  view the 2D projection
      */
-    static pandora::CartesianVector ProjectDirection(const pandora::Pandora &pandora, const pandora::CartesianVector &direction3D,
-        const pandora::HitType view);
+    static pandora::CartesianVector ProjectDirection(
+        const pandora::Pandora &pandora, const pandora::CartesianVector &direction3D, const pandora::HitType view);
 
     /**
      *  @brief  Return the wire pitch
@@ -199,7 +200,7 @@ public:
      *  @param  view the 2D projection
      */
     static pandora::CartesianVector GetWireAxis(const pandora::Pandora &pandora, const pandora::HitType view);
- 
+
     /**
      *  @brief  Whether a 2D test point lies in a registered gap with the associated hit type
      *
@@ -236,8 +237,8 @@ public:
      *
      *  @return boolean
      */
-    static bool IsXSamplingPointInGap(const pandora::Pandora &pandora, const float xSample, const TwoDSlidingFitResult &slidingFitResult,
-        const float gapTolerance = 0.f);
+    static bool IsXSamplingPointInGap(
+        const pandora::Pandora &pandora, const float xSample, const TwoDSlidingFitResult &slidingFitResult, const float gapTolerance = 0.f);
 
     /**
      *  @brief  Calculate the total distance within a given 2D region that is composed of detector gaps
@@ -264,7 +265,7 @@ public:
      *  @param  pCluster1 the first cluster
      *  @param  pCluster2 the second cluster
      */
-    static void GetCommonDaughterVolumes (const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, UIntSet &intersect);
+    static void GetCommonDaughterVolumes(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, UIntSet &intersect);
 };
 //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandoracontent/LArHelpers/LArHitWidthHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHitWidthHelper.cc
@@ -22,7 +22,7 @@ LArHitWidthHelper::ConstituentHit::ConstituentHit(const CartesianVector &positio
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool LArHitWidthHelper::ConstituentHit::SortByDistanceToPoint::operator() (const ConstituentHit &lhs, const ConstituentHit &rhs)
+bool LArHitWidthHelper::ConstituentHit::SortByDistanceToPoint::operator()(const ConstituentHit &lhs, const ConstituentHit &rhs)
 {
     const CartesianVector &lhsPosition(lhs.GetPositionVector());
     const CartesianVector &rhsPosition(rhs.GetPositionVector());
@@ -33,8 +33,8 @@ bool LArHitWidthHelper::ConstituentHit::SortByDistanceToPoint::operator() (const
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LArHitWidthHelper::ClusterParameters::ClusterParameters(const Cluster *const pCluster, const float maxConstituentHitWidth, const bool isUniformHits,
-        const float hitWidthScalingFactor) :
+LArHitWidthHelper::ClusterParameters::ClusterParameters(
+    const Cluster *const pCluster, const float maxConstituentHitWidth, const bool isUniformHits, const float hitWidthScalingFactor) :
     m_pCluster(pCluster),
     m_numCaloHits(pCluster->GetNCaloHits()),
     m_constituentHitVector(LArHitWidthHelper::GetConstituentHits(pCluster, maxConstituentHitWidth, hitWidthScalingFactor, isUniformHits)),
@@ -47,7 +47,7 @@ LArHitWidthHelper::ClusterParameters::ClusterParameters(const Cluster *const pCl
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHitWidthHelper::ClusterParameters::ClusterParameters(const Cluster *const pCluster, const unsigned int numCaloHits, const float totalWeight,
-        const LArHitWidthHelper::ConstituentHitVector &constituentHitVector, const CartesianVector &lowerXExtrema, const CartesianVector &higherXExtrema) :
+    const LArHitWidthHelper::ConstituentHitVector &constituentHitVector, const CartesianVector &lowerXExtrema, const CartesianVector &higherXExtrema) :
     m_pCluster(pCluster),
     m_numCaloHits(numCaloHits),
     m_constituentHitVector(constituentHitVector),
@@ -60,10 +60,10 @@ LArHitWidthHelper::ClusterParameters::ClusterParameters(const Cluster *const pCl
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool LArHitWidthHelper::SortByHigherXExtrema::operator() (const Cluster *const pLhs, const Cluster *const pRhs)
+bool LArHitWidthHelper::SortByHigherXExtrema::operator()(const Cluster *const pLhs, const Cluster *const pRhs)
 {
-    const LArHitWidthHelper::ClusterParameters& lhsClusterParameters(LArHitWidthHelper::GetClusterParameters(pLhs, m_clusterToParametersMap));
-    const LArHitWidthHelper::ClusterParameters& rhsClusterParameters(LArHitWidthHelper::GetClusterParameters(pRhs, m_clusterToParametersMap));
+    const LArHitWidthHelper::ClusterParameters &lhsClusterParameters(LArHitWidthHelper::GetClusterParameters(pLhs, m_clusterToParametersMap));
+    const LArHitWidthHelper::ClusterParameters &rhsClusterParameters(LArHitWidthHelper::GetClusterParameters(pRhs, m_clusterToParametersMap));
 
     return (lhsClusterParameters.GetHigherXExtrema().GetX() < rhsClusterParameters.GetHigherXExtrema().GetX());
 }
@@ -71,7 +71,8 @@ bool LArHitWidthHelper::SortByHigherXExtrema::operator() (const Cluster *const p
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const LArHitWidthHelper::ClusterParameters& LArHitWidthHelper::GetClusterParameters(const Cluster *const pCluster, const ClusterToParametersMap &clusterToParametersMap)
+const LArHitWidthHelper::ClusterParameters &LArHitWidthHelper::GetClusterParameters(
+    const Cluster *const pCluster, const ClusterToParametersMap &clusterToParametersMap)
 {
     if (clusterToParametersMap.empty())
         throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
@@ -86,8 +87,7 @@ const LArHitWidthHelper::ClusterParameters& LArHitWidthHelper::GetClusterParamet
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-unsigned int LArHitWidthHelper::GetNProposedConstituentHits(const Cluster *const pCluster, const float maxConstituentHitWidth,
-    const float hitWidthScalingFactor)
+unsigned int LArHitWidthHelper::GetNProposedConstituentHits(const Cluster *const pCluster, const float maxConstituentHitWidth, const float hitWidthScalingFactor)
 {
     if (maxConstituentHitWidth < std::numeric_limits<float>::epsilon())
     {
@@ -117,8 +117,8 @@ unsigned int LArHitWidthHelper::GetNProposedConstituentHits(const Cluster *const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LArHitWidthHelper::ConstituentHitVector LArHitWidthHelper::GetConstituentHits(const Cluster *const pCluster, const float maxConstituentHitWidth,
-    const float hitWidthScalingFactor, const bool isUniform)
+LArHitWidthHelper::ConstituentHitVector LArHitWidthHelper::GetConstituentHits(
+    const Cluster *const pCluster, const float maxConstituentHitWidth, const float hitWidthScalingFactor, const bool isUniform)
 {
     if (maxConstituentHitWidth < std::numeric_limits<float>::epsilon())
     {
@@ -155,8 +155,8 @@ LArHitWidthHelper::ConstituentHitVector LArHitWidthHelper::GetConstituentHits(co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArHitWidthHelper::SplitHitIntoConstituents(const CaloHit *const pCaloHit, const Cluster *const pCluster, const unsigned int numberOfConstituentHits,
-    const float constituentHitWidth, LArHitWidthHelper::ConstituentHitVector &constituentHitVector)
+void LArHitWidthHelper::SplitHitIntoConstituents(const CaloHit *const pCaloHit, const Cluster *const pCluster,
+    const unsigned int numberOfConstituentHits, const float constituentHitWidth, LArHitWidthHelper::ConstituentHitVector &constituentHitVector)
 {
     const CartesianVector &hitCenter(pCaloHit->GetPositionVector());
     const bool isOdd(numberOfConstituentHits % 2 == 1);
@@ -183,7 +183,8 @@ void LArHitWidthHelper::SplitHitIntoConstituents(const CaloHit *const pCaloHit, 
             xDistanceFromCenter += constituentHitWidth;
         }
 
-        CartesianVector positivePosition(hitCenter + CartesianVector(xDistanceFromCenter, 0.f, 0.f)), negativePosition(hitCenter - CartesianVector(xDistanceFromCenter, 0.f, 0.f));
+        CartesianVector positivePosition(hitCenter + CartesianVector(xDistanceFromCenter, 0.f, 0.f)),
+            negativePosition(hitCenter - CartesianVector(xDistanceFromCenter, 0.f, 0.f));
 
         constituentHitVector.push_back(ConstituentHit(positivePosition, constituentHitWidth, pCluster));
         constituentHitVector.push_back(ConstituentHit(negativePosition, constituentHitWidth, pCluster));
@@ -251,8 +252,8 @@ CartesianVector LArHitWidthHelper::GetExtremalCoordinatesHigherX(const Constitue
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArHitWidthHelper::GetExtremalCoordinatesX(const ConstituentHitVector &constituentHitVector, CartesianVector &lowerXCoordinate,
-    CartesianVector &higherXCoordinate)
+void LArHitWidthHelper::GetExtremalCoordinatesX(
+    const ConstituentHitVector &constituentHitVector, CartesianVector &lowerXCoordinate, CartesianVector &higherXCoordinate)
 {
     const CartesianPointVector &constituentHitPositionVector(GetConstituentHitPositionVector(constituentHitVector));
 
@@ -277,7 +278,8 @@ void LArHitWidthHelper::GetExtremalCoordinatesX(const ConstituentHitVector &cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-CartesianVector LArHitWidthHelper::GetClosestPointToLine2D(const CartesianVector &lineStart, const CartesianVector &lineDirection, const CaloHit *const pCaloHit)
+CartesianVector LArHitWidthHelper::GetClosestPointToLine2D(
+    const CartesianVector &lineStart, const CartesianVector &lineDirection, const CaloHit *const pCaloHit)
 {
     const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
 
@@ -294,8 +296,7 @@ CartesianVector LArHitWidthHelper::GetClosestPointToLine2D(const CartesianVector
     const float &hitWidth(pCaloHit->GetCellSize1());
     const float hitLowXEdge(hitPosition.GetX() - (hitWidth * 0.5f));
     const float hitHighXEdge(hitPosition.GetX() + (hitWidth * 0.5f));
-    const float closestPointX(xOnLine < hitLowXEdge ? hitLowXEdge :
-        xOnLine > hitHighXEdge ? hitHighXEdge : xOnLine);
+    const float closestPointX(xOnLine < hitLowXEdge ? hitLowXEdge : xOnLine > hitHighXEdge ? hitHighXEdge : xOnLine);
 
     return CartesianVector(closestPointX, 0.f, hitPosition.GetZ());
 }

--- a/larpandoracontent/LArHelpers/LArHitWidthHelper.h
+++ b/larpandoracontent/LArHelpers/LArHitWidthHelper.h
@@ -37,7 +37,7 @@ public:
         /**
          *  @brief  Returns the constituent hit central position
          */
-        const pandora::CartesianVector& GetPositionVector() const;
+        const pandora::CartesianVector &GetPositionVector() const;
 
         /**
          *  @brief  Returns the constituent hit width
@@ -47,9 +47,9 @@ public:
         /**
          *  @brief  Returns the address of the parent cluster
          */
-        const pandora::Cluster* GetParentClusterAddress() const;
+        const pandora::Cluster *GetParentClusterAddress() const;
 
-         /**
+        /**
           *  @brief  SortByDistanceToPoint class
           */
         class SortByDistanceToPoint
@@ -60,7 +60,9 @@ public:
              *
              *  @param  referencePoint the point relative to which constituent hits are ordered
              */
-            SortByDistanceToPoint(const pandora::CartesianVector referencePoint) : m_referencePoint(referencePoint) {}
+            SortByDistanceToPoint(const pandora::CartesianVector referencePoint) : m_referencePoint(referencePoint)
+            {
+            }
 
             /**
              *  @brief  Sort constituent hits by their position relative to a referencePoint
@@ -70,16 +72,16 @@ public:
              *
              *  @return  whether lhs hit is closer to the referencePoint than the rhs hit
              */
-            bool operator() (const ConstituentHit &lhs, const ConstituentHit &rhs);
+            bool operator()(const ConstituentHit &lhs, const ConstituentHit &rhs);
 
         private:
-            const pandora::CartesianVector m_referencePoint;   ///< The point relative to which constituent hits are ordered
+            const pandora::CartesianVector m_referencePoint; ///< The point relative to which constituent hits are ordered
         };
 
     private:
-        pandora::CartesianVector    m_positionVector;          ///< The central position of the consituent hit
-        float                       m_hitWidth;                ///< The width of the constituent hit
-        const pandora::Cluster     *m_pParentClusterAddress;   ///< The address of the cluster the constituent hit belongs to
+        pandora::CartesianVector m_positionVector;       ///< The central position of the consituent hit
+        float m_hitWidth;                                ///< The width of the constituent hit
+        const pandora::Cluster *m_pParentClusterAddress; ///< The address of the cluster the constituent hit belongs to
     };
 
     typedef std::vector<ConstituentHit> ConstituentHitVector;
@@ -99,7 +101,8 @@ public:
          *          in the non-uniform case constituent hits from different hits may have different weights
          *  @param  hitWidthScalingFactor the constituent hit width scaling factor
          */
-        ClusterParameters(const pandora::Cluster *const pCluster, const float maxConsituentHitWidth, const bool isUniformHits, const float hitWidthScalingFactor);
+        ClusterParameters(const pandora::Cluster *const pCluster, const float maxConsituentHitWidth, const bool isUniformHits,
+            const float hitWidthScalingFactor);
 
         /**
          *  @brief  Constructor
@@ -112,12 +115,13 @@ public:
          *  @param  higherXExtrema the higher x extremal point of the constituent hits
          */
         ClusterParameters(const pandora::Cluster *const pCluster, const unsigned int numCaloHits, const float totalWeight,
-            const ConstituentHitVector &constituentHitVector, const pandora::CartesianVector &lowerXExtrema, const pandora::CartesianVector &higherXExtrema);
+            const ConstituentHitVector &constituentHitVector, const pandora::CartesianVector &lowerXExtrema,
+            const pandora::CartesianVector &higherXExtrema);
 
         /**
          *  @brief  Returns the address of the cluster
          */
-        const pandora::Cluster* GetClusterAddress() const;
+        const pandora::Cluster *GetClusterAddress() const;
 
         /**
          *  @brief  Returns the number of calo hits within the cluster
@@ -132,28 +136,28 @@ public:
         /**
          *  @brief  Returns the vector of constituent hits
          */
-        const ConstituentHitVector& GetConstituentHitVector() const;
+        const ConstituentHitVector &GetConstituentHitVector() const;
 
         /**
          *  @brief  Returns the lower x extremal point of the constituent hits
          */
-        const pandora::CartesianVector& GetLowerXExtrema() const;
+        const pandora::CartesianVector &GetLowerXExtrema() const;
 
         /**
          *  @brief  Returns the higher x extremal point of the constituent hits
          */
-        const pandora::CartesianVector& GetHigherXExtrema() const;
+        const pandora::CartesianVector &GetHigherXExtrema() const;
 
     private:
-        const pandora::Cluster           *m_pCluster;               ///< The address of the cluster
-        const unsigned int                m_numCaloHits;            ///< The number of calo hits within the cluster
-        const ConstituentHitVector        m_constituentHitVector;   ///< The vector of constituent hits
-        const float                       m_totalWeight;            ///< The total hit weight of the contituent hits
-        const pandora::CartesianVector    m_lowerXExtrema;          ///< The lower x extremal point of the constituent hits
-        const pandora::CartesianVector    m_higherXExtrema;         ///< The higher x extremal point of the constituent hits
+        const pandora::Cluster *m_pCluster;                ///< The address of the cluster
+        const unsigned int m_numCaloHits;                  ///< The number of calo hits within the cluster
+        const ConstituentHitVector m_constituentHitVector; ///< The vector of constituent hits
+        const float m_totalWeight;                         ///< The total hit weight of the contituent hits
+        const pandora::CartesianVector m_lowerXExtrema;    ///< The lower x extremal point of the constituent hits
+        const pandora::CartesianVector m_higherXExtrema;   ///< The higher x extremal point of the constituent hits
     };
 
-    typedef std::unordered_map<const pandora::Cluster*, const ClusterParameters> ClusterToParametersMap;
+    typedef std::unordered_map<const pandora::Cluster *, const ClusterParameters> ClusterToParametersMap;
 
     /**
      *  @brief  SortByHigherExtrema class
@@ -176,10 +180,10 @@ public:
          *
          *  @return  whether the pLhs cluster has a lower higherXExtrema than the pRhs cluster
          */
-        bool operator() (const pandora::Cluster *const pLhs, const pandora::Cluster *const pRhs);
+        bool operator()(const pandora::Cluster *const pLhs, const pandora::Cluster *const pRhs);
 
     private:
-        const ClusterToParametersMap& m_clusterToParametersMap;   ///< The map [cluster -> cluster parameters]
+        const ClusterToParametersMap &m_clusterToParametersMap; ///< The map [cluster -> cluster parameters]
     };
 
     /**
@@ -190,7 +194,7 @@ public:
      *
      *  @return  the cluster parameters of the input cluster
      */
-    static const ClusterParameters& GetClusterParameters(const pandora::Cluster *const pCluster, const ClusterToParametersMap &clusterToParametersMap);
+    static const ClusterParameters &GetClusterParameters(const pandora::Cluster *const pCluster, const ClusterToParametersMap &clusterToParametersMap);
 
     /**
      *  @brief  Return the number of constituent hits that a given cluster would be broken into
@@ -201,7 +205,8 @@ public:
      *
      *  @return  the number of constituent hits the cluster would be broken into
      */
-    static unsigned int GetNProposedConstituentHits(const pandora::Cluster *const pCluster, const float maxConstituentHitWidth, const float hitWidthScalingFactor);
+    static unsigned int GetNProposedConstituentHits(
+        const pandora::Cluster *const pCluster, const float maxConstituentHitWidth, const float hitWidthScalingFactor);
 
     /**
      *  @brief  Break up the cluster hits into constituent hits
@@ -214,8 +219,8 @@ public:
      *
      *  @return  the vector of constituent hits
      */
-    static ConstituentHitVector GetConstituentHits(const pandora::Cluster *const pCluster, const float maxConstituentHitWidth, const float hitWidthScalingFactor,
-        const bool isUniform);
+    static ConstituentHitVector GetConstituentHits(
+        const pandora::Cluster *const pCluster, const float maxConstituentHitWidth, const float hitWidthScalingFactor, const bool isUniform);
 
     /**
      *  @brief  Break up the calo hit into constituent hits
@@ -227,8 +232,8 @@ public:
      *  @param  constituentHitVector the input vector to which to add the contituent hits
      *
      */
-    static void SplitHitIntoConstituents(const pandora::CaloHit *const pCaloHit, const pandora::Cluster *const pCluster, const unsigned int numberOfConstituentHits,
-        const float constituentHitWidth, ConstituentHitVector &constituentHitVector);
+    static void SplitHitIntoConstituents(const pandora::CaloHit *const pCaloHit, const pandora::Cluster *const pCluster,
+        const unsigned int numberOfConstituentHits, const float constituentHitWidth, ConstituentHitVector &constituentHitVector);
 
     /**
      *  @brief  Obtain a vector of the contituent hit central positions
@@ -294,8 +299,8 @@ public:
      *
      *  @return  the closest position
      */
-    static pandora::CartesianVector GetClosestPointToLine2D(const pandora::CartesianVector &lineStart, const pandora::CartesianVector &lineDirection,
-        const pandora::CaloHit *const pCaloHit);
+    static pandora::CartesianVector GetClosestPointToLine2D(
+        const pandora::CartesianVector &lineStart, const pandora::CartesianVector &lineDirection, const pandora::CaloHit *const pCaloHit);
 
     /**
      *  @brief  Consider the hit width to find the smallest distance between a calo hit and a given point
@@ -310,7 +315,7 @@ public:
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline const pandora::CartesianVector& LArHitWidthHelper::ConstituentHit::GetPositionVector() const
+inline const pandora::CartesianVector &LArHitWidthHelper::ConstituentHit::GetPositionVector() const
 {
     return m_positionVector;
 }
@@ -324,7 +329,7 @@ inline float LArHitWidthHelper::ConstituentHit::GetHitWidth() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline const pandora::Cluster* LArHitWidthHelper::ConstituentHit::GetParentClusterAddress() const
+inline const pandora::Cluster *LArHitWidthHelper::ConstituentHit::GetParentClusterAddress() const
 {
     return m_pParentClusterAddress;
 }
@@ -332,7 +337,7 @@ inline const pandora::Cluster* LArHitWidthHelper::ConstituentHit::GetParentClust
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline const pandora::Cluster* LArHitWidthHelper::ClusterParameters::GetClusterAddress() const
+inline const pandora::Cluster *LArHitWidthHelper::ClusterParameters::GetClusterAddress() const
 {
     return m_pCluster;
 }
@@ -353,21 +358,21 @@ inline float LArHitWidthHelper::ClusterParameters::GetTotalWeight() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline const LArHitWidthHelper::ConstituentHitVector& LArHitWidthHelper::ClusterParameters::GetConstituentHitVector() const
+inline const LArHitWidthHelper::ConstituentHitVector &LArHitWidthHelper::ClusterParameters::GetConstituentHitVector() const
 {
     return m_constituentHitVector;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline const pandora::CartesianVector& LArHitWidthHelper::ClusterParameters::GetLowerXExtrema() const
+inline const pandora::CartesianVector &LArHitWidthHelper::ClusterParameters::GetLowerXExtrema() const
 {
     return m_lowerXExtrema;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline const pandora::CartesianVector& LArHitWidthHelper::ClusterParameters::GetHigherXExtrema() const
+inline const pandora::CartesianVector &LArHitWidthHelper::ClusterParameters::GetHigherXExtrema() const
 {
     return m_higherXExtrema;
 }

--- a/larpandoracontent/LArHelpers/LArInteractionTypeHelper.cc
+++ b/larpandoracontent/LArHelpers/LArInteractionTypeHelper.cc
@@ -30,22 +30,32 @@ LArInteractionTypeHelper::InteractionType LArInteractionTypeHelper::GetInteracti
 
     if ((1 == mcPrimaryList.size()) && LArMCParticleHelper::IsBeamParticle(mcPrimaryList.front()))
     {
-        if (1 == parameters.m_nMuons) return BEAM_PARTICLE_MU;
-        if (1 == parameters.m_nProtons) return BEAM_PARTICLE_P;
-        if (1 == parameters.m_nElectrons) return BEAM_PARTICLE_E;
-        if (1 == parameters.m_nPhotons) return BEAM_PARTICLE_PHOTON;
-        if (1 == parameters.m_nPiPlus) return BEAM_PARTICLE_PI_PLUS;
-        if (1 == parameters.m_nPiMinus) return BEAM_PARTICLE_PI_MINUS;
-        if (1 == parameters.m_nKaonPlus) return BEAM_PARTICLE_KAON_PLUS;
-        if (1 == parameters.m_nKaonMinus) return BEAM_PARTICLE_KAON_MINUS;
-        else return BEAM_PARTICLE_OTHER;
+        if (1 == parameters.m_nMuons)
+            return BEAM_PARTICLE_MU;
+        if (1 == parameters.m_nProtons)
+            return BEAM_PARTICLE_P;
+        if (1 == parameters.m_nElectrons)
+            return BEAM_PARTICLE_E;
+        if (1 == parameters.m_nPhotons)
+            return BEAM_PARTICLE_PHOTON;
+        if (1 == parameters.m_nPiPlus)
+            return BEAM_PARTICLE_PI_PLUS;
+        if (1 == parameters.m_nPiMinus)
+            return BEAM_PARTICLE_PI_MINUS;
+        if (1 == parameters.m_nKaonPlus)
+            return BEAM_PARTICLE_KAON_PLUS;
+        if (1 == parameters.m_nKaonMinus)
+            return BEAM_PARTICLE_KAON_MINUS;
+        else
+            return BEAM_PARTICLE_OTHER;
     }
 
     const MCParticle *pMCNeutrino(nullptr);
 
     for (const MCParticle *const pMCPrimary : mcPrimaryList)
     {
-        if (!LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCPrimary) || (pMCNeutrino && (pMCNeutrino != LArMCParticleHelper::GetParentMCParticle(pMCPrimary))))
+        if (!LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCPrimary) ||
+            (pMCNeutrino && (pMCNeutrino != LArMCParticleHelper::GetParentMCParticle(pMCPrimary))))
             throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
         pMCNeutrino = LArMCParticleHelper::GetParentMCParticle(pMCPrimary);
@@ -58,196 +68,345 @@ LArInteractionTypeHelper::InteractionType LArInteractionTypeHelper::GetInteracti
 
     if (1001 == nuNuanceCode)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons)) return CCQEL_MU;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons)) return CCQEL_MU_P;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons)) return CCQEL_MU_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons)) return CCQEL_MU_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons)) return CCQEL_MU_P_P_P_P;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons)) return CCQEL_MU_P_P_P_P_P;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons))
+            return CCQEL_MU;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons))
+            return CCQEL_MU_P;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons))
+            return CCQEL_MU_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons))
+            return CCQEL_MU_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons))
+            return CCQEL_MU_P_P_P_P;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons))
+            return CCQEL_MU_P_P_P_P_P;
 
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons)) return CCQEL_E;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons)) return CCQEL_E_P;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons)) return CCQEL_E_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons)) return CCQEL_E_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons)) return CCQEL_E_P_P_P_P;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons)) return CCQEL_E_P_P_P_P_P;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons))
+            return CCQEL_E;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons))
+            return CCQEL_E_P;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons))
+            return CCQEL_E_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons))
+            return CCQEL_E_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons))
+            return CCQEL_E_P_P_P_P;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons))
+            return CCQEL_E_P_P_P_P_P;
     }
 
     if (1002 == nuNuanceCode)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons)) return NCQEL_P;
-        if ((2 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons)) return NCQEL_P_P;
-        if ((3 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons)) return NCQEL_P_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons)) return NCQEL_P_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons)) return NCQEL_P_P_P_P_P;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons))
+            return NCQEL_P;
+        if ((2 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons))
+            return NCQEL_P_P;
+        if ((3 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons))
+            return NCQEL_P_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons))
+            return NCQEL_P_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons))
+            return NCQEL_P_P_P_P_P;
     }
 
     if ((nuNuanceCode >= 1003) && (nuNuanceCode <= 1005))
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons)) return CCRES_MU;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons)) return CCRES_MU_P;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons)) return CCRES_MU_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons)) return CCRES_MU_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons)) return CCRES_MU_P_P_P_P;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons)) return CCRES_MU_P_P_P_P_P;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons))
+            return CCRES_MU;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons))
+            return CCRES_MU_P;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons))
+            return CCRES_MU_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons))
+            return CCRES_MU_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons))
+            return CCRES_MU_P_P_P_P;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons))
+            return CCRES_MU_P_P_P_P_P;
 
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_MU_PIPLUS;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_MU_P_PIPLUS;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_MU_P_P_PIPLUS;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_MU_P_P_P_PIPLUS;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_MU_P_P_P_P_PIPLUS;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_MU_P_P_P_P_P_PIPLUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_MU_PIPLUS;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_MU_P_PIPLUS;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_MU_P_P_PIPLUS;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_MU_P_P_P_PIPLUS;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_MU_P_P_P_P_PIPLUS;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_MU_P_P_P_P_P_PIPLUS;
 
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_MU_PHOTON;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_MU_P_PHOTON;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_MU_P_P_PHOTON;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_MU_P_P_P_PHOTON;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_MU_P_P_P_P_PHOTON;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_MU_P_P_P_P_P_PHOTON;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_MU_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_MU_P_PHOTON;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_MU_P_P_PHOTON;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_MU_P_P_P_PHOTON;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_MU_P_P_P_P_PHOTON;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_MU_P_P_P_P_P_PHOTON;
 
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_MU_PIZERO;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_MU_P_PIZERO;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_MU_P_P_PIZERO;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_MU_P_P_P_PIZERO;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_MU_P_P_P_P_PIZERO;
-        if ((8 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_MU_P_P_P_P_P_PIZERO;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_MU_PIZERO;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_MU_P_PIZERO;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_MU_P_P_PIZERO;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_MU_P_P_P_PIZERO;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_MU_P_P_P_P_PIZERO;
+        if ((8 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_MU_P_P_P_P_P_PIZERO;
 
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons)) return CCRES_E;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons)) return CCRES_E_P;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons)) return CCRES_E_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons)) return CCRES_E_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons)) return CCRES_E_P_P_P_P;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons)) return CCRES_E_P_P_P_P_P;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons))
+            return CCRES_E;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons))
+            return CCRES_E_P;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons))
+            return CCRES_E_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons))
+            return CCRES_E_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons))
+            return CCRES_E_P_P_P_P;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons))
+            return CCRES_E_P_P_P_P_P;
 
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_E_PIPLUS;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_E_P_PIPLUS;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_E_P_P_PIPLUS;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_E_P_P_P_PIPLUS;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_E_P_P_P_P_PIPLUS;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCRES_E_P_P_P_P_P_PIPLUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_E_PIPLUS;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_E_P_PIPLUS;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_E_P_P_PIPLUS;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_E_P_P_P_PIPLUS;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_E_P_P_P_P_PIPLUS;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCRES_E_P_P_P_P_P_PIPLUS;
 
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_E_PHOTON;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_E_P_PHOTON;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_E_P_P_PHOTON;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_E_P_P_P_PHOTON;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_E_P_P_P_P_PHOTON;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCRES_E_P_P_P_P_P_PHOTON;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_E_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_E_P_PHOTON;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_E_P_P_PHOTON;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_E_P_P_P_PHOTON;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_E_P_P_P_P_PHOTON;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCRES_E_P_P_P_P_P_PHOTON;
 
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_E_PIZERO;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_E_P_PIZERO;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_E_P_P_PIZERO;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_E_P_P_P_PIZERO;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_E_P_P_P_P_PIZERO;
-        if ((8 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCRES_E_P_P_P_P_P_PIZERO;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_E_PIZERO;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_E_P_PIZERO;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_E_P_P_PIZERO;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_E_P_P_P_PIZERO;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_E_P_P_P_P_PIZERO;
+        if ((8 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCRES_E_P_P_P_P_P_PIZERO;
     }
 
     if ((nuNuanceCode >= 1006) && (nuNuanceCode <= 1009))
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons)) return NCRES_P;
-        if ((2 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons)) return NCRES_P_P;
-        if ((3 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons)) return NCRES_P_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons)) return NCRES_P_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons)) return NCRES_P_P_P_P_P;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons))
+            return NCRES_P;
+        if ((2 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons))
+            return NCRES_P_P;
+        if ((3 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons))
+            return NCRES_P_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons))
+            return NCRES_P_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons))
+            return NCRES_P_P_P_P_P;
 
-        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCRES_PIPLUS;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCRES_P_PIPLUS;
-        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCRES_P_P_PIPLUS;
-        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCRES_P_P_P_PIPLUS;
-        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCRES_P_P_P_P_PIPLUS;
-        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCRES_P_P_P_P_P_PIPLUS;
+        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCRES_PIPLUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCRES_P_PIPLUS;
+        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCRES_P_P_PIPLUS;
+        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCRES_P_P_P_PIPLUS;
+        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCRES_P_P_P_P_PIPLUS;
+        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCRES_P_P_P_P_P_PIPLUS;
 
-        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCRES_PIMINUS;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCRES_P_PIMINUS;
-        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCRES_P_P_PIMINUS;
-        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCRES_P_P_P_PIMINUS;
-        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCRES_P_P_P_P_PIMINUS;
-        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCRES_P_P_P_P_P_PIMINUS;
+        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCRES_PIMINUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCRES_P_PIMINUS;
+        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCRES_P_P_PIMINUS;
+        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCRES_P_P_P_PIMINUS;
+        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCRES_P_P_P_P_PIMINUS;
+        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCRES_P_P_P_P_P_PIMINUS;
 
-        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCRES_PHOTON;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCRES_P_PHOTON;
-        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCRES_P_P_PHOTON;
-        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCRES_P_P_P_PHOTON;
-        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCRES_P_P_P_P_PHOTON;
-        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCRES_P_P_P_P_P_PHOTON;
+        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCRES_PHOTON;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCRES_P_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCRES_P_P_PHOTON;
+        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCRES_P_P_P_PHOTON;
+        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCRES_P_P_P_P_PHOTON;
+        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCRES_P_P_P_P_P_PHOTON;
 
-        if ((2 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCRES_PIZERO;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCRES_P_PIZERO;
-        if ((4 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCRES_P_P_PIZERO;
-        if ((5 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCRES_P_P_P_PIZERO;
-        if ((6 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCRES_P_P_P_P_PIZERO;
-        if ((7 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCRES_P_P_P_P_P_PIZERO;
+        if ((2 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCRES_PIZERO;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCRES_P_PIZERO;
+        if ((4 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCRES_P_P_PIZERO;
+        if ((5 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCRES_P_P_P_PIZERO;
+        if ((6 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCRES_P_P_P_P_PIZERO;
+        if ((7 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCRES_P_P_P_P_P_PIZERO;
     }
 
     if (1091 == nuNuanceCode)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons)) return CCDIS_MU;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons)) return CCDIS_MU_P;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons)) return CCDIS_MU_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons)) return CCDIS_MU_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons)) return CCDIS_MU_P_P_P_P;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons)) return CCDIS_MU_P_P_P_P_P;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons))
+            return CCDIS_MU;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons))
+            return CCDIS_MU_P;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons))
+            return CCDIS_MU_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons))
+            return CCDIS_MU_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons))
+            return CCDIS_MU_P_P_P_P;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons))
+            return CCDIS_MU_P_P_P_P_P;
 
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCDIS_MU_PIPLUS;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCDIS_MU_P_PIPLUS;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCDIS_MU_P_P_PIPLUS;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCDIS_MU_P_P_P_PIPLUS;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCDIS_MU_P_P_P_P_PIPLUS;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return CCDIS_MU_P_P_P_P_P_PIPLUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCDIS_MU_PIPLUS;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCDIS_MU_P_PIPLUS;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCDIS_MU_P_P_PIPLUS;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCDIS_MU_P_P_P_PIPLUS;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCDIS_MU_P_P_P_P_PIPLUS;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return CCDIS_MU_P_P_P_P_P_PIPLUS;
 
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCDIS_MU_PHOTON;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCDIS_MU_P_PHOTON;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCDIS_MU_P_P_PHOTON;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCDIS_MU_P_P_P_PHOTON;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCDIS_MU_P_P_P_P_PHOTON;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return CCDIS_MU_P_P_P_P_P_PHOTON;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCDIS_MU_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCDIS_MU_P_PHOTON;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCDIS_MU_P_P_PHOTON;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCDIS_MU_P_P_P_PHOTON;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCDIS_MU_P_P_P_P_PHOTON;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return CCDIS_MU_P_P_P_P_P_PHOTON;
 
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCDIS_MU_PIZERO;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCDIS_MU_P_PIZERO;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCDIS_MU_P_P_PIZERO;
-        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCDIS_MU_P_P_P_PIZERO;
-        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCDIS_MU_P_P_P_P_PIZERO;
-        if ((8 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return CCDIS_MU_P_P_P_P_P_PIZERO;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCDIS_MU_PIZERO;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCDIS_MU_P_PIZERO;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCDIS_MU_P_P_PIZERO;
+        if ((6 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCDIS_MU_P_P_P_PIZERO;
+        if ((7 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCDIS_MU_P_P_P_P_PIZERO;
+        if ((8 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return CCDIS_MU_P_P_P_P_P_PIZERO;
     }
 
     if (1092 == nuNuanceCode)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons)) return NCDIS_P;
-        if ((2 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons)) return NCDIS_P_P;
-        if ((3 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons)) return NCDIS_P_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons)) return NCDIS_P_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons)) return NCDIS_P_P_P_P_P;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons))
+            return NCDIS_P;
+        if ((2 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons))
+            return NCDIS_P_P;
+        if ((3 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons))
+            return NCDIS_P_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons))
+            return NCDIS_P_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons))
+            return NCDIS_P_P_P_P_P;
 
-        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCDIS_PIPLUS;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCDIS_P_PIPLUS;
-        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCDIS_P_P_PIPLUS;
-        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCDIS_P_P_P_PIPLUS;
-        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCDIS_P_P_P_P_PIPLUS;
-        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus)) return NCDIS_P_P_P_P_P_PIPLUS;
+        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCDIS_PIPLUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCDIS_P_PIPLUS;
+        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCDIS_P_P_PIPLUS;
+        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCDIS_P_P_P_PIPLUS;
+        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCDIS_P_P_P_P_PIPLUS;
+        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiPlus))
+            return NCDIS_P_P_P_P_P_PIPLUS;
 
-        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCDIS_PIMINUS;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCDIS_P_PIMINUS;
-        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCDIS_P_P_PIMINUS;
-        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCDIS_P_P_P_PIMINUS;
-        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCDIS_P_P_P_P_PIMINUS;
-        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus)) return NCDIS_P_P_P_P_P_PIMINUS;
+        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCDIS_PIMINUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCDIS_P_PIMINUS;
+        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCDIS_P_P_PIMINUS;
+        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCDIS_P_P_P_PIMINUS;
+        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCDIS_P_P_P_P_PIMINUS;
+        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPiMinus))
+            return NCDIS_P_P_P_P_P_PIMINUS;
 
-        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCDIS_PHOTON;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCDIS_P_PHOTON;
-        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCDIS_P_P_PHOTON;
-        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCDIS_P_P_P_PHOTON;
-        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCDIS_P_P_P_P_PHOTON;
-        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return NCDIS_P_P_P_P_P_PHOTON;
+        if ((1 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCDIS_PHOTON;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCDIS_P_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCDIS_P_P_PHOTON;
+        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCDIS_P_P_P_PHOTON;
+        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCDIS_P_P_P_P_PHOTON;
+        if ((6 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return NCDIS_P_P_P_P_P_PHOTON;
 
-        if ((2 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCDIS_PIZERO;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCDIS_P_PIZERO;
-        if ((4 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCDIS_P_P_PIZERO;
-        if ((5 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCDIS_P_P_P_PIZERO;
-        if ((6 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCDIS_P_P_P_P_PIZERO;
-        if ((7 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return NCDIS_P_P_P_P_P_PIZERO;
+        if ((2 == parameters.m_nNonNeutrons) && (0 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCDIS_PIZERO;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCDIS_P_PIZERO;
+        if ((4 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCDIS_P_P_PIZERO;
+        if ((5 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCDIS_P_P_P_PIZERO;
+        if ((6 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCDIS_P_P_P_P_PIZERO;
+        if ((7 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return NCDIS_P_P_P_P_P_PIZERO;
     }
 
-    if (1096 == nuNuanceCode) return NCCOH;
-    if (1097 == nuNuanceCode) return CCCOH;
+    if (1096 == nuNuanceCode)
+        return NCCOH;
+    if (1097 == nuNuanceCode)
+        return CCCOH;
 
     return OTHER_INTERACTION;
 }
@@ -274,14 +433,22 @@ LArInteractionTypeHelper::InteractionType LArInteractionTypeHelper::GetTestBeamH
         if (LArMCParticleHelper::GetParentMCParticle(pMCPrimary) != pMCPrimary)
             continue;
 
-        if (13 == std::fabs(pMCPrimary->GetParticleId())) --parameters.m_nMuons;
-        else if (11 == std::fabs(pMCPrimary->GetParticleId())) --parameters.m_nElectrons;
-        else if (2212 == std::fabs(pMCPrimary->GetParticleId())) --parameters.m_nProtons;
-        else if (22 == pMCPrimary->GetParticleId()) --parameters.m_nPhotons;
-        else if (211 == pMCPrimary->GetParticleId()) --parameters.m_nPiPlus;
-        else if (-211 == pMCPrimary->GetParticleId()) --parameters.m_nPiMinus;
-        else if (321 == pMCPrimary->GetParticleId()) --parameters.m_nKaonPlus;
-        else if (-321 == pMCPrimary->GetParticleId()) --parameters.m_nKaonMinus;
+        if (13 == std::fabs(pMCPrimary->GetParticleId()))
+            --parameters.m_nMuons;
+        else if (11 == std::fabs(pMCPrimary->GetParticleId()))
+            --parameters.m_nElectrons;
+        else if (2212 == std::fabs(pMCPrimary->GetParticleId()))
+            --parameters.m_nProtons;
+        else if (22 == pMCPrimary->GetParticleId())
+            --parameters.m_nPhotons;
+        else if (211 == pMCPrimary->GetParticleId())
+            --parameters.m_nPiPlus;
+        else if (-211 == pMCPrimary->GetParticleId())
+            --parameters.m_nPiMinus;
+        else if (321 == pMCPrimary->GetParticleId())
+            --parameters.m_nKaonPlus;
+        else if (-321 == pMCPrimary->GetParticleId())
+            --parameters.m_nKaonMinus;
 
         --parameters.m_nNonNeutrons;
         targetParentId = pMCPrimary->GetParticleId();
@@ -309,103 +476,148 @@ LArInteractionTypeHelper::InteractionType LArInteractionTypeHelper::GetTestBeamH
 
     if (211 == targetParentId)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiPlus)) return BEAM_PARTICLE_PI_PLUS_PI_PLUS;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiPlus) && (1 == parameters.m_nPhotons)) return BEAM_PARTICLE_PI_PLUS_PI_PLUS_PHOTON;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiPlus) && (1 == parameters.m_nPiZero)) return BEAM_PARTICLE_PI_PLUS_PI_PLUS_PIZERO;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiPlus))
+            return BEAM_PARTICLE_PI_PLUS_PI_PLUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiPlus) && (1 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_PI_PLUS_PI_PLUS_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiPlus) && (1 == parameters.m_nPiZero))
+            return BEAM_PARTICLE_PI_PLUS_PI_PLUS_PIZERO;
         return BEAM_PARTICLE_PI_PLUS_COMPLEX;
     }
     else if (-211 == targetParentId)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiMinus)) return BEAM_PARTICLE_PI_MINUS_PI_MINUS;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiMinus) && (1 == parameters.m_nPhotons)) return BEAM_PARTICLE_PI_MINUS_PI_MINUS_PHOTON;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiMinus) && (1 == parameters.m_nPiZero)) return BEAM_PARTICLE_PI_MINUS_PI_MINUS_PIZERO;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiMinus))
+            return BEAM_PARTICLE_PI_MINUS_PI_MINUS;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiMinus) && (1 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_PI_MINUS_PI_MINUS_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nPiMinus) && (1 == parameters.m_nPiZero))
+            return BEAM_PARTICLE_PI_MINUS_PI_MINUS_PIZERO;
         return BEAM_PARTICLE_PI_MINUS_COMPLEX;
     }
     else if (2212 == targetParentId)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons)) return BEAM_PARTICLE_P_P;
-        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_PHOTON;
-        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_PHOTON_PHOTON;
-        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (3 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_PHOTON_PHOTON_PHOTON;
-        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (4 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_PHOTON_PHOTON_PHOTON_PHOTON;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons))
+            return BEAM_PARTICLE_P_P;
+        if ((2 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_PHOTON_PHOTON;
+        if ((4 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (3 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_PHOTON_PHOTON_PHOTON;
+        if ((5 == parameters.m_nNonNeutrons) && (1 == parameters.m_nProtons) && (4 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_PHOTON_PHOTON_PHOTON_PHOTON;
 
-        if ((2 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons)) return BEAM_PARTICLE_P_P_P;
-        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_P_PHOTON;
-        if ((4 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_P_PHOTON_PHOTON;
-        if ((5 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (3 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_P_PHOTON_PHOTON_PHOTON;
+        if ((2 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons))
+            return BEAM_PARTICLE_P_P_P;
+        if ((3 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_P_PHOTON;
+        if ((4 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_P_PHOTON_PHOTON;
+        if ((5 == parameters.m_nNonNeutrons) && (2 == parameters.m_nProtons) && (3 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_P_PHOTON_PHOTON_PHOTON;
 
-        if ((3 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons)) return BEAM_PARTICLE_P_P_P_P;
-        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_P_P_PHOTON;
-        if ((5 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_P_P_PHOTON_PHOTON;
+        if ((3 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons))
+            return BEAM_PARTICLE_P_P_P_P;
+        if ((4 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_P_P_PHOTON;
+        if ((5 == parameters.m_nNonNeutrons) && (3 == parameters.m_nProtons) && (2 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_P_P_PHOTON_PHOTON;
 
-        if ((4 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons)) return BEAM_PARTICLE_P_P_P_P_P;
-        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons)) return BEAM_PARTICLE_P_P_P_P_P_PHOTON;
+        if ((4 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons))
+            return BEAM_PARTICLE_P_P_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (4 == parameters.m_nProtons) && (1 == parameters.m_nPhotons))
+            return BEAM_PARTICLE_P_P_P_P_P_PHOTON;
 
-        if ((5 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons)) return BEAM_PARTICLE_P_P_P_P_P_P;
+        if ((5 == parameters.m_nNonNeutrons) && (5 == parameters.m_nProtons))
+            return BEAM_PARTICLE_P_P_P_P_P_P;
 
         return BEAM_PARTICLE_P_COMPLEX;
     }
     else if (13 == std::fabs(targetParentId))
     {
-        if (0 == parameters.m_nNonNeutrons) return BEAM_PARTICLE_MU;
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons)) return BEAM_PARTICLE_MU_E;
+        if (0 == parameters.m_nNonNeutrons)
+            return BEAM_PARTICLE_MU;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nElectrons))
+            return BEAM_PARTICLE_MU_E;
         return BEAM_PARTICLE_MU_COMPLEX;
     }
     else if (321 == targetParentId)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons)) return BEAM_PARTICLE_KAON_PLUS_MU;
-        if ((parameters.m_nNonNeutrons >= 2) && (1 == parameters.m_nKaonPlus) && (1 == parameters.m_nKaon0L)) return BEAM_PARTICLE_KAON_PLUS_KAON_PLUS_KAON0L_COMPLEX;
-        if ((parameters.m_nNonNeutrons > 1) && (1 == parameters.m_nKaonPlus)) return BEAM_PARTICLE_KAON_PLUS_KAON_PLUS_COMPLEX;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons))
+            return BEAM_PARTICLE_KAON_PLUS_MU;
+        if ((parameters.m_nNonNeutrons >= 2) && (1 == parameters.m_nKaonPlus) && (1 == parameters.m_nKaon0L))
+            return BEAM_PARTICLE_KAON_PLUS_KAON_PLUS_KAON0L_COMPLEX;
+        if ((parameters.m_nNonNeutrons > 1) && (1 == parameters.m_nKaonPlus))
+            return BEAM_PARTICLE_KAON_PLUS_KAON_PLUS_COMPLEX;
         return BEAM_PARTICLE_KAON_PLUS_COMPLEX;
     }
     else if (-321 == targetParentId)
     {
-        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons)) return BEAM_PARTICLE_KAON_MINUS_MU;
-        if ((parameters.m_nNonNeutrons >= 2) && (1 == parameters.m_nKaonMinus) && (1 == parameters.m_nKaon0L)) return BEAM_PARTICLE_KAON_MINUS_KAON_MINUS_KAON0L_COMPLEX;
-        if ((parameters.m_nNonNeutrons > 1) && (1 == parameters.m_nKaonMinus)) return BEAM_PARTICLE_KAON_MINUS_KAON_MINUS_COMPLEX;
+        if ((1 == parameters.m_nNonNeutrons) && (1 == parameters.m_nMuons))
+            return BEAM_PARTICLE_KAON_MINUS_MU;
+        if ((parameters.m_nNonNeutrons >= 2) && (1 == parameters.m_nKaonMinus) && (1 == parameters.m_nKaon0L))
+            return BEAM_PARTICLE_KAON_MINUS_KAON_MINUS_KAON0L_COMPLEX;
+        if ((parameters.m_nNonNeutrons > 1) && (1 == parameters.m_nKaonMinus))
+            return BEAM_PARTICLE_KAON_MINUS_KAON_MINUS_COMPLEX;
         return BEAM_PARTICLE_KAON_MINUS_COMPLEX;
     }
     else if (11 == std::fabs(targetParentId))
     {
-        if (0 == parameters.m_nNonNeutrons) return BEAM_PARTICLE_E;
+        if (0 == parameters.m_nNonNeutrons)
+            return BEAM_PARTICLE_E;
         return BEAM_PARTICLE_E_COMPLEX;
     }
 
-    if (parameters.m_nNonNeutrons > 5) return BEAM_PARTICLE_COMPLEX_HIERARCHY;
+    if (parameters.m_nNonNeutrons > 5)
+        return BEAM_PARTICLE_COMPLEX_HIERARCHY;
 
     return BEAM_PARTICLE_UNKNOWN_HIERARCHY;
 }
 
-//------------------------------------------------------------------------------------------------------------------------------------------ 
+//------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArInteractionTypeHelper::SetInteractionParameters(const MCParticleList &mcPrimaryList, InteractionParameters &parameters)
 {
     for (const MCParticle *const pMCPrimary : mcPrimaryList)
     {
-        if (2112 != pMCPrimary->GetParticleId()) ++parameters.m_nNonNeutrons;
-        if (13 == std::fabs(pMCPrimary->GetParticleId())) ++parameters.m_nMuons;
-        if (11 == std::fabs(pMCPrimary->GetParticleId())) ++parameters.m_nElectrons;
-        else if (2212 == std::fabs(pMCPrimary->GetParticleId())) ++parameters.m_nProtons;
-        else if (22 == pMCPrimary->GetParticleId()) ++parameters.m_nPhotons;
-        else if (211 == pMCPrimary->GetParticleId()) ++parameters.m_nPiPlus;
-        else if (-211 == pMCPrimary->GetParticleId()) ++parameters.m_nPiMinus;
-        else if (321 == pMCPrimary->GetParticleId()) ++parameters.m_nKaonPlus;
-        else if (-321 == pMCPrimary->GetParticleId()) ++parameters.m_nKaonMinus;
+        if (2112 != pMCPrimary->GetParticleId())
+            ++parameters.m_nNonNeutrons;
+        if (13 == std::fabs(pMCPrimary->GetParticleId()))
+            ++parameters.m_nMuons;
+        if (11 == std::fabs(pMCPrimary->GetParticleId()))
+            ++parameters.m_nElectrons;
+        else if (2212 == std::fabs(pMCPrimary->GetParticleId()))
+            ++parameters.m_nProtons;
+        else if (22 == pMCPrimary->GetParticleId())
+            ++parameters.m_nPhotons;
+        else if (211 == pMCPrimary->GetParticleId())
+            ++parameters.m_nPiPlus;
+        else if (-211 == pMCPrimary->GetParticleId())
+            ++parameters.m_nPiMinus;
+        else if (321 == pMCPrimary->GetParticleId())
+            ++parameters.m_nKaonPlus;
+        else if (-321 == pMCPrimary->GetParticleId())
+            ++parameters.m_nKaonMinus;
     }
 }
 
-//------------------------------------------------------------------------------------------------------------------------------------------ 
+//------------------------------------------------------------------------------------------------------------------------------------------
 
-LArInteractionTypeHelper::InteractionType LArInteractionTypeHelper::CosmicRayHypothesis(const MCParticleList &mcPrimaryList,
-    const InteractionParameters &parameters)
+LArInteractionTypeHelper::InteractionType LArInteractionTypeHelper::CosmicRayHypothesis(
+    const MCParticleList &mcPrimaryList, const InteractionParameters &parameters)
 {
     if ((1 == mcPrimaryList.size()) && LArMCParticleHelper::IsCosmicRay(mcPrimaryList.front()))
     {
-        if (1 == parameters.m_nMuons) return COSMIC_RAY_MU;
-        if (1 == parameters.m_nProtons) return COSMIC_RAY_P;
-        if (1 == parameters.m_nElectrons) return COSMIC_RAY_E;
-        if (1 == parameters.m_nPhotons) return COSMIC_RAY_PHOTON;
-        else return COSMIC_RAY_OTHER;
+        if (1 == parameters.m_nMuons)
+            return COSMIC_RAY_MU;
+        if (1 == parameters.m_nProtons)
+            return COSMIC_RAY_P;
+        if (1 == parameters.m_nElectrons)
+            return COSMIC_RAY_E;
+        if (1 == parameters.m_nPhotons)
+            return COSMIC_RAY_PHOTON;
+        else
+            return COSMIC_RAY_OTHER;
     }
 
     return OTHER_INTERACTION;
@@ -418,7 +630,8 @@ std::string LArInteractionTypeHelper::ToString(const InteractionType interaction
     switch (interactionType)
     {
         INTERACTION_TYPE_TABLE(GET_INTERACTION_TYPE_NAME_SWITCH)
-        default: throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+        default:
+            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
     }
 }
 

--- a/larpandoracontent/LArHelpers/LArInteractionTypeHelper.h
+++ b/larpandoracontent/LArHelpers/LArInteractionTypeHelper.h
@@ -15,7 +15,7 @@
 namespace lar_content
 {
 
-// Specify (name)
+// clang-format off
 #define INTERACTION_TYPE_TABLE(d)                         \
     d(CCQEL_MU                                          ) \
     d(CCQEL_MU_P                                        ) \
@@ -231,6 +231,7 @@ namespace lar_content
  */
 #define GET_INTERACTION_TYPE_NAME_SWITCH(a)               \
     case a : return std::string(#a);
+// clang-format on
 
 /**
  *  @brief  LArInteractionTypeHelper class
@@ -243,8 +244,7 @@ public:
      */
     enum InteractionType : unsigned int
     {
-        INTERACTION_TYPE_TABLE(GET_INTERACTION_TYPE_ENTRY)
-        UNKNOWN_INTERACTION_TYPE = 0
+        INTERACTION_TYPE_TABLE(GET_INTERACTION_TYPE_ENTRY) UNKNOWN_INTERACTION_TYPE = 0
     };
 
     /**
@@ -320,4 +320,3 @@ public:
 } // namespace lar_content
 
 #endif // #ifndef LAR_INTERACTION_TYPE_HELPER_H
-

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -49,7 +49,9 @@ bool LArMCParticleHelper::DoesPrimaryMeetCriteria(const MCParticle *const pMCPar
         const MCParticle *const pPrimaryMCParticle = LArMCParticleHelper::GetPrimaryMCParticle(pMCParticle);
         return fCriteria(pPrimaryMCParticle);
     }
-    catch (const StatusCodeException &) {}
+    catch (const StatusCodeException &)
+    {
+    }
 
     return false;
 }
@@ -63,7 +65,9 @@ bool LArMCParticleHelper::DoesLeadingMeetCriteria(const MCParticle *const pMCPar
         const MCParticle *const pLeadingMCParticle = LArMCParticleHelper::GetLeadingMCParticle(pMCParticle);
         return fCriteria(pLeadingMCParticle);
     }
-    catch (const StatusCodeException &) {}
+    catch (const StatusCodeException &)
+    {
+    }
 
     return false;
 }
@@ -106,14 +110,15 @@ bool LArMCParticleHelper::IsLeadingBeamParticle(const MCParticle *const pMCParti
 bool LArMCParticleHelper::IsCosmicRay(const MCParticle *const pMCParticle)
 {
     const int nuance(LArMCParticleHelper::GetNuanceCode(pMCParticle));
-    return (LArMCParticleHelper::IsPrimary(pMCParticle) && ((nuance == 3000) || ((nuance == 0) && !LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle))));
+    return (LArMCParticleHelper::IsPrimary(pMCParticle) &&
+            ((nuance == 3000) || ((nuance == 0) && !LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle))));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 unsigned int LArMCParticleHelper::GetNuanceCode(const MCParticle *const pMCParticle)
 {
-    const LArMCParticle *const pLArMCParticle(dynamic_cast<const LArMCParticle*>(pMCParticle));
+    const LArMCParticle *const pLArMCParticle(dynamic_cast<const LArMCParticle *>(pMCParticle));
     if (pLArMCParticle)
         return pLArMCParticle->GetNuanceCode();
 
@@ -141,7 +146,9 @@ bool LArMCParticleHelper::IsPrimary(const pandora::MCParticle *const pMCParticle
     {
         return (LArMCParticleHelper::GetPrimaryMCParticle(pMCParticle) == pMCParticle);
     }
-    catch (const StatusCodeException &) {}
+    catch (const StatusCodeException &)
+    {
+    }
 
     return false;
 }
@@ -154,7 +161,9 @@ bool LArMCParticleHelper::IsLeading(const pandora::MCParticle *const pMCParticle
     {
         return (LArMCParticleHelper::GetLeadingMCParticle(pMCParticle) == pMCParticle);
     }
-    catch (const StatusCodeException &) {}
+    catch (const StatusCodeException &)
+    {
+    }
 
     return false;
 }
@@ -184,11 +193,9 @@ bool LArMCParticleHelper::IsVisible(const MCParticle *const pMCParticle)
 {
     const int absoluteParticleId(std::abs(pMCParticle->GetParticleId()));
 
-    if ((E_MINUS == absoluteParticleId) || (MU_MINUS == absoluteParticleId) ||
-        (PI_PLUS == absoluteParticleId) || (K_PLUS == absoluteParticleId) ||
+    if ((E_MINUS == absoluteParticleId) || (MU_MINUS == absoluteParticleId) || (PI_PLUS == absoluteParticleId) || (K_PLUS == absoluteParticleId) ||
         (SIGMA_MINUS == absoluteParticleId) || (SIGMA_PLUS == absoluteParticleId) || (HYPERON_MINUS == absoluteParticleId) ||
-        (PROTON == absoluteParticleId) || (PHOTON == absoluteParticleId) ||
-        (NEUTRON == absoluteParticleId))
+        (PROTON == absoluteParticleId) || (PHOTON == absoluteParticleId) || (NEUTRON == absoluteParticleId))
         return true;
 
     return false;
@@ -239,14 +246,12 @@ const MCParticle *LArMCParticleHelper::GetParentMCParticle(const MCParticle *con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle,
-    pandora::MCParticleList &descendentMCParticleList)
+void LArMCParticleHelper::GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &descendentMCParticleList)
 {
     const MCParticleList &daughterMCParticleList = pMCParticle->GetDaughterList();
     for (const MCParticle *pDaughterMCParticle : daughterMCParticleList)
     {
-        if (std::find(descendentMCParticleList.begin(), descendentMCParticleList.end(), pDaughterMCParticle) ==
-            descendentMCParticleList.end())
+        if (std::find(descendentMCParticleList.begin(), descendentMCParticleList.end(), pDaughterMCParticle) == descendentMCParticleList.end())
         {
             descendentMCParticleList.push_back(pDaughterMCParticle);
             LArMCParticleHelper::GetAllDescendentMCParticles(pDaughterMCParticle, descendentMCParticleList);
@@ -256,17 +261,16 @@ void LArMCParticleHelper::GetAllDescendentMCParticles(const pandora::MCParticle 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::GetAllAncestorMCParticles(const pandora::MCParticle *const pMCParticle,
-    pandora::MCParticleList &ancestorMCParticleList)
+void LArMCParticleHelper::GetAllAncestorMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &ancestorMCParticleList)
 {
     const MCParticleList &parentMCParticleList = pMCParticle->GetParentList();
-    if (parentMCParticleList.empty()) return;
+    if (parentMCParticleList.empty())
+        return;
     if (parentMCParticleList.size() != 1)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     const MCParticle *pParentMCParticle = *parentMCParticleList.begin();
-    if (std::find(ancestorMCParticleList.begin(), ancestorMCParticleList.end(), pParentMCParticle) ==
-        ancestorMCParticleList.end())
+    if (std::find(ancestorMCParticleList.begin(), ancestorMCParticleList.end(), pParentMCParticle) == ancestorMCParticleList.end())
     {
         ancestorMCParticleList.push_back(pParentMCParticle);
         LArMCParticleHelper::GetAllAncestorMCParticles(pParentMCParticle, ancestorMCParticleList);
@@ -394,7 +398,9 @@ void LArMCParticleHelper::GetMCPrimaryMap(const MCParticleList *const pMCParticl
             const MCParticle *const pPrimaryMCParticle = LArMCParticleHelper::GetPrimaryMCParticle(pMCParticle);
             mcPrimaryMap[pMCParticle] = pPrimaryMCParticle;
         }
-        catch (const StatusCodeException &) {}
+        catch (const StatusCodeException &)
+        {
+        }
     }
 }
 
@@ -409,7 +415,9 @@ void LArMCParticleHelper::GetMCLeadingMap(const MCParticleList *const pMCParticl
             const MCParticle *const pLeadingMCParticle = LArMCParticleHelper::GetLeadingMCParticle(pMCParticle);
             mcLeadingMap[pMCParticle] = pLeadingMCParticle;
         }
-        catch (const StatusCodeException &) {}
+        catch (const StatusCodeException &)
+        {
+        }
     }
 }
 
@@ -494,12 +502,13 @@ void LArMCParticleHelper::GetMCParticleToCaloHitMatches(const CaloHitList *const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
-    std::function<bool(const MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap)
+void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList,
+    const PrimaryParameters &parameters, std::function<bool(const MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap)
 {
     // Obtain map: [mc particle -> target mc particle]
     LArMCParticleHelper::MCRelationMap mcToTargetMCMap;
-    parameters.m_foldBackHierarchy ? LArMCParticleHelper::GetMCPrimaryMap(pMCParticleList, mcToTargetMCMap) : LArMCParticleHelper::GetMCToSelfMap(pMCParticleList, mcToTargetMCMap);
+    parameters.m_foldBackHierarchy ? LArMCParticleHelper::GetMCPrimaryMap(pMCParticleList, mcToTargetMCMap)
+                                   : LArMCParticleHelper::GetMCToSelfMap(pMCParticleList, mcToTargetMCMap);
 
     // Remove non-reconstructable hits, e.g. those downstream of a neutron
     // Unless selectInputHits == false
@@ -532,12 +541,13 @@ void LArMCParticleHelper::SelectReconstructableMCParticles(const MCParticleList 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
-    std::function<bool(const MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap)
+void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(const MCParticleList *pMCParticleList, const CaloHitList *pCaloHitList,
+    const PrimaryParameters &parameters, std::function<bool(const MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap)
 {
     // Obtain map: [mc particle -> target mc particle]
     LArMCParticleHelper::MCRelationMap mcToTargetMCMap;
-    parameters.m_foldBackHierarchy ? LArMCParticleHelper::GetMCLeadingMap(pMCParticleList, mcToTargetMCMap) : LArMCParticleHelper::GetMCToSelfMap(pMCParticleList, mcToTargetMCMap);
+    parameters.m_foldBackHierarchy ? LArMCParticleHelper::GetMCLeadingMap(pMCParticleList, mcToTargetMCMap)
+                                   : LArMCParticleHelper::GetMCToSelfMap(pMCParticleList, mcToTargetMCMap);
 
     // Remove non-reconstructable hits, e.g. those downstream of a neutron
     // Unless selectInputHits == false
@@ -587,15 +597,17 @@ void LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(cons
 void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
     PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
 {
-    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(pfoList, MCContributionMapVector({selectedMCParticleToHitsMap}), pfoToReconstructable2DHitsMap, foldBackHierarchy);
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(
+        pfoList, MCContributionMapVector({selectedMCParticleToHitsMap}), pfoToReconstructable2DHitsMap, foldBackHierarchy);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-    PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
+void LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const PfoList &pfoList,
+    const MCContributionMap &selectedMCParticleToHitsMap, PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
 {
-    LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(pfoList, MCContributionMapVector({selectedMCParticleToHitsMap}), pfoToReconstructable2DHitsMap, foldBackHierarchy);
+    LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(
+        pfoList, MCContributionMapVector({selectedMCParticleToHitsMap}), pfoToReconstructable2DHitsMap, foldBackHierarchy);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -615,8 +627,8 @@ void LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(const PfoList &pfoLis
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
+void LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const PfoList &pfoList,
+    const MCContributionMapVector &selectedMCParticleToHitsMaps, PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy)
 {
     for (const ParticleFlowObject *const pPfo : pfoList)
     {
@@ -630,11 +642,13 @@ void LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const PfoContributionMap &pfoToReconstructable2DHitsMap, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap)
+void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const PfoContributionMap &pfoToReconstructable2DHitsMap,
+    const MCContributionMapVector &selectedMCParticleToHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap,
+    MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap)
 {
     PfoVector sortedPfos;
-    for (const auto &mapEntry : pfoToReconstructable2DHitsMap) sortedPfos.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoToReconstructable2DHitsMap)
+        sortedPfos.push_back(mapEntry.first);
     std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
 
     for (const ParticleFlowObject *const pPfo : sortedPfos)
@@ -642,7 +656,8 @@ void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const PfoContributionMa
         for (const MCContributionMap &mcParticleToHitsMap : selectedMCParticleToHitsMaps)
         {
             MCParticleVector sortedMCParticles;
-            for (const auto &mapEntry : mcParticleToHitsMap) sortedMCParticles.push_back(mapEntry.first);
+            for (const auto &mapEntry : mcParticleToHitsMap)
+                sortedMCParticles.push_back(mapEntry.first);
             std::sort(sortedMCParticles.begin(), sortedMCParticles.end(), PointerLessThan<MCParticle>());
 
             for (const MCParticle *const pMCParticle : sortedMCParticles)
@@ -660,25 +675,30 @@ void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const PfoContributionMa
                 MCParticleToSharedHitsVector &mcHitPairs(pfoToMCParticleHitSharingMap.at(pPfo));
                 PfoToSharedHitsVector &pfoHitPairs(mcParticleToPfoHitSharingMap.at(pMCParticle));
 
-                if (std::any_of(mcHitPairs.begin(), mcHitPairs.end(), [&] (const MCParticleCaloHitListPair &pair) { return (pair.first == pMCParticle); }))
+                if (std::any_of(mcHitPairs.begin(), mcHitPairs.end(),
+                        [&](const MCParticleCaloHitListPair &pair) { return (pair.first == pMCParticle); }))
                     throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
 
-                if (std::any_of(pfoHitPairs.begin(), pfoHitPairs.end(), [&] (const PfoCaloHitListPair &pair) { return (pair.first == pPfo); }))
+                if (std::any_of(pfoHitPairs.begin(), pfoHitPairs.end(), [&](const PfoCaloHitListPair &pair) { return (pair.first == pPfo); }))
                     throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
 
                 // Add records to maps if there are any shared hits
-                const CaloHitList sharedHits(LArMCParticleHelper::GetSharedHits(pfoToReconstructable2DHitsMap.at(pPfo), mcParticleToHitsMap.at(pMCParticle)));
+                const CaloHitList sharedHits(
+                    LArMCParticleHelper::GetSharedHits(pfoToReconstructable2DHitsMap.at(pPfo), mcParticleToHitsMap.at(pMCParticle)));
 
                 if (!sharedHits.empty())
                 {
                     mcHitPairs.push_back(MCParticleCaloHitListPair(pMCParticle, sharedHits));
                     pfoHitPairs.push_back(PfoCaloHitListPair(pPfo, sharedHits));
 
-                    std::sort(mcHitPairs.begin(), mcHitPairs.end(), [] (const MCParticleCaloHitListPair &a, const MCParticleCaloHitListPair &b) -> bool {
-                        return ((a.second.size() != b.second.size()) ? a.second.size() > b.second.size() : LArMCParticleHelper::SortByMomentum(a.first, b.first)); });
+                    std::sort(mcHitPairs.begin(), mcHitPairs.end(), [](const MCParticleCaloHitListPair &a, const MCParticleCaloHitListPair &b) -> bool {
+                        return ((a.second.size() != b.second.size()) ? a.second.size() > b.second.size()
+                                                                     : LArMCParticleHelper::SortByMomentum(a.first, b.first));
+                    });
 
-                    std::sort(pfoHitPairs.begin(), pfoHitPairs.end(), [] (const PfoCaloHitListPair &a, const PfoCaloHitListPair &b) -> bool {
-                        return ((a.second.size() != b.second.size()) ? a.second.size() > b.second.size() : LArPfoHelper::SortByNHits(a.first, b.first)); });
+                    std::sort(pfoHitPairs.begin(), pfoHitPairs.end(), [](const PfoCaloHitListPair &a, const PfoCaloHitListPair &b) -> bool {
+                        return ((a.second.size() != b.second.size()) ? a.second.size() > b.second.size() : LArPfoHelper::SortByNHits(a.first, b.first));
+                    });
                 }
             }
         }
@@ -688,8 +708,8 @@ void LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(const PfoContributionMa
 // private
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy)
+void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject *const pPfo,
+    const MCContributionMapVector &selectedMCParticleToHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy)
 {
 
     PfoList pfoList;
@@ -710,8 +730,8 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const ParticleFlowObject 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::CollectReconstructableTestBeamHierarchy2DHits(const ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy)
+void LArMCParticleHelper::CollectReconstructableTestBeamHierarchy2DHits(const ParticleFlowObject *const pPfo,
+    const MCContributionMapVector &selectedMCParticleToHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy)
 {
 
     PfoList pfoList;
@@ -739,8 +759,8 @@ void LArMCParticleHelper::CollectReconstructableTestBeamHierarchy2DHits(const Pa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::CollectReconstructable2DHits(const PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-    pandora::CaloHitList &reconstructableCaloHitList2D)
+void LArMCParticleHelper::CollectReconstructable2DHits(
+    const PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D)
 {
     CaloHitList caloHitList2D;
     LArPfoHelper::GetCaloHits(pfoList, TPC_VIEW_U, caloHitList2D);
@@ -765,7 +785,8 @@ void LArMCParticleHelper::CollectReconstructable2DHits(const PfoList &pfoList, c
                     break;
                 }
             }
-            if (isTargetHit) break;
+            if (isTargetHit)
+                break;
         }
 
         if (isTargetHit)
@@ -813,7 +834,7 @@ bool LArMCParticleHelper::IsDescendentOf(const MCParticle *const pMCParticle, co
 {
     const MCParticle *pCurrentParticle = pMCParticle;
     while (!pCurrentParticle->GetParentList().empty())
-    {   
+    {
         if (pCurrentParticle->GetParentList().size() > 1)
             throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
@@ -862,7 +883,8 @@ void LArMCParticleHelper::SelectGoodCaloHits(const CaloHitList *const pSelectedC
     for (const CaloHit *const pCaloHit : *pSelectedCaloHitList)
     {
         MCParticleVector mcParticleVector;
-        for (const auto &mapEntry : pCaloHit->GetMCParticleWeightMap()) mcParticleVector.push_back(mapEntry.first);
+        for (const auto &mapEntry : pCaloHit->GetMCParticleWeightMap())
+            mcParticleVector.push_back(mapEntry.first);
         std::sort(mcParticleVector.begin(), mcParticleVector.end(), PointerLessThan<MCParticle>());
 
         MCParticleWeightMap targetWeightMap;
@@ -877,7 +899,8 @@ void LArMCParticleHelper::SelectGoodCaloHits(const CaloHitList *const pSelectedC
         }
 
         MCParticleVector mcTargetVector;
-        for (const auto &mapEntry : targetWeightMap) mcTargetVector.push_back(mapEntry.first);
+        for (const auto &mapEntry : targetWeightMap)
+            mcTargetVector.push_back(mapEntry.first);
         std::sort(mcTargetVector.begin(), mcTargetVector.end(), PointerLessThan<MCParticle>());
 
         const MCParticle *pBestTargetParticle(nullptr);
@@ -904,8 +927,8 @@ void LArMCParticleHelper::SelectGoodCaloHits(const CaloHitList *const pSelectedC
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMCParticleHelper::SelectParticlesMatchingCriteria(const MCParticleVector &inputMCParticles, std::function<bool(const MCParticle *const)> fCriteria,
-    MCParticleVector &selectedParticles, const PrimaryParameters &parameters, const bool isTestBeam)
+void LArMCParticleHelper::SelectParticlesMatchingCriteria(const MCParticleVector &inputMCParticles,
+    std::function<bool(const MCParticle *const)> fCriteria, MCParticleVector &selectedParticles, const PrimaryParameters &parameters, const bool isTestBeam)
 {
     for (const MCParticle *const pMCParticle : inputMCParticles)
     {
@@ -937,7 +960,7 @@ void LArMCParticleHelper::SelectParticlesByHitCount(const MCParticleVector &cand
     const MCRelationMap &mcToTargetMCMap, const PrimaryParameters &parameters, MCContributionMap &selectedMCParticlesToHitsMap)
 {
     // Apply restrictions on the number of good hits associated with the MCParticles
-    for (const MCParticle * const pMCTarget : candidateTargets)
+    for (const MCParticle *const pMCTarget : candidateTargets)
     {
         MCContributionMap::const_iterator trueHitsIter = mcToTrueHitListMap.find(pMCTarget);
         if (mcToTrueHitListMap.end() == trueHitsIter)
@@ -947,7 +970,8 @@ void LArMCParticleHelper::SelectParticlesByHitCount(const MCParticleVector &cand
 
         // Remove shared hits where target particle deposits below threshold energy fraction
         CaloHitList goodCaloHitList;
-        LArMCParticleHelper::SelectGoodCaloHits(&caloHitList, mcToTargetMCMap, goodCaloHitList, parameters.m_selectInputHits, parameters.m_minHitSharingFraction);
+        LArMCParticleHelper::SelectGoodCaloHits(
+            &caloHitList, mcToTargetMCMap, goodCaloHitList, parameters.m_selectInputHits, parameters.m_minHitSharingFraction);
 
         if (goodCaloHitList.size() < parameters.m_minPrimaryGoodHits)
             continue;
@@ -978,7 +1002,8 @@ bool LArMCParticleHelper::PassMCParticleChecks(const MCParticle *const pOriginal
     if (NEUTRON == std::abs(pThisMCParticle->GetParticleId()))
         return false;
 
-    if ((PHOTON == pThisMCParticle->GetParticleId()) && (PHOTON != pOriginalPrimary->GetParticleId()) && (E_MINUS != std::abs(pOriginalPrimary->GetParticleId())))
+    if ((PHOTON == pThisMCParticle->GetParticleId()) && (PHOTON != pOriginalPrimary->GetParticleId()) &&
+        (E_MINUS != std::abs(pOriginalPrimary->GetParticleId())))
     {
         if ((pThisMCParticle->GetEndpoint() - pThisMCParticle->GetVertex()).GetMagnitude() > maxPhotonPropagation)
             return false;
@@ -1010,6 +1035,5 @@ CaloHitList LArMCParticleHelper::GetSharedHits(const CaloHitList &hitListA, cons
 
     return sharedHits;
 }
-
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -12,8 +12,8 @@
 
 #include "larpandoracontent/LArObjects/LArMCParticle.h"
 
-#include <unordered_map>
 #include <functional>
+#include <unordered_map>
 
 namespace lar_content
 {
@@ -24,28 +24,28 @@ namespace lar_content
 class LArMCParticleHelper
 {
 public:
-    typedef std::unordered_map<const pandora::MCParticle*, const pandora::MCParticle*> MCRelationMap;
-    typedef std::unordered_map<const pandora::MCParticle*, int> MCParticleIntMap;
+    typedef std::unordered_map<const pandora::MCParticle *, const pandora::MCParticle *> MCRelationMap;
+    typedef std::unordered_map<const pandora::MCParticle *, int> MCParticleIntMap;
 
-    typedef std::unordered_map<const pandora::MCParticle*, const pandora::ParticleFlowObject*> MCToPfoMap;
+    typedef std::unordered_map<const pandora::MCParticle *, const pandora::ParticleFlowObject *> MCToPfoMap;
 
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::MCParticle*> CaloHitToMCMap;
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::ParticleFlowObject*> CaloHitToPfoMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::MCParticle *> CaloHitToMCMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::ParticleFlowObject *> CaloHitToPfoMap;
 
-    typedef std::unordered_map<const pandora::MCParticle*, pandora::CaloHitList> MCContributionMap;
+    typedef std::unordered_map<const pandora::MCParticle *, pandora::CaloHitList> MCContributionMap;
     typedef std::vector<MCContributionMap> MCContributionMapVector;
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, pandora::CaloHitList> PfoContributionMap;
-    typedef std::unordered_map<const pandora::MCParticle*, PfoContributionMap> MCToPfoMatchingMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, pandora::CaloHitList> PfoContributionMap;
+    typedef std::unordered_map<const pandora::MCParticle *, PfoContributionMap> MCToPfoMatchingMap;
 
-    typedef std::pair<const pandora::MCParticle*, pandora::CaloHitList > MCParticleCaloHitListPair;
-    typedef std::pair<const pandora::ParticleFlowObject*, pandora::CaloHitList > PfoCaloHitListPair;
+    typedef std::pair<const pandora::MCParticle *, pandora::CaloHitList> MCParticleCaloHitListPair;
+    typedef std::pair<const pandora::ParticleFlowObject *, pandora::CaloHitList> PfoCaloHitListPair;
 
     typedef std::vector<MCParticleCaloHitListPair> MCParticleToSharedHitsVector;
     typedef std::vector<PfoCaloHitListPair> PfoToSharedHitsVector;
 
-    typedef std::map<const pandora::ParticleFlowObject*, MCParticleToSharedHitsVector> PfoToMCParticleHitSharingMap;
-    typedef std::map<const pandora::MCParticle*, PfoToSharedHitsVector> MCParticleToPfoHitSharingMap;
+    typedef std::map<const pandora::ParticleFlowObject *, MCParticleToSharedHitsVector> PfoToMCParticleHitSharingMap;
+    typedef std::map<const pandora::MCParticle *, PfoToSharedHitsVector> MCParticleToPfoHitSharingMap;
 
     /**
      *  @brief   PrimaryParameters class
@@ -58,13 +58,13 @@ public:
          */
         PrimaryParameters();
 
-        unsigned int  m_minPrimaryGoodHits;       ///< the minimum number of primary good Hits
-        unsigned int  m_minHitsForGoodView;       ///< the minimum number of Hits for a good view
-        unsigned int  m_minPrimaryGoodViews;      ///< the minimum number of primary good views
-        bool          m_selectInputHits;          ///< whether to select input hits
-        float         m_maxPhotonPropagation;     ///< the maximum photon propagation length
-        float         m_minHitSharingFraction;    ///< the minimum Hit sharing fraction
-        bool          m_foldBackHierarchy;        ///< whether to fold the hierarchy back to the primary (neutrino) or leading particles (test beam)
+        unsigned int m_minPrimaryGoodHits;  ///< the minimum number of primary good Hits
+        unsigned int m_minHitsForGoodView;  ///< the minimum number of Hits for a good view
+        unsigned int m_minPrimaryGoodViews; ///< the minimum number of primary good views
+        bool m_selectInputHits;             ///< whether to select input hits
+        float m_maxPhotonPropagation;       ///< the maximum photon propagation length
+        float m_minHitSharingFraction;      ///< the minimum Hit sharing fraction
+        bool m_foldBackHierarchy; ///< whether to fold the hierarchy back to the primary (neutrino) or leading particles (test beam)
     };
 
     /**
@@ -223,8 +223,7 @@ public:
      *  @param  pMCParticle the input mc particle
      *  @param  descendentMCParticleList the output descendent mc particle list
      */
-    static void GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle,
-        pandora::MCParticleList &descendentMCParticleList);
+    static void GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &descendentMCParticleList);
 
     /**
      *  @brief  Get all ancestor mc particles
@@ -232,8 +231,7 @@ public:
      *  @param  pMCParticle the input mc particle
      *  @param  ancestorMCParticleList the output ancestor mc particle list
      */
-    static void GetAllAncestorMCParticles(const pandora::MCParticle *const pMCParticle,
-        pandora::MCParticleList &ancestorMCParticleList);
+    static void GetAllAncestorMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &ancestorMCParticleList);
 
     /**
      *  @brief  Get mapping from individual mc particles (in a provided list) and their primary parent mc particles
@@ -297,7 +295,8 @@ public:
      *  @param  selectedMCParticlesToHitsMap the output mapping from selected mcparticles to their hits
      */
     static void SelectReconstructableMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList,
-        const PrimaryParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap);
+        const PrimaryParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria,
+        MCContributionMap &selectedMCParticlesToHitsMap);
 
     /**
      *  @brief  Select target, reconstructable mc particles in the relevant hierarchy that match given criteria.
@@ -308,8 +307,9 @@ public:
      *  @param  fCriteria a function which returns a bool (= shouldSelect) for a given input MCParticle
      *  @param  selectedMCParticlesToHitsMap the output mapping from selected mcparticles to their hits
      */
-    static void SelectReconstructableTestBeamHierarchyMCParticles(const pandora::MCParticleList *pMCParticleList, const pandora::CaloHitList *pCaloHitList,
-        const PrimaryParameters &parameters, std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap);
+    static void SelectReconstructableTestBeamHierarchyMCParticles(const pandora::MCParticleList *pMCParticleList,
+        const pandora::CaloHitList *pCaloHitList, const PrimaryParameters &parameters,
+        std::function<bool(const pandora::MCParticle *const)> fCriteria, MCContributionMap &selectedMCParticlesToHitsMap);
 
     /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
@@ -331,8 +331,8 @@ public:
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      *  @param  foldBackHierarchy whether to fold the particle hierarchy back to the leading particles
      */
-    static void GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMap &selectedMCParticleToHitsMap,
-        PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy);
+    static void GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList,
+        const MCContributionMap &selectedMCParticleToHitsMap, PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy);
 
     /**
      *  @brief  Get mapping from Pfo to reconstructable 2D hits (=good hits belonging to a selected reconstructable MCParticle)
@@ -354,8 +354,8 @@ public:
      *  @param  pfoToReconstructable2DHitsMap the output mapping from Pfos to their reconstructable 2D hits
      *  @param  foldBackHierarchy whether to fold the particle hierarchy back to the leading particles
      */
-    static void GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy);
+    static void GetTestBeamHierarchyPfoToReconstructable2DHitsMap(const pandora::PfoList &pfoList,
+        const MCContributionMapVector &selectedMCParticleToHitsMaps, PfoContributionMap &pfoToReconstructable2DHitsMap, const bool foldBackHierarchy);
 
     /**
      *  @brief  Get the mappings from Pfo -> pair (reconstructable MCparticles, number of reconstructable 2D hits shared with Pfo)
@@ -366,8 +366,9 @@ public:
      *  @param  pfoToMCParticleHitSharingMap the output mapping from Pfos to selected reconstructable MCParticles and the number hits shared
      *  @param  mcParticleToPfoHitSharingMap the output mapping from selected reconstructable MCParticles to Pfos and the number hits shared
      */
-    static void GetPfoMCParticleHitSharingMaps(const PfoContributionMap &pfoToReconstructable2DHitsMap, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap, MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
+    static void GetPfoMCParticleHitSharingMaps(const PfoContributionMap &pfoToReconstructable2DHitsMap,
+        const MCContributionMapVector &selectedMCParticleToHitsMaps, PfoToMCParticleHitSharingMap &pfoToMCParticleHitSharingMap,
+        MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap);
 
     /**
      *  @brief  Select a subset of calo hits representing those that represent "reconstructable" regions of the event
@@ -423,8 +424,8 @@ private:
      *  @param  reconstructableCaloHitList2D the output list of reconstructable 2D calo hits in the input pfo
      *  @param  foldBackHierarchy whether to fold the particle hierarchy back to leading particles
      */
-    static void CollectReconstructableTestBeamHierarchy2DHits(const pandora::ParticleFlowObject *const pPfo, const MCContributionMapVector &selectedMCParticleToHitsMaps,
-        pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy);
+    static void CollectReconstructableTestBeamHierarchy2DHits(const pandora::ParticleFlowObject *const pPfo,
+        const MCContributionMapVector &selectedMCParticleToHitsMaps, pandora::CaloHitList &reconstructableCaloHitList2D, const bool foldBackHierarchy);
 
     /**
      *  @brief  For a given Pfo list, collect the hits which are reconstructable (=good hits belonging to a selected reconstructable MCParticle)
@@ -458,8 +459,9 @@ private:
      *  @param  parameters validation parameters to decide when an MCParticle is considered reconstructable
      *  @param  isTestBeam whether the mc particles correspond to the test beam case or the neutrino case
      */
-    static void SelectParticlesMatchingCriteria(const pandora::MCParticleVector &inputMCParticles, std::function<bool(const pandora::MCParticle *const)> fCriteria,
-        pandora::MCParticleVector &selectedParticles, const PrimaryParameters &parameters, const bool isTestBeam);
+    static void SelectParticlesMatchingCriteria(const pandora::MCParticleVector &inputMCParticles,
+        std::function<bool(const pandora::MCParticle *const)> fCriteria, pandora::MCParticleVector &selectedParticles,
+        const PrimaryParameters &parameters, const bool isTestBeam);
 
     /**
      *  @brief  Filter an input vector of MCParticles to ensure they have sufficient good hits to be reconstructable

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
@@ -14,9 +14,9 @@
 
 #include "Helpers/MCParticleHelper.h"
 
+#include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
 #include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
-#include "larpandoracontent/LArHelpers/LArFormattingHelper.h"
 
 #include <algorithm>
 
@@ -40,7 +40,8 @@ unsigned int LArMonitoringHelper::CountHitsByType(const HitType hitType, const C
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMonitoringHelper::GetOrderedMCParticleVector(const LArMCParticleHelper::MCContributionMapVector &selectedMCParticleToGoodHitsMaps, MCParticleVector &orderedMCParticleVector)
+void LArMonitoringHelper::GetOrderedMCParticleVector(
+    const LArMCParticleHelper::MCContributionMapVector &selectedMCParticleToGoodHitsMaps, MCParticleVector &orderedMCParticleVector)
 {
     for (const LArMCParticleHelper::MCContributionMap &mcParticleToGoodHitsMap : selectedMCParticleToGoodHitsMaps)
     {
@@ -52,26 +53,28 @@ void LArMonitoringHelper::GetOrderedMCParticleVector(const LArMCParticleHelper::
         std::copy(mcParticleToGoodHitsMap.begin(), mcParticleToGoodHitsMap.end(), std::back_inserter(mcParticleToGoodHitsVect));
 
         // Sort by number of hits descending
-        std::sort(mcParticleToGoodHitsVect.begin(), mcParticleToGoodHitsVect.end(), [] (const LArMCParticleHelper::MCParticleCaloHitListPair &a, const LArMCParticleHelper::MCParticleCaloHitListPair &b) -> bool
-        {
-            // Neutrinos, then beam particles, then cosmic rays
-            const bool isANuFinalState(LArMCParticleHelper::IsBeamNeutrinoFinalState(a.first)), isBNuFinalState(LArMCParticleHelper::IsBeamNeutrinoFinalState(b.first));
+        std::sort(mcParticleToGoodHitsVect.begin(), mcParticleToGoodHitsVect.end(),
+            [](const LArMCParticleHelper::MCParticleCaloHitListPair &a, const LArMCParticleHelper::MCParticleCaloHitListPair &b) -> bool {
+                // Neutrinos, then beam particles, then cosmic rays
+                const bool isANuFinalState(LArMCParticleHelper::IsBeamNeutrinoFinalState(a.first)),
+                    isBNuFinalState(LArMCParticleHelper::IsBeamNeutrinoFinalState(b.first));
 
-            if (isANuFinalState != isBNuFinalState)
-                return isANuFinalState;
+                if (isANuFinalState != isBNuFinalState)
+                    return isANuFinalState;
 
-            const bool isABeamParticle(LArMCParticleHelper::IsBeamParticle(a.first)), isBBeamParticle(LArMCParticleHelper::IsBeamParticle(b.first));
+                const bool isABeamParticle(LArMCParticleHelper::IsBeamParticle(a.first)),
+                    isBBeamParticle(LArMCParticleHelper::IsBeamParticle(b.first));
 
-            if (isABeamParticle != isBBeamParticle)
-                return isABeamParticle;
+                if (isABeamParticle != isBBeamParticle)
+                    return isABeamParticle;
 
-            // Then sort by numbers of true hits
-            if (a.second.size() != b.second.size())
-                return (a.second.size() > b.second.size());
+                // Then sort by numbers of true hits
+                if (a.second.size() != b.second.size())
+                    return (a.second.size() > b.second.size());
 
-            // Default to normal MCParticle sorting
-            return LArMCParticleHelper::SortByMomentum(a.first, b.first);
-        });
+                // Default to normal MCParticle sorting
+                return LArMCParticleHelper::SortByMomentum(a.first, b.first);
+            });
 
         for (const LArMCParticleHelper::MCParticleCaloHitListPair &mcParticleCaloHitPair : mcParticleToGoodHitsVect)
             orderedMCParticleVector.push_back(mcParticleCaloHitPair.first);
@@ -92,20 +95,20 @@ void LArMonitoringHelper::GetOrderedPfoVector(const LArMCParticleHelper::PfoCont
     std::copy(pfoToReconstructable2DHitsMap.begin(), pfoToReconstructable2DHitsMap.end(), std::back_inserter(pfoToReconstructable2DHitsVect));
 
     // Sort by number of hits descending putting neutrino final states first
-    std::sort(pfoToReconstructable2DHitsVect.begin(), pfoToReconstructable2DHitsVect.end(), [] (const LArMCParticleHelper::PfoCaloHitListPair &a, const LArMCParticleHelper::PfoCaloHitListPair &b) -> bool
-    {
-        // Neutrinos before cosmic rays
-        const bool isANuFinalState(LArPfoHelper::IsNeutrinoFinalState(a.first)), isBNuFinalState(LArPfoHelper::IsNeutrinoFinalState(b.first));
+    std::sort(pfoToReconstructable2DHitsVect.begin(), pfoToReconstructable2DHitsVect.end(),
+        [](const LArMCParticleHelper::PfoCaloHitListPair &a, const LArMCParticleHelper::PfoCaloHitListPair &b) -> bool {
+            // Neutrinos before cosmic rays
+            const bool isANuFinalState(LArPfoHelper::IsNeutrinoFinalState(a.first)), isBNuFinalState(LArPfoHelper::IsNeutrinoFinalState(b.first));
 
-        if (isANuFinalState != isBNuFinalState)
-            return isANuFinalState;
+            if (isANuFinalState != isBNuFinalState)
+                return isANuFinalState;
 
-        if (a.second.size() != b.second.size())
-            return (a.second.size() > b.second.size());
+            if (a.second.size() != b.second.size())
+                return (a.second.size() > b.second.size());
 
-        // Default to normal pfo sorting
-        return LArPfoHelper::SortByNHits(a.first, b.first);
-    });
+            // Default to normal pfo sorting
+            return LArPfoHelper::SortByNHits(a.first, b.first);
+        });
 
     for (const LArMCParticleHelper::PfoCaloHitListPair &pfoCaloHitPair : pfoToReconstructable2DHitsVect)
         orderedPfoVector.push_back(pfoCaloHitPair.first);
@@ -118,7 +121,8 @@ void LArMonitoringHelper::GetOrderedPfoVector(const LArMCParticleHelper::PfoCont
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMonitoringHelper::PrintMCParticleTable(const LArMCParticleHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, const MCParticleVector &orderedMCParticleVector)
+void LArMonitoringHelper::PrintMCParticleTable(
+    const LArMCParticleHelper::MCContributionMap &selectedMCParticleToGoodHitsMap, const MCParticleVector &orderedMCParticleVector)
 {
     if (selectedMCParticleToGoodHitsMap.empty())
     {
@@ -135,7 +139,7 @@ void LArMonitoringHelper::PrintMCParticleTable(const LArMCParticleHelper::MCCont
 
         LArMCParticleHelper::MCContributionMap::const_iterator it = selectedMCParticleToGoodHitsMap.find(pMCParticle);
         if (selectedMCParticleToGoodHitsMap.end() == it)
-            continue;  // ATTN MCParticles in selectedMCParticleToGoodHitsMap may be a subset of orderedMCParticleVector
+            continue; // ATTN MCParticles in selectedMCParticleToGoodHitsMap may be a subset of orderedMCParticleVector
 
         // ATTN enumerate from 1 to match event validation algorithm
         table.AddElement(id + 1);
@@ -196,7 +200,8 @@ void LArMonitoringHelper::PrintPfoTable(const LArMCParticleHelper::PfoContributi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, const MCParticleVector &orderedMCParticleVector, const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap, const unsigned int nMatches)
+void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, const MCParticleVector &orderedMCParticleVector,
+    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap, const unsigned int nMatches)
 {
     if (orderedPfoVector.empty())
     {
@@ -219,7 +224,7 @@ void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, 
     const unsigned int nMatchesToShow(std::min(maxMatches, nMatches));
 
     // Set up the table headers
-    std::vector<std::string> tableHeaders({"MCParticle",""});
+    std::vector<std::string> tableHeaders({"MCParticle", ""});
     for (unsigned int i = 0; i < nMatchesToShow; ++i)
     {
         tableHeaders.push_back("");
@@ -248,11 +253,9 @@ void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, 
             pfoToSharedHitsVector = it->second;
 
         const LArFormattingHelper::Color mcCol(
-            LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle) ?
-                LArFormattingHelper::LIGHT_GREEN : (LArMCParticleHelper::IsBeamParticle(pMCParticle) ?
-                    LArFormattingHelper::LIGHT_BLUE : LArFormattingHelper::LIGHT_RED
-                )
-            );
+            LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCParticle)
+                ? LArFormattingHelper::LIGHT_GREEN
+                : (LArMCParticleHelper::IsBeamParticle(pMCParticle) ? LArFormattingHelper::LIGHT_BLUE : LArFormattingHelper::LIGHT_RED));
 
         // ATTN enumerate from 1 to match event validation algorithm
         table.AddElement(mcParticleId + 1, LArFormattingHelper::REGULAR, mcCol);
@@ -264,12 +267,14 @@ void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, 
         {
             for (unsigned int pfoId = 0; pfoId < orderedPfoVector.size(); ++pfoId)
             {
-                if (pfoNSharedHitsPair.first != orderedPfoVector.at(pfoId)) continue;
+                if (pfoNSharedHitsPair.first != orderedPfoVector.at(pfoId))
+                    continue;
 
                 if (nPfosShown < nMatchesToShow)
                 {
                     // ATTN enumerate from 1 to match event validation algorithm
-                    const LArFormattingHelper::Color pfoCol(LArPfoHelper::IsNeutrinoFinalState(pfoNSharedHitsPair.first) ? LArFormattingHelper::LIGHT_GREEN : LArFormattingHelper::LIGHT_RED);
+                    const LArFormattingHelper::Color pfoCol(
+                        LArPfoHelper::IsNeutrinoFinalState(pfoNSharedHitsPair.first) ? LArFormattingHelper::LIGHT_GREEN : LArFormattingHelper::LIGHT_RED);
                     table.AddElement(pfoId + 1, LArFormattingHelper::REGULAR, pfoCol);
                     table.AddElement(pfoNSharedHitsPair.second.size(), LArFormattingHelper::REGULAR, pfoCol);
                     nPfosShown++;
@@ -290,7 +295,8 @@ void LArMonitoringHelper::PrintMatchingTable(const PfoVector &orderedPfoVector, 
         }
 
         // Print any remaining matches
-        if (!showOthersColumn) continue;
+        if (!showOthersColumn)
+            continue;
 
         if (nOtherHits != 0)
         {

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.h
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.h
@@ -37,7 +37,8 @@ public:
      *  @param  selectedMCParticleToGoodHitsMaps the input vector of mappings from selected reconstructable MCParticles to their good hits
      *  @param  orderedMCParticleVector the output vector of ordered MCParticles
      */
-    static void GetOrderedMCParticleVector(const LArMCParticleHelper::MCContributionMapVector &selectedMCParticleToGoodHitsMaps, pandora::MCParticleVector &orderedMCParticleVector);
+    static void GetOrderedMCParticleVector(const LArMCParticleHelper::MCContributionMapVector &selectedMCParticleToGoodHitsMaps,
+        pandora::MCParticleVector &orderedMCParticleVector);
 
     /**
      *  @brief  Order input Pfos by their number of hits.
@@ -53,7 +54,8 @@ public:
      *  @param  selectedMCParticleToGoodHitsMap the input mapping from selected reconstructable MCParticles to their good hits
      *  @param  orderedMCParticleVector the input vector of ordered MCParticles
      */
-    static void PrintMCParticleTable(const LArMCParticleHelper::MCContributionMap &selectedMCParticleToGoodHitsMaps, const pandora::MCParticleVector &orderedMCParticleVector);
+    static void PrintMCParticleTable(const LArMCParticleHelper::MCContributionMap &selectedMCParticleToGoodHitsMaps,
+        const pandora::MCParticleVector &orderedMCParticleVector);
 
     /**
      *  @brief  Print details of input Pfos to the terminal in a table.
@@ -71,7 +73,8 @@ public:
      *  @param  mcParticleToPfoHitSharingMap the output mapping from selected reconstructable MCParticles to Pfos and the number hits shared
      *  @param  nMatches the maximum number of Pfo matches to show
      */
-    static void PrintMatchingTable(const pandora::PfoVector &orderedPfoVector, const pandora::MCParticleVector &orderedMCParticleVector, const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap, const unsigned int nMatches);
+    static void PrintMatchingTable(const pandora::PfoVector &orderedPfoVector, const pandora::MCParticleVector &orderedMCParticleVector,
+        const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap, const unsigned int nMatches);
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArMvaHelper.h
+++ b/larpandoracontent/LArHelpers/LArMvaHelper.h
@@ -13,9 +13,9 @@
 #include "Pandora/AlgorithmTool.h"
 #include "Pandora/StatusCodes.h"
 
-#include <fstream>
 #include <chrono>
 #include <ctime>
+#include <fstream>
 
 namespace lar_content
 {
@@ -23,7 +23,7 @@ namespace lar_content
 /**
  *  @brief  MvaFeatureTool class template
  */
-template <typename ...Ts>
+template <typename... Ts>
 class MvaFeatureTool : public pandora::AlgorithmTool
 {
 public:
@@ -43,7 +43,7 @@ public:
     virtual void Run(MvaTypes::MvaFeatureVector &featureVector, Ts... args) = 0;
 };
 
-template <typename ...Ts>
+template <typename... Ts>
 using MvaFeatureToolVector = std::vector<MvaFeatureTool<Ts...> *>;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ public:
      *
      *  @return success
      */
-    template <typename ...TLISTS>
+    template <typename... TLISTS>
     static pandora::StatusCode ProduceTrainingExample(const std::string &trainingOutputFile, const bool result, TLISTS &&... featureLists);
 
     /**
@@ -76,7 +76,7 @@ public:
      *
      *  @return the predicted boolean class of the example
      */
-    template <typename ...TLISTS>
+    template <typename... TLISTS>
     static bool Classify(const MvaInterface &classifier, TLISTS &&... featureLists);
 
     /**
@@ -87,7 +87,7 @@ public:
      *
      *  @return the classification score
      */
-    template <typename ...TLISTS>
+    template <typename... TLISTS>
     static double CalculateClassificationScore(const MvaInterface &classifier, TLISTS &&... featureLists);
 
     /**
@@ -98,7 +98,7 @@ public:
      *
      *  @return the classification probability
      */
-    template <typename ...TLISTS>
+    template <typename... TLISTS>
     static double CalculateProbability(const MvaInterface &classifier, TLISTS &&... featureLists);
 
     /**
@@ -109,7 +109,7 @@ public:
      *
      *  @return the vector of features
      */
-    template <typename ...Ts, typename ...TARGS>
+    template <typename... Ts, typename... TARGS>
     static MvaFeatureVector CalculateFeatures(const MvaFeatureToolVector<Ts...> &featureToolVector, TARGS &&... args);
 
     /**
@@ -120,7 +120,7 @@ public:
      *
      *  @return the vector of features
      */
-    template <typename T, typename ...Ts, typename ...TARGS>
+    template <typename T, typename... Ts, typename... TARGS>
     static MvaFeatureVector CalculateFeaturesOfType(const MvaFeatureToolVector<Ts...> &featureToolVector, TARGS &&... args);
 
     /**
@@ -131,7 +131,7 @@ public:
      *
      *  @return success
      */
-    template <typename ...Ts>
+    template <typename... Ts>
     static pandora::StatusCode AddFeatureToolToVector(pandora::AlgorithmTool *const pFeatureTool, MvaFeatureToolVector<Ts...> &featureToolVector);
 
 private:
@@ -152,7 +152,7 @@ private:
      *
      *  @return success
      */
-    template <typename TLIST, typename ...TLISTS>
+    template <typename TLIST, typename... TLISTS>
     static pandora::StatusCode WriteFeaturesToFile(std::ofstream &outfile, const std::string &delimiter, TLIST &&featureList, TLISTS &&... featureLists);
 
     /**
@@ -182,7 +182,7 @@ private:
      *
      *  @return the concatenated vector of features
      */
-    template <typename TLIST, typename ...TLISTS>
+    template <typename TLIST, typename... TLISTS>
     static MvaFeatureVector ConcatenateFeatureLists(TLIST &&featureList, TLISTS &&... featureLists);
 
     /**
@@ -193,7 +193,7 @@ private:
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename ...TLISTS>
+template <typename... TLISTS>
 pandora::StatusCode LArMvaHelper::ProduceTrainingExample(const std::string &trainingOutputFile, const bool result, TLISTS &&... featureLists)
 {
     std::ofstream outfile;
@@ -216,7 +216,7 @@ pandora::StatusCode LArMvaHelper::ProduceTrainingExample(const std::string &trai
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename ...TLISTS>
+template <typename... TLISTS>
 bool LArMvaHelper::Classify(const MvaInterface &classifier, TLISTS &&... featureLists)
 {
     return classifier.Classify(ConcatenateFeatureLists(std::forward<TLISTS>(featureLists)...));
@@ -224,7 +224,7 @@ bool LArMvaHelper::Classify(const MvaInterface &classifier, TLISTS &&... feature
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename ...TLISTS>
+template <typename... TLISTS>
 double LArMvaHelper::CalculateClassificationScore(const MvaInterface &classifier, TLISTS &&... featureLists)
 {
     return classifier.CalculateClassificationScore(ConcatenateFeatureLists(std::forward<TLISTS>(featureLists)...));
@@ -232,7 +232,7 @@ double LArMvaHelper::CalculateClassificationScore(const MvaInterface &classifier
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename ...TLISTS>
+template <typename... TLISTS>
 double LArMvaHelper::CalculateProbability(const MvaInterface &classifier, TLISTS &&... featureLists)
 {
     return classifier.CalculateProbability(ConcatenateFeatureLists(std::forward<TLISTS>(featureLists)...));
@@ -240,7 +240,7 @@ double LArMvaHelper::CalculateProbability(const MvaInterface &classifier, TLISTS
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename ...Ts, typename ...TARGS>
+template <typename... Ts, typename... TARGS>
 LArMvaHelper::MvaFeatureVector LArMvaHelper::CalculateFeatures(const MvaFeatureToolVector<Ts...> &featureToolVector, TARGS &&... args)
 {
     LArMvaHelper::MvaFeatureVector featureVector;
@@ -253,7 +253,7 @@ LArMvaHelper::MvaFeatureVector LArMvaHelper::CalculateFeatures(const MvaFeatureT
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename T, typename ...Ts, typename ...TARGS>
+template <typename T, typename... Ts, typename... TARGS>
 LArMvaHelper::MvaFeatureVector LArMvaHelper::CalculateFeaturesOfType(const MvaFeatureToolVector<Ts...> &featureToolVector, TARGS &&... args)
 {
     using TD = typename std::decay<T>::type;
@@ -270,7 +270,7 @@ LArMvaHelper::MvaFeatureVector LArMvaHelper::CalculateFeaturesOfType(const MvaFe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename ...Ts>
+template <typename... Ts>
 pandora::StatusCode LArMvaHelper::AddFeatureToolToVector(pandora::AlgorithmTool *const pFeatureTool, MvaFeatureToolVector<Ts...> &featureToolVector)
 {
     if (MvaFeatureTool<Ts...> *const pCastFeatureTool = dynamic_cast<MvaFeatureTool<Ts...> *const>(pFeatureTool))
@@ -304,8 +304,9 @@ inline std::string LArMvaHelper::GetTimestampString()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename TLIST, typename ...TLISTS>
-inline pandora::StatusCode LArMvaHelper::WriteFeaturesToFile(std::ofstream &outfile, const std::string &delimiter, TLIST &&featureList, TLISTS &&... featureLists)
+template <typename TLIST, typename... TLISTS>
+inline pandora::StatusCode LArMvaHelper::WriteFeaturesToFile(
+    std::ofstream &outfile, const std::string &delimiter, TLIST &&featureList, TLISTS &&... featureLists)
 {
     static_assert(std::is_same<typename std::decay<TLIST>::type, LArMvaHelper::MvaFeatureVector>::value,
         "LArMvaHelper: Could not write training set example because a passed parameter was not a vector of MvaFeatures");
@@ -334,7 +335,7 @@ pandora::StatusCode LArMvaHelper::WriteFeaturesToFileImpl(std::ofstream &outfile
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename TLIST, typename ...TLISTS>
+template <typename TLIST, typename... TLISTS>
 LArMvaHelper::MvaFeatureVector LArMvaHelper::ConcatenateFeatureLists(TLIST &&featureList, TLISTS &&... featureLists)
 {
     static_assert(std::is_same<typename std::decay<TLIST>::type, LArMvaHelper::MvaFeatureVector>::value,

--- a/larpandoracontent/LArHelpers/LArObjectHelper.cc
+++ b/larpandoracontent/LArHelpers/LArObjectHelper.cc
@@ -36,7 +36,7 @@ const CaloHit *LArObjectHelper::TypeAdaptor::GetCaloHit(const CartesianVector &)
 template <>
 const CaloHit *LArObjectHelper::TypeAdaptor::GetCaloHit(const CaloHit *const &pCaloHit3D)
 {
-    const CaloHit *const pCaloHit2D = static_cast<const CaloHit*>(pCaloHit3D->GetParentAddress());
+    const CaloHit *const pCaloHit2D = static_cast<const CaloHit *>(pCaloHit3D->GetParentAddress());
     return pCaloHit2D;
 }
 

--- a/larpandoracontent/LArHelpers/LArObjectHelper.h
+++ b/larpandoracontent/LArHelpers/LArObjectHelper.h
@@ -32,7 +32,7 @@ public:
          *
          *  @return the associated position
          */
-        template<typename T>
+        template <typename T>
         static pandora::CartesianVector GetPosition(const T &t);
 
         /**
@@ -42,7 +42,7 @@ public:
          *
          *  @return the associated calo hit, or nullptr if none
          */
-        template<typename T>
+        template <typename T>
         static const pandora::CaloHit *GetCaloHit(const T &t);
     };
 };

--- a/larpandoracontent/LArHelpers/LArPcaHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPcaHelper.cc
@@ -6,9 +6,9 @@
  *  $Log: $
  */
 
+#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArObjectHelper.h"
-#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
 
 #include <Eigen/Dense>
 
@@ -92,20 +92,18 @@ void LArPcaHelper::RunPca(const WeightedPointVector &pointVector, CartesianVecto
         const double y(static_cast<double>((point.GetY()) - meanPosition[1]));
         const double z(static_cast<double>((point.GetZ()) - meanPosition[2]));
 
-        xi2  += x * x * weight;
+        xi2 += x * x * weight;
         xiyi += x * y * weight;
         xizi += x * z * weight;
-        yi2  += y * y * weight;
+        yi2 += y * y * weight;
         yizi += y * z * weight;
-        zi2  += z * z * weight;
+        zi2 += z * z * weight;
     }
 
     // Using Eigen package
     Eigen::Matrix3f sig;
 
-    sig <<  xi2, xiyi, xizi,
-           xiyi,  yi2, yizi,
-           xizi, yizi,  zi2;
+    sig << xi2, xiyi, xizi, xiyi, yi2, yizi, xizi, yizi, zi2;
 
     sig *= 1. / sumWeight;
 
@@ -126,7 +124,8 @@ void LArPcaHelper::RunPca(const WeightedPointVector &pointVector, CartesianVecto
     eigenValColVector.emplace_back(resultEigenMat(1), 1);
     eigenValColVector.emplace_back(resultEigenMat(2), 2);
 
-    std::sort(eigenValColVector.begin(), eigenValColVector.end(), [](const EigenValColPair &left, const EigenValColPair &right){return left.first > right.first;});
+    std::sort(eigenValColVector.begin(), eigenValColVector.end(),
+        [](const EigenValColPair &left, const EigenValColPair &right) { return left.first > right.first; });
 
     // Get the eigen values
     outputEigenValues = CartesianVector(eigenValColVector.at(0).first, eigenValColVector.at(1).first, eigenValColVector.at(2).first);

--- a/larpandoracontent/LArHelpers/LArPcaHelper.h
+++ b/larpandoracontent/LArHelpers/LArPcaHelper.h
@@ -10,6 +10,8 @@
 
 #include "Objects/CartesianVector.h"
 
+#include <vector>
+
 namespace lar_content
 {
 

--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -8,10 +8,10 @@
 
 #include "Pandora/PdgTable.h"
 
-#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
-#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArObjectHelper.h"
+#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h"
 
@@ -459,7 +459,7 @@ const ParticleFlowObject *LArPfoHelper::GetParentNeutrino(const ParticleFlowObje
 {
     const ParticleFlowObject *const pParentPfo = LArPfoHelper::GetParentPfo(pPfo);
 
-    if(!LArPfoHelper::IsNeutrino(pParentPfo))
+    if (!LArPfoHelper::IsNeutrino(pParentPfo))
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
     return pParentPfo;
@@ -608,7 +608,8 @@ bool LArPfoHelper::SortByHitProjection(const LArTrackTrajectoryPoint &lhs, const
 
 bool LArPfoHelper::SortByNHits(const ParticleFlowObject *const pLhs, const ParticleFlowObject *const pRhs)
 {
-    unsigned int nTwoDHitsLhs(0), nThreeDHitsLhs(0); float energyLhs(0.f);
+    unsigned int nTwoDHitsLhs(0), nThreeDHitsLhs(0);
+    float energyLhs(0.f);
     for (ClusterList::const_iterator iter = pLhs->GetClusterList().begin(), iterEnd = pLhs->GetClusterList().end(); iter != iterEnd; ++iter)
     {
         const Cluster *const pClusterLhs = *iter;
@@ -621,7 +622,8 @@ bool LArPfoHelper::SortByNHits(const ParticleFlowObject *const pLhs, const Parti
         energyLhs += pClusterLhs->GetHadronicEnergy();
     }
 
-    unsigned int nTwoDHitsRhs(0), nThreeDHitsRhs(0); float energyRhs(0.f);
+    unsigned int nTwoDHitsRhs(0), nThreeDHitsRhs(0);
+    float energyRhs(0.f);
     for (ClusterList::const_iterator iter = pRhs->GetClusterList().begin(), iterEnd = pRhs->GetClusterList().end(); iter != iterEnd; ++iter)
     {
         const Cluster *const pClusterRhs = *iter;
@@ -691,7 +693,8 @@ void LArPfoHelper::SlidingFitTrajectoryImpl(const T *const pT, const CartesianVe
 
     LArTrackTrajectory trackTrajectory;
     IntVector indicesWithoutSpacePoints;
-    if (pIndexVector) pIndexVector->clear();
+    if (pIndexVector)
+        pIndexVector->clear();
 
     try
     {
@@ -754,7 +757,8 @@ void LArPfoHelper::SlidingFitTrajectoryImpl(const T *const pT, const CartesianVe
     for (const LArTrackTrajectoryPoint &larTrackTrajectoryPoint : trackTrajectory)
     {
         trackStateVector.push_back(larTrackTrajectoryPoint.second);
-        if (pIndexVector) pIndexVector->push_back(larTrackTrajectoryPoint.GetIndex());
+        if (pIndexVector)
+            pIndexVector->push_back(larTrackTrajectoryPoint.GetIndex());
     }
 
     // Store indices of spacepoints with no associated trajectory point at the end of pIndexVector
@@ -767,7 +771,9 @@ void LArPfoHelper::SlidingFitTrajectoryImpl(const T *const pT, const CartesianVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template void LArPfoHelper::SlidingFitTrajectoryImpl(const CartesianPointVector *const, const CartesianVector &, const unsigned int, const float, LArTrackStateVector &, IntVector *const);
-template void LArPfoHelper::SlidingFitTrajectoryImpl(const CaloHitList *const, const CartesianVector &, const unsigned int, const float, LArTrackStateVector &, IntVector *const);
+template void LArPfoHelper::SlidingFitTrajectoryImpl(
+    const CartesianPointVector *const, const CartesianVector &, const unsigned int, const float, LArTrackStateVector &, IntVector *const);
+template void LArPfoHelper::SlidingFitTrajectoryImpl(
+    const CaloHitList *const, const CartesianVector &, const unsigned int, const float, LArTrackStateVector &, IntVector *const);
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -30,8 +30,8 @@ public:
      *  @param  hitType the cluster hit type
      *  @param  coordinateVector the output list of coordinates
      */
-    static void GetCoordinateVector(const pandora::ParticleFlowObject *const pPfo, const pandora::HitType &hitType,
-        pandora::CartesianPointVector &coordinateVector);
+    static void GetCoordinateVector(
+        const pandora::ParticleFlowObject *const pPfo, const pandora::HitType &hitType, pandora::CartesianPointVector &coordinateVector);
 
     /**
      *  @brief  Get a list of calo hits of a particular hit type from a list of pfos
@@ -240,7 +240,7 @@ public:
      */
     static bool IsFinalState(const pandora::ParticleFlowObject *const pPfo);
 
-     /**
+    /**
      *  @brief  Whether a pfo is a final-state particle from a neutrino (or antineutrino) interaction
      *
      *  @param  pPfo the address of the Pfo
@@ -258,7 +258,7 @@ public:
      */
     static bool IsNeutrino(const pandora::ParticleFlowObject *const pPfo);
 
-     /**
+    /**
      *  @brief  Whether a pfo is a final-state particle from a test beam particle interaction
      *
      *  @param  pPfo the address of the Pfo

--- a/larpandoracontent/LArHelpers/LArPointingClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPointingClusterHelper.cc
@@ -6,8 +6,8 @@
  *  $Log: $
  */
 
-#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 
 using namespace pandora;
 
@@ -37,7 +37,7 @@ bool LArPointingClusterHelper::IsNode(const CartesianVector &parentVertex, const
     LArPointingClusterHelper::GetImpactParameters(daughterVertex.GetPosition(), daughterVertex.GetDirection(), parentVertex, rL, rT);
 
     if (std::fabs(rL) > std::fabs(minLongitudinalDistance) || rT > maxTransverseDistance)
-	return false;
+        return false;
 
     return true;
 }
@@ -51,20 +51,20 @@ bool LArPointingClusterHelper::IsEmission(const CartesianVector &parentVertex, c
     LArPointingClusterHelper::GetImpactParameters(daughterVertex.GetPosition(), daughterVertex.GetDirection(), parentVertex, rL, rT);
 
     if (std::fabs(rL) > std::fabs(minLongitudinalDistance) && (rL < 0 || rL > maxLongitudinalDistance))
-	return false;
+        return false;
 
     const float tanSqTheta(std::pow(std::tan(M_PI * angularAllowance / 180.f), 2.0));
 
     if (rT * rT > maxTransverseDistance * maxTransverseDistance + rL * rL * tanSqTheta)
-	return false;
+        return false;
 
     return true;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-CartesianVector LArPointingClusterHelper::GetProjectedPosition(const CartesianVector &vertexPosition, const CartesianVector &vertexDirection,
-    const pandora::Cluster *const pCluster, const float projectionAngularAllowance)
+CartesianVector LArPointingClusterHelper::GetProjectedPosition(const CartesianVector &vertexPosition,
+    const CartesianVector &vertexDirection, const pandora::Cluster *const pCluster, const float projectionAngularAllowance)
 {
     const CaloHit *pClosestCaloHit(nullptr);
     float closestDistanceSquared(std::numeric_limits<float>::max());
@@ -72,86 +72,84 @@ CartesianVector LArPointingClusterHelper::GetProjectedPosition(const CartesianVe
 
     for (const OrderedCaloHitList::value_type &layerEntry : pCluster->GetOrderedCaloHitList())
     {
-	for (const CaloHit *const pCaloHit : *layerEntry.second)
-	{
-	    const CartesianVector hitProjection(pCaloHit->GetPositionVector() - vertexPosition);
-	    const float distanceSquared(hitProjection.GetMagnitudeSquared());
+        for (const CaloHit *const pCaloHit : *layerEntry.second)
+        {
+            const CartesianVector hitProjection(pCaloHit->GetPositionVector() - vertexPosition);
+            const float distanceSquared(hitProjection.GetMagnitudeSquared());
 
-	    if (distanceSquared > std::numeric_limits<float>::epsilon())
-	    {
-		// TODO Try to give more weight to on-axis projections
-		if (distanceSquared < closestDistanceSquared)
-		{
-		    if (-hitProjection.GetUnitVector().GetDotProduct(vertexDirection) > minCosTheta)
-		    {
-			pClosestCaloHit = pCaloHit;
-			closestDistanceSquared = distanceSquared;
-		    }
-		}
-	    }
-	    else
-	    {
-		return pCaloHit->GetPositionVector();
-	    }
-	}
+            if (distanceSquared > std::numeric_limits<float>::epsilon())
+            {
+                // TODO Try to give more weight to on-axis projections
+                if (distanceSquared < closestDistanceSquared)
+                {
+                    if (-hitProjection.GetUnitVector().GetDotProduct(vertexDirection) > minCosTheta)
+                    {
+                        pClosestCaloHit = pCaloHit;
+                        closestDistanceSquared = distanceSquared;
+                    }
+                }
+            }
+            else
+            {
+                return pCaloHit->GetPositionVector();
+            }
+        }
     }
 
     if (pClosestCaloHit)
-	return pClosestCaloHit->GetPositionVector();
+        return pClosestCaloHit->GetPositionVector();
 
     throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPointingClusterHelper::GetClosestVertices(const bool useX, const bool useY, const bool useZ,
-    const LArPointingCluster &pointingClusterI, const LArPointingCluster &pointingClusterJ,
-    LArPointingCluster::Vertex &closestVertexI, LArPointingCluster::Vertex &closestVertexJ)
+void LArPointingClusterHelper::GetClosestVertices(const bool useX, const bool useY, const bool useZ, const LArPointingCluster &pointingClusterI,
+    const LArPointingCluster &pointingClusterJ, LArPointingCluster::Vertex &closestVertexI, LArPointingCluster::Vertex &closestVertexJ)
 {
     if (pointingClusterI.GetCluster() == pointingClusterJ.GetCluster())
-	throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
     if (!useX && !useY && !useZ)
-	throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     for (unsigned int useInnerI = 0; useInnerI < 2; ++useInnerI)
     {
-	const LArPointingCluster::Vertex &vtxI(useInnerI == 1 ? pointingClusterI.GetInnerVertex() : pointingClusterI.GetOuterVertex());
-	const LArPointingCluster::Vertex &endI(useInnerI == 0 ? pointingClusterI.GetInnerVertex() : pointingClusterI.GetOuterVertex());
+        const LArPointingCluster::Vertex &vtxI(useInnerI == 1 ? pointingClusterI.GetInnerVertex() : pointingClusterI.GetOuterVertex());
+        const LArPointingCluster::Vertex &endI(useInnerI == 0 ? pointingClusterI.GetInnerVertex() : pointingClusterI.GetOuterVertex());
 
-	for (unsigned int useInnerJ = 0; useInnerJ < 2; ++useInnerJ)
-	{
-	    const LArPointingCluster::Vertex &vtxJ(useInnerJ == 1 ? pointingClusterJ.GetInnerVertex() : pointingClusterJ.GetOuterVertex());
-	    const LArPointingCluster::Vertex &endJ(useInnerJ == 0 ? pointingClusterJ.GetInnerVertex() : pointingClusterJ.GetOuterVertex());
+        for (unsigned int useInnerJ = 0; useInnerJ < 2; ++useInnerJ)
+        {
+            const LArPointingCluster::Vertex &vtxJ(useInnerJ == 1 ? pointingClusterJ.GetInnerVertex() : pointingClusterJ.GetOuterVertex());
+            const LArPointingCluster::Vertex &endJ(useInnerJ == 0 ? pointingClusterJ.GetInnerVertex() : pointingClusterJ.GetOuterVertex());
 
-	    const float vtxI_vtxJ_dx(useX ? (vtxI.GetPosition().GetX() - vtxJ.GetPosition().GetX()) : 0.f);
-	    const float vtxI_vtxJ_dy(useY ? (vtxI.GetPosition().GetY() - vtxJ.GetPosition().GetY()) : 0.f);
-	    const float vtxI_vtxJ_dz(useZ ? (vtxI.GetPosition().GetZ() - vtxJ.GetPosition().GetZ()) : 0.f);
-	    const float vtxI_vtxJ(vtxI_vtxJ_dx * vtxI_vtxJ_dx + vtxI_vtxJ_dy * vtxI_vtxJ_dy + vtxI_vtxJ_dz * vtxI_vtxJ_dz);
+            const float vtxI_vtxJ_dx(useX ? (vtxI.GetPosition().GetX() - vtxJ.GetPosition().GetX()) : 0.f);
+            const float vtxI_vtxJ_dy(useY ? (vtxI.GetPosition().GetY() - vtxJ.GetPosition().GetY()) : 0.f);
+            const float vtxI_vtxJ_dz(useZ ? (vtxI.GetPosition().GetZ() - vtxJ.GetPosition().GetZ()) : 0.f);
+            const float vtxI_vtxJ(vtxI_vtxJ_dx * vtxI_vtxJ_dx + vtxI_vtxJ_dy * vtxI_vtxJ_dy + vtxI_vtxJ_dz * vtxI_vtxJ_dz);
 
-	    const float vtxI_endJ_dx(useX ? (vtxI.GetPosition().GetX() - endJ.GetPosition().GetX()) : 0.f);
-	    const float vtxI_endJ_dy(useY ? (vtxI.GetPosition().GetY() - endJ.GetPosition().GetY()) : 0.f);
-	    const float vtxI_endJ_dz(useZ ? (vtxI.GetPosition().GetZ() - endJ.GetPosition().GetZ()) : 0.f);
-	    const float vtxI_endJ(vtxI_endJ_dx * vtxI_endJ_dx + vtxI_endJ_dy * vtxI_endJ_dy + vtxI_endJ_dz * vtxI_endJ_dz);
+            const float vtxI_endJ_dx(useX ? (vtxI.GetPosition().GetX() - endJ.GetPosition().GetX()) : 0.f);
+            const float vtxI_endJ_dy(useY ? (vtxI.GetPosition().GetY() - endJ.GetPosition().GetY()) : 0.f);
+            const float vtxI_endJ_dz(useZ ? (vtxI.GetPosition().GetZ() - endJ.GetPosition().GetZ()) : 0.f);
+            const float vtxI_endJ(vtxI_endJ_dx * vtxI_endJ_dx + vtxI_endJ_dy * vtxI_endJ_dy + vtxI_endJ_dz * vtxI_endJ_dz);
 
-	    const float endI_vtxJ_dx(useX ? (endI.GetPosition().GetX() - vtxJ.GetPosition().GetX()) : 0.f);
-	    const float endI_vtxJ_dy(useY ? (endI.GetPosition().GetY() - vtxJ.GetPosition().GetY()) : 0.f);
-	    const float endI_vtxJ_dz(useZ ? (endI.GetPosition().GetZ() - vtxJ.GetPosition().GetZ()) : 0.f);
-	    const float endI_vtxJ(endI_vtxJ_dx * endI_vtxJ_dx + endI_vtxJ_dy * endI_vtxJ_dy + endI_vtxJ_dz * endI_vtxJ_dz);
+            const float endI_vtxJ_dx(useX ? (endI.GetPosition().GetX() - vtxJ.GetPosition().GetX()) : 0.f);
+            const float endI_vtxJ_dy(useY ? (endI.GetPosition().GetY() - vtxJ.GetPosition().GetY()) : 0.f);
+            const float endI_vtxJ_dz(useZ ? (endI.GetPosition().GetZ() - vtxJ.GetPosition().GetZ()) : 0.f);
+            const float endI_vtxJ(endI_vtxJ_dx * endI_vtxJ_dx + endI_vtxJ_dy * endI_vtxJ_dy + endI_vtxJ_dz * endI_vtxJ_dz);
 
-	    const float endI_endJ_dx(useX ? (endI.GetPosition().GetX() - endJ.GetPosition().GetX()) : 0.f);
-	    const float endI_endJ_dy(useY ? (endI.GetPosition().GetY() - endJ.GetPosition().GetY()) : 0.f);
-	    const float endI_endJ_dz(useZ ? (endI.GetPosition().GetZ() - endJ.GetPosition().GetZ()) : 0.f);
-	    const float endI_endJ(endI_endJ_dx * endI_endJ_dx + endI_endJ_dy * endI_endJ_dy + endI_endJ_dz * endI_endJ_dz);
+            const float endI_endJ_dx(useX ? (endI.GetPosition().GetX() - endJ.GetPosition().GetX()) : 0.f);
+            const float endI_endJ_dy(useY ? (endI.GetPosition().GetY() - endJ.GetPosition().GetY()) : 0.f);
+            const float endI_endJ_dz(useZ ? (endI.GetPosition().GetZ() - endJ.GetPosition().GetZ()) : 0.f);
+            const float endI_endJ(endI_endJ_dx * endI_endJ_dx + endI_endJ_dy * endI_endJ_dy + endI_endJ_dz * endI_endJ_dz);
 
-	    if ((vtxI_vtxJ < std::min(vtxI_endJ, std::min(endI_vtxJ, endI_endJ))) &&
-		(endI_endJ > std::max(vtxI_endJ, std::max(endI_vtxJ, vtxI_vtxJ))))
-	    {
-		closestVertexI = vtxI;
-		closestVertexJ = vtxJ;
-		return;
-	    }
-	}
+            if ((vtxI_vtxJ < std::min(vtxI_endJ, std::min(endI_vtxJ, endI_endJ))) && (endI_endJ > std::max(vtxI_endJ, std::max(endI_vtxJ, vtxI_vtxJ))))
+            {
+                closestVertexI = vtxI;
+                closestVertexJ = vtxJ;
+                return;
+            }
+        }
     }
 
     throw StatusCodeException(STATUS_CODE_NOT_FOUND);
@@ -175,44 +173,43 @@ void LArPointingClusterHelper::GetClosestVerticesInX(const LArPointingCluster &p
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPointingClusterHelper::GetClosestVerticesInYZ(const LArPointingCluster &pointingClusterI, const LArPointingCluster &pointingClusterJ,
-    LArPointingCluster::Vertex &closestVertexI, LArPointingCluster::Vertex &closestVertexJ)
+void LArPointingClusterHelper::GetClosestVerticesInYZ(const LArPointingCluster &pointingClusterI,
+    const LArPointingCluster &pointingClusterJ, LArPointingCluster::Vertex &closestVertexI, LArPointingCluster::Vertex &closestVertexJ)
 {
     return LArPointingClusterHelper::GetClosestVertices(false, true, true, pointingClusterI, pointingClusterJ, closestVertexI, closestVertexJ);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPointingClusterHelper::GetImpactParametersInYZ(const LArPointingCluster::Vertex &initialVertex,
-    const LArPointingCluster::Vertex &targetVertex, float &longitudinal, float &transverse)
+void LArPointingClusterHelper::GetImpactParametersInYZ(
+    const LArPointingCluster::Vertex &initialVertex, const LArPointingCluster::Vertex &targetVertex, float &longitudinal, float &transverse)
 {
     if (std::fabs(initialVertex.GetDirection().GetX()) > 1.f - std::numeric_limits<float>::epsilon())
-	throw pandora::StatusCodeException(pandora::STATUS_CODE_NOT_FOUND);
+        throw pandora::StatusCodeException(pandora::STATUS_CODE_NOT_FOUND);
 
     const pandora::CartesianVector initialPosition(0.f, initialVertex.GetPosition().GetY(), initialVertex.GetPosition().GetZ());
     const pandora::CartesianVector initialDirection(0.f, initialVertex.GetDirection().GetY(), initialVertex.GetDirection().GetZ());
     const pandora::CartesianVector targetPosition(0.f, targetVertex.GetPosition().GetY(), targetVertex.GetPosition().GetZ());
 
-    return LArPointingClusterHelper::GetImpactParameters(initialPosition, initialDirection.GetUnitVector(),
-	targetPosition, longitudinal, transverse);
+    return LArPointingClusterHelper::GetImpactParameters(initialPosition, initialDirection.GetUnitVector(), targetPosition, longitudinal, transverse);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPointingClusterHelper::GetImpactParameters(const LArPointingCluster::Vertex &pointingVertex,
-    const LArPointingCluster::Vertex &targetVertex, float &longitudinal, float &transverse)
+void LArPointingClusterHelper::GetImpactParameters(
+    const LArPointingCluster::Vertex &pointingVertex, const LArPointingCluster::Vertex &targetVertex, float &longitudinal, float &transverse)
 {
-    return LArPointingClusterHelper::GetImpactParameters(pointingVertex.GetPosition(), pointingVertex.GetDirection(),
-	targetVertex.GetPosition(), longitudinal, transverse);
+    return LArPointingClusterHelper::GetImpactParameters(
+        pointingVertex.GetPosition(), pointingVertex.GetDirection(), targetVertex.GetPosition(), longitudinal, transverse);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPointingClusterHelper::GetImpactParameters(const LArPointingCluster::Vertex &pointingVertex,
-    const CartesianVector &targetPosition, float &longitudinal, float &transverse)
+void LArPointingClusterHelper::GetImpactParameters(
+    const LArPointingCluster::Vertex &pointingVertex, const CartesianVector &targetPosition, float &longitudinal, float &transverse)
 {
-    return LArPointingClusterHelper::GetImpactParameters(pointingVertex.GetPosition(), pointingVertex.GetDirection(),
-	targetPosition, longitudinal, transverse);
+    return LArPointingClusterHelper::GetImpactParameters(
+        pointingVertex.GetPosition(), pointingVertex.GetDirection(), targetPosition, longitudinal, transverse);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -222,43 +219,43 @@ void LArPointingClusterHelper::GetImpactParameters(const CartesianVector &initia
 {
     // sign convention for longitudinal distance:
     // -positive value means initial position is downstream of target position
-    transverse = initialDirection.GetCrossProduct(targetPosition-initialPosition).GetMagnitude();
-    longitudinal = -initialDirection.GetDotProduct(targetPosition-initialPosition);
+    transverse = initialDirection.GetCrossProduct(targetPosition - initialPosition).GetMagnitude();
+    longitudinal = -initialDirection.GetDotProduct(targetPosition - initialPosition);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPointingClusterHelper::GetAverageDirection(const LArPointingCluster::Vertex &firstVertex,
-    const LArPointingCluster::Vertex &secondVertex, CartesianVector &averageDirection)
+void LArPointingClusterHelper::GetAverageDirection(
+    const LArPointingCluster::Vertex &firstVertex, const LArPointingCluster::Vertex &secondVertex, CartesianVector &averageDirection)
 {
     const Cluster *const pFirstCluster(firstVertex.GetCluster());
     const Cluster *const pSecondCluster(secondVertex.GetCluster());
 
     if (pFirstCluster == pSecondCluster)
-	throw pandora::StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+        throw pandora::StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     const float energy1(pFirstCluster->GetHadronicEnergy());
     const float energy2(pSecondCluster->GetHadronicEnergy());
 
     if ((energy1 < std::numeric_limits<float>::epsilon()) || (energy2 < std::numeric_limits<float>::epsilon()))
-	throw pandora::StatusCodeException(STATUS_CODE_NOT_ALLOWED);
+        throw pandora::StatusCodeException(STATUS_CODE_NOT_ALLOWED);
 
     averageDirection = (firstVertex.GetDirection() * energy1 + secondVertex.GetDirection() * energy2).GetUnitVector();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPointingClusterHelper::GetIntersection( const LArPointingCluster::Vertex &firstVertex, const LArPointingCluster::Vertex &secondVertex,
-    CartesianVector &intersectPosition, float &firstDisplacement, float &secondDisplacement)
+void LArPointingClusterHelper::GetIntersection(const LArPointingCluster::Vertex &firstVertex,
+    const LArPointingCluster::Vertex &secondVertex, CartesianVector &intersectPosition, float &firstDisplacement, float &secondDisplacement)
 {
     const Cluster *const pFirstCluster(firstVertex.GetCluster());
     const Cluster *const pSecondCluster(secondVertex.GetCluster());
 
     if (pFirstCluster == pSecondCluster)
-	throw pandora::StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+        throw pandora::StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     LArPointingClusterHelper::GetIntersection(firstVertex.GetPosition(), firstVertex.GetDirection(), secondVertex.GetPosition(),
-	secondVertex.GetDirection(), intersectPosition, firstDisplacement, secondDisplacement );
+        secondVertex.GetDirection(), intersectPosition, firstDisplacement, secondDisplacement);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -271,7 +268,7 @@ void LArPointingClusterHelper::GetIntersection(const CartesianVector &a1, const 
 
     // lines must be non-parallel
     if (1.f - std::fabs(cosTheta) < std::numeric_limits<float>::epsilon())
-	throw pandora::StatusCodeException(STATUS_CODE_NOT_ALLOWED);
+        throw pandora::StatusCodeException(STATUS_CODE_NOT_ALLOWED);
 
     // calculate the intersection (by minimising the distance between the lines)
     const float P = ((a2 - b2 * cosTheta).GetDotProduct(b1 - a1)) / (1.f - cosTheta * cosTheta);
@@ -301,28 +298,27 @@ void LArPointingClusterHelper::GetIntersection(const LArPointingCluster::Vertex 
 
     for (OrderedCaloHitList::const_iterator iter1 = orderedCaloHitList.begin(), iterEnd1 = orderedCaloHitList.end(); iter1 != iterEnd1; ++iter1)
     {
-	for (CaloHitList::const_iterator iter2 = iter1->second->begin(), iterEnd2 = iter1->second->end(); iter2 != iterEnd2; ++iter2)
-	{
-	    const CartesianVector &hitPosition = (*iter2)->GetPositionVector();
+        for (CaloHitList::const_iterator iter2 = iter1->second->begin(), iterEnd2 = iter1->second->end(); iter2 != iterEnd2; ++iter2)
+        {
+            const CartesianVector &hitPosition = (*iter2)->GetPositionVector();
 
-	    LArPointingClusterHelper::GetImpactParameters(vertexCluster.GetPosition(), vertexCluster.GetDirection(), hitPosition, rL, rT);
+            LArPointingClusterHelper::GetImpactParameters(vertexCluster.GetPosition(), vertexCluster.GetDirection(), hitPosition, rL, rT);
 
-	    if (rT < figureOfMerit)
-	    {
-		figureOfMerit = rT;
+            if (rT < figureOfMerit)
+            {
+                figureOfMerit = rT;
 
-		displacementL = rL;
-		displacementT = rT;
-		intersectPosition = hitPosition;
-		foundIntersection = true;
-	    }
-	}
+                displacementL = rL;
+                displacementT = rT;
+                intersectPosition = hitPosition;
+                foundIntersection = true;
+            }
+        }
     }
 
     if (!foundIntersection)
-	throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 }
-
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -335,23 +331,23 @@ LArPointingCluster::Vertex LArPointingClusterHelper::GetBestVertexEstimate(const
 
     for (LArPointingClusterVertexList::const_iterator iter = vertexList.begin(), iterEnd = vertexList.end(); iter != iterEnd; ++iter)
     {
-	const LArPointingCluster::Vertex &vertex(*iter);
+        const LArPointingCluster::Vertex &vertex(*iter);
 
-	LArPointingClusterVertexList associatedVertices;
-	LArPointingClusterHelper::CollectAssociatedClusters(vertex, pointingClusterList, minLongitudinalDistance,
-	    maxLongitudinalDistance, maxTransverseDistance, angularAllowance, associatedVertices);
+        LArPointingClusterVertexList associatedVertices;
+        LArPointingClusterHelper::CollectAssociatedClusters(vertex, pointingClusterList, minLongitudinalDistance, maxLongitudinalDistance,
+            maxTransverseDistance, angularAllowance, associatedVertices);
 
-	const float associatedEnergy(LArPointingClusterHelper::GetAssociatedEnergy(vertex, associatedVertices));
+        const float associatedEnergy(LArPointingClusterHelper::GetAssociatedEnergy(vertex, associatedVertices));
 
-	if (associatedEnergy > bestAssociatedEnergy)
-	{
-	    bestVertexIter = iter;
-	    bestAssociatedEnergy = associatedEnergy;
-	}
+        if (associatedEnergy > bestAssociatedEnergy)
+        {
+            bestVertexIter = iter;
+            bestAssociatedEnergy = associatedEnergy;
+        }
     }
 
     if (vertexList.end() == bestVertexIter)
-	throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
     return (*bestVertexIter);
 }
@@ -359,25 +355,26 @@ LArPointingCluster::Vertex LArPointingClusterHelper::GetBestVertexEstimate(const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void LArPointingClusterHelper::CollectAssociatedClusters(const LArPointingCluster::Vertex &vertex, const LArPointingClusterList &inputList,
-    const float minLongitudinalDistance, const float maxLongitudinalDistance, const float maxTransverseDistance, const float angularAllowance,
-    LArPointingClusterVertexList &outputList)
+    const float minLongitudinalDistance, const float maxLongitudinalDistance, const float maxTransverseDistance,
+    const float angularAllowance, LArPointingClusterVertexList &outputList)
 {
     for (LArPointingClusterList::const_iterator iter = inputList.begin(), iterEnd = inputList.end(); iter != iterEnd; ++iter)
     {
-	const LArPointingCluster &pointingCluster = *iter;
-	const LArPointingCluster::Vertex &innerVertex = pointingCluster.GetInnerVertex();
-	const LArPointingCluster::Vertex &outerVertex = pointingCluster.GetOuterVertex();
+        const LArPointingCluster &pointingCluster = *iter;
+        const LArPointingCluster::Vertex &innerVertex = pointingCluster.GetInnerVertex();
+        const LArPointingCluster::Vertex &outerVertex = pointingCluster.GetOuterVertex();
 
-	const float innerDistanceSquared = (innerVertex.GetPosition() - vertex.GetPosition()).GetMagnitudeSquared();
-	const float outerDistanceSquared = (outerVertex.GetPosition() - vertex.GetPosition()).GetMagnitudeSquared();
+        const float innerDistanceSquared = (innerVertex.GetPosition() - vertex.GetPosition()).GetMagnitudeSquared();
+        const float outerDistanceSquared = (outerVertex.GetPosition() - vertex.GetPosition()).GetMagnitudeSquared();
 
-	const LArPointingCluster::Vertex &chosenVertex((innerDistanceSquared < outerDistanceSquared) ? innerVertex : outerVertex);
+        const LArPointingCluster::Vertex &chosenVertex((innerDistanceSquared < outerDistanceSquared) ? innerVertex : outerVertex);
 
-	if (LArPointingClusterHelper::IsNode(vertex.GetPosition(), chosenVertex, minLongitudinalDistance, maxTransverseDistance) ||
-	    LArPointingClusterHelper::IsEmission(vertex.GetPosition(), chosenVertex, minLongitudinalDistance, maxLongitudinalDistance, maxTransverseDistance, angularAllowance))
-	{
-	    outputList.push_back(chosenVertex);
-	}
+        if (LArPointingClusterHelper::IsNode(vertex.GetPosition(), chosenVertex, minLongitudinalDistance, maxTransverseDistance) ||
+            LArPointingClusterHelper::IsEmission(vertex.GetPosition(), chosenVertex, minLongitudinalDistance, maxLongitudinalDistance,
+                maxTransverseDistance, angularAllowance))
+        {
+            outputList.push_back(chosenVertex);
+        }
     }
 }
 
@@ -389,21 +386,21 @@ float LArPointingClusterHelper::GetAssociatedEnergy(const LArPointingCluster::Ve
 
     for (LArPointingClusterVertexList::const_iterator iter = associatedVertices.begin(), iterEnd = associatedVertices.end(); iter != iterEnd; ++iter)
     {
-	const LArPointingCluster::Vertex &clusterVertex(*iter);
-	const Cluster *const pCluster(clusterVertex.GetCluster());
+        const LArPointingCluster::Vertex &clusterVertex(*iter);
+        const Cluster *const pCluster(clusterVertex.GetCluster());
 
-	const float clusterEnergy(LArClusterHelper::GetEnergyFromLength(pCluster));
-	const float clusterLength(LArClusterHelper::GetLength(pCluster));
-	const float deltaLength(clusterVertex.GetDirection().GetDotProduct(vertex.GetPosition() - clusterVertex.GetPosition()));
+        const float clusterEnergy(LArClusterHelper::GetEnergyFromLength(pCluster));
+        const float clusterLength(LArClusterHelper::GetLength(pCluster));
+        const float deltaLength(clusterVertex.GetDirection().GetDotProduct(vertex.GetPosition() - clusterVertex.GetPosition()));
 
-	if (deltaLength < std::numeric_limits<float>::epsilon())
-	{
-	    associatedEnergy += clusterEnergy;
-	}
-	else if(deltaLength < clusterLength)
-	{
-	    associatedEnergy += clusterEnergy * (1.f - (deltaLength / clusterLength));
-	}
+        if (deltaLength < std::numeric_limits<float>::epsilon())
+        {
+            associatedEnergy += clusterEnergy;
+        }
+        else if (deltaLength < clusterLength)
+        {
+            associatedEnergy += clusterEnergy * (1.f - (deltaLength / clusterLength));
+        }
     }
 
     return associatedEnergy;

--- a/larpandoracontent/LArHelpers/LArPointingClusterHelper.h
+++ b/larpandoracontent/LArHelpers/LArPointingClusterHelper.h
@@ -77,8 +77,8 @@ public:
      *
      *  @return the projected position
      */
-    static pandora::CartesianVector GetProjectedPosition(const pandora::CartesianVector &initialPosition, const pandora::CartesianVector &initialDirection,
-        const pandora::Cluster *const pCluster, const float projectionAngularAllowance);
+    static pandora::CartesianVector GetProjectedPosition(const pandora::CartesianVector &initialPosition,
+        const pandora::CartesianVector &initialDirection, const pandora::Cluster *const pCluster, const float projectionAngularAllowance);
 
     /**
      *  @brief  Given a pair of pointing clusters, receive the closest or farthest pair of vertices
@@ -90,9 +90,8 @@ public:
      *  @param  closestVertexI to receive the relevant vertex from the first pointing cluster
      *  @param  closestVertexJ to receive the relevant vertex from the second pointing cluster
      */
-    static void GetClosestVertices(const bool useX, const bool useY, const bool useZ,
-        const LArPointingCluster &pointingClusterI, const LArPointingCluster &pointingClusterJ,
-        LArPointingCluster::Vertex &closestVertexI, LArPointingCluster::Vertex &closestVertexJ);
+    static void GetClosestVertices(const bool useX, const bool useY, const bool useZ, const LArPointingCluster &pointingClusterI,
+        const LArPointingCluster &pointingClusterJ, LArPointingCluster::Vertex &closestVertexI, LArPointingCluster::Vertex &closestVertexJ);
 
     /**
      *  @brief  Given a pair of pointing clusters, find the closest pair of vertices
@@ -233,8 +232,9 @@ public:
      *
      *  @return the best vertex estimate
      */
-    static LArPointingCluster::Vertex GetBestVertexEstimate(const LArPointingClusterVertexList &vertexList, const LArPointingClusterList &pointingClusterList,
-        const float minLongitudinalDistance, const float maxLongitudinalDistance, const float maxTransverseDistance, const float angularAllowance);
+    static LArPointingCluster::Vertex GetBestVertexEstimate(const LArPointingClusterVertexList &vertexList,
+        const LArPointingClusterList &pointingClusterList, const float minLongitudinalDistance, const float maxLongitudinalDistance,
+        const float maxTransverseDistance, const float angularAllowance);
 
 private:
     /**
@@ -248,8 +248,9 @@ private:
      *  @param  angularAllowance the pointing angular allowance in degrees
      *  @param  outputList to receive the output list of cluster vertices associated with the specified vertex
      */
-    static void CollectAssociatedClusters(const LArPointingCluster::Vertex &vertex, const LArPointingClusterList &inputList, const float minLongitudinalDistance,
-        const float maxLongitudinalDistance, const float maxTransverseDistance, const float angularAllowance, LArPointingClusterVertexList &outputList);
+    static void CollectAssociatedClusters(const LArPointingCluster::Vertex &vertex, const LArPointingClusterList &inputList,
+        const float minLongitudinalDistance, const float maxLongitudinalDistance, const float maxTransverseDistance,
+        const float angularAllowance, LArPointingClusterVertexList &outputList);
 
     /**
      *  @brief  Get an estimate of the energy associated with a specified vertex

--- a/larpandoracontent/LArHelpers/LArStitchingHelper.cc
+++ b/larpandoracontent/LArHelpers/LArStitchingHelper.cc
@@ -89,7 +89,7 @@ bool LArStitchingHelper::AreTPCsAdjacent(const LArTPC &firstTPC, const LArTPC &s
     const float deltaY(std::fabs(firstTPC.GetCenterY() - secondTPC.GetCenterY()));
     const float deltaZ(std::fabs(firstTPC.GetCenterZ() - secondTPC.GetCenterZ()));
 
-    if (std::fabs(deltaX-widthX) > maxDisplacement || deltaY > maxDisplacement || deltaZ > maxDisplacement)
+    if (std::fabs(deltaX - widthX) > maxDisplacement || deltaY > maxDisplacement || deltaZ > maxDisplacement)
         return false;
 
     return true;
@@ -108,7 +108,7 @@ bool LArStitchingHelper::AreTPCsAdjacent(const Pandora &pandora, const LArTPC &f
         if ((&firstTPCCheck == &firstTPC) && (&secondTPCCheck == &secondTPC))
             return true;
     }
-    catch (pandora::StatusCodeException& )
+    catch (pandora::StatusCodeException &)
     {
     }
 
@@ -121,7 +121,7 @@ bool LArStitchingHelper::AreTPCsAdjacent(const Pandora &pandora, const LArTPC &f
         if ((&firstTPCCheck == &firstTPC) && (&secondTPCCheck == &secondTPC))
             return true;
     }
-    catch (pandora::StatusCodeException& )
+    catch (pandora::StatusCodeException &)
     {
     }
 
@@ -175,9 +175,8 @@ float LArStitchingHelper::GetTPCDisplacement(const LArTPC &firstTPC, const LArTP
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArStitchingHelper::GetClosestVertices(const LArTPC &larTPC1, const LArTPC &larTPC2,
-    const LArPointingCluster &pointingCluster1, const LArPointingCluster &pointingCluster2,
-    LArPointingCluster::Vertex &closestVertex1, LArPointingCluster::Vertex &closestVertex2)
+void LArStitchingHelper::GetClosestVertices(const LArTPC &larTPC1, const LArTPC &larTPC2, const LArPointingCluster &pointingCluster1,
+    const LArPointingCluster &pointingCluster2, LArPointingCluster::Vertex &closestVertex1, LArPointingCluster::Vertex &closestVertex2)
 {
     if (&larTPC1 == &larTPC2)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -194,11 +193,11 @@ void LArStitchingHelper::GetClosestVertices(const LArTPC &larTPC1, const LArTPC 
     const bool useInner2((dxVolume > 0.f) == (dx2 > 0.f)); // xVol1 - | - INNER - OUTER - xVol2  [xVol2-xVol1>0; xOuter2-xInner2>0]
 
     // Confirm that these really are the closest pair of vertices by checking the other possible pairs
-    const LArPointingCluster::Vertex &nearVertex1(useInner1 ?  pointingCluster1.GetInnerVertex() : pointingCluster1.GetOuterVertex());
-    const LArPointingCluster::Vertex &nearVertex2(useInner2 ?  pointingCluster2.GetInnerVertex() : pointingCluster2.GetOuterVertex());
+    const LArPointingCluster::Vertex &nearVertex1(useInner1 ? pointingCluster1.GetInnerVertex() : pointingCluster1.GetOuterVertex());
+    const LArPointingCluster::Vertex &nearVertex2(useInner2 ? pointingCluster2.GetInnerVertex() : pointingCluster2.GetOuterVertex());
 
-    const LArPointingCluster::Vertex &farVertex1(useInner1 ?  pointingCluster1.GetOuterVertex() : pointingCluster1.GetInnerVertex());
-    const LArPointingCluster::Vertex &farVertex2(useInner2 ?  pointingCluster2.GetOuterVertex() : pointingCluster2.GetInnerVertex());
+    const LArPointingCluster::Vertex &farVertex1(useInner1 ? pointingCluster1.GetOuterVertex() : pointingCluster1.GetInnerVertex());
+    const LArPointingCluster::Vertex &farVertex2(useInner2 ? pointingCluster2.GetOuterVertex() : pointingCluster2.GetInnerVertex());
 
     const float dxNearNear(0.f);
     const float dyNearNear(nearVertex1.GetPosition().GetY() - nearVertex2.GetPosition().GetY());
@@ -229,8 +228,8 @@ void LArStitchingHelper::GetClosestVertices(const LArTPC &larTPC1, const LArTPC 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float LArStitchingHelper::CalculateX0(const LArTPC &firstTPC, const LArTPC &secondTPC,
-    const LArPointingCluster::Vertex &firstVertex, const LArPointingCluster::Vertex &secondVertex)
+float LArStitchingHelper::CalculateX0(const LArTPC &firstTPC, const LArTPC &secondTPC, const LArPointingCluster::Vertex &firstVertex,
+    const LArPointingCluster::Vertex &secondVertex)
 {
     if (&firstTPC == &secondTPC)
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
@@ -264,10 +263,12 @@ float LArStitchingHelper::CalculateX0(const LArTPC &firstTPC, const LArTPC &seco
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
     const float R1(firstDirectionYZ.GetUnitVector().GetDotProduct(firstPositionYZ - secondPositionYZ) / firstDirectionYZmag);
-    const float X1(-1.f * firstDirectionX.GetUnitVector().GetDotProduct(secondVertex.GetPosition() - (firstVertex.GetPosition() - firstVertex.GetDirection() * R1)));
+    const float X1(-1.f * firstDirectionX.GetUnitVector().GetDotProduct(
+                              secondVertex.GetPosition() - (firstVertex.GetPosition() - firstVertex.GetDirection() * R1)));
 
     const float R2(secondDirectionYZ.GetUnitVector().GetDotProduct(secondPositionYZ - firstPositionYZ) / secondDirectionYZmag);
-    const float X2(-1.f * secondDirectionX.GetUnitVector().GetDotProduct(firstVertex.GetPosition() - (secondVertex.GetPosition() - secondVertex.GetDirection() * R2)));
+    const float X2(-1.f * secondDirectionX.GetUnitVector().GetDotProduct(
+                              firstVertex.GetPosition() - (secondVertex.GetPosition() - secondVertex.GetDirection() * R2)));
 
     // ATTN: By convention, X0 is half the displacement in x (because both Pfos will be corrected)
     return (X1 + X2) * 0.25f;

--- a/larpandoracontent/LArHelpers/LArStitchingHelper.h
+++ b/larpandoracontent/LArHelpers/LArStitchingHelper.h
@@ -23,7 +23,7 @@ namespace lar_content
 class LArStitchingHelper
 {
 public:
-   /**
+    /**
      *  @brief  Find closest tpc to a specified input tpc
      *
      *  @param  pandora the pandora stitching instance
@@ -105,9 +105,8 @@ public:
      *  @param  closestVertex1 to receive the relevant vertex from the first pointing cluster
      *  @param  closestVertex2 to receive the relevant vertex from the second pointing cluster
      */
-    static void GetClosestVertices(const pandora::LArTPC &larTPC1, const pandora::LArTPC &larTPC2,
-        const LArPointingCluster &pointingCluster1, const LArPointingCluster &pointingCluster2,
-        LArPointingCluster::Vertex &closestVertex1, LArPointingCluster::Vertex &closestVertex2);
+    static void GetClosestVertices(const pandora::LArTPC &larTPC1, const pandora::LArTPC &larTPC2, const LArPointingCluster &pointingCluster1,
+        const LArPointingCluster &pointingCluster2, LArPointingCluster::Vertex &closestVertex1, LArPointingCluster::Vertex &closestVertex2);
 
     /**
      *  @brief  Calculate X0 for a pair of vertices

--- a/larpandoracontent/LArHelpers/LArVertexHelper.cc
+++ b/larpandoracontent/LArHelpers/LArVertexHelper.cc
@@ -6,10 +6,10 @@
  *  $Log: $
  */
 
+#include "larpandoracontent/LArHelpers/LArVertexHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
-#include "larpandoracontent/LArHelpers/LArVertexHelper.h"
 
 #include <limits>
 
@@ -18,8 +18,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-LArVertexHelper::ClusterDirection LArVertexHelper::GetClusterDirectionInZ(const Pandora &pandora, const Vertex *const pVertex,
-    const Cluster *const pCluster, const float tanAngle, const float apexShift)
+LArVertexHelper::ClusterDirection LArVertexHelper::GetClusterDirectionInZ(
+    const Pandora &pandora, const Vertex *const pVertex, const Cluster *const pCluster, const float tanAngle, const float apexShift)
 {
     if ((VERTEX_3D != pVertex->GetVertexType()) || (tanAngle < std::numeric_limits<float>::epsilon()))
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.cc
+++ b/larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.cc
@@ -11,8 +11,8 @@
 
 #include "larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.h"
 
-#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 #include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
 
@@ -47,26 +47,33 @@ void CosmicRayTaggingMonitoringTool::FindAmbiguousPfos(const PfoList &parentCosm
     LArMCParticleHelper::MCContributionMap beamMCParticlesToGoodHitsMap;
     LArMCParticleHelper::MCContributionMap crMCParticlesToGoodHitsMap;
 
-    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
-    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
-    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(
+        pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(
+        pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(
+        pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
 
     // Get the hit sharing maps between Pfos and reconstructable MCParticles
-    LArMCParticleHelper::MCContributionMapVector mcParticlesToGoodHitsMaps({nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap, crMCParticlesToGoodHitsMap});
+    LArMCParticleHelper::MCContributionMapVector mcParticlesToGoodHitsMaps(
+        {nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap, crMCParticlesToGoodHitsMap});
 
     LArMCParticleHelper::PfoContributionMap pfoToReconstructable2DHitsMap;
-    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(parentCosmicRayPfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap, m_parameters.m_foldBackHierarchy);
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(
+        parentCosmicRayPfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap, m_parameters.m_foldBackHierarchy);
 
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCParticleHitSharingMap;
     LArMCParticleHelper::MCParticleToPfoHitSharingMap mcParticleToPfoHitSharingMap;
-    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(pfoToReconstructable2DHitsMap, mcParticlesToGoodHitsMaps, pfoToMCParticleHitSharingMap, mcParticleToPfoHitSharingMap);
+    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(
+        pfoToReconstructable2DHitsMap, mcParticlesToGoodHitsMaps, pfoToMCParticleHitSharingMap, mcParticleToPfoHitSharingMap);
 
     // Calculate the purity and significane and classification of each Pfo
     PfoToFloatMap pfoSignificanceMap;
     PfoToFloatMap pfoPurityMap;
     PfoClassificationMap pfoClassificationMap;
     LArMCParticleHelper::MCContributionMapVector targetsToGoodHitsMaps({nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap});
-    this->CalculatePfoMetrics(pfoToMCParticleHitSharingMap, pfoToReconstructable2DHitsMap, targetsToGoodHitsMaps, pfoSignificanceMap, pfoPurityMap, pfoClassificationMap);
+    this->CalculatePfoMetrics(pfoToMCParticleHitSharingMap, pfoToReconstructable2DHitsMap, targetsToGoodHitsMaps, pfoSignificanceMap,
+        pfoPurityMap, pfoClassificationMap);
 
     // -------------------------------------------------------------------------------------------------------------------------------------
 
@@ -93,11 +100,13 @@ void CosmicRayTaggingMonitoringTool::FindAmbiguousPfos(const PfoList &parentCosm
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTaggingMonitoringTool::CalculatePfoMetrics(const LArMCParticleHelper::PfoToMCParticleHitSharingMap &hitSharingMap, const LArMCParticleHelper::PfoContributionMap &pfoToCaloHitListMap,
-    const LArMCParticleHelper::MCContributionMapVector &targetsToGoodHitsMaps, PfoToFloatMap &pfoSignificanceMap, PfoToFloatMap &pfoPurityMap, PfoClassificationMap &pfoClassificationMap) const
+void CosmicRayTaggingMonitoringTool::CalculatePfoMetrics(const LArMCParticleHelper::PfoToMCParticleHitSharingMap &hitSharingMap,
+    const LArMCParticleHelper::PfoContributionMap &pfoToCaloHitListMap, const LArMCParticleHelper::MCContributionMapVector &targetsToGoodHitsMaps,
+    PfoToFloatMap &pfoSignificanceMap, PfoToFloatMap &pfoPurityMap, PfoClassificationMap &pfoClassificationMap) const
 {
     PfoVector sortedPfos;
-    for (const auto &mapEntry : hitSharingMap) sortedPfos.push_back(mapEntry.first);
+    for (const auto &mapEntry : hitSharingMap)
+        sortedPfos.push_back(mapEntry.first);
     std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
 
     for (const ParticleFlowObject *const pPfo : sortedPfos)
@@ -155,7 +164,7 @@ bool CosmicRayTaggingMonitoringTool::IsMainMCParticleMuon(const ParticleFlowObje
     bool isMuon(false);
     try
     {
-        isMuon = false;// TODO Local treatment is being developed, specific to this tool (std::abs(LArMCParticleHelper::GetMainMCParticle(pPfo)->GetParticleId()) == MU_MINUS);
+        isMuon = false; // TODO Local treatment is being developed, specific to this tool (std::abs(LArMCParticleHelper::GetMainMCParticle(pPfo)->GetParticleId()) == MU_MINUS);
     }
     catch (const StatusCodeException &)
     {
@@ -166,7 +175,8 @@ bool CosmicRayTaggingMonitoringTool::IsMainMCParticleMuon(const ParticleFlowObje
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-CosmicRayTaggingMonitoringTool::Classification CosmicRayTaggingMonitoringTool::ClassifyPfo(const unsigned int &nHits, const float &significance, const float &purity, const bool isMuon) const
+CosmicRayTaggingMonitoringTool::Classification CosmicRayTaggingMonitoringTool::ClassifyPfo(
+    const unsigned int &nHits, const float &significance, const float &purity, const bool isMuon) const
 {
     if (nHits < m_minHitsToConsiderTagging)
         return SPARSE;
@@ -196,7 +206,9 @@ CosmicRayTaggingMonitoringTool::Classification CosmicRayTaggingMonitoringTool::C
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTaggingMonitoringTool::PrintPfoTable(const PfoVector &orderedPfoVector, const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const PfoToFloatMap &pfoPurityMap, const PfoToFloatMap &pfoSignificanceMap, const PfoClassificationMap &pfoClassificationMap, const PfoList &ambiguousPfos) const
+void CosmicRayTaggingMonitoringTool::PrintPfoTable(const PfoVector &orderedPfoVector,
+    const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const PfoToFloatMap &pfoPurityMap,
+    const PfoToFloatMap &pfoSignificanceMap, const PfoClassificationMap &pfoClassificationMap, const PfoList &ambiguousPfos) const
 {
     if (orderedPfoVector.empty())
     {
@@ -204,7 +216,8 @@ void CosmicRayTaggingMonitoringTool::PrintPfoTable(const PfoVector &orderedPfoVe
         return;
     }
 
-    LArFormattingHelper::Table table({"ID", "PID", "", "nHits", "U", "V", "W", "", "nGoodHits", "U", "V", "W", "", "Purity", "Significance", "Classification", "", "Tagged?"});
+    LArFormattingHelper::Table table(
+        {"ID", "PID", "", "nHits", "U", "V", "W", "", "nGoodHits", "U", "V", "W", "", "Purity", "Significance", "Classification", "", "Tagged?"});
 
     for (unsigned int id = 0; id < orderedPfoVector.size(); ++id)
     {
@@ -250,7 +263,8 @@ void CosmicRayTaggingMonitoringTool::PrintPfoTable(const PfoVector &orderedPfoVe
         const bool isTagged(std::find(ambiguousPfos.begin(), ambiguousPfos.end(), pPfo) == ambiguousPfos.end());
         const bool isGoodTag(isTagged && (classification == CR_MUON || classification == CR_OTHER));
         const bool isBadTag(isTagged && (classification == TARGET));
-        const LArFormattingHelper::Color tagColor(isGoodTag ? LArFormattingHelper::LIGHT_GREEN : (isBadTag ? LArFormattingHelper::LIGHT_RED : LArFormattingHelper::LIGHT_YELLOW));
+        const LArFormattingHelper::Color tagColor(
+            isGoodTag ? LArFormattingHelper::LIGHT_GREEN : (isBadTag ? LArFormattingHelper::LIGHT_RED : LArFormattingHelper::LIGHT_YELLOW));
         table.AddElement(isTagged ? "yes" : "no", LArFormattingHelper::INVERTED, tagColor);
     }
 
@@ -263,13 +277,20 @@ LArFormattingHelper::Color CosmicRayTaggingMonitoringTool::GetClassificationColo
 {
     switch (classification)
     {
-        case TARGET: return LArFormattingHelper::LIGHT_GREEN;
-        case CR_MUON: return LArFormattingHelper::LIGHT_RED;
-        case CR_OTHER: return LArFormattingHelper::LIGHT_YELLOW;
-        case FRAGMENTED: return LArFormattingHelper::LIGHT_BLUE;
-        case ABSORBED: return LArFormattingHelper::LIGHT_MAGENTA;
-        case MIXED: return LArFormattingHelper::LIGHT_CYAN;
-        default: return LArFormattingHelper::LIGHT_GRAY;
+        case TARGET:
+            return LArFormattingHelper::LIGHT_GREEN;
+        case CR_MUON:
+            return LArFormattingHelper::LIGHT_RED;
+        case CR_OTHER:
+            return LArFormattingHelper::LIGHT_YELLOW;
+        case FRAGMENTED:
+            return LArFormattingHelper::LIGHT_BLUE;
+        case ABSORBED:
+            return LArFormattingHelper::LIGHT_MAGENTA;
+        case MIXED:
+            return LArFormattingHelper::LIGHT_CYAN;
+        default:
+            return LArFormattingHelper::LIGHT_GRAY;
     }
 }
 
@@ -279,14 +300,22 @@ std::string CosmicRayTaggingMonitoringTool::GetClassificationName(const Classifi
 {
     switch (classification)
     {
-        case TARGET: return "TARGET";
-        case CR_MUON: return "CR_MUON";
-        case CR_OTHER: return "CR_OTHER";
-        case FRAGMENTED: return "FRAGMENTED";
-        case ABSORBED: return "ABSORBED";
-        case MIXED: return "MIXED";
-        case SPARSE: return "SPARSE";
-        default: return "UNCLASSIFIED";
+        case TARGET:
+            return "TARGET";
+        case CR_MUON:
+            return "CR_MUON";
+        case CR_OTHER:
+            return "CR_OTHER";
+        case FRAGMENTED:
+            return "FRAGMENTED";
+        case ABSORBED:
+            return "ABSORBED";
+        case MIXED:
+            return "MIXED";
+        case SPARSE:
+            return "SPARSE";
+        default:
+            return "UNCLASSIFIED";
     }
 }
 
@@ -294,38 +323,34 @@ std::string CosmicRayTaggingMonitoringTool::GetClassificationName(const Classifi
 
 StatusCode CosmicRayTaggingMonitoringTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "CaloHitList2D", m_caloHitList2D));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitList2D", m_caloHitList2D));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPrimaryGoodHits", m_parameters.m_minPrimaryGoodHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinPrimaryGoodHits", m_parameters.m_minPrimaryGoodHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsForGoodView", m_parameters.m_minHitsForGoodView));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitsForGoodView", m_parameters.m_minHitsForGoodView));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPrimaryGoodViews", m_parameters.m_minPrimaryGoodViews));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinPrimaryGoodViews", m_parameters.m_minPrimaryGoodViews));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectInputHits", m_parameters.m_selectInputHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SelectInputHits", m_parameters.m_selectInputHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxPhotonPropagation", m_parameters.m_maxPhotonPropagation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxPhotonPropagation", m_parameters.m_maxPhotonPropagation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitSharingFraction", m_parameters.m_minHitSharingFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitSharingFraction", m_parameters.m_minHitSharingFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsToConsiderTagging", m_minHitsToConsiderTagging));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitsToConsiderTagging", m_minHitsToConsiderTagging));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPurity", m_minPurity));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinPurity", m_minPurity));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinImpurity", m_minImpurity));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinImpurity", m_minImpurity));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSignificance", m_minSignificance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinSignificance", m_minSignificance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.h
+++ b/larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.h
@@ -47,8 +47,8 @@ private:
         UNCLASSIFIED
     };
 
-    typedef std::map<const pandora::ParticleFlowObject*, float > PfoToFloatMap;
-    typedef std::map<const pandora::ParticleFlowObject*, Classification > PfoClassificationMap;
+    typedef std::map<const pandora::ParticleFlowObject *, float> PfoToFloatMap;
+    typedef std::map<const pandora::ParticleFlowObject *, Classification> PfoClassificationMap;
 
     /**
      *  @brief  Calculate metrics to classify Pfos based on the target reconstructable MCParticles with which they share hits
@@ -60,8 +60,9 @@ private:
      *  @param  pfoPurityMap output mapping from Pfos to their target purities
      *  @param  pfoClassificationMap output mapping from Pfos to their classification
      */
-    void CalculatePfoMetrics(const LArMCParticleHelper::PfoToMCParticleHitSharingMap &hitSharingMap, const LArMCParticleHelper::PfoContributionMap &pfoToCaloHitListMap,
-        const LArMCParticleHelper::MCContributionMapVector &targetsToGoodHitsMaps, PfoToFloatMap &pfoSignificanceMap, PfoToFloatMap &pfoPurityMap, PfoClassificationMap &pfoClassificationMap) const;
+    void CalculatePfoMetrics(const LArMCParticleHelper::PfoToMCParticleHitSharingMap &hitSharingMap,
+        const LArMCParticleHelper::PfoContributionMap &pfoToCaloHitListMap, const LArMCParticleHelper::MCContributionMapVector &targetsToGoodHitsMaps,
+        PfoToFloatMap &pfoSignificanceMap, PfoToFloatMap &pfoPurityMap, PfoClassificationMap &pfoClassificationMap) const;
 
     /**
      *  @brief  Returns true if the main MCParticle of the supplied Pfo is a muon
@@ -98,20 +99,21 @@ private:
      *  @param  pfoClassificationMap input mapping from Pfos to their classification
      *  @param  ambiguousPfos input list of ambiguous Pfos as (not) tagged by a previous CR tagging module
      */
-    void PrintPfoTable(const pandora::PfoVector &orderedPfoVector, const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap,
-        const PfoToFloatMap &pfoPurityMap, const PfoToFloatMap &pfoSignificanceMap, const PfoClassificationMap &pfoClassificationMap, const pandora::PfoList &ambiguousPfos) const;
+    void PrintPfoTable(const pandora::PfoVector &orderedPfoVector,
+        const LArMCParticleHelper::PfoContributionMap &pfoToReconstructable2DHitsMap, const PfoToFloatMap &pfoPurityMap,
+        const PfoToFloatMap &pfoSignificanceMap, const PfoClassificationMap &pfoClassificationMap, const pandora::PfoList &ambiguousPfos) const;
 
     /**
      *  @brief  Read settings
      */
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    LArMCParticleHelper::PrimaryParameters      m_parameters;                 ///< Parameters used to decide when an MCParticle is reconstructable
-    unsigned int                                m_minHitsToConsiderTagging;   ///< The minimum number of hits to consider a Pfo for tagging
-    float                                       m_minPurity;                  ///< The minimum purity to consider a Pfo as "pure"
-    float                                       m_minImpurity;                ///< The minimum impurity to consider a Pfo as "impure"
-    float                                       m_minSignificance;            ///< The minimum significance to consider a Pfo as "significant"
-    std::string                                 m_caloHitList2D;              ///< The 2D calo hit list
+    LArMCParticleHelper::PrimaryParameters m_parameters; ///< Parameters used to decide when an MCParticle is reconstructable
+    unsigned int m_minHitsToConsiderTagging;             ///< The minimum number of hits to consider a Pfo for tagging
+    float m_minPurity;                                   ///< The minimum purity to consider a Pfo as "pure"
+    float m_minImpurity;                                 ///< The minimum impurity to consider a Pfo as "impure"
+    float m_minSignificance;                             ///< The minimum significance to consider a Pfo as "significant"
+    std::string m_caloHitList2D;                         ///< The 2D calo hit list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/EventValidationBaseAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventValidationBaseAlgorithm.cc
@@ -64,7 +64,7 @@ StatusCode EventValidationBaseAlgorithm::Run()
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_caloHitListName, pCaloHitList));
 
     const PfoList *pPfoList = nullptr;
-    (void) PandoraContentApi::GetList(*this, m_pfoListName, pPfoList);
+    (void)PandoraContentApi::GetList(*this, m_pfoListName, pPfoList);
 
     ValidationInfo validationInfo;
     this->FillValidationInfo(pMCParticleList, pCaloHitList, pPfoList, validationInfo);
@@ -83,21 +83,26 @@ StatusCode EventValidationBaseAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventValidationBaseAlgorithm::InterpretMatching(const ValidationInfo &validationInfo, LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap) const
+void EventValidationBaseAlgorithm::InterpretMatching(
+    const ValidationInfo &validationInfo, LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap) const
 {
     MCParticleVector mcPrimaryVector;
     LArMonitoringHelper::GetOrderedMCParticleVector({validationInfo.GetAllMCParticleToHitsMap()}, mcPrimaryVector);
 
     PfoSet usedPfos;
-    while (this->GetStrongestPfoMatch(validationInfo, mcPrimaryVector, usedPfos, interpretedMCToPfoHitSharingMap)) {}
+    while (this->GetStrongestPfoMatch(validationInfo, mcPrimaryVector, usedPfos, interpretedMCToPfoHitSharingMap))
+    {
+    }
     this->GetRemainingPfoMatches(validationInfo, mcPrimaryVector, usedPfos, interpretedMCToPfoHitSharingMap);
 
     // Ensure all primaries have an entry, and sorting is as desired
     for (const MCParticle *const pMCPrimary : mcPrimaryVector)
     {
         LArMCParticleHelper::PfoToSharedHitsVector &pfoHitPairs(interpretedMCToPfoHitSharingMap[pMCPrimary]);
-        std::sort(pfoHitPairs.begin(), pfoHitPairs.end(), [] (const LArMCParticleHelper::PfoCaloHitListPair &a, const LArMCParticleHelper::PfoCaloHitListPair &b) -> bool {
-            return ((a.second.size() != b.second.size()) ? a.second.size() > b.second.size() : LArPfoHelper::SortByNHits(a.first, b.first)); });
+        std::sort(pfoHitPairs.begin(), pfoHitPairs.end(),
+            [](const LArMCParticleHelper::PfoCaloHitListPair &a, const LArMCParticleHelper::PfoCaloHitListPair &b) -> bool {
+                return ((a.second.size() != b.second.size()) ? a.second.size() > b.second.size() : LArPfoHelper::SortByNHits(a.first, b.first));
+            });
     }
 }
 
@@ -125,7 +130,8 @@ bool EventValidationBaseAlgorithm::GetStrongestPfoMatch(const ValidationInfo &va
             if (usedPfos.count(pfoToSharedHits.first))
                 continue;
 
-            if (!this->IsGoodMatch(validationInfo.GetAllMCParticleToHitsMap().at(pMCPrimary), validationInfo.GetPfoToHitsMap().at(pfoToSharedHits.first), pfoToSharedHits.second))
+            if (!this->IsGoodMatch(validationInfo.GetAllMCParticleToHitsMap().at(pMCPrimary),
+                    validationInfo.GetPfoToHitsMap().at(pfoToSharedHits.first), pfoToSharedHits.second))
                 continue;
 
             if (pfoToSharedHits.second.size() > bestPfoHitPair.second.size())
@@ -187,7 +193,8 @@ void EventValidationBaseAlgorithm::GetRemainingPfoMatches(const ValidationInfo &
     for (const auto &mapEntry : pfoToMCParticleHitSharingMap)
     {
         const LArMCParticleHelper::MCParticleCaloHitListPair &mcParticleToHits(mapEntry.second.at(0));
-        interpretedMCToPfoHitSharingMap[mcParticleToHits.first].push_back(LArMCParticleHelper::PfoCaloHitListPair(mapEntry.first, mcParticleToHits.second));
+        interpretedMCToPfoHitSharingMap[mcParticleToHits.first].push_back(
+            LArMCParticleHelper::PfoCaloHitListPair(mapEntry.first, mcParticleToHits.second));
     }
 }
 
@@ -209,55 +216,54 @@ StatusCode EventValidationBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPrimaryGoodHits", m_primaryParameters.m_minPrimaryGoodHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinPrimaryGoodHits", m_primaryParameters.m_minPrimaryGoodHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsForGoodView", m_primaryParameters.m_minHitsForGoodView));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitsForGoodView", m_primaryParameters.m_minHitsForGoodView));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPrimaryGoodViews", m_primaryParameters.m_minPrimaryGoodViews));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinPrimaryGoodViews", m_primaryParameters.m_minPrimaryGoodViews));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectInputHits", m_primaryParameters.m_selectInputHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "SelectInputHits", m_primaryParameters.m_selectInputHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitSharingFraction", m_primaryParameters.m_minHitSharingFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitSharingFraction", m_primaryParameters.m_minHitSharingFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxPhotonPropagation", m_primaryParameters.m_maxPhotonPropagation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxPhotonPropagation", m_primaryParameters.m_maxPhotonPropagation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FoldToPrimaries", m_primaryParameters.m_foldBackHierarchy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "FoldToPrimaries", m_primaryParameters.m_foldBackHierarchy));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PrintAllToScreen", m_printAllToScreen));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PrintAllToScreen", m_printAllToScreen));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PrintMatchingToScreen", m_printMatchingToScreen));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PrintMatchingToScreen", m_printMatchingToScreen));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "WriteToTree", m_writeToTree));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "WriteToTree", m_writeToTree));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseSmallPrimaries", m_useSmallPrimaries));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseSmallPrimaries", m_useSmallPrimaries));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MatchingMinSharedHits", m_matchingMinSharedHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MatchingMinSharedHits", m_matchingMinSharedHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MatchingMinCompleteness", m_matchingMinCompleteness));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MatchingMinCompleteness", m_matchingMinCompleteness));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MatchingMinPurity", m_matchingMinPurity));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MatchingMinPurity", m_matchingMinPurity));
 
     if (m_writeToTree)
     {
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputTree", m_treeName));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputFile", m_fileName));
 
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-            "FileIdentifier", m_fileIdentifier));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FileIdentifier", m_fileIdentifier));
     }
 
     return STATUS_CODE_SUCCESS;

--- a/larpandoracontent/LArMonitoring/EventValidationBaseAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventValidationBaseAlgorithm.h
@@ -24,7 +24,7 @@ namespace lar_content
 /**
  *  @brief  EventValidationBaseAlgorithm class
  */
-class EventValidationBaseAlgorithm: public pandora::Algorithm
+class EventValidationBaseAlgorithm : public pandora::Algorithm
 {
 protected:
     /**
@@ -38,7 +38,7 @@ protected:
     ~EventValidationBaseAlgorithm();
 
 protected:
-   /**
+    /**
      *  @brief  ValidationInfo class
      */
     class ValidationInfo
@@ -115,11 +115,11 @@ protected:
         void SetInterpretedMCToPfoHitSharingMap(const LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap);
 
     private:
-        LArMCParticleHelper::MCContributionMap              m_allMCParticleToHitsMap;               ///< The all mc particle to hits map
-        LArMCParticleHelper::MCContributionMap              m_targetMCParticleToHitsMap;            ///< The target mc particle to hits map
-        LArMCParticleHelper::PfoContributionMap             m_pfoToHitsMap;                         ///< The pfo to hits map
-        LArMCParticleHelper::MCParticleToPfoHitSharingMap   m_mcToPfoHitSharingMap;                 ///< The mc to pfo hit sharing map
-        LArMCParticleHelper::MCParticleToPfoHitSharingMap   m_interpretedMCToPfoHitSharingMap;      ///< The interpreted mc to pfo hit sharing map
+        LArMCParticleHelper::MCContributionMap m_allMCParticleToHitsMap;                     ///< The all mc particle to hits map
+        LArMCParticleHelper::MCContributionMap m_targetMCParticleToHitsMap;                  ///< The target mc particle to hits map
+        LArMCParticleHelper::PfoContributionMap m_pfoToHitsMap;                              ///< The pfo to hits map
+        LArMCParticleHelper::MCParticleToPfoHitSharingMap m_mcToPfoHitSharingMap;            ///< The mc to pfo hit sharing map
+        LArMCParticleHelper::MCParticleToPfoHitSharingMap m_interpretedMCToPfoHitSharingMap; ///< The interpreted mc to pfo hit sharing map
     };
 
     /**
@@ -141,8 +141,8 @@ protected:
      *  @param  printToScreen whether to print the information to screen
      *  @param  fillTree whether to write the information to tree
      */
-    virtual void ProcessOutput(const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen,
-        const bool fillTree) const = 0;
+    virtual void ProcessOutput(
+        const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const = 0;
 
     /**
      *  @brief  Apply an interpretative matching procedure to the comprehensive matches in the provided validation info object
@@ -162,8 +162,8 @@ protected:
      *
      *  @return whether a strong match was identified
      */
-    bool GetStrongestPfoMatch(const ValidationInfo &validationInfo, const pandora::MCParticleVector &mcPrimaryVector, pandora::PfoSet &usedPfos,
-        LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap) const;
+    bool GetStrongestPfoMatch(const ValidationInfo &validationInfo, const pandora::MCParticleVector &mcPrimaryVector,
+        pandora::PfoSet &usedPfos, LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap) const;
 
     /**
      *  @brief  Get the best matches for any pfos left-over after the strong matching procedure
@@ -173,8 +173,8 @@ protected:
      *  @param  usedPfos the set of previously used pfos
      *  @param  interpretedMCToPfoHitSharingMap the output, interpreted mc particle to pfo hit sharing map
      */
-    void GetRemainingPfoMatches(const ValidationInfo &validationInfo, const pandora::MCParticleVector &mcPrimaryVector, const pandora::PfoSet &usedPfos,
-        LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap) const;
+    void GetRemainingPfoMatches(const ValidationInfo &validationInfo, const pandora::MCParticleVector &mcPrimaryVector,
+        const pandora::PfoSet &usedPfos, LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap) const;
 
     /**
      *  @brief  Whether a provided mc primary and pfo are deemed to be a good match
@@ -189,11 +189,11 @@ protected:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    LArMCParticleHelper::PrimaryParameters  m_primaryParameters;        ///< The mc particle primary selection parameters
-    int                                     m_fileIdentifier;           ///< The input file identifier
-    int                                     m_eventNumber;              ///< The event number
+    LArMCParticleHelper::PrimaryParameters m_primaryParameters; ///< The mc particle primary selection parameters
+    int m_fileIdentifier;                                       ///< The input file identifier
+    int m_eventNumber;                                          ///< The event number
 
-    std::string                             m_treeName;                 ///< Name of output tree
+    std::string m_treeName; ///< Name of output tree
 
 private:
     pandora::StatusCode Run();
@@ -219,20 +219,20 @@ private:
      */
     void WriteInterpretedMatches(const ValidationInfo &validationInfo) const;
 
-    std::string             m_caloHitListName;              ///< Name of input calo hit list
-    std::string             m_mcParticleListName;           ///< Name of input MC particle list
-    std::string             m_pfoListName;                  ///< Name of input Pfo list
+    std::string m_caloHitListName;    ///< Name of input calo hit list
+    std::string m_mcParticleListName; ///< Name of input MC particle list
+    std::string m_pfoListName;        ///< Name of input Pfo list
 
-    bool                    m_printAllToScreen;             ///< Whether to print all/raw matching details to screen
-    bool                    m_printMatchingToScreen;        ///< Whether to print matching output to screen
-    bool                    m_writeToTree;                  ///< Whether to write all/raw matching details to tree
+    bool m_printAllToScreen;      ///< Whether to print all/raw matching details to screen
+    bool m_printMatchingToScreen; ///< Whether to print matching output to screen
+    bool m_writeToTree;           ///< Whether to write all/raw matching details to tree
 
-    bool                    m_useSmallPrimaries;            ///< Whether to consider matches to mc primaries with fewer than m_matchingMinPrimaryHits
-    unsigned int            m_matchingMinSharedHits;        ///< The minimum number of shared hits used in matching scheme
-    float                   m_matchingMinCompleteness;      ///< The minimum particle completeness to declare a match
-    float                   m_matchingMinPurity;            ///< The minimum particle purity to declare a match
+    bool m_useSmallPrimaries;             ///< Whether to consider matches to mc primaries with fewer than m_matchingMinPrimaryHits
+    unsigned int m_matchingMinSharedHits; ///< The minimum number of shared hits used in matching scheme
+    float m_matchingMinCompleteness;      ///< The minimum particle completeness to declare a match
+    float m_matchingMinPurity;            ///< The minimum particle purity to declare a match
 
-    std::string             m_fileName;                     ///< Name of output file
+    std::string m_fileName; ///< Name of output file
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -301,7 +301,8 @@ inline void EventValidationBaseAlgorithm::ValidationInfo::SetMCToPfoHitSharingMa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline void EventValidationBaseAlgorithm::ValidationInfo::SetInterpretedMCToPfoHitSharingMap(const LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap)
+inline void EventValidationBaseAlgorithm::ValidationInfo::SetInterpretedMCToPfoHitSharingMap(
+    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &interpretedMCToPfoHitSharingMap)
 {
     m_interpretedMCToPfoHitSharingMap = interpretedMCToPfoHitSharingMap;
 }

--- a/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.cc
@@ -23,9 +23,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-MCParticleMonitoringAlgorithm::MCParticleMonitoringAlgorithm() :
-    m_useTrueNeutrinosOnly(false),
-    m_minHitsForDisplay(1)
+MCParticleMonitoringAlgorithm::MCParticleMonitoringAlgorithm() : m_useTrueNeutrinosOnly(false), m_minHitsForDisplay(1)
 {
 }
 
@@ -46,12 +44,15 @@ StatusCode MCParticleMonitoringAlgorithm::Run()
     LArMCParticleHelper::MCContributionMap nuMCParticlesToGoodHitsMap;
     LArMCParticleHelper::MCContributionMap beamMCParticlesToGoodHitsMap;
     LArMCParticleHelper::MCContributionMap crMCParticlesToGoodHitsMap;
-    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(
+        pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
 
     if (!m_useTrueNeutrinosOnly)
     {
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
     }
 
     if (!nuMCParticlesToGoodHitsMap.empty())
@@ -92,11 +93,12 @@ void MCParticleMonitoringAlgorithm::PrintPrimaryMCParticles(const LArMCParticleH
 
         if (caloHitList.size() >= m_minHitsForDisplay)
         {
-            std::cout << std::endl << "--Primary " << index << ", MCPDG " << pMCPrimary->GetParticleId() << ", Energy " << pMCPrimary->GetEnergy()
-                      << ", Dist. " << (pMCPrimary->GetEndpoint() - pMCPrimary->GetVertex()).GetMagnitude() << ", nMCHits " << caloHitList.size()
-                      << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, caloHitList)
-                      << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, caloHitList)
-                      << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, caloHitList) << ")" << std::endl;
+            std::cout << std::endl
+                      << "--Primary " << index << ", MCPDG " << pMCPrimary->GetParticleId() << ", Energy " << pMCPrimary->GetEnergy()
+                      << ", Dist. " << (pMCPrimary->GetEndpoint() - pMCPrimary->GetVertex()).GetMagnitude() << ", nMCHits "
+                      << caloHitList.size() << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, caloHitList) << ", "
+                      << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, caloHitList) << ", "
+                      << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, caloHitList) << ")" << std::endl;
 
             LArMCParticleHelper::MCRelationMap mcToPrimaryMCMap;
             LArMCParticleHelper::CaloHitToMCMap caloHitToPrimaryMCMap;
@@ -111,8 +113,8 @@ void MCParticleMonitoringAlgorithm::PrintPrimaryMCParticles(const LArMCParticleH
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MCParticleMonitoringAlgorithm::PrintMCParticle(const MCParticle *const pMCParticle, const LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap,
-    const int depth) const
+void MCParticleMonitoringAlgorithm::PrintMCParticle(
+    const MCParticle *const pMCParticle, const LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap, const int depth) const
 {
     const CaloHitList &caloHitList(mcToTrueHitListMap.count(pMCParticle) ? mcToTrueHitListMap.at(pMCParticle) : CaloHitList());
 
@@ -120,15 +122,16 @@ void MCParticleMonitoringAlgorithm::PrintMCParticle(const MCParticle *const pMCP
     {
         if (depth > 1)
         {
-            for (int iDepth = 1; iDepth < depth - 1; ++iDepth) std::cout << "   ";
+            for (int iDepth = 1; iDepth < depth - 1; ++iDepth)
+                std::cout << "   ";
             std::cout << "\\_ ";
         }
 
-        std::cout << "MCPDG " << pMCParticle->GetParticleId() << ", Energy " << pMCParticle->GetEnergy()
-                  << ", Dist. " << (pMCParticle->GetEndpoint() - pMCParticle->GetVertex()).GetMagnitude() << ", nMCHits " << caloHitList.size()
-                  << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, caloHitList)
-                  << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, caloHitList)
-                  << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, caloHitList) << ")" << std::endl;
+        std::cout << "MCPDG " << pMCParticle->GetParticleId() << ", Energy " << pMCParticle->GetEnergy() << ", Dist. "
+                  << (pMCParticle->GetEndpoint() - pMCParticle->GetVertex()).GetMagnitude() << ", nMCHits " << caloHitList.size() << " ("
+                  << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, caloHitList) << ", "
+                  << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, caloHitList) << ", "
+                  << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, caloHitList) << ")" << std::endl;
     }
 
     for (const MCParticle *const pDaughterParticle : pMCParticle->GetDaughterList())
@@ -142,11 +145,11 @@ StatusCode MCParticleMonitoringAlgorithm::ReadSettings(const TiXmlHandle xmlHand
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseTrueNeutrinosOnly", m_useTrueNeutrinosOnly));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseTrueNeutrinosOnly", m_useTrueNeutrinosOnly));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsForDisplay", m_minHitsForDisplay));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinHitsForDisplay", m_minHitsForDisplay));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/MCParticleMonitoringAlgorithm.h
@@ -18,7 +18,7 @@ namespace lar_content
 /**
  *  @brief  MCParticleMonitoringAlgorithm class
  */
-class MCParticleMonitoringAlgorithm: public pandora::Algorithm
+class MCParticleMonitoringAlgorithm : public pandora::Algorithm
 {
 public:
     /**
@@ -47,11 +47,11 @@ private:
     void PrintMCParticle(const pandora::MCParticle *const pMCParticle, const LArMCParticleHelper::MCContributionMap &mcToTrueHitListMap,
         const int depth) const;
 
-    std::string     m_caloHitListName;          ///< Name of input calo hit list
-    std::string     m_mcParticleListName;       ///< Name of input MC particle list
+    std::string m_caloHitListName;    ///< Name of input calo hit list
+    std::string m_mcParticleListName; ///< Name of input MC particle list
 
-    bool            m_useTrueNeutrinosOnly;     ///< Whether to consider only mc particles that were neutrino induced
-    unsigned int    m_minHitsForDisplay;        ///< Min hits associated with mc particle to warrant display to terminal
+    bool m_useTrueNeutrinosOnly;      ///< Whether to consider only mc particles that were neutrino induced
+    unsigned int m_minHitsForDisplay; ///< Min hits associated with mc particle to warrant display to terminal
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.cc
@@ -21,8 +21,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-NeutrinoEventValidationAlgorithm::NeutrinoEventValidationAlgorithm() :
-    m_useTrueNeutrinosOnly(false)
+NeutrinoEventValidationAlgorithm::NeutrinoEventValidationAlgorithm() : m_useTrueNeutrinosOnly(false)
 {
 }
 
@@ -34,22 +33,28 @@ NeutrinoEventValidationAlgorithm::~NeutrinoEventValidationAlgorithm()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void NeutrinoEventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pMCParticleList, const CaloHitList *const pCaloHitList,
-    const PfoList *const pPfoList, ValidationInfo &validationInfo) const
+void NeutrinoEventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pMCParticleList,
+    const CaloHitList *const pCaloHitList, const PfoList *const pPfoList, ValidationInfo &validationInfo) const
 {
     if (pMCParticleList && pCaloHitList)
     {
         LArMCParticleHelper::MCContributionMap targetMCParticleToHitsMap;
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, targetMCParticleToHitsMap);
-        if (!m_useTrueNeutrinosOnly) LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsCosmicRay, targetMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, targetMCParticleToHitsMap);
+        if (!m_useTrueNeutrinosOnly)
+            LArMCParticleHelper::SelectReconstructableMCParticles(
+                pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsCosmicRay, targetMCParticleToHitsMap);
 
         LArMCParticleHelper::PrimaryParameters parameters(m_primaryParameters);
         parameters.m_minPrimaryGoodHits = 0;
         parameters.m_minHitsForGoodView = 0;
         parameters.m_minHitSharingFraction = 0.f;
         LArMCParticleHelper::MCContributionMap allMCParticleToHitsMap;
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, allMCParticleToHitsMap);
-        if (!m_useTrueNeutrinosOnly) LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, allMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, allMCParticleToHitsMap);
+        if (!m_useTrueNeutrinosOnly)
+            LArMCParticleHelper::SelectReconstructableMCParticles(
+                pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, allMCParticleToHitsMap);
 
         validationInfo.SetTargetMCParticleToHitsMap(targetMCParticleToHitsMap);
         validationInfo.SetAllMCParticleToHitsMap(allMCParticleToHitsMap);
@@ -68,14 +73,16 @@ void NeutrinoEventValidationAlgorithm::FillValidationInfo(const MCParticleList *
         }
 
         LArMCParticleHelper::PfoContributionMap pfoToHitsMap;
-        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
+        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(
+            finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
 
         validationInfo.SetPfoToHitsMap(pfoToHitsMap);
     }
 
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCHitSharingMap;
     LArMCParticleHelper::MCParticleToPfoHitSharingMap mcToPfoHitSharingMap;
-    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(validationInfo.GetPfoToHitsMap(), {validationInfo.GetAllMCParticleToHitsMap()}, pfoToMCHitSharingMap, mcToPfoHitSharingMap);
+    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(
+        validationInfo.GetPfoToHitsMap(), {validationInfo.GetAllMCParticleToHitsMap()}, pfoToMCHitSharingMap, mcToPfoHitSharingMap);
 
     // ATTN : Ensure all mc primaries have an entry in mcToPfoHitSharingMap, even if no associated pfos.
     MCParticleVector mcPrimaryVector;
@@ -98,13 +105,16 @@ void NeutrinoEventValidationAlgorithm::FillValidationInfo(const MCParticleList *
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const
+void NeutrinoEventValidationAlgorithm::ProcessOutput(
+    const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const
 {
-    if (printToScreen && useInterpretedMatching) std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
-    else if (printToScreen) std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
+    if (printToScreen && useInterpretedMatching)
+        std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
+    else if (printToScreen)
+        std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
 
-    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcToPfoHitSharingMap(useInterpretedMatching ?
-        validationInfo.GetInterpretedMCToPfoHitSharingMap() : validationInfo.GetMCToPfoHitSharingMap());
+    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcToPfoHitSharingMap(
+        useInterpretedMatching ? validationInfo.GetInterpretedMCToPfoHitSharingMap() : validationInfo.GetMCToPfoHitSharingMap());
 
     MCParticleVector mcPrimaryVector;
     LArMonitoringHelper::GetOrderedMCParticleVector({validationInfo.GetTargetMCParticleToHitsMap()}, mcPrimaryVector);
@@ -112,7 +122,8 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
     // Neutrino Validation Bookkeeping
     int nNeutrinoPrimaries(0);
     for (const MCParticle *const pMCPrimary : mcPrimaryVector)
-        if (LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCPrimary) && validationInfo.GetTargetMCParticleToHitsMap().count(pMCPrimary)) ++nNeutrinoPrimaries;
+        if (LArMCParticleHelper::IsBeamNeutrinoFinalState(pMCPrimary) && validationInfo.GetTargetMCParticleToHitsMap().count(pMCPrimary))
+            ++nNeutrinoPrimaries;
 
     PfoVector primaryPfoVector;
     LArMonitoringHelper::GetOrderedPfoVector(validationInfo.GetPfoToHitsMap(), primaryPfoVector);
@@ -169,17 +180,12 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
         const float targetVertexX(targetVertex.GetX()), targetVertexY(targetVertex.GetY()), targetVertexZ(targetVertex.GetZ());
 #endif
 
-        targetSS << (!isTargetPrimary ? "(Non target) " : "")
-                 << "PrimaryId " << mcPrimaryIndex
-                 << ", Nu " << isBeamNeutrinoFinalState
-                 << ", CR " << isCosmicRay
-                 << ", MCPDG " << pMCPrimary->GetParticleId()
-                 << ", Energy " << pMCPrimary->GetEnergy()
-                 << ", Dist. " << (pMCPrimary->GetEndpoint() - pMCPrimary->GetVertex()).GetMagnitude()
-                 << ", nMCHits " << mcPrimaryHitList.size()
-                 << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, mcPrimaryHitList)
-                 << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, mcPrimaryHitList)
-                 << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, mcPrimaryHitList) << ")" << std::endl;
+        targetSS << (!isTargetPrimary ? "(Non target) " : "") << "PrimaryId " << mcPrimaryIndex << ", Nu " << isBeamNeutrinoFinalState
+                 << ", CR " << isCosmicRay << ", MCPDG " << pMCPrimary->GetParticleId() << ", Energy " << pMCPrimary->GetEnergy()
+                 << ", Dist. " << (pMCPrimary->GetEndpoint() - pMCPrimary->GetVertex()).GetMagnitude() << ", nMCHits "
+                 << mcPrimaryHitList.size() << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, mcPrimaryHitList) << ", "
+                 << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, mcPrimaryHitList) << ", "
+                 << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, mcPrimaryHitList) << ")" << std::endl;
 
         mcPrimaryId.push_back(mcPrimaryIndex);
         mcPrimaryPdg.push_back(pMCPrimary->GetParticleId());
@@ -200,7 +206,8 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
 
         int matchIndex(0), nPrimaryMatches(0), nPrimaryNuMatches(0), nPrimaryCRMatches(0), nPrimaryGoodNuMatches(0), nPrimaryNuSplits(0);
 #ifdef MONITORING
-        float recoVertexX(std::numeric_limits<float>::max()), recoVertexY(std::numeric_limits<float>::max()), recoVertexZ(std::numeric_limits<float>::max());
+        float recoVertexX(std::numeric_limits<float>::max()), recoVertexY(std::numeric_limits<float>::max()),
+            recoVertexZ(std::numeric_limits<float>::max());
 #endif
         for (const LArMCParticleHelper::PfoCaloHitListPair &pfoToSharedHits : mcToPfoHitSharingMap.at(pMCPrimary))
         {
@@ -230,51 +237,64 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
 #ifdef MONITORING
                 try
                 {
-                    const Vertex *const pRecoVertex(LArPfoHelper::GetVertex(isRecoNeutrinoFinalState ? LArPfoHelper::GetParentNeutrino(pfoToSharedHits.first) : pfoToSharedHits.first));
+                    const Vertex *const pRecoVertex(LArPfoHelper::GetVertex(
+                        isRecoNeutrinoFinalState ? LArPfoHelper::GetParentNeutrino(pfoToSharedHits.first) : pfoToSharedHits.first));
                     recoVertexX = pRecoVertex->GetPosition().GetX();
                     recoVertexY = pRecoVertex->GetPosition().GetY();
                     recoVertexZ = pRecoVertex->GetPosition().GetZ();
                 }
-                catch (const StatusCodeException &) {}
+                catch (const StatusCodeException &)
+                {
+                }
 #endif
             }
 
-            if (isGoodMatch) ++nPrimaryMatches;
+            if (isGoodMatch)
+                ++nPrimaryMatches;
 
             if (isRecoNeutrinoFinalState)
             {
                 const Pfo *const pRecoNeutrino(LArPfoHelper::GetParentNeutrino(pfoToSharedHits.first));
                 const bool isSplitRecoNeutrino(!recoNeutrinos.empty() && !recoNeutrinos.count(pRecoNeutrino));
-                if (!isSplitRecoNeutrino && isGoodMatch) ++nPrimaryGoodNuMatches;
-                if (isSplitRecoNeutrino && isBeamNeutrinoFinalState && isGoodMatch) ++nPrimaryNuSplits;
+                if (!isSplitRecoNeutrino && isGoodMatch)
+                    ++nPrimaryGoodNuMatches;
+                if (isSplitRecoNeutrino && isBeamNeutrinoFinalState && isGoodMatch)
+                    ++nPrimaryNuSplits;
                 recoNeutrinos.insert(pRecoNeutrino);
             }
 
-            if (isRecoNeutrinoFinalState && isGoodMatch) ++nPrimaryNuMatches;
-            if (!isRecoNeutrinoFinalState && isGoodMatch) ++nPrimaryCRMatches;
+            if (isRecoNeutrinoFinalState && isGoodMatch)
+                ++nPrimaryNuMatches;
+            if (!isRecoNeutrinoFinalState && isGoodMatch)
+                ++nPrimaryCRMatches;
 
-            targetSS << "-" << (!isGoodMatch ? "(Below threshold) " : "")
-                     << "MatchedPfoId " << pfoId
-                     << ", Nu " << isRecoNeutrinoFinalState;
-            if (isRecoNeutrinoFinalState) targetSS << " [NuId: " << recoNuId << "]";
-            targetSS << ", CR " << (!isRecoNeutrinoFinalState)
-                     << ", PDG " << pfoToSharedHits.first->GetParticleId()
-                     << ", nMatchedHits " << sharedHitList.size()
-                     << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, sharedHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, sharedHitList) << ")"
-                     << ", nPfoHits " << pfoHitList.size()
-                     << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, pfoHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, pfoHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, pfoHitList) << ")" << std::endl;
+            targetSS << "-" << (!isGoodMatch ? "(Below threshold) " : "") << "MatchedPfoId " << pfoId << ", Nu " << isRecoNeutrinoFinalState;
+            if (isRecoNeutrinoFinalState)
+                targetSS << " [NuId: " << recoNuId << "]";
+            targetSS << ", CR " << (!isRecoNeutrinoFinalState) << ", PDG " << pfoToSharedHits.first->GetParticleId() << ", nMatchedHits "
+                     << sharedHitList.size() << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, sharedHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, sharedHitList) << ")"
+                     << ", nPfoHits " << pfoHitList.size() << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, pfoHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, pfoHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, pfoHitList) << ")" << std::endl;
         }
 
         if (mcToPfoHitSharingMap.at(pMCPrimary).empty())
         {
             targetSS << "-No matched Pfo" << std::endl;
-            bestMatchPfoId.push_back(-1); bestMatchPfoPdg.push_back(0); bestMatchPfoIsRecoNu.push_back(0); bestMatchPfoRecoNuId.push_back(-1);
-            bestMatchPfoNHitsTotal.push_back(0); bestMatchPfoNHitsU.push_back(0); bestMatchPfoNHitsV.push_back(0); bestMatchPfoNHitsW.push_back(0);
-            bestMatchPfoNSharedHitsTotal.push_back(0); bestMatchPfoNSharedHitsU.push_back(0); bestMatchPfoNSharedHitsV.push_back(0); bestMatchPfoNSharedHitsW.push_back(0);
+            bestMatchPfoId.push_back(-1);
+            bestMatchPfoPdg.push_back(0);
+            bestMatchPfoIsRecoNu.push_back(0);
+            bestMatchPfoRecoNuId.push_back(-1);
+            bestMatchPfoNHitsTotal.push_back(0);
+            bestMatchPfoNHitsU.push_back(0);
+            bestMatchPfoNHitsV.push_back(0);
+            bestMatchPfoNHitsW.push_back(0);
+            bestMatchPfoNSharedHitsTotal.push_back(0);
+            bestMatchPfoNSharedHitsU.push_back(0);
+            bestMatchPfoNSharedHitsV.push_back(0);
+            bestMatchPfoNSharedHitsW.push_back(0);
         }
 
         nPrimaryMatchedPfos.push_back(nPrimaryMatches);
@@ -285,9 +305,10 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
         nTargetCRMatches += nPrimaryCRMatches;
         nTargetGoodNuMatches += nPrimaryGoodNuMatches;
         nTargetNuSplits += nPrimaryNuSplits;
-        if (0 == nPrimaryMatches) ++nTargetNuLosses;
+        if (0 == nPrimaryMatches)
+            ++nTargetNuLosses;
 
-	if (fillTree)
+        if (fillTree)
         {
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "fileIdentifier", m_fileIdentifier));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "eventNumber", m_eventNumber - 1));
@@ -347,7 +368,8 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
             const int interactionTypeInt(static_cast<int>(interactionType));
 #endif
             // ATTN Some redundancy introduced to contributing variables
-            const int isCorrectNu(isBeamNeutrinoFinalState && (nTargetGoodNuMatches == nTargetNuMatches) && (nTargetGoodNuMatches == nTargetPrimaries) && (nTargetCRMatches == 0) && (nTargetNuSplits == 0) && (nTargetNuLosses == 0));
+            const int isCorrectNu(isBeamNeutrinoFinalState && (nTargetGoodNuMatches == nTargetNuMatches) && (nTargetGoodNuMatches == nTargetPrimaries) &&
+                                  (nTargetCRMatches == 0) && (nTargetNuSplits == 0) && (nTargetNuLosses == 0));
             const int isCorrectCR(isCosmicRay && (nTargetNuMatches == 0) && (nTargetCRMatches == 1));
             const int isFakeNu(isCosmicRay && (nTargetNuMatches > 0));
             const int isFakeCR(!isCosmicRay && (nTargetCRMatches > 0));
@@ -356,30 +378,52 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
             const int isLost(nTargetMatches == 0);
 
             std::stringstream outcomeSS;
-            outcomeSS << LArInteractionTypeHelper::ToString(interactionType) << " (Nuance " << mcNuanceCode << ", Nu " << isBeamNeutrinoFinalState << ", CR " << isCosmicRay << ")" << std::endl;
+            outcomeSS << LArInteractionTypeHelper::ToString(interactionType) << " (Nuance " << mcNuanceCode << ", Nu "
+                      << isBeamNeutrinoFinalState << ", CR " << isCosmicRay << ")" << std::endl;
 
-            if (isLastNeutrinoPrimary) ++nTotalNu;
-            if (isCosmicRay) ++nTotalCR;
-            if (isCorrectNu) ++nCorrectNu;
-            if (isCorrectCR) ++nCorrectCR;
-            if (isFakeNu) ++nFakeNu;
-            if (isFakeCR) ++nFakeCR;
-            if (isSplitNu) ++nSplitNu;
-            if (isSplitCR) ++nSplitCR;
-            if (isLost) ++nLost;
+            if (isLastNeutrinoPrimary)
+                ++nTotalNu;
+            if (isCosmicRay)
+                ++nTotalCR;
+            if (isCorrectNu)
+                ++nCorrectNu;
+            if (isCorrectCR)
+                ++nCorrectCR;
+            if (isFakeNu)
+                ++nFakeNu;
+            if (isFakeCR)
+                ++nFakeCR;
+            if (isSplitNu)
+                ++nSplitNu;
+            if (isSplitCR)
+                ++nSplitCR;
+            if (isLost)
+                ++nLost;
 
-            if (isCorrectNu) outcomeSS << "IsCorrectNu ";
-            if (isCorrectCR) outcomeSS << "IsCorrectCR ";
-            if (isFakeNu) outcomeSS << "IsFake" << name << " ";
-            if (isFakeCR) outcomeSS << "IsFakeCR ";
-            if (isSplitNu) outcomeSS << "isSplit" << name << " ";
-            if (isSplitCR) outcomeSS << "IsSplitCR ";
-            if (isLost) outcomeSS << "IsLost ";
-            if (nTargetNuMatches > 0) outcomeSS << "(N" << name << "Matches: " << nTargetNuMatches << ") ";
-            if (nTargetNuLosses > 0) outcomeSS << "(N" << name << "Losses: " << nTargetNuLosses << ") ";
-            if (nTargetNuSplits > 0) outcomeSS << "(N" << name << "Splits: " << nTargetNuSplits << ") ";
-            if (nTargetCRMatches > 0) outcomeSS << "(NCRMatches: " << nTargetCRMatches << ") ";
-            if (printToScreen) std::cout << outcomeSS.str() << std::endl << targetSS.str() << std::endl;
+            if (isCorrectNu)
+                outcomeSS << "IsCorrectNu ";
+            if (isCorrectCR)
+                outcomeSS << "IsCorrectCR ";
+            if (isFakeNu)
+                outcomeSS << "IsFake" << name << " ";
+            if (isFakeCR)
+                outcomeSS << "IsFakeCR ";
+            if (isSplitNu)
+                outcomeSS << "isSplit" << name << " ";
+            if (isSplitCR)
+                outcomeSS << "IsSplitCR ";
+            if (isLost)
+                outcomeSS << "IsLost ";
+            if (nTargetNuMatches > 0)
+                outcomeSS << "(N" << name << "Matches: " << nTargetNuMatches << ") ";
+            if (nTargetNuLosses > 0)
+                outcomeSS << "(N" << name << "Losses: " << nTargetNuLosses << ") ";
+            if (nTargetNuSplits > 0)
+                outcomeSS << "(N" << name << "Splits: " << nTargetNuSplits << ") ";
+            if (nTargetCRMatches > 0)
+                outcomeSS << "(NCRMatches: " << nTargetCRMatches << ") ";
+            if (printToScreen)
+                std::cout << outcomeSS.str() << std::endl << targetSS.str() << std::endl;
 
             if (fillTree)
             {
@@ -394,16 +438,47 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
                 PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_treeName.c_str()));
             }
 
-            targetSS.str(std::string()); targetSS.clear();
-            recoNeutrinos.clear(); associatedMCPrimaries.clear();
-            nTargetMatches = 0; nTargetNuMatches = 0; nTargetCRMatches = 0; nTargetGoodNuMatches = 0; nTargetNuSplits = 0; nTargetNuLosses = 0;
-            mcPrimaryId.clear(); mcPrimaryPdg.clear(); nMCHitsTotal.clear(); nMCHitsU.clear(); nMCHitsV.clear(); nMCHitsW.clear();
-            mcPrimaryE.clear(); mcPrimaryPX.clear(); mcPrimaryPY.clear(); mcPrimaryPZ.clear();
-            mcPrimaryVtxX.clear(); mcPrimaryVtxY.clear(); mcPrimaryVtxZ.clear(); mcPrimaryEndX.clear(); mcPrimaryEndY.clear(); mcPrimaryEndZ.clear();
-            nPrimaryMatchedPfos.clear(); nPrimaryMatchedNuPfos.clear(); nPrimaryMatchedCRPfos.clear();
-            bestMatchPfoId.clear(); bestMatchPfoPdg.clear(); bestMatchPfoIsRecoNu.clear(); bestMatchPfoRecoNuId.clear();
-            bestMatchPfoNHitsTotal.clear(); bestMatchPfoNHitsU.clear(); bestMatchPfoNHitsV.clear(); bestMatchPfoNHitsW.clear();
-            bestMatchPfoNSharedHitsTotal.clear(); bestMatchPfoNSharedHitsU.clear(); bestMatchPfoNSharedHitsV.clear(); bestMatchPfoNSharedHitsW.clear();
+            targetSS.str(std::string());
+            targetSS.clear();
+            recoNeutrinos.clear();
+            associatedMCPrimaries.clear();
+            nTargetMatches = 0;
+            nTargetNuMatches = 0;
+            nTargetCRMatches = 0;
+            nTargetGoodNuMatches = 0;
+            nTargetNuSplits = 0;
+            nTargetNuLosses = 0;
+            mcPrimaryId.clear();
+            mcPrimaryPdg.clear();
+            nMCHitsTotal.clear();
+            nMCHitsU.clear();
+            nMCHitsV.clear();
+            nMCHitsW.clear();
+            mcPrimaryE.clear();
+            mcPrimaryPX.clear();
+            mcPrimaryPY.clear();
+            mcPrimaryPZ.clear();
+            mcPrimaryVtxX.clear();
+            mcPrimaryVtxY.clear();
+            mcPrimaryVtxZ.clear();
+            mcPrimaryEndX.clear();
+            mcPrimaryEndY.clear();
+            mcPrimaryEndZ.clear();
+            nPrimaryMatchedPfos.clear();
+            nPrimaryMatchedNuPfos.clear();
+            nPrimaryMatchedCRPfos.clear();
+            bestMatchPfoId.clear();
+            bestMatchPfoPdg.clear();
+            bestMatchPfoIsRecoNu.clear();
+            bestMatchPfoRecoNuId.clear();
+            bestMatchPfoNHitsTotal.clear();
+            bestMatchPfoNHitsU.clear();
+            bestMatchPfoNHitsV.clear();
+            bestMatchPfoNHitsW.clear();
+            bestMatchPfoNSharedHitsTotal.clear();
+            bestMatchPfoNSharedHitsU.clear();
+            bestMatchPfoNSharedHitsV.clear();
+            bestMatchPfoNSharedHitsW.clear();
         }
     }
 
@@ -411,26 +486,39 @@ void NeutrinoEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
     {
         std::stringstream summarySS;
         summarySS << "---SUMMARY--------------------------------------------------------------------------------------" << std::endl;
-        if (nTotalNu > 0) summarySS << "#CorrectNu: " << nCorrectNu << "/" << nTotalNu << ", Fraction: " << (nTotalNu > 0 ? static_cast<float>(nCorrectNu) / static_cast<float>(nTotalNu) : 0.f) << std::endl;
-        if (nTotalCR > 0) summarySS << "#CorrectCR: " << nCorrectCR << "/" << nTotalCR << ", Fraction: " << (nTotalCR > 0 ? static_cast<float>(nCorrectCR) / static_cast<float>(nTotalCR) : 0.f) << std::endl;
-        if (nFakeNu > 0) summarySS << "#Fake" << name << ": " << nFakeNu << " ";
-        if (nFakeCR > 0) summarySS << "#FakeCR: " << nFakeCR << " ";
-        if (nSplitNu > 0) summarySS << "#Split" << name << ": " << nSplitNu << " ";
-        if (nSplitCR > 0) summarySS << "#SplitCR: " << nSplitCR << " ";
-        if (nLost > 0) summarySS << "#Lost: " << nLost << " ";
-        if (nFakeNu || nFakeCR || nSplitNu || nSplitCR || nLost) summarySS << std::endl;
-        if (printToScreen) std::cout << summarySS.str();
+        if (nTotalNu > 0)
+            summarySS << "#CorrectNu: " << nCorrectNu << "/" << nTotalNu
+                      << ", Fraction: " << (nTotalNu > 0 ? static_cast<float>(nCorrectNu) / static_cast<float>(nTotalNu) : 0.f) << std::endl;
+        if (nTotalCR > 0)
+            summarySS << "#CorrectCR: " << nCorrectCR << "/" << nTotalCR
+                      << ", Fraction: " << (nTotalCR > 0 ? static_cast<float>(nCorrectCR) / static_cast<float>(nTotalCR) : 0.f) << std::endl;
+        if (nFakeNu > 0)
+            summarySS << "#Fake" << name << ": " << nFakeNu << " ";
+        if (nFakeCR > 0)
+            summarySS << "#FakeCR: " << nFakeCR << " ";
+        if (nSplitNu > 0)
+            summarySS << "#Split" << name << ": " << nSplitNu << " ";
+        if (nSplitCR > 0)
+            summarySS << "#SplitCR: " << nSplitCR << " ";
+        if (nLost > 0)
+            summarySS << "#Lost: " << nLost << " ";
+        if (nFakeNu || nFakeCR || nSplitNu || nSplitCR || nLost)
+            summarySS << std::endl;
+        if (printToScreen)
+            std::cout << summarySS.str();
     }
 
-    if (printToScreen) std::cout << "------------------------------------------------------------------------------------------------" << std::endl << std::endl;
+    if (printToScreen)
+        std::cout << "------------------------------------------------------------------------------------------------" << std::endl
+                  << std::endl;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode NeutrinoEventValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseTrueNeutrinosOnly", m_useTrueNeutrinosOnly));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseTrueNeutrinosOnly", m_useTrueNeutrinosOnly));
 
     return EventValidationBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/NeutrinoEventValidationAlgorithm.h
@@ -26,7 +26,7 @@ namespace lar_content
 /**
  *  @brief  NeutrinoEventValidationAlgorithm class
  */
-class NeutrinoEventValidationAlgorithm: public EventValidationBaseAlgorithm
+class NeutrinoEventValidationAlgorithm : public EventValidationBaseAlgorithm
 {
 public:
     /**
@@ -51,7 +51,7 @@ private:
     void FillValidationInfo(const pandora::MCParticleList *const pMCParticleList, const pandora::CaloHitList *const pCaloHitList,
         const pandora::PfoList *const pPfoList, ValidationInfo &validationInfo) const;
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, unsigned int> PfoToIdMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, unsigned int> PfoToIdMap;
 
     /**
      *  @brief  Print matching information in a provided validation info object, and write information to tree if configured to do so
@@ -67,7 +67,7 @@ private:
 
     typedef std::vector<pandora::HitType> HitTypeVector;
 
-    bool                    m_useTrueNeutrinosOnly;         ///< Whether to consider only mc particles that were neutrino induced
+    bool m_useTrueNeutrinosOnly; ///< Whether to consider only mc particles that were neutrino induced
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.cc
@@ -20,8 +20,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-PfoValidationAlgorithm::PfoValidationAlgorithm() :
-    m_nMatchesToShow(3)
+PfoValidationAlgorithm::PfoValidationAlgorithm() : m_nMatchesToShow(3)
 {
 }
 
@@ -43,11 +42,15 @@ StatusCode PfoValidationAlgorithm::Run()
     LArMCParticleHelper::MCContributionMap beamMCParticlesToGoodHitsMap;
     LArMCParticleHelper::MCContributionMap crMCParticlesToGoodHitsMap;
 
-    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
-    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
-    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(
+        pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, nuMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(
+        pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsBeamParticle, beamMCParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(
+        pMCParticleList, pCaloHitList, m_parameters, LArMCParticleHelper::IsCosmicRay, crMCParticlesToGoodHitsMap);
 
-    const LArMCParticleHelper::MCContributionMapVector mcParticlesToGoodHitsMaps{nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap, crMCParticlesToGoodHitsMap};
+    const LArMCParticleHelper::MCContributionMapVector mcParticlesToGoodHitsMaps{
+        nuMCParticlesToGoodHitsMap, beamMCParticlesToGoodHitsMap, crMCParticlesToGoodHitsMap};
 
     // Get the mappings detailing the hits shared between Pfos and reconstructable MCParticles
     PfoList finalStatePfos;
@@ -59,11 +62,13 @@ StatusCode PfoValidationAlgorithm::Run()
     }
 
     LArMCParticleHelper::PfoContributionMap pfoToReconstructable2DHitsMap;
-    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap, m_parameters.m_foldBackHierarchy);
+    LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(
+        finalStatePfos, mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap, m_parameters.m_foldBackHierarchy);
 
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCParticleHitSharingMap;
     LArMCParticleHelper::MCParticleToPfoHitSharingMap mcParticleToPfoHitSharingMap;
-    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(pfoToReconstructable2DHitsMap, mcParticlesToGoodHitsMaps, pfoToMCParticleHitSharingMap, mcParticleToPfoHitSharingMap);
+    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(
+        pfoToReconstructable2DHitsMap, mcParticlesToGoodHitsMaps, pfoToMCParticleHitSharingMap, mcParticleToPfoHitSharingMap);
 
     // Print the monte-carlo information for this event
     MCParticleVector orderedMCParticleVector;
@@ -99,26 +104,25 @@ StatusCode PfoValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPrimaryGoodHits", m_parameters.m_minPrimaryGoodHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinPrimaryGoodHits", m_parameters.m_minPrimaryGoodHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsForGoodView", m_parameters.m_minHitsForGoodView));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitsForGoodView", m_parameters.m_minHitsForGoodView));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPrimaryGoodViews", m_parameters.m_minPrimaryGoodViews));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinPrimaryGoodViews", m_parameters.m_minPrimaryGoodViews));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectInputHits", m_parameters.m_selectInputHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SelectInputHits", m_parameters.m_selectInputHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxPhotonPropagation", m_parameters.m_maxPhotonPropagation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxPhotonPropagation", m_parameters.m_maxPhotonPropagation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitSharingFraction", m_parameters.m_minHitSharingFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitSharingFraction", m_parameters.m_minHitSharingFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NumMatchesToShow", m_nMatchesToShow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NumMatchesToShow", m_nMatchesToShow));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/PfoValidationAlgorithm.h
@@ -16,7 +16,7 @@ namespace lar_content
 /**
  *  @brief  PfoValidationAlgorithm class
  */
-class PfoValidationAlgorithm: public pandora::Algorithm
+class PfoValidationAlgorithm : public pandora::Algorithm
 {
 public:
     /**
@@ -28,10 +28,10 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string                                 m_caloHitListName;          ///< Name of input calo hit list
-    std::string                                 m_pfoListName;              ///< Name of input pfo list
-    LArMCParticleHelper::PrimaryParameters      m_parameters;               ///< Parameters used to decide when an MCParticle is reconstructable
-    unsigned int                                m_nMatchesToShow;           ///< The maximum number of MCParticle to Pfo matches to show
+    std::string m_caloHitListName;                       ///< Name of input calo hit list
+    std::string m_pfoListName;                           ///< Name of input pfo list
+    LArMCParticleHelper::PrimaryParameters m_parameters; ///< Parameters used to decide when an MCParticle is reconstructable
+    unsigned int m_nMatchesToShow;                       ///< The maximum number of MCParticle to Pfo matches to show
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/ShowerTensorVisualizationTool.cc
+++ b/larpandoracontent/LArMonitoring/ShowerTensorVisualizationTool.cc
@@ -28,7 +28,7 @@ ShowerTensorVisualizationTool::ShowerTensorVisualizationTool() :
 bool ShowerTensorVisualizationTool::Run(ThreeViewShowersAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ClusterSet usedKeyClusters;
     ClusterVector sortedKeyClusters;
@@ -58,24 +58,28 @@ bool ShowerTensorVisualizationTool::Run(ThreeViewShowersAlgorithm *const pAlgori
 
         for (TensorType::ElementList::const_iterator eIter = elementList.begin(); eIter != elementList.end(); ++eIter)
         {
-            if (allClusterListU.end() == std::find(allClusterListU.begin(), allClusterListU.end(), eIter->GetClusterU())) allClusterListU.push_back(eIter->GetClusterU());
-            if (allClusterListV.end() == std::find(allClusterListV.begin(), allClusterListV.end(), eIter->GetClusterV())) allClusterListV.push_back(eIter->GetClusterV());
-            if (allClusterListW.end() == std::find(allClusterListW.begin(), allClusterListW.end(), eIter->GetClusterW())) allClusterListW.push_back(eIter->GetClusterW());
+            if (allClusterListU.end() == std::find(allClusterListU.begin(), allClusterListU.end(), eIter->GetClusterU()))
+                allClusterListU.push_back(eIter->GetClusterU());
+            if (allClusterListV.end() == std::find(allClusterListV.begin(), allClusterListV.end(), eIter->GetClusterV()))
+                allClusterListV.push_back(eIter->GetClusterV());
+            if (allClusterListW.end() == std::find(allClusterListW.begin(), allClusterListW.end(), eIter->GetClusterW()))
+                allClusterListW.push_back(eIter->GetClusterW());
             usedKeyClusters.insert(eIter->GetClusterU());
 
             std::cout << " Element " << counter++ << ": MatchedFraction " << eIter->GetOverlapResult().GetMatchedFraction()
-                      << ", MatchedSamplingPoints " << eIter->GetOverlapResult().GetNMatchedSamplingPoints()
-                      << ", xSpanU " << eIter->GetOverlapResult().GetXOverlap().GetXSpanU()
-                      << ", xSpanV " << eIter->GetOverlapResult().GetXOverlap().GetXSpanV()
-                      << ", xSpanW " << eIter->GetOverlapResult().GetXOverlap().GetXSpanW()
-                      << ", xOverlapSpan " << eIter->GetOverlapResult().GetXOverlap().GetXOverlapSpan()
-                      << ", Availability (" << eIter->GetClusterU()->IsAvailable() << eIter->GetClusterV()->IsAvailable() << eIter->GetClusterW()->IsAvailable() << ") "
-                      << ", TrackFlags (" << (MU_MINUS == std::abs(eIter->GetClusterU()->GetParticleId())) << (MU_MINUS == std::abs(eIter->GetClusterV()->GetParticleId())) << (MU_MINUS == std::abs(eIter->GetClusterW()->GetParticleId())) << ") "
-                      << std::endl;
+                      << ", MatchedSamplingPoints " << eIter->GetOverlapResult().GetNMatchedSamplingPoints() << ", xSpanU "
+                      << eIter->GetOverlapResult().GetXOverlap().GetXSpanU() << ", xSpanV " << eIter->GetOverlapResult().GetXOverlap().GetXSpanV()
+                      << ", xSpanW " << eIter->GetOverlapResult().GetXOverlap().GetXSpanW() << ", xOverlapSpan "
+                      << eIter->GetOverlapResult().GetXOverlap().GetXOverlapSpan() << ", Availability (" << eIter->GetClusterU()->IsAvailable()
+                      << eIter->GetClusterV()->IsAvailable() << eIter->GetClusterW()->IsAvailable() << ") "
+                      << ", TrackFlags (" << (MU_MINUS == std::abs(eIter->GetClusterU()->GetParticleId()))
+                      << (MU_MINUS == std::abs(eIter->GetClusterV()->GetParticleId()))
+                      << (MU_MINUS == std::abs(eIter->GetClusterW()->GetParticleId())) << ") " << std::endl;
 
             if (m_showEachIndividualElement)
             {
-                const ClusterList clusterListU(1, eIter->GetClusterU()), clusterListV(1, eIter->GetClusterV()), clusterListW(1, eIter->GetClusterW());
+                const ClusterList clusterListU(1, eIter->GetClusterU()), clusterListV(1, eIter->GetClusterV()),
+                    clusterListW(1, eIter->GetClusterW());
                 PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1.f, -1.f, 1.f));
                 PANDORA_MONITORING_API(VisualizeClusters(this->GetPandora(), &clusterListU, "UCluster", RED));
                 PANDORA_MONITORING_API(VisualizeClusters(this->GetPandora(), &clusterListV, "VCluster", GREEN));
@@ -107,17 +111,16 @@ bool ShowerTensorVisualizationTool::Run(ThreeViewShowersAlgorithm *const pAlgori
 
 StatusCode ShowerTensorVisualizationTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterConnections", m_minClusterConnections));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterConnections", m_minClusterConnections));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IgnoreUnavailableClusters", m_ignoreUnavailableClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "IgnoreUnavailableClusters", m_ignoreUnavailableClusters));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowEachIndividualElement", m_showEachIndividualElement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShowEachIndividualElement", m_showEachIndividualElement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowContext", m_showContext));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowContext", m_showContext));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArMonitoring/ShowerTensorVisualizationTool.h
+++ b/larpandoracontent/LArMonitoring/ShowerTensorVisualizationTool.h
@@ -29,10 +29,10 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_minClusterConnections;        ///< The minimum number of cluster connections for display
-    bool            m_ignoreUnavailableClusters;    ///< Whether to ignore (skip-over) unavailable clusters in the tensor
-    bool            m_showEachIndividualElement;    ///< Whether to draw each individual tensor element
-    bool            m_showContext;                  ///< Whether to show input cluster lists to add context to tensor elements
+    unsigned int m_minClusterConnections; ///< The minimum number of cluster connections for display
+    bool m_ignoreUnavailableClusters;     ///< Whether to ignore (skip-over) unavailable clusters in the tensor
+    bool m_showEachIndividualElement;     ///< Whether to draw each individual tensor element
+    bool m_showContext;                   ///< Whether to show input cluster lists to add context to tensor elements
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.cc
@@ -33,22 +33,26 @@ TestBeamEventValidationAlgorithm::~TestBeamEventValidationAlgorithm()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TestBeamEventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pMCParticleList, const CaloHitList *const pCaloHitList,
-    const PfoList *const pPfoList, ValidationInfo &validationInfo) const
+void TestBeamEventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pMCParticleList,
+    const CaloHitList *const pCaloHitList, const PfoList *const pPfoList, ValidationInfo &validationInfo) const
 {
     if (pMCParticleList && pCaloHitList)
     {
         LArMCParticleHelper::MCContributionMap targetMCParticleToHitsMap;
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsBeamParticle, targetMCParticleToHitsMap);
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsCosmicRay, targetMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsBeamParticle, targetMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsCosmicRay, targetMCParticleToHitsMap);
 
         LArMCParticleHelper::PrimaryParameters parameters(m_primaryParameters);
         parameters.m_minPrimaryGoodHits = 0;
         parameters.m_minHitsForGoodView = 0;
         parameters.m_minHitSharingFraction = 0.f;
         LArMCParticleHelper::MCContributionMap allMCParticleToHitsMap;
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamParticle, allMCParticleToHitsMap);
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, allMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamParticle, allMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, allMCParticleToHitsMap);
 
         validationInfo.SetTargetMCParticleToHitsMap(targetMCParticleToHitsMap);
         validationInfo.SetAllMCParticleToHitsMap(allMCParticleToHitsMap);
@@ -67,14 +71,16 @@ void TestBeamEventValidationAlgorithm::FillValidationInfo(const MCParticleList *
         }
 
         LArMCParticleHelper::PfoContributionMap pfoToHitsMap;
-        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
+        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(
+            finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
 
         validationInfo.SetPfoToHitsMap(pfoToHitsMap);
     }
 
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCHitSharingMap;
     LArMCParticleHelper::MCParticleToPfoHitSharingMap mcToPfoHitSharingMap;
-    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(validationInfo.GetPfoToHitsMap(), {validationInfo.GetAllMCParticleToHitsMap()}, pfoToMCHitSharingMap, mcToPfoHitSharingMap);
+    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(
+        validationInfo.GetPfoToHitsMap(), {validationInfo.GetAllMCParticleToHitsMap()}, pfoToMCHitSharingMap, mcToPfoHitSharingMap);
     validationInfo.SetMCToPfoHitSharingMap(mcToPfoHitSharingMap);
 
     LArMCParticleHelper::MCParticleToPfoHitSharingMap interpretedMCToPfoHitSharingMap;
@@ -84,13 +90,16 @@ void TestBeamEventValidationAlgorithm::FillValidationInfo(const MCParticleList *
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const
+void TestBeamEventValidationAlgorithm::ProcessOutput(
+    const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const
 {
-    if (printToScreen && useInterpretedMatching) std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
-    else if (printToScreen) std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
+    if (printToScreen && useInterpretedMatching)
+        std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
+    else if (printToScreen)
+        std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
 
-    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcToPfoHitSharingMap(useInterpretedMatching ?
-        validationInfo.GetInterpretedMCToPfoHitSharingMap() : validationInfo.GetMCToPfoHitSharingMap());
+    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcToPfoHitSharingMap(
+        useInterpretedMatching ? validationInfo.GetInterpretedMCToPfoHitSharingMap() : validationInfo.GetMCToPfoHitSharingMap());
 
     MCParticleVector mcPrimaryVector;
     LArMonitoringHelper::GetOrderedMCParticleVector({validationInfo.GetTargetMCParticleToHitsMap()}, mcPrimaryVector);
@@ -149,17 +158,12 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
         const float targetVertexX(targetVertex.GetX()), targetVertexY(targetVertex.GetY()), targetVertexZ(targetVertex.GetZ());
 #endif
 
-        targetSS << (!isTargetPrimary ? "(Non target) " : "")
-                 << "PrimaryId " << mcPrimaryIndex
-                 << ", TB " << isBeamParticle
-                 << ", CR " << isCosmicRay
-                 << ", MCPDG " << pMCPrimary->GetParticleId()
-                 << ", Energy " << pMCPrimary->GetEnergy()
-                 << ", Dist. " << (pMCPrimary->GetEndpoint() - pMCPrimary->GetVertex()).GetMagnitude()
-                 << ", nMCHits " << mcPrimaryHitList.size()
-                 << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, mcPrimaryHitList)
-                 << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, mcPrimaryHitList)
-                 << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, mcPrimaryHitList) << ")" << std::endl;
+        targetSS << (!isTargetPrimary ? "(Non target) " : "") << "PrimaryId " << mcPrimaryIndex << ", TB " << isBeamParticle << ", CR "
+                 << isCosmicRay << ", MCPDG " << pMCPrimary->GetParticleId() << ", Energy " << pMCPrimary->GetEnergy() << ", Dist. "
+                 << (pMCPrimary->GetEndpoint() - pMCPrimary->GetVertex()).GetMagnitude() << ", nMCHits " << mcPrimaryHitList.size() << " ("
+                 << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, mcPrimaryHitList) << ", "
+                 << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, mcPrimaryHitList) << ", "
+                 << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, mcPrimaryHitList) << ")" << std::endl;
 
         mcPrimaryId.push_back(mcPrimaryIndex);
         mcPrimaryPdg.push_back(pMCPrimary->GetParticleId());
@@ -180,7 +184,8 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
 
         int matchIndex(0), nPrimaryMatches(0), nPrimaryTBMatches(0), nPrimaryCRMatches(0), nPrimaryGoodNuMatches(0);
 #ifdef MONITORING
-        float recoVertexX(std::numeric_limits<float>::max()), recoVertexY(std::numeric_limits<float>::max()), recoVertexZ(std::numeric_limits<float>::max());
+        float recoVertexX(std::numeric_limits<float>::max()), recoVertexY(std::numeric_limits<float>::max()),
+            recoVertexZ(std::numeric_limits<float>::max());
 #endif
         for (const LArMCParticleHelper::PfoCaloHitListPair &pfoToSharedHits : mcToPfoHitSharingMap.at(pMCPrimary))
         {
@@ -205,46 +210,55 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
                 bestMatchPfoNSharedHitsU.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList));
                 bestMatchPfoNSharedHitsV.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, sharedHitList));
                 bestMatchPfoNSharedHitsW.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, sharedHitList));
-                bestMatchPfoX0.push_back(pfoToSharedHits.first->GetPropertiesMap().count("X0") ? pfoToSharedHits.first->GetPropertiesMap().at("X0") : std::numeric_limits<float>::max());
+                bestMatchPfoX0.push_back(pfoToSharedHits.first->GetPropertiesMap().count("X0") ? pfoToSharedHits.first->GetPropertiesMap().at("X0")
+                                                                                               : std::numeric_limits<float>::max());
 #ifdef MONITORING
                 try
                 {
-                    const Vertex *const pRecoVertex(isRecoTestBeam ? LArPfoHelper::GetTestBeamInteractionVertex(pfoToSharedHits.first) : LArPfoHelper::GetVertex(pfoToSharedHits.first));
+                    const Vertex *const pRecoVertex(isRecoTestBeam ? LArPfoHelper::GetTestBeamInteractionVertex(pfoToSharedHits.first)
+                                                                   : LArPfoHelper::GetVertex(pfoToSharedHits.first));
                     recoVertexX = pRecoVertex->GetPosition().GetX();
                     recoVertexY = pRecoVertex->GetPosition().GetY();
                     recoVertexZ = pRecoVertex->GetPosition().GetZ();
                 }
-                catch (const StatusCodeException &) {}
+                catch (const StatusCodeException &)
+                {
+                }
 #endif
             }
 
-            if (isGoodMatch) ++nPrimaryMatches;
+            if (isGoodMatch)
+                ++nPrimaryMatches;
 
-            if (isRecoTestBeam && isGoodMatch) ++nPrimaryTBMatches;
-            if (!isRecoTestBeam && isGoodMatch) ++nPrimaryCRMatches;
+            if (isRecoTestBeam && isGoodMatch)
+                ++nPrimaryTBMatches;
+            if (!isRecoTestBeam && isGoodMatch)
+                ++nPrimaryCRMatches;
 
-            targetSS << "-" << (!isGoodMatch ? "(Below threshold) " : "")
-                     << "MatchedPfoId " << pfoId
-                     << ", TB " << isRecoTestBeam
-                     << ", CR " << (!isRecoTestBeam)
-                     << ", PDG " << pfoToSharedHits.first->GetParticleId()
-                     << ", nMatchedHits " << sharedHitList.size()
-                     << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, sharedHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, sharedHitList) << ")"
-                     << ", nPfoHits " << pfoHitList.size()
-                     << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, pfoHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, pfoHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, pfoHitList) << ")" << std::endl;
+            targetSS << "-" << (!isGoodMatch ? "(Below threshold) " : "") << "MatchedPfoId " << pfoId << ", TB " << isRecoTestBeam
+                     << ", CR " << (!isRecoTestBeam) << ", PDG " << pfoToSharedHits.first->GetParticleId() << ", nMatchedHits "
+                     << sharedHitList.size() << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, sharedHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, sharedHitList) << ")"
+                     << ", nPfoHits " << pfoHitList.size() << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, pfoHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, pfoHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, pfoHitList) << ")" << std::endl;
         }
 
         if (mcToPfoHitSharingMap.at(pMCPrimary).empty())
         {
             targetSS << "-No matched Pfo" << std::endl;
-            bestMatchPfoId.push_back(-1); bestMatchPfoPdg.push_back(0); bestMatchPfoIsTB.push_back(0);
-            bestMatchPfoNHitsTotal.push_back(0); bestMatchPfoNHitsU.push_back(0);
-            bestMatchPfoNHitsV.push_back(0); bestMatchPfoNHitsW.push_back(0); bestMatchPfoNSharedHitsTotal.push_back(0);
-            bestMatchPfoNSharedHitsU.push_back(0); bestMatchPfoNSharedHitsV.push_back(0); bestMatchPfoNSharedHitsW.push_back(0);
+            bestMatchPfoId.push_back(-1);
+            bestMatchPfoPdg.push_back(0);
+            bestMatchPfoIsTB.push_back(0);
+            bestMatchPfoNHitsTotal.push_back(0);
+            bestMatchPfoNHitsU.push_back(0);
+            bestMatchPfoNHitsV.push_back(0);
+            bestMatchPfoNHitsW.push_back(0);
+            bestMatchPfoNSharedHitsTotal.push_back(0);
+            bestMatchPfoNSharedHitsU.push_back(0);
+            bestMatchPfoNSharedHitsV.push_back(0);
+            bestMatchPfoNSharedHitsW.push_back(0);
             bestMatchPfoX0.push_back(std::numeric_limits<float>::max());
         }
 
@@ -256,7 +270,7 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
         nTargetCRMatches += nPrimaryCRMatches;
         nTargetGoodTBMatches += nPrimaryGoodNuMatches;
 
-	if (fillTree)
+        if (fillTree)
         {
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "fileIdentifier", m_fileIdentifier));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "eventNumber", m_eventNumber - 1));
@@ -322,28 +336,48 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
             const int isLost(nTargetMatches == 0);
 
             std::stringstream outcomeSS;
-            outcomeSS << LArInteractionTypeHelper::ToString(interactionType) << " (Nuance " << mcNuanceCode << ", TB " << isBeamParticle << ", CR " << isCosmicRay << ")" << std::endl;
+            outcomeSS << LArInteractionTypeHelper::ToString(interactionType) << " (Nuance " << mcNuanceCode << ", TB " << isBeamParticle
+                      << ", CR " << isCosmicRay << ")" << std::endl;
 
-            if (isBeamParticle) ++nTotalTB;
-            if (isCosmicRay) ++nTotalCR;
-            if (isCorrectTB) ++nCorrectTB;
-            if (isCorrectCR) ++nCorrectCR;
-            if (isFakeTB) ++nFakeTB;
-            if (isFakeCR) ++nFakeCR;
-            if (isSplitTB) ++nSplitTB;
-            if (isSplitCR) ++nSplitCR;
-            if (isLost) ++nLost;
+            if (isBeamParticle)
+                ++nTotalTB;
+            if (isCosmicRay)
+                ++nTotalCR;
+            if (isCorrectTB)
+                ++nCorrectTB;
+            if (isCorrectCR)
+                ++nCorrectCR;
+            if (isFakeTB)
+                ++nFakeTB;
+            if (isFakeCR)
+                ++nFakeCR;
+            if (isSplitTB)
+                ++nSplitTB;
+            if (isSplitCR)
+                ++nSplitCR;
+            if (isLost)
+                ++nLost;
 
-            if (isCorrectTB) outcomeSS << "IsCorrectTB ";
-            if (isCorrectCR) outcomeSS << "IsCorrectCR ";
-            if (isFakeTB) outcomeSS << "IsFakeTB ";
-            if (isFakeCR) outcomeSS << "IsFakeCR ";
-            if (isSplitTB) outcomeSS << "isSplitTB ";
-            if (isSplitCR) outcomeSS << "IsSplitCR ";
-            if (isLost) outcomeSS << "IsLost ";
-            if (nTargetTBMatches > 0) outcomeSS << "(NTBMatches: " << nTargetTBMatches << ") ";
-            if (nTargetCRMatches > 0) outcomeSS << "(NCRMatches: " << nTargetCRMatches << ") ";
-            if (printToScreen) std::cout << outcomeSS.str() << std::endl << targetSS.str() << std::endl;
+            if (isCorrectTB)
+                outcomeSS << "IsCorrectTB ";
+            if (isCorrectCR)
+                outcomeSS << "IsCorrectCR ";
+            if (isFakeTB)
+                outcomeSS << "IsFakeTB ";
+            if (isFakeCR)
+                outcomeSS << "IsFakeCR ";
+            if (isSplitTB)
+                outcomeSS << "isSplitTB ";
+            if (isSplitCR)
+                outcomeSS << "IsSplitCR ";
+            if (isLost)
+                outcomeSS << "IsLost ";
+            if (nTargetTBMatches > 0)
+                outcomeSS << "(NTBMatches: " << nTargetTBMatches << ") ";
+            if (nTargetCRMatches > 0)
+                outcomeSS << "(NCRMatches: " << nTargetCRMatches << ") ";
+            if (printToScreen)
+                std::cout << outcomeSS.str() << std::endl << targetSS.str() << std::endl;
 
             if (fillTree)
             {
@@ -358,16 +392,43 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
                 PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_treeName.c_str()));
             }
 
-            targetSS.str(std::string()); targetSS.clear();
+            targetSS.str(std::string());
+            targetSS.clear();
             associatedMCPrimaries.clear();
-            nTargetMatches = 0; nTargetTBMatches = 0; nTargetCRMatches = 0; nTargetGoodTBMatches = 0;
-            mcPrimaryId.clear(); mcPrimaryPdg.clear(); nMCHitsTotal.clear(); nMCHitsU.clear(); nMCHitsV.clear(); nMCHitsW.clear();
-            mcPrimaryE.clear(); mcPrimaryPX.clear(); mcPrimaryPY.clear(); mcPrimaryPZ.clear();
-            mcPrimaryVtxX.clear(); mcPrimaryVtxY.clear(); mcPrimaryVtxZ.clear(); mcPrimaryEndX.clear(); mcPrimaryEndY.clear(); mcPrimaryEndZ.clear();
-            nPrimaryMatchedPfos.clear(); nPrimaryMatchedTBPfos.clear(); nPrimaryMatchedCRPfos.clear();
-            bestMatchPfoId.clear(); bestMatchPfoPdg.clear(); bestMatchPfoIsTB.clear();
-            bestMatchPfoNHitsTotal.clear(); bestMatchPfoNHitsU.clear(); bestMatchPfoNHitsV.clear(); bestMatchPfoNHitsW.clear();
-            bestMatchPfoNSharedHitsTotal.clear(); bestMatchPfoNSharedHitsU.clear(); bestMatchPfoNSharedHitsV.clear(); bestMatchPfoNSharedHitsW.clear();
+            nTargetMatches = 0;
+            nTargetTBMatches = 0;
+            nTargetCRMatches = 0;
+            nTargetGoodTBMatches = 0;
+            mcPrimaryId.clear();
+            mcPrimaryPdg.clear();
+            nMCHitsTotal.clear();
+            nMCHitsU.clear();
+            nMCHitsV.clear();
+            nMCHitsW.clear();
+            mcPrimaryE.clear();
+            mcPrimaryPX.clear();
+            mcPrimaryPY.clear();
+            mcPrimaryPZ.clear();
+            mcPrimaryVtxX.clear();
+            mcPrimaryVtxY.clear();
+            mcPrimaryVtxZ.clear();
+            mcPrimaryEndX.clear();
+            mcPrimaryEndY.clear();
+            mcPrimaryEndZ.clear();
+            nPrimaryMatchedPfos.clear();
+            nPrimaryMatchedTBPfos.clear();
+            nPrimaryMatchedCRPfos.clear();
+            bestMatchPfoId.clear();
+            bestMatchPfoPdg.clear();
+            bestMatchPfoIsTB.clear();
+            bestMatchPfoNHitsTotal.clear();
+            bestMatchPfoNHitsU.clear();
+            bestMatchPfoNHitsV.clear();
+            bestMatchPfoNHitsW.clear();
+            bestMatchPfoNSharedHitsTotal.clear();
+            bestMatchPfoNSharedHitsU.clear();
+            bestMatchPfoNSharedHitsV.clear();
+            bestMatchPfoNSharedHitsW.clear();
             bestMatchPfoX0.clear();
         }
     }
@@ -376,18 +437,31 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(const ValidationInfo &valid
     {
         std::stringstream summarySS;
         summarySS << "---SUMMARY--------------------------------------------------------------------------------------" << std::endl;
-        if (nTotalTB > 0) summarySS << "#CorrectTB: " << nCorrectTB << "/" << nTotalTB << ", Fraction: " << (nTotalTB > 0 ? static_cast<float>(nCorrectTB) / static_cast<float>(nTotalTB) : 0.f) << std::endl;
-        if (nTotalCR > 0) summarySS << "#CorrectCR: " << nCorrectCR << "/" << nTotalCR << ", Fraction: " << (nTotalCR > 0 ? static_cast<float>(nCorrectCR) / static_cast<float>(nTotalCR) : 0.f) << std::endl;
-        if (nFakeTB > 0) summarySS << "#FakeTB: " << nFakeTB << " ";
-        if (nFakeCR > 0) summarySS << "#FakeCR: " << nFakeCR << " ";
-        if (nSplitTB > 0) summarySS << "#SplitTB: " << nSplitTB << " ";
-        if (nSplitCR > 0) summarySS << "#SplitCR: " << nSplitCR << " ";
-        if (nLost > 0) summarySS << "#Lost: " << nLost << " ";
-        if (nFakeTB || nFakeCR || nSplitTB || nSplitCR || nLost) summarySS << std::endl;
-        if (printToScreen) std::cout << summarySS.str();
+        if (nTotalTB > 0)
+            summarySS << "#CorrectTB: " << nCorrectTB << "/" << nTotalTB
+                      << ", Fraction: " << (nTotalTB > 0 ? static_cast<float>(nCorrectTB) / static_cast<float>(nTotalTB) : 0.f) << std::endl;
+        if (nTotalCR > 0)
+            summarySS << "#CorrectCR: " << nCorrectCR << "/" << nTotalCR
+                      << ", Fraction: " << (nTotalCR > 0 ? static_cast<float>(nCorrectCR) / static_cast<float>(nTotalCR) : 0.f) << std::endl;
+        if (nFakeTB > 0)
+            summarySS << "#FakeTB: " << nFakeTB << " ";
+        if (nFakeCR > 0)
+            summarySS << "#FakeCR: " << nFakeCR << " ";
+        if (nSplitTB > 0)
+            summarySS << "#SplitTB: " << nSplitTB << " ";
+        if (nSplitCR > 0)
+            summarySS << "#SplitCR: " << nSplitCR << " ";
+        if (nLost > 0)
+            summarySS << "#Lost: " << nLost << " ";
+        if (nFakeTB || nFakeCR || nSplitTB || nSplitCR || nLost)
+            summarySS << std::endl;
+        if (printToScreen)
+            std::cout << summarySS.str();
     }
 
-    if (printToScreen) std::cout << "------------------------------------------------------------------------------------------------" << std::endl << std::endl;
+    if (printToScreen)
+        std::cout << "------------------------------------------------------------------------------------------------" << std::endl
+                  << std::endl;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.h
@@ -26,7 +26,7 @@ namespace lar_content
 /**
  *  @brief  TestBeamEventValidationAlgorithm class
  */
-class TestBeamEventValidationAlgorithm: public EventValidationBaseAlgorithm
+class TestBeamEventValidationAlgorithm : public EventValidationBaseAlgorithm
 {
 public:
     /**
@@ -51,7 +51,7 @@ private:
     void FillValidationInfo(const pandora::MCParticleList *const pMCParticleList, const pandora::CaloHitList *const pCaloHitList,
         const pandora::PfoList *const pPfoList, ValidationInfo &validationInfo) const;
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, unsigned int> PfoToIdMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, unsigned int> PfoToIdMap;
 
     /**
      *  @brief  Print matching information in a provided validation info object, and write information to tree if configured to do so

--- a/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
@@ -21,8 +21,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-TestBeamHierarchyEventValidationAlgorithm::TestBeamHierarchyEventValidationAlgorithm() :
-    m_eventNumber(0)
+TestBeamHierarchyEventValidationAlgorithm::TestBeamHierarchyEventValidationAlgorithm() : m_eventNumber(0)
 {
 }
 
@@ -34,22 +33,26 @@ TestBeamHierarchyEventValidationAlgorithm::~TestBeamHierarchyEventValidationAlgo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TestBeamHierarchyEventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pMCParticleList, const CaloHitList *const pCaloHitList,
-    const PfoList *const pPfoList, ValidationInfo &validationInfo) const
+void TestBeamHierarchyEventValidationAlgorithm::FillValidationInfo(const MCParticleList *const pMCParticleList,
+    const CaloHitList *const pCaloHitList, const PfoList *const pPfoList, ValidationInfo &validationInfo) const
 {
     if (pMCParticleList && pCaloHitList)
     {
         LArMCParticleHelper::MCContributionMap targetMCParticleToHitsMap;
-        LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsLeadingBeamParticle, targetMCParticleToHitsMap);
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsCosmicRay, targetMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(
+            pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsLeadingBeamParticle, targetMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsCosmicRay, targetMCParticleToHitsMap);
 
         LArMCParticleHelper::PrimaryParameters parameters(m_primaryParameters);
         parameters.m_minPrimaryGoodHits = 0;
         parameters.m_minHitsForGoodView = 0;
         parameters.m_minHitSharingFraction = 0.f;
         LArMCParticleHelper::MCContributionMap allMCParticleToHitsMap;
-        LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsLeadingBeamParticle, allMCParticleToHitsMap);
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, allMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableTestBeamHierarchyMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsLeadingBeamParticle, allMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, allMCParticleToHitsMap);
 
         validationInfo.SetTargetMCParticleToHitsMap(targetMCParticleToHitsMap);
         validationInfo.SetAllMCParticleToHitsMap(allMCParticleToHitsMap);
@@ -77,13 +80,15 @@ void TestBeamHierarchyEventValidationAlgorithm::FillValidationInfo(const MCParti
         }
 
         LArMCParticleHelper::PfoContributionMap pfoToHitsMap;
-        LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
+        LArMCParticleHelper::GetTestBeamHierarchyPfoToReconstructable2DHitsMap(
+            finalStatePfos, validationInfo.GetAllMCParticleToHitsMap(), pfoToHitsMap, m_primaryParameters.m_foldBackHierarchy);
         validationInfo.SetPfoToHitsMap(pfoToHitsMap);
     }
 
     LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCHitSharingMap;
     LArMCParticleHelper::MCParticleToPfoHitSharingMap mcToPfoHitSharingMap;
-    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(validationInfo.GetPfoToHitsMap(), {validationInfo.GetAllMCParticleToHitsMap()}, pfoToMCHitSharingMap, mcToPfoHitSharingMap);
+    LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(
+        validationInfo.GetPfoToHitsMap(), {validationInfo.GetAllMCParticleToHitsMap()}, pfoToMCHitSharingMap, mcToPfoHitSharingMap);
     validationInfo.SetMCToPfoHitSharingMap(mcToPfoHitSharingMap);
 
     LArMCParticleHelper::MCParticleToPfoHitSharingMap interpretedMCToPfoHitSharingMap;
@@ -93,10 +98,13 @@ void TestBeamHierarchyEventValidationAlgorithm::FillValidationInfo(const MCParti
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const
+void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(
+    const ValidationInfo &validationInfo, const bool useInterpretedMatching, const bool printToScreen, const bool fillTree) const
 {
-    if (printToScreen && useInterpretedMatching) std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
-    else if (printToScreen) std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
+    if (printToScreen && useInterpretedMatching)
+        std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
+    else if (printToScreen)
+        std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
 
     PfoVector primaryPfoVector;
     LArMonitoringHelper::GetOrderedPfoVector(validationInfo.GetPfoToHitsMap(), primaryPfoVector);
@@ -114,8 +122,8 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
             testBeamPfoToIdMap.insert(PfoToIdMap::value_type(pRecoTestBeam, ++testBeamPfoIndex));
     }
 
-    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcToPfoHitSharingMap(useInterpretedMatching ?
-        validationInfo.GetInterpretedMCToPfoHitSharingMap() : validationInfo.GetMCToPfoHitSharingMap());
+    const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcToPfoHitSharingMap(
+        useInterpretedMatching ? validationInfo.GetInterpretedMCToPfoHitSharingMap() : validationInfo.GetMCToPfoHitSharingMap());
 
     // Test Beam Hierarchy Validation MCParticle Bookkeeping
     MCParticleVector mcPrimaryVector;
@@ -132,7 +140,7 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
     for (const MCParticle *const pMCPrimary : mcPrimaryVectorCopy)
     {
         if (LArMCParticleHelper::IsLeadingBeamParticle(pMCPrimary))
-         {
+        {
             const MCParticle *const pParentMCParticle(LArMCParticleHelper::GetParentMCParticle(pMCPrimary));
             leadingToTriggeredMap.insert(LArMCParticleHelper::MCRelationMap::value_type(pMCPrimary, pParentMCParticle));
 
@@ -167,7 +175,8 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
     MCParticleList associatedMCPrimaries;
 
     int nCorrectTB(0), nTotalTB(0), nCorrectTBHierarchy(0), nTotalTBHierarchy(0), nCorrectCR(0), nTotalCR(0);
-    int nFakeTBHierarchy(0), nFakeCR(0), nSplitTBHierarchy(0), nSplitCR(0), nLost(0), mcPrimaryIndex(0), nTargetMatches(0), nTargetTBHierarchyMatches(0);
+    int nFakeTBHierarchy(0), nFakeCR(0), nSplitTBHierarchy(0), nSplitCR(0), nLost(0), mcPrimaryIndex(0), nTargetMatches(0),
+        nTargetTBHierarchyMatches(0);
     int nTargetCRMatches(0), nTargetGoodTBHierarchyMatches(0), nTargetTBHierarchySplits(0), nTargetTBHierarchyLosses(0);
     IntVector mcPrimaryId, mcPrimaryPdg, mcPrimaryTier, nMCHitsTotal, nMCHitsU, nMCHitsV, nMCHitsW;
     FloatVector mcPrimaryE, mcPrimaryPX, mcPrimaryPY, mcPrimaryPZ;
@@ -190,8 +199,10 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
             continue;
 
         // Parent in hierarchy needed even if no match
-        const bool hasVisibleTargets((!triggeredToLeading.empty() && LArMCParticleHelper::IsBeamParticle(LArMCParticleHelper::GetParentMCParticle(pMCPrimary))) ?
-            triggeredToLeading.at(LArMCParticleHelper::GetParentMCParticle(pMCPrimary)) != 1 : false);
+        const bool hasVisibleTargets(
+            (!triggeredToLeading.empty() && LArMCParticleHelper::IsBeamParticle(LArMCParticleHelper::GetParentMCParticle(pMCPrimary)))
+                ? triggeredToLeading.at(LArMCParticleHelper::GetParentMCParticle(pMCPrimary)) != 1
+                : false);
 
         if (!hasMatch && !hasVisibleTargets)
             continue;
@@ -225,21 +236,15 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
         const float targetVertexX(targetVertex.GetX()), targetVertexY(targetVertex.GetY()), targetVertexZ(targetVertex.GetZ());
 #endif
 
-        for (int tier = 0; tier < mcHierarchyTier; tier++) targetSS << " -> ";
+        for (int tier = 0; tier < mcHierarchyTier; tier++)
+            targetSS << " -> ";
 
-        targetSS << (!isTargetPrimary ? "(Non target) " : "")
-                 << "PrimaryId " << mcPrimaryIndex
-                 << ", TB " << isBeamParticle
-                 << ", TB Hierarchy " << isLeadingBeamParticle
-                 << ", CR " << isCosmicRay
-                 << ", MCPDG " << pMCPrimary->GetParticleId()
-                 << ", Tier " << mcHierarchyTier
-                 << ", Energy " << pMCPrimary->GetEnergy()
-                 << ", Dist. " << (pMCPrimary->GetEndpoint() - pMCPrimary->GetVertex()).GetMagnitude()
-                 << ", nMCHits " << mcPrimaryHitList.size()
-                 << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, mcPrimaryHitList)
-                 << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, mcPrimaryHitList)
-                 << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, mcPrimaryHitList) << ")" << std::endl;
+        targetSS << (!isTargetPrimary ? "(Non target) " : "") << "PrimaryId " << mcPrimaryIndex << ", TB " << isBeamParticle << ", TB Hierarchy "
+                 << isLeadingBeamParticle << ", CR " << isCosmicRay << ", MCPDG " << pMCPrimary->GetParticleId() << ", Tier " << mcHierarchyTier
+                 << ", Energy " << pMCPrimary->GetEnergy() << ", Dist. " << (pMCPrimary->GetEndpoint() - pMCPrimary->GetVertex()).GetMagnitude()
+                 << ", nMCHits " << mcPrimaryHitList.size() << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, mcPrimaryHitList)
+                 << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, mcPrimaryHitList) << ", "
+                 << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, mcPrimaryHitList) << ")" << std::endl;
 
         mcPrimaryId.push_back(mcPrimaryIndex);
         mcPrimaryPdg.push_back(pMCPrimary->GetParticleId());
@@ -259,9 +264,11 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
         nMCHitsV.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, mcPrimaryHitList));
         nMCHitsW.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, mcPrimaryHitList));
 
-        int matchIndex(0), nPrimaryMatches(0), nPrimaryTBHierarchyMatches(0), nPrimaryCRMatches(0), nPrimaryGoodTBHierarchyMatches(0), nPrimaryTBHierarchySplits(0);
+        int matchIndex(0), nPrimaryMatches(0), nPrimaryTBHierarchyMatches(0), nPrimaryCRMatches(0), nPrimaryGoodTBHierarchyMatches(0),
+            nPrimaryTBHierarchySplits(0);
 #ifdef MONITORING
-        float recoVertexX(std::numeric_limits<float>::max()), recoVertexY(std::numeric_limits<float>::max()), recoVertexZ(std::numeric_limits<float>::max());
+        float recoVertexX(std::numeric_limits<float>::max()), recoVertexY(std::numeric_limits<float>::max()),
+            recoVertexZ(std::numeric_limits<float>::max());
 #endif
         for (const LArMCParticleHelper::PfoCaloHitListPair &pfoToSharedHits : mcToPfoHitSharingMap.at(pMCPrimary))
         {
@@ -275,7 +282,8 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
             // Tier (0) : Primary, (1) : Daughter, (2) : Granddaughter etc...  Note that the tier only increases for visible particle
             const int pfoHierarchyTier(LArPfoHelper::GetHierarchyTier(pfoToSharedHits.first));
             const int pfoId(pfoToIdMap.at(pfoToSharedHits.first));
-            const int recoTBId(isRecoTestBeam || isRecoTestBeamHierarchy ? testBeamPfoToIdMap.at(LArPfoHelper::GetParentPfo(pfoToSharedHits.first)) : -1);
+            const int recoTBId(
+                isRecoTestBeam || isRecoTestBeamHierarchy ? testBeamPfoToIdMap.at(LArPfoHelper::GetParentPfo(pfoToSharedHits.first)) : -1);
 
             if (0 == matchIndex++)
             {
@@ -293,63 +301,81 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
                 bestMatchPfoNSharedHitsU.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList));
                 bestMatchPfoNSharedHitsV.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, sharedHitList));
                 bestMatchPfoNSharedHitsW.push_back(LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, sharedHitList));
-                bestMatchPfoX0.push_back(pfoToSharedHits.first->GetPropertiesMap().count("X0") ? pfoToSharedHits.first->GetPropertiesMap().at("X0") : std::numeric_limits<float>::max());
+                bestMatchPfoX0.push_back(pfoToSharedHits.first->GetPropertiesMap().count("X0") ? pfoToSharedHits.first->GetPropertiesMap().at("X0")
+                                                                                               : std::numeric_limits<float>::max());
 #ifdef MONITORING
                 try
                 {
-                    const Vertex *const pRecoVertex(isRecoTestBeamHierarchy ? LArPfoHelper::GetTestBeamInteractionVertex(LArPfoHelper::GetParentPfo(pfoToSharedHits.first)) : LArPfoHelper::GetVertex(pfoToSharedHits.first));
+                    const Vertex *const pRecoVertex(
+                        isRecoTestBeamHierarchy ? LArPfoHelper::GetTestBeamInteractionVertex(LArPfoHelper::GetParentPfo(pfoToSharedHits.first))
+                                                : LArPfoHelper::GetVertex(pfoToSharedHits.first));
                     recoVertexX = pRecoVertex->GetPosition().GetX();
                     recoVertexY = pRecoVertex->GetPosition().GetY();
                     recoVertexZ = pRecoVertex->GetPosition().GetZ();
                 }
-                catch (const StatusCodeException &) {}
+                catch (const StatusCodeException &)
+                {
+                }
 #endif
             }
 
-            if (isGoodMatch) ++nPrimaryMatches;
+            if (isGoodMatch)
+                ++nPrimaryMatches;
 
             // ATTN: In hierarchy mode let TBHierarchyMatches become effective TBHierarchyMatches and treat the same
-            if (isRecoTestBeamHierarchy && isGoodMatch) ++nPrimaryTBHierarchyMatches;
-            if (!isRecoTestBeamHierarchy && isGoodMatch) ++nPrimaryCRMatches;
+            if (isRecoTestBeamHierarchy && isGoodMatch)
+                ++nPrimaryTBHierarchyMatches;
+            if (!isRecoTestBeamHierarchy && isGoodMatch)
+                ++nPrimaryCRMatches;
 
             if (isRecoTestBeamHierarchy)
             {
                 // Account for splitting of test beam particle into separate reconstructed primary pfos
                 const Pfo *const pRecoTB(LArPfoHelper::GetParentPfo(pfoToSharedHits.first));
                 const bool isSplitRecoTBHierarchy(!recoTestBeamHierarchies.empty() && !recoTestBeamHierarchies.count(pRecoTB));
-                if (!isSplitRecoTBHierarchy && isGoodMatch) ++nPrimaryGoodTBHierarchyMatches;
-                if (isSplitRecoTBHierarchy && isLeadingBeamParticle && isGoodMatch) ++nPrimaryTBHierarchySplits;
+                if (!isSplitRecoTBHierarchy && isGoodMatch)
+                    ++nPrimaryGoodTBHierarchyMatches;
+                if (isSplitRecoTBHierarchy && isLeadingBeamParticle && isGoodMatch)
+                    ++nPrimaryTBHierarchySplits;
                 recoTestBeamHierarchies.insert(pRecoTB);
             }
 
-            for (int tier = 0; tier < mcHierarchyTier; tier++) targetSS << "    ";
+            for (int tier = 0; tier < mcHierarchyTier; tier++)
+                targetSS << "    ";
 
-            targetSS << "-" << (!isGoodMatch ? "(Below threshold) " : "")
-                     << "MatchedPfoId " << pfoId
-                     << ", TB " << isRecoTestBeam
+            targetSS << "-" << (!isGoodMatch ? "(Below threshold) " : "") << "MatchedPfoId " << pfoId << ", TB " << isRecoTestBeam
                      << ", TB Hierarchy " << isRecoTestBeamHierarchy;
-            if (isRecoTestBeamHierarchy) targetSS << " [TBId: " << recoTBId << "]";
-            targetSS << ", CR " << (!isRecoTestBeam && !isRecoTestBeamHierarchy)
-                     << ", PDG " << pfoToSharedHits.first->GetParticleId()
-                     << ", Tier " << pfoHierarchyTier
-                     << ", nMatchedHits " << sharedHitList.size()
-                     << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, sharedHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, sharedHitList) << ")"
-                     << ", nPfoHits " << pfoHitList.size()
-                     << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, pfoHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, pfoHitList)
-                     << ", " << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, pfoHitList) << ")" << std::endl;
+            if (isRecoTestBeamHierarchy)
+                targetSS << " [TBId: " << recoTBId << "]";
+            targetSS << ", CR " << (!isRecoTestBeam && !isRecoTestBeamHierarchy) << ", PDG " << pfoToSharedHits.first->GetParticleId()
+                     << ", Tier " << pfoHierarchyTier << ", nMatchedHits " << sharedHitList.size() << " ("
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, sharedHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, sharedHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, sharedHitList) << ")"
+                     << ", nPfoHits " << pfoHitList.size() << " (" << LArMonitoringHelper::CountHitsByType(TPC_VIEW_U, pfoHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_V, pfoHitList) << ", "
+                     << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, pfoHitList) << ")" << std::endl;
         }
 
         if (mcToPfoHitSharingMap.at(pMCPrimary).empty())
         {
-            for (int tier = 0; tier < mcHierarchyTier; tier++) targetSS << "    ";
+            for (int tier = 0; tier < mcHierarchyTier; tier++)
+                targetSS << "    ";
             targetSS << "-No matched Pfo" << std::endl;
-            bestMatchPfoId.push_back(-1); bestMatchPfoPdg.push_back(0); bestMatchPfoTier.push_back(-1);
-            bestMatchPfoIsTestBeam.push_back(0); bestMatchPfoIsTestBeamHierarchy.push_back(0); bestMatchPfoRecoTBId.push_back(-1);
-            bestMatchPfoNHitsTotal.push_back(0); bestMatchPfoNHitsU.push_back(0); bestMatchPfoNHitsV.push_back(0); bestMatchPfoNHitsW.push_back(0);
-            bestMatchPfoNSharedHitsTotal.push_back(0); bestMatchPfoNSharedHitsU.push_back(0); bestMatchPfoNSharedHitsV.push_back(0); bestMatchPfoNSharedHitsW.push_back(0);
+            bestMatchPfoId.push_back(-1);
+            bestMatchPfoPdg.push_back(0);
+            bestMatchPfoTier.push_back(-1);
+            bestMatchPfoIsTestBeam.push_back(0);
+            bestMatchPfoIsTestBeamHierarchy.push_back(0);
+            bestMatchPfoRecoTBId.push_back(-1);
+            bestMatchPfoNHitsTotal.push_back(0);
+            bestMatchPfoNHitsU.push_back(0);
+            bestMatchPfoNHitsV.push_back(0);
+            bestMatchPfoNHitsW.push_back(0);
+            bestMatchPfoNSharedHitsTotal.push_back(0);
+            bestMatchPfoNSharedHitsU.push_back(0);
+            bestMatchPfoNSharedHitsV.push_back(0);
+            bestMatchPfoNSharedHitsW.push_back(0);
             bestMatchPfoX0.push_back(std::numeric_limits<float>::max());
         }
 
@@ -361,9 +387,10 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
         nTargetCRMatches += nPrimaryCRMatches;
         nTargetGoodTBHierarchyMatches += nPrimaryGoodTBHierarchyMatches;
         nTargetTBHierarchySplits += nPrimaryTBHierarchySplits;
-        if (0 == nPrimaryMatches) ++nTargetTBHierarchyLosses;
+        if (0 == nPrimaryMatches)
+            ++nTargetTBHierarchyLosses;
 
-	if (fillTree)
+        if (fillTree)
         {
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "fileIdentifier", m_fileIdentifier));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "eventNumber", m_eventNumber - 1));
@@ -395,7 +422,8 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "mcPrimaryNHitsV", &nMCHitsV));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "mcPrimaryNHitsW", &nMCHitsW));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nPrimaryMatchedPfos", &nPrimaryMatchedPfos));
-            PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nPrimaryMatchedTBHierarchyPfos", &nPrimaryMatchedTBHierarchyPfos));
+            PANDORA_MONITORING_API(
+                SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nPrimaryMatchedTBHierarchyPfos", &nPrimaryMatchedTBHierarchyPfos));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nPrimaryMatchedCRPfos", &nPrimaryMatchedCRPfos));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "bestMatchPfoId", &bestMatchPfoId));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "bestMatchPfoPdg", &bestMatchPfoPdg));
@@ -414,22 +442,27 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetCRMatches", nTargetCRMatches));
 
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "bestMatchPfoIsTestBeam", &bestMatchPfoIsTestBeam));
-            PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "bestMatchPfoIsTestBeamHierarchy", &bestMatchPfoIsTestBeamHierarchy));
+            PANDORA_MONITORING_API(
+                SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "bestMatchPfoIsTestBeamHierarchy", &bestMatchPfoIsTestBeamHierarchy));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "bestMatchPfoRecoTBId", &bestMatchPfoRecoTBId));
-            PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetGoodTBHierarchyMatches", nTargetGoodTBHierarchyMatches));
+            PANDORA_MONITORING_API(
+                SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetGoodTBHierarchyMatches", nTargetGoodTBHierarchyMatches));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetTBHierarchySplits", nTargetTBHierarchySplits));
             PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "nTargetTBHierarchyLosses", nTargetTBHierarchyLosses));
         }
 
         if (isCosmicRay || isLastTestBeamLeading)
         {
-            const LArInteractionTypeHelper::InteractionType interactionType(LArInteractionTypeHelper::GetTestBeamHierarchyInteractionType(associatedMCPrimaries));
+            const LArInteractionTypeHelper::InteractionType interactionType(
+                LArInteractionTypeHelper::GetTestBeamHierarchyInteractionType(associatedMCPrimaries));
 #ifdef MONITORING
             const int interactionTypeInt(static_cast<int>(interactionType));
 #endif
             // ATTN Some redundancy introduced to contributing variables
             const int isCorrectTB(isBeamParticle && (nTargetTBHierarchyMatches == 1) && (nTargetCRMatches == 0));
-            const int isCorrectTBHierarchy(isLeadingBeamParticle && (nTargetGoodTBHierarchyMatches == nTargetTBHierarchyMatches) && (nTargetGoodTBHierarchyMatches == nTargetPrimaries) && (nTargetCRMatches == 0) && (nTargetTBHierarchySplits == 0) && (nTargetTBHierarchyLosses == 0));
+            const int isCorrectTBHierarchy(isLeadingBeamParticle && (nTargetGoodTBHierarchyMatches == nTargetTBHierarchyMatches) &&
+                                           (nTargetGoodTBHierarchyMatches == nTargetPrimaries) && (nTargetCRMatches == 0) &&
+                                           (nTargetTBHierarchySplits == 0) && (nTargetTBHierarchyLosses == 0));
             const int isCorrectCR(isCosmicRay && (nTargetTBHierarchyMatches == 0) && (nTargetCRMatches == 1));
             const int isFakeTBHierarchy(isCosmicRay && (nTargetTBHierarchyMatches > 0));
             const int isFakeCR(!isCosmicRay && (nTargetCRMatches > 0));
@@ -439,32 +472,56 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
 
             std::stringstream outcomeSS;
             const bool isBeamHierarchy((mcNuanceCode == 2001) | (mcNuanceCode == 2000));
-            outcomeSS << LArInteractionTypeHelper::ToString(interactionType) << " (Nuance " << mcNuanceCode << ", TB " << isBeamHierarchy << ", CR " << isCosmicRay << ")" << std::endl;
+            outcomeSS << LArInteractionTypeHelper::ToString(interactionType) << " (Nuance " << mcNuanceCode << ", TB " << isBeamHierarchy
+                      << ", CR " << isCosmicRay << ")" << std::endl;
 
-            if (isBeamParticle) ++nTotalTB;
-            if (isLastTestBeamLeading) ++nTotalTBHierarchy;
-            if (isCosmicRay) ++nTotalCR;
-            if (isCorrectTB) ++nCorrectTB;
-            if (isCorrectTBHierarchy) ++nCorrectTBHierarchy;
-            if (isCorrectCR) ++nCorrectCR;
-            if (isFakeTBHierarchy) ++nFakeTBHierarchy;
-            if (isFakeCR) ++nFakeCR;
-            if (isSplitTBHierarchy) ++nSplitTBHierarchy;
-            if (isSplitCR) ++nSplitCR;
-            if (isLost) ++nLost;
+            if (isBeamParticle)
+                ++nTotalTB;
+            if (isLastTestBeamLeading)
+                ++nTotalTBHierarchy;
+            if (isCosmicRay)
+                ++nTotalCR;
+            if (isCorrectTB)
+                ++nCorrectTB;
+            if (isCorrectTBHierarchy)
+                ++nCorrectTBHierarchy;
+            if (isCorrectCR)
+                ++nCorrectCR;
+            if (isFakeTBHierarchy)
+                ++nFakeTBHierarchy;
+            if (isFakeCR)
+                ++nFakeCR;
+            if (isSplitTBHierarchy)
+                ++nSplitTBHierarchy;
+            if (isSplitCR)
+                ++nSplitCR;
+            if (isLost)
+                ++nLost;
 
-            if (isCorrectTBHierarchy) outcomeSS << "IsCorrectTBHierarchy";
-            if (isCorrectCR) outcomeSS << "IsCorrectCR ";
-            if (isFakeTBHierarchy) outcomeSS << "IsFake" << name << " ";
-            if (isFakeCR) outcomeSS << "IsFakeCR ";
-            if (isSplitTBHierarchy) outcomeSS << "isSplit" << name << " ";
-            if (isSplitCR) outcomeSS << "IsSplitCR ";
-            if (isLost) outcomeSS << "IsLost ";
-            if (nTargetTBHierarchyMatches > 0) outcomeSS << "(N" << name << "Matches: " << nTargetTBHierarchyMatches << ") ";
-            if (nTargetTBHierarchyLosses > 0) outcomeSS << "(N" << name << "Losses: " << nTargetTBHierarchyLosses << ") ";
-            if (nTargetTBHierarchySplits > 0) outcomeSS << "(N" << name << "Splits: " << nTargetTBHierarchySplits << ") ";
-            if (nTargetCRMatches > 0) outcomeSS << "(NCRMatches: " << nTargetCRMatches << ") ";
-            if (printToScreen) std::cout << outcomeSS.str() << std::endl << targetSS.str() << std::endl;
+            if (isCorrectTBHierarchy)
+                outcomeSS << "IsCorrectTBHierarchy";
+            if (isCorrectCR)
+                outcomeSS << "IsCorrectCR ";
+            if (isFakeTBHierarchy)
+                outcomeSS << "IsFake" << name << " ";
+            if (isFakeCR)
+                outcomeSS << "IsFakeCR ";
+            if (isSplitTBHierarchy)
+                outcomeSS << "isSplit" << name << " ";
+            if (isSplitCR)
+                outcomeSS << "IsSplitCR ";
+            if (isLost)
+                outcomeSS << "IsLost ";
+            if (nTargetTBHierarchyMatches > 0)
+                outcomeSS << "(N" << name << "Matches: " << nTargetTBHierarchyMatches << ") ";
+            if (nTargetTBHierarchyLosses > 0)
+                outcomeSS << "(N" << name << "Losses: " << nTargetTBHierarchyLosses << ") ";
+            if (nTargetTBHierarchySplits > 0)
+                outcomeSS << "(N" << name << "Splits: " << nTargetTBHierarchySplits << ") ";
+            if (nTargetCRMatches > 0)
+                outcomeSS << "(NCRMatches: " << nTargetCRMatches << ") ";
+            if (printToScreen)
+                std::cout << outcomeSS.str() << std::endl << targetSS.str() << std::endl;
 
             if (fillTree)
             {
@@ -479,16 +536,49 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
                 PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_treeName.c_str()));
             }
 
-            targetSS.str(std::string()); targetSS.clear();
+            targetSS.str(std::string());
+            targetSS.clear();
             associatedMCPrimaries.clear();
-            nTargetMatches = 0; nTargetTBHierarchyMatches = 0; nTargetCRMatches = 0; nTargetGoodTBHierarchyMatches = 0; nTargetTBHierarchySplits = 0; nTargetTBHierarchyLosses = 0;
-            mcPrimaryId.clear(); mcPrimaryPdg.clear(); mcPrimaryTier.clear(); nMCHitsTotal.clear(); nMCHitsU.clear(); nMCHitsV.clear(); nMCHitsW.clear();
-            mcPrimaryE.clear(); mcPrimaryPX.clear(); mcPrimaryPY.clear(); mcPrimaryPZ.clear();
-            mcPrimaryVtxX.clear(); mcPrimaryVtxY.clear(); mcPrimaryVtxZ.clear(); mcPrimaryEndX.clear(); mcPrimaryEndY.clear(); mcPrimaryEndZ.clear();
-            nPrimaryMatchedPfos.clear(); nPrimaryMatchedTBHierarchyPfos.clear(); nPrimaryMatchedCRPfos.clear();
-            bestMatchPfoId.clear(); bestMatchPfoPdg.clear(); bestMatchPfoTier.clear(); bestMatchPfoIsTestBeam.clear(); bestMatchPfoIsTestBeamHierarchy.clear();
-            bestMatchPfoRecoTBId.clear(); bestMatchPfoNHitsTotal.clear(); bestMatchPfoNHitsU.clear(); bestMatchPfoNHitsV.clear(); bestMatchPfoNHitsW.clear();
-            bestMatchPfoNSharedHitsTotal.clear(); bestMatchPfoNSharedHitsU.clear(); bestMatchPfoNSharedHitsV.clear(); bestMatchPfoNSharedHitsW.clear();
+            nTargetMatches = 0;
+            nTargetTBHierarchyMatches = 0;
+            nTargetCRMatches = 0;
+            nTargetGoodTBHierarchyMatches = 0;
+            nTargetTBHierarchySplits = 0;
+            nTargetTBHierarchyLosses = 0;
+            mcPrimaryId.clear();
+            mcPrimaryPdg.clear();
+            mcPrimaryTier.clear();
+            nMCHitsTotal.clear();
+            nMCHitsU.clear();
+            nMCHitsV.clear();
+            nMCHitsW.clear();
+            mcPrimaryE.clear();
+            mcPrimaryPX.clear();
+            mcPrimaryPY.clear();
+            mcPrimaryPZ.clear();
+            mcPrimaryVtxX.clear();
+            mcPrimaryVtxY.clear();
+            mcPrimaryVtxZ.clear();
+            mcPrimaryEndX.clear();
+            mcPrimaryEndY.clear();
+            mcPrimaryEndZ.clear();
+            nPrimaryMatchedPfos.clear();
+            nPrimaryMatchedTBHierarchyPfos.clear();
+            nPrimaryMatchedCRPfos.clear();
+            bestMatchPfoId.clear();
+            bestMatchPfoPdg.clear();
+            bestMatchPfoTier.clear();
+            bestMatchPfoIsTestBeam.clear();
+            bestMatchPfoIsTestBeamHierarchy.clear();
+            bestMatchPfoRecoTBId.clear();
+            bestMatchPfoNHitsTotal.clear();
+            bestMatchPfoNHitsU.clear();
+            bestMatchPfoNHitsV.clear();
+            bestMatchPfoNHitsW.clear();
+            bestMatchPfoNSharedHitsTotal.clear();
+            bestMatchPfoNSharedHitsU.clear();
+            bestMatchPfoNSharedHitsV.clear();
+            bestMatchPfoNSharedHitsW.clear();
             bestMatchPfoX0.clear();
         }
     }
@@ -497,18 +587,32 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(const ValidationIn
     {
         std::stringstream summarySS;
         summarySS << "---SUMMARY--------------------------------------------------------------------------------------" << std::endl;
-        if (nTotalTBHierarchy > 0) summarySS << "#CorrectTBHierarchy: " << nCorrectTBHierarchy << "/" << nTotalTBHierarchy << ", Fraction: " << (nTotalTBHierarchy > 0 ? static_cast<float>(nCorrectTBHierarchy) / static_cast<float>(nTotalTBHierarchy) : 0.f) << std::endl;
-        if (nTotalCR > 0) summarySS << "#CorrectCR: " << nCorrectCR << "/" << nTotalCR << ", Fraction: " << (nTotalCR > 0 ? static_cast<float>(nCorrectCR) / static_cast<float>(nTotalCR) : 0.f) << std::endl;
-        if (nFakeTBHierarchy > 0) summarySS << "#Fake" << name << ": " << nFakeTBHierarchy << " ";
-        if (nFakeCR > 0) summarySS << "#FakeCR: " << nFakeCR << " ";
-        if (nSplitTBHierarchy > 0) summarySS << "#Split" << name << ": " << nSplitTBHierarchy << " ";
-        if (nSplitCR > 0) summarySS << "#SplitCR: " << nSplitCR << " ";
-        if (nLost > 0) summarySS << "#Lost: " << nLost << " ";
-        if (nFakeTBHierarchy || nFakeCR || nSplitTBHierarchy || nSplitCR || nLost) summarySS << std::endl;
-        if (printToScreen) std::cout << summarySS.str();
+        if (nTotalTBHierarchy > 0)
+            summarySS << "#CorrectTBHierarchy: " << nCorrectTBHierarchy << "/" << nTotalTBHierarchy << ", Fraction: "
+                      << (nTotalTBHierarchy > 0 ? static_cast<float>(nCorrectTBHierarchy) / static_cast<float>(nTotalTBHierarchy) : 0.f)
+                      << std::endl;
+        if (nTotalCR > 0)
+            summarySS << "#CorrectCR: " << nCorrectCR << "/" << nTotalCR
+                      << ", Fraction: " << (nTotalCR > 0 ? static_cast<float>(nCorrectCR) / static_cast<float>(nTotalCR) : 0.f) << std::endl;
+        if (nFakeTBHierarchy > 0)
+            summarySS << "#Fake" << name << ": " << nFakeTBHierarchy << " ";
+        if (nFakeCR > 0)
+            summarySS << "#FakeCR: " << nFakeCR << " ";
+        if (nSplitTBHierarchy > 0)
+            summarySS << "#Split" << name << ": " << nSplitTBHierarchy << " ";
+        if (nSplitCR > 0)
+            summarySS << "#SplitCR: " << nSplitCR << " ";
+        if (nLost > 0)
+            summarySS << "#Lost: " << nLost << " ";
+        if (nFakeTBHierarchy || nFakeCR || nSplitTBHierarchy || nSplitCR || nLost)
+            summarySS << std::endl;
+        if (printToScreen)
+            std::cout << summarySS.str();
     }
 
-    if (printToScreen) std::cout << "------------------------------------------------------------------------------------------------" << std::endl << std::endl;
+    if (printToScreen)
+        std::cout << "------------------------------------------------------------------------------------------------" << std::endl
+                  << std::endl;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.h
@@ -26,7 +26,7 @@ namespace lar_content
 /**
  *  @brief  TestBeamHierarchyEventValidationAlgorithm class
  */
-class TestBeamHierarchyEventValidationAlgorithm: public EventValidationBaseAlgorithm
+class TestBeamHierarchyEventValidationAlgorithm : public EventValidationBaseAlgorithm
 {
 public:
     /**
@@ -51,7 +51,7 @@ private:
     void FillValidationInfo(const pandora::MCParticleList *const pMCParticleList, const pandora::CaloHitList *const pCaloHitList,
         const pandora::PfoList *const pPfoList, ValidationInfo &validationInfo) const;
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, unsigned int> PfoToIdMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, unsigned int> PfoToIdMap;
 
     /**
      *  @brief  Print matching information in a provided validation info object, and write information to tree if configured to do so
@@ -67,7 +67,7 @@ private:
 
     typedef std::vector<pandora::HitType> HitTypeVector;
 
-    int                     m_eventNumber;                  ///< The event number
+    int m_eventNumber; ///< The event number
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/TransverseMatrixVisualizationTool.cc
+++ b/larpandoracontent/LArMonitoring/TransverseMatrixVisualizationTool.cc
@@ -28,7 +28,7 @@ TransverseMatrixVisualizationTool::TransverseMatrixVisualizationTool() :
 bool TransverseMatrixVisualizationTool::Run(TwoViewTransverseTracksAlgorithm *const pAlgorithm, MatrixType &overlapMatrix)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ClusterSet usedKeyClusters;
     ClusterVector sortedKeyClusters;
@@ -63,7 +63,6 @@ bool TransverseMatrixVisualizationTool::Run(TwoViewTransverseTracksAlgorithm *co
             if (allClusterList2.end() == std::find(allClusterList2.begin(), allClusterList2.end(), eIter->GetCluster2()))
                 allClusterList2.push_back(eIter->GetCluster2());
             usedKeyClusters.insert(eIter->GetCluster1());
-
         }
 
         for (MatrixType::ElementList::const_iterator eIter = elementList.begin(); eIter != elementList.end(); ++eIter)
@@ -75,39 +74,40 @@ bool TransverseMatrixVisualizationTool::Run(TwoViewTransverseTracksAlgorithm *co
             bool sameParticle(false);
             try
             {
-                const MCParticle* particle0(MCParticleHelper::GetMainMCParticle(eIter->GetCluster1()));
-                const MCParticle* particle1(MCParticleHelper::GetMainMCParticle(eIter->GetCluster2()));
+                const MCParticle *particle0(MCParticleHelper::GetMainMCParticle(eIter->GetCluster1()));
+                const MCParticle *particle1(MCParticleHelper::GetMainMCParticle(eIter->GetCluster2()));
                 pdg0 = (particle0->GetParticleId());
                 isPrimary0 = (particle0->IsRootParticle());
                 pdg1 = (particle1->GetParticleId());
                 isPrimary1 = (particle1->IsRootParticle());
                 sameParticle = (particle0->GetUid() == particle1->GetUid());
             }
-            catch(const StatusCodeException &){};
+            catch (const StatusCodeException &)
+            {
+            };
 
             if (m_showOnlyTrueMatchIndividualElements && !sameParticle)
                 continue;
 
             std::cout << " Element " << counter++ << std::endl;
-            std::cout <<" ---True PDG 0: " << pdg0 << std::endl;
-            std::cout <<" ---True PDG 1: " << pdg1 << std::endl;
-            std::cout <<" ---True is primary 0: " << isPrimary0 << std::endl;
-            std::cout <<" ---True is primary 1: " << isPrimary1 << std::endl;
-            std::cout <<" ---True is same particle: " << sameParticle << std::endl;
-            std::cout <<" ---Is cluster 0 available: " << eIter->GetCluster1()->IsAvailable() << std::endl;
-            std::cout <<" ---Is cluster 1 available: " << eIter->GetCluster2()->IsAvailable() << std::endl;
-            std::cout <<" ---XOverlap: " << eIter->GetOverlapResult().GetTwoViewXOverlap().GetTwoViewXOverlapSpan() <<std::endl;
-            std::cout <<" ---XOverlap fraction view0: " <<
-                eIter->GetOverlapResult().GetTwoViewXOverlap().GetXOverlapFraction0() << std::endl;
-            std::cout <<" ---XOverlap fraction view1: " <<
-                eIter->GetOverlapResult().GetTwoViewXOverlap().GetXOverlapFraction1() << std::endl;
-            std::cout <<" ---Matching score: " << eIter->GetOverlapResult().GetMatchingScore() << std::endl;
-            std::cout <<" ---N. sampling points: " << eIter->GetOverlapResult().GetNSamplingPoints() << std::endl;
-            std::cout <<" ---N. matched sampling points: " << eIter->GetOverlapResult().GetNMatchedSamplingPoints() << std::endl;
-            std::cout <<" ---N. (re-)upsampled sampling points: " << eIter->GetOverlapResult().GetNReUpsampledSamplingPoints() << std::endl;
-            std::cout <<" ---N. (re-)upsampled matched sampling points: " << eIter->GetOverlapResult().GetNMatchedReUpsampledSamplingPoints() << std::endl;
-            std::cout <<" ---Correlation coeff.: " << eIter->GetOverlapResult().GetCorrelationCoefficient() << std::endl;
-            std::cout <<" ---Locally matched fraction: " << eIter->GetOverlapResult().GetLocallyMatchedFraction() << std::endl;
+            std::cout << " ---True PDG 0: " << pdg0 << std::endl;
+            std::cout << " ---True PDG 1: " << pdg1 << std::endl;
+            std::cout << " ---True is primary 0: " << isPrimary0 << std::endl;
+            std::cout << " ---True is primary 1: " << isPrimary1 << std::endl;
+            std::cout << " ---True is same particle: " << sameParticle << std::endl;
+            std::cout << " ---Is cluster 0 available: " << eIter->GetCluster1()->IsAvailable() << std::endl;
+            std::cout << " ---Is cluster 1 available: " << eIter->GetCluster2()->IsAvailable() << std::endl;
+            std::cout << " ---XOverlap: " << eIter->GetOverlapResult().GetTwoViewXOverlap().GetTwoViewXOverlapSpan() << std::endl;
+            std::cout << " ---XOverlap fraction view0: " << eIter->GetOverlapResult().GetTwoViewXOverlap().GetXOverlapFraction0() << std::endl;
+            std::cout << " ---XOverlap fraction view1: " << eIter->GetOverlapResult().GetTwoViewXOverlap().GetXOverlapFraction1() << std::endl;
+            std::cout << " ---Matching score: " << eIter->GetOverlapResult().GetMatchingScore() << std::endl;
+            std::cout << " ---N. sampling points: " << eIter->GetOverlapResult().GetNSamplingPoints() << std::endl;
+            std::cout << " ---N. matched sampling points: " << eIter->GetOverlapResult().GetNMatchedSamplingPoints() << std::endl;
+            std::cout << " ---N. (re-)upsampled sampling points: " << eIter->GetOverlapResult().GetNReUpsampledSamplingPoints() << std::endl;
+            std::cout << " ---N. (re-)upsampled matched sampling points: " << eIter->GetOverlapResult().GetNMatchedReUpsampledSamplingPoints()
+                      << std::endl;
+            std::cout << " ---Correlation coeff.: " << eIter->GetOverlapResult().GetCorrelationCoefficient() << std::endl;
+            std::cout << " ---Locally matched fraction: " << eIter->GetOverlapResult().GetLocallyMatchedFraction() << std::endl;
 
             if (m_showEachIndividualElement)
             {
@@ -136,17 +136,17 @@ bool TransverseMatrixVisualizationTool::Run(TwoViewTransverseTracksAlgorithm *co
 
 StatusCode TransverseMatrixVisualizationTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterConnections", m_minClusterConnections));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterConnections", m_minClusterConnections));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IgnoreUnavailableClusters", m_ignoreUnavailableClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "IgnoreUnavailableClusters", m_ignoreUnavailableClusters));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowEachIndividualElement", m_showEachIndividualElement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShowEachIndividualElement", m_showEachIndividualElement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowOnlyTrueMatchIndividualElements", m_showOnlyTrueMatchIndividualElements));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShowOnlyTrueMatchIndividualElements", m_showOnlyTrueMatchIndividualElements));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArMonitoring/TransverseMatrixVisualizationTool.h
+++ b/larpandoracontent/LArMonitoring/TransverseMatrixVisualizationTool.h
@@ -29,10 +29,10 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_minClusterConnections;                   ///< The minimum number of cluster connections for display
-    bool            m_ignoreUnavailableClusters;               ///< Whether to ignore (skip-over) unavailable clusters in the matrix
-    bool            m_showEachIndividualElement;               ///< Whether to draw each individual matrix element
-    bool            m_showOnlyTrueMatchIndividualElements;     ///< Whether to draw only truly matching individual matrix elements
+    unsigned int m_minClusterConnections;       ///< The minimum number of cluster connections for display
+    bool m_ignoreUnavailableClusters;           ///< Whether to ignore (skip-over) unavailable clusters in the matrix
+    bool m_showEachIndividualElement;           ///< Whether to draw each individual matrix element
+    bool m_showOnlyTrueMatchIndividualElements; ///< Whether to draw only truly matching individual matrix elements
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/TransverseTensorVisualizationTool.cc
+++ b/larpandoracontent/LArMonitoring/TransverseTensorVisualizationTool.cc
@@ -28,7 +28,7 @@ TransverseTensorVisualizationTool::TransverseTensorVisualizationTool() :
 bool TransverseTensorVisualizationTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ClusterSet usedKeyClusters;
     ClusterVector sortedKeyClusters;
@@ -58,21 +58,24 @@ bool TransverseTensorVisualizationTool::Run(ThreeViewTransverseTracksAlgorithm *
 
         for (TensorType::ElementList::const_iterator eIter = elementList.begin(); eIter != elementList.end(); ++eIter)
         {
-            if (allClusterListU.end() == std::find(allClusterListU.begin(), allClusterListU.end(), eIter->GetClusterU())) allClusterListU.push_back(eIter->GetClusterU());
-            if (allClusterListV.end() == std::find(allClusterListV.begin(), allClusterListV.end(), eIter->GetClusterV())) allClusterListV.push_back(eIter->GetClusterV());
-            if (allClusterListW.end() == std::find(allClusterListW.begin(), allClusterListW.end(), eIter->GetClusterW())) allClusterListW.push_back(eIter->GetClusterW());
+            if (allClusterListU.end() == std::find(allClusterListU.begin(), allClusterListU.end(), eIter->GetClusterU()))
+                allClusterListU.push_back(eIter->GetClusterU());
+            if (allClusterListV.end() == std::find(allClusterListV.begin(), allClusterListV.end(), eIter->GetClusterV()))
+                allClusterListV.push_back(eIter->GetClusterV());
+            if (allClusterListW.end() == std::find(allClusterListW.begin(), allClusterListW.end(), eIter->GetClusterW()))
+                allClusterListW.push_back(eIter->GetClusterW());
             usedKeyClusters.insert(eIter->GetClusterU());
 
             std::cout << " Element " << counter++ << ": MatchedFraction " << eIter->GetOverlapResult().GetMatchedFraction()
-                      << ", MatchedSamplingPoints " << eIter->GetOverlapResult().GetNMatchedSamplingPoints()
-                      << ", xSpanU " << eIter->GetOverlapResult().GetXOverlap().GetXSpanU()
-                      << ", xSpanV " << eIter->GetOverlapResult().GetXOverlap().GetXSpanV()
-                      << ", xSpanW " << eIter->GetOverlapResult().GetXOverlap().GetXSpanW()
-                      << ", xOverlapSpan " << eIter->GetOverlapResult().GetXOverlap().GetXOverlapSpan() << std::endl;
+                      << ", MatchedSamplingPoints " << eIter->GetOverlapResult().GetNMatchedSamplingPoints() << ", xSpanU "
+                      << eIter->GetOverlapResult().GetXOverlap().GetXSpanU() << ", xSpanV " << eIter->GetOverlapResult().GetXOverlap().GetXSpanV()
+                      << ", xSpanW " << eIter->GetOverlapResult().GetXOverlap().GetXSpanW() << ", xOverlapSpan "
+                      << eIter->GetOverlapResult().GetXOverlap().GetXOverlapSpan() << std::endl;
 
             if (m_showEachIndividualElement)
             {
-                const ClusterList clusterListU(1, eIter->GetClusterU()), clusterListV(1, eIter->GetClusterV()), clusterListW(1, eIter->GetClusterW());
+                const ClusterList clusterListU(1, eIter->GetClusterU()), clusterListV(1, eIter->GetClusterV()),
+                    clusterListW(1, eIter->GetClusterW());
                 PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1.f, -1.f, 1.f));
                 PANDORA_MONITORING_API(VisualizeClusters(this->GetPandora(), &clusterListU, "UCluster", RED));
                 PANDORA_MONITORING_API(VisualizeClusters(this->GetPandora(), &clusterListV, "VCluster", GREEN));
@@ -104,17 +107,16 @@ bool TransverseTensorVisualizationTool::Run(ThreeViewTransverseTracksAlgorithm *
 
 StatusCode TransverseTensorVisualizationTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterConnections", m_minClusterConnections));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterConnections", m_minClusterConnections));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IgnoreUnavailableClusters", m_ignoreUnavailableClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "IgnoreUnavailableClusters", m_ignoreUnavailableClusters));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowEachIndividualElement", m_showEachIndividualElement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShowEachIndividualElement", m_showEachIndividualElement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowContext", m_showContext));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowContext", m_showContext));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArMonitoring/TransverseTensorVisualizationTool.h
+++ b/larpandoracontent/LArMonitoring/TransverseTensorVisualizationTool.h
@@ -29,10 +29,10 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_minClusterConnections;        ///< The minimum number of cluster connections for display
-    bool            m_ignoreUnavailableClusters;    ///< Whether to ignore (skip-over) unavailable clusters in the tensor
-    bool            m_showEachIndividualElement;    ///< Whether to draw each individual tensor element
-    bool            m_showContext;                  ///< Whether to show input cluster lists to add context to tensor elements
+    unsigned int m_minClusterConnections; ///< The minimum number of cluster connections for display
+    bool m_ignoreUnavailableClusters;     ///< Whether to ignore (skip-over) unavailable clusters in the tensor
+    bool m_showEachIndividualElement;     ///< Whether to draw each individual tensor element
+    bool m_showContext;                   ///< Whether to show input cluster lists to add context to tensor elements
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
@@ -42,8 +42,9 @@ VisualMonitoringAlgorithm::VisualMonitoringAlgorithm() :
 
 StatusCode VisualMonitoringAlgorithm::Run()
 {
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), m_showDetector, (m_detectorView.find("xz") != std::string::npos) ? DETECTOR_VIEW_XZ :
-        (m_detectorView.find("xy") != std::string::npos) ? DETECTOR_VIEW_XY : DETECTOR_VIEW_DEFAULT, m_transparencyThresholdE, m_energyScaleThresholdE, m_scalingFactor));
+    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), m_showDetector,
+        (m_detectorView.find("xz") != std::string::npos) ? DETECTOR_VIEW_XZ : (m_detectorView.find("xy") != std::string::npos) ? DETECTOR_VIEW_XY : DETECTOR_VIEW_DEFAULT,
+        m_transparencyThresholdE, m_energyScaleThresholdE, m_scalingFactor));
 
     // Show current mc particles
     if (m_showCurrentMCParticles)
@@ -156,8 +157,8 @@ void VisualMonitoringAlgorithm::VisualizeMCParticleList(const std::string &listN
         }
     }
 
-    PANDORA_MONITORING_API(VisualizeMCParticles(this->GetPandora(), pMCParticleList, listName.empty() ? "CurrentMCParticles" : listName.c_str(),
-        AUTO, &m_particleSuppressionMap));
+    PANDORA_MONITORING_API(VisualizeMCParticles(
+        this->GetPandora(), pMCParticleList, listName.empty() ? "CurrentMCParticles" : listName.c_str(), AUTO, &m_particleSuppressionMap));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -192,8 +193,7 @@ void VisualMonitoringAlgorithm::VisualizeCaloHitList(const std::string &listName
     {
         const CaloHit *const pCaloHit = *iter;
 
-        if ((pCaloHit->GetElectromagneticEnergy() > m_thresholdEnergy) &&
-            (!m_showOnlyAvailable || PandoraContentApi::IsAvailable(*this, pCaloHit)))
+        if ((pCaloHit->GetElectromagneticEnergy() > m_thresholdEnergy) && (!m_showOnlyAvailable || PandoraContentApi::IsAvailable(*this, pCaloHit)))
         {
             caloHitList.push_back(pCaloHit);
         }
@@ -279,9 +279,9 @@ void VisualMonitoringAlgorithm::VisualizeClusterList(const std::string &listName
     }
 
     PANDORA_MONITORING_API(VisualizeClusters(this->GetPandora(), &clusterList, listName.empty() ? "CurrentClusters" : listName.c_str(),
-        (m_hitColors.find("particleid") != std::string::npos) ? AUTOID :
-        (m_hitColors.find("iterate") != std::string::npos) ? AUTOITER :
-        (m_hitColors.find("energy") != std::string::npos) ? AUTOENERGY : AUTO,
+        (m_hitColors.find("particleid") != std::string::npos)
+            ? AUTOID
+            : (m_hitColors.find("iterate") != std::string::npos) ? AUTOITER : (m_hitColors.find("energy") != std::string::npos) ? AUTOENERGY : AUTO,
         m_showAssociatedTracks));
 }
 
@@ -311,10 +311,10 @@ void VisualMonitoringAlgorithm::VisualizeParticleFlowList(const std::string &lis
     }
 
     PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), pPfoList, listName.empty() ? "CurrentPfos" : listName.c_str(),
-        (m_hitColors.find("particleid") != std::string::npos) ? AUTOID :
-        (m_hitColors.find("iterate") != std::string::npos ? AUTOITER :
-        (m_hitColors.find("energy") != std::string::npos ? AUTOENERGY :
-        AUTO)), m_showPfoVertices, m_showPfoHierarchy));
+        (m_hitColors.find("particleid") != std::string::npos)
+            ? AUTOID
+            : (m_hitColors.find("iterate") != std::string::npos ? AUTOITER : (m_hitColors.find("energy") != std::string::npos ? AUTOENERGY : AUTO)),
+        m_showPfoVertices, m_showPfoHierarchy));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -360,85 +360,76 @@ void VisualMonitoringAlgorithm::VisualizeVertexList(const std::string &listName)
 
 StatusCode VisualMonitoringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowCurrentMCParticles", m_showCurrentMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowCurrentMCParticles", m_showCurrentMCParticles));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "MCParticleListNames", m_mcParticleListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "MCParticleListNames", m_mcParticleListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowCurrentCaloHits", m_showCurrentCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowCurrentCaloHits", m_showCurrentCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "CaloHitListNames", m_caloHitListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "CaloHitListNames", m_caloHitListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowCurrentTracks", m_showCurrentTracks));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowCurrentTracks", m_showCurrentTracks));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "TrackListNames", m_trackListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "TrackListNames", m_trackListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowCurrentClusters", m_showCurrentClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowCurrentClusters", m_showCurrentClusters));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "ClusterListNames", m_clusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowCurrentPfos", m_showCurrentPfos));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowCurrentPfos", m_showCurrentPfos));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "PfoListNames", m_pfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowCurrentVertices", m_showCurrentVertices));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowCurrentVertices", m_showCurrentVertices));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "VertexListNames", m_vertexListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "VertexListNames", m_vertexListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DisplayEvent", m_displayEvent));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DisplayEvent", m_displayEvent));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SaveEventPath", m_saveEventPath));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SaveEventPath", m_saveEventPath));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowDetector", m_showDetector));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowDetector", m_showDetector));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DetectorView", m_detectorView));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DetectorView", m_detectorView));
     std::transform(m_detectorView.begin(), m_detectorView.end(), m_detectorView.begin(), ::tolower);
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowOnlyAvailable", m_showOnlyAvailable));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowOnlyAvailable", m_showOnlyAvailable));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowAssociatedTracks", m_showAssociatedTracks));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowAssociatedTracks", m_showAssociatedTracks));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HitColors", m_hitColors));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitColors", m_hitColors));
     std::transform(m_hitColors.begin(), m_hitColors.end(), m_hitColors.begin(), ::tolower);
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ThresholdEnergy", m_thresholdEnergy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ThresholdEnergy", m_thresholdEnergy));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TransparencyThresholdE", m_transparencyThresholdE));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TransparencyThresholdE", m_transparencyThresholdE));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EnergyScaleThresholdE", m_energyScaleThresholdE));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EnergyScaleThresholdE", m_energyScaleThresholdE));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ScalingFactor", m_scalingFactor));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ScalingFactor", m_scalingFactor));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowPfoVertices", m_showPfoVertices));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowPfoVertices", m_showPfoVertices));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowPfoHierarchy", m_showPfoHierarchy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowPfoHierarchy", m_showPfoHierarchy));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "SuppressMCParticles", m_suppressMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "SuppressMCParticles", m_suppressMCParticles));
 
     for (StringVector::iterator iter = m_suppressMCParticles.begin(), iterEnd = m_suppressMCParticles.end(); iter != iterEnd; ++iter)
     {

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h
@@ -72,42 +72,42 @@ private:
 
     typedef std::map<int, float> PdgCodeToEnergyMap;
 
-    bool                    m_showCurrentMCParticles;   ///< Whether to show current mc particles
-    pandora::StringVector   m_mcParticleListNames;      ///< Names of mc particles lists to show
+    bool m_showCurrentMCParticles;               ///< Whether to show current mc particles
+    pandora::StringVector m_mcParticleListNames; ///< Names of mc particles lists to show
 
-    bool                    m_showCurrentCaloHits;      ///< Whether to show current calohitlist
-    pandora::StringVector   m_caloHitListNames;         ///< Names of calo hit lists to show
+    bool m_showCurrentCaloHits;               ///< Whether to show current calohitlist
+    pandora::StringVector m_caloHitListNames; ///< Names of calo hit lists to show
 
-    bool                    m_showCurrentTracks;        ///< Whether to show current tracks
-    pandora::StringVector   m_trackListNames;           ///< Names of track lists to show
+    bool m_showCurrentTracks;               ///< Whether to show current tracks
+    pandora::StringVector m_trackListNames; ///< Names of track lists to show
 
-    bool                    m_showCurrentClusters;      ///< Whether to show current clusters
-    pandora::StringVector   m_clusterListNames;         ///< Names of cluster lists to show
+    bool m_showCurrentClusters;               ///< Whether to show current clusters
+    pandora::StringVector m_clusterListNames; ///< Names of cluster lists to show
 
-    bool                    m_showCurrentPfos;          ///< Whether to show current particle flow object list
-    pandora::StringVector   m_pfoListNames;             ///< Names of pfo lists to show
+    bool m_showCurrentPfos;               ///< Whether to show current particle flow object list
+    pandora::StringVector m_pfoListNames; ///< Names of pfo lists to show
 
-    bool                    m_showCurrentVertices;      ///< Whether to show current vertex list
-    pandora::StringVector   m_vertexListNames;          ///< Names of vertex lists to show
+    bool m_showCurrentVertices;              ///< Whether to show current vertex list
+    pandora::StringVector m_vertexListNames; ///< Names of vertex lists to show
 
-    bool                    m_displayEvent;             ///< Whether to display the event
-    std::string             m_saveEventPath;            ///< The path to save event displays to. m_displayEvent must also be set.
-    bool                    m_showDetector;             ///< Whether to display the detector geometry
-    std::string             m_detectorView;             ///< The detector view, default, xy or xz
+    bool m_displayEvent;         ///< Whether to display the event
+    std::string m_saveEventPath; ///< The path to save event displays to. m_displayEvent must also be set.
+    bool m_showDetector;         ///< Whether to display the detector geometry
+    std::string m_detectorView;  ///< The detector view, default, xy or xz
 
-    bool                    m_showOnlyAvailable;        ///< Whether to show only available  (i.e. non-clustered) calohits and tracks
-    bool                    m_showAssociatedTracks;     ///< Whether to display tracks associated to clusters when viewing cluster lists
-    std::string             m_hitColors;                ///< Define the hit coloring scheme (default: pfo, choices: pfo, particleid)
-    float                   m_thresholdEnergy;          ///< Cell energy threshold for display (em scale)
-    float                   m_transparencyThresholdE;   ///< Cell energy for which transparency is saturated (0%, fully opaque)
-    float                   m_energyScaleThresholdE;    ///< Cell energy for which color is at top end of continous color palette
-    float                   m_scalingFactor;            ///< TEve works with [cm], Pandora usually works with [mm] (but LArContent went with cm too)
+    bool m_showOnlyAvailable;       ///< Whether to show only available  (i.e. non-clustered) calohits and tracks
+    bool m_showAssociatedTracks;    ///< Whether to display tracks associated to clusters when viewing cluster lists
+    std::string m_hitColors;        ///< Define the hit coloring scheme (default: pfo, choices: pfo, particleid)
+    float m_thresholdEnergy;        ///< Cell energy threshold for display (em scale)
+    float m_transparencyThresholdE; ///< Cell energy for which transparency is saturated (0%, fully opaque)
+    float m_energyScaleThresholdE;  ///< Cell energy for which color is at top end of continous color palette
+    float m_scalingFactor;          ///< TEve works with [cm], Pandora usually works with [mm] (but LArContent went with cm too)
 
-    bool                    m_showPfoVertices;          ///< Whether to display pfo vertices
-    bool                    m_showPfoHierarchy;         ///< Whether to display daughter pfos only under parent pfo elements
+    bool m_showPfoVertices;  ///< Whether to display pfo vertices
+    bool m_showPfoHierarchy; ///< Whether to display daughter pfos only under parent pfo elements
 
-    pandora::StringVector   m_suppressMCParticles;      ///< List of PDG numbers and energies for MC particles to be suppressed (e.g. " 22:0.1 2112:1.0 ")
-    PdgCodeToEnergyMap      m_particleSuppressionMap;   ///< Map from pdg-codes to energy for suppression of particles types below specific energies
+    pandora::StringVector m_suppressMCParticles; ///< List of PDG numbers and energies for MC particles to be suppressed (e.g. " 22:0.1 2112:1.0 ")
+    PdgCodeToEnergyMap m_particleSuppressionMap; ///< Map from pdg-codes to energy for suppression of particles types below specific energies
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/VisualParticleMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualParticleMonitoringAlgorithm.cc
@@ -92,8 +92,8 @@ void VisualParticleMonitoringAlgorithm::VisualizeIndependentMC(const LArMCPartic
     if (mcMap.empty())
         return;
 
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE,
-        m_energyScaleThresholdE, m_scalingFactor));
+    PANDORA_MONITORING_API(
+        SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE, m_energyScaleThresholdE, m_scalingFactor));
     LArMCParticleHelper::GetBreadthFirstHierarchyRepresentation(mcMap.begin()->first, linearisedMC);
 
     size_t colorIdx{0};
@@ -110,7 +110,7 @@ void VisualParticleMonitoringAlgorithm::VisualizeIndependentMC(const LArMCPartic
             if (keys.find(pdg) != keys.end())
                 key = keys.at(pdg);
         }
-        catch (const StatusCodeException&)
+        catch (const StatusCodeException &)
         {
             key = "unknown";
         }
@@ -145,13 +145,13 @@ void VisualParticleMonitoringAlgorithm::VisualizeIndependentMC(const LArMCPartic
 void VisualParticleMonitoringAlgorithm::VisualizeMCByPdgCode(const LArMCParticleHelper::MCContributionMap &mcMap) const
 {
     const std::map<int, const std::string> keys = {{13, "mu"}, {11, "e"}, {22, "gamma"}, {321, "kaon"}, {211, "pi"}, {2212, "p"}};
-    const std::map<std::string, Color> colors = {{"mu", MAGENTA}, {"e", RED}, {"gamma", ORANGE}, {"kaon", BLACK}, {"pi", GREEN}, {"p", BLUE},
-        {"other", GRAY}};
+    const std::map<std::string, Color> colors = {
+        {"mu", MAGENTA}, {"e", RED}, {"gamma", ORANGE}, {"kaon", BLACK}, {"pi", GREEN}, {"p", BLUE}, {"other", GRAY}};
 
     std::map<std::string, CaloHitList> uHits, vHits, wHits;
-    for (const auto [ key, value ] : keys)
+    for (const auto [key, value] : keys)
     {
-        (void)key;  // GCC 7 support, 8+ doesn't need this
+        (void)key; // GCC 7 support, 8+ doesn't need this
         uHits[value] = CaloHitList();
         vHits[value] = CaloHitList();
         wHits[value] = CaloHitList();
@@ -160,7 +160,7 @@ void VisualParticleMonitoringAlgorithm::VisualizeMCByPdgCode(const LArMCParticle
     vHits["other"] = CaloHitList();
     wHits["other"] = CaloHitList();
 
-    for (const auto [ pMC, pCaloHits ] : mcMap)
+    for (const auto [pMC, pCaloHits] : mcMap)
     {
         for (const CaloHit *pCaloHit : pCaloHits)
         {
@@ -180,37 +180,37 @@ void VisualParticleMonitoringAlgorithm::VisualizeMCByPdgCode(const LArMCParticle
                 else
                     wHits[key].emplace_back(pCaloHit);
             }
-            catch (const StatusCodeException&)
+            catch (const StatusCodeException &)
             {
                 continue;
             }
         }
     }
 
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE,
-        m_energyScaleThresholdE, m_scalingFactor));
+    PANDORA_MONITORING_API(
+        SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE, m_energyScaleThresholdE, m_scalingFactor));
 
-    for (const auto [ key, value ] : keys)
+    for (const auto [key, value] : keys)
     {
-        (void)key;  // GCC 7 support, 8+ doesn't need this
+        (void)key; // GCC 7 support, 8+ doesn't need this
         if (!uHits[value].empty())
             PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &uHits[value], "u_" + value, colors.at(value)));
     }
     if (!uHits["other"].empty())
         PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &uHits["other"], "u_other", colors.at("other")));
 
-    for (const auto [ key, value ] : keys)
+    for (const auto [key, value] : keys)
     {
-        (void)key;  // GCC 7 support, 8+ doesn't need this
+        (void)key; // GCC 7 support, 8+ doesn't need this
         if (!vHits[value].empty())
             PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &vHits[value], "v_" + value, colors.at(value)));
     }
     if (!vHits["other"].empty())
         PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &uHits["other"], "v_other", colors.at("other")));
 
-    for (const auto [ key, value ] : keys)
+    for (const auto [key, value] : keys)
     {
-        (void)key;  // GCC 7 support, 8+ doesn't need this
+        (void)key; // GCC 7 support, 8+ doesn't need this
         if (!wHits[value].empty())
             PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &wHits[value], "w_" + value, colors.at(value)));
     }
@@ -238,8 +238,8 @@ void VisualParticleMonitoringAlgorithm::VisualizeIndependentPfo(const PfoList &p
     if (pfoList.empty())
         return;
 
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE,
-        m_energyScaleThresholdE, m_scalingFactor));
+    PANDORA_MONITORING_API(
+        SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE, m_energyScaleThresholdE, m_scalingFactor));
     LArPfoHelper::GetBreadthFirstHierarchyRepresentation(pfoList.front(), linearisedPfo);
 
     size_t colorIdx{0};
@@ -304,8 +304,8 @@ void VisualParticleMonitoringAlgorithm::VisualizeIndependentPfo(const PfoList &p
                     }
                 }
             }
-            catch (const StatusCodeException&)
-            {   // No matched MC, move on
+            catch (const StatusCodeException &)
+            { // No matched MC, move on
             }
         }
         ++pfoIdx;
@@ -322,8 +322,8 @@ void VisualParticleMonitoringAlgorithm::VisualizePfoByParticleId(const PfoList &
     if (pfoList.empty())
         return;
 
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE,
-        m_energyScaleThresholdE, m_scalingFactor));
+    PANDORA_MONITORING_API(
+        SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE, m_energyScaleThresholdE, m_scalingFactor));
     LArPfoHelper::GetBreadthFirstHierarchyRepresentation(pfoList.front(), linearisedPfo);
 
     int pfoIdx{0};
@@ -390,8 +390,8 @@ void VisualParticleMonitoringAlgorithm::VisualizePfoByParticleId(const PfoList &
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void VisualParticleMonitoringAlgorithm::MakeSelection(const MCParticleList *pMCList, const CaloHitList *pCaloHitList,
-    LArMCParticleHelper::MCContributionMap &mcMap) const
+void VisualParticleMonitoringAlgorithm::MakeSelection(
+    const MCParticleList *pMCList, const CaloHitList *pCaloHitList, LArMCParticleHelper::MCContributionMap &mcMap) const
 {
     // Default reconstructability criteria are very liberal to allow for unfolded hierarchy
     LArMCParticleHelper::PrimaryParameters parameters;
@@ -418,30 +418,23 @@ void VisualParticleMonitoringAlgorithm::MakeSelection(const MCParticleList *pMCL
 
 StatusCode VisualParticleMonitoringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName",
-        m_caloHitListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
     if (m_caloHitListName.empty())
         m_caloHitListName = "CaloHitList2D";
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName",
-        m_pfoListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
     if (m_pfoListName.empty())
         m_pfoListName = "RecreatedPfos";
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VisualizeMC",
-        m_visualizeMC));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VisualizePFO",
-        m_visualizePfo));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "GroupMCByPDG",
-        m_groupMCByPdg));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowPFOByPID",
-        m_showPfoByPid));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowPFOMatchedMC",
-        m_showPfoMatchedMC));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TransparencyThresholdE",
-        m_transparencyThresholdE));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EnergyScaleThresholdE",
-        m_energyScaleThresholdE));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ScalingFactor",
-        m_scalingFactor));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VisualizeMC", m_visualizeMC));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VisualizePFO", m_visualizePfo));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "GroupMCByPDG", m_groupMCByPdg));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowPFOByPID", m_showPfoByPid));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowPFOMatchedMC", m_showPfoMatchedMC));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TransparencyThresholdE", m_transparencyThresholdE));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EnergyScaleThresholdE", m_energyScaleThresholdE));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ScalingFactor", m_scalingFactor));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArMonitoring/VisualParticleMonitoringAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/VisualParticleMonitoringAlgorithm.h
@@ -18,7 +18,7 @@ namespace lar_content
 /**
  *  @brief  VisualParticleMonitoringAlgorithm class
  */
-class VisualParticleMonitoringAlgorithm: public pandora::Algorithm
+class VisualParticleMonitoringAlgorithm : public pandora::Algorithm
 {
 public:
     /**
@@ -90,17 +90,17 @@ private:
         LArMCParticleHelper::MCContributionMap &mcMap) const;
 #endif // MONITORING
 
-    std::string     m_caloHitListName;          ///< Name of input calo hit list
-    std::string     m_pfoListName;              ///< Name of input PFO list
-    bool            m_visualizeMC;              ///< Whether or not to visualize MC particles
-    bool            m_visualizePfo;             ///< Whether or not to visualize PFOs
-    bool            m_groupMCByPdg;             ///< Whether or not to group MC particles by particle id
-    bool            m_showPfoByPid;             ///< Whether or not to colour PFOs by particle id
-    bool            m_showPfoMatchedMC;         ///< Whether or not to display the best matched MC particle for a PFO
-    bool            m_isTestBeam;               ///< Whether or not this is a test beam experiment
-    float           m_transparencyThresholdE;   ///< Cell energy for which transparency is saturated (0%, fully opaque)
-    float           m_energyScaleThresholdE;    ///< Cell energy for which color is at top end of continous color palette
-    float           m_scalingFactor;            ///< TEve works with [cm], Pandora usually works with [mm] (but LArContent went with cm too)
+    std::string m_caloHitListName;  ///< Name of input calo hit list
+    std::string m_pfoListName;      ///< Name of input PFO list
+    bool m_visualizeMC;             ///< Whether or not to visualize MC particles
+    bool m_visualizePfo;            ///< Whether or not to visualize PFOs
+    bool m_groupMCByPdg;            ///< Whether or not to group MC particles by particle id
+    bool m_showPfoByPid;            ///< Whether or not to colour PFOs by particle id
+    bool m_showPfoMatchedMC;        ///< Whether or not to display the best matched MC particle for a PFO
+    bool m_isTestBeam;              ///< Whether or not this is a test beam experiment
+    float m_transparencyThresholdE; ///< Cell energy for which transparency is saturated (0%, fully opaque)
+    float m_energyScaleThresholdE;  ///< Cell energy for which color is at top end of continous color palette
+    float m_scalingFactor;          ///< TEve works with [cm], Pandora usually works with [mm] (but LArContent went with cm too)
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArObjects/LArAdaBoostDecisionTree.cc
+++ b/larpandoracontent/LArObjects/LArAdaBoostDecisionTree.cc
@@ -15,8 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-AdaBoostDecisionTree::AdaBoostDecisionTree() :
-    m_pStrongClassifier(nullptr)
+AdaBoostDecisionTree::AdaBoostDecisionTree() : m_pStrongClassifier(nullptr)
 {
 }
 
@@ -161,7 +160,8 @@ double AdaBoostDecisionTree::CalculateScore(const LArMvaHelper::MvaFeatureVector
         }
         else if (STATUS_CODE_INVALID_PARAMETER == statusCodeException.GetStatusCode())
         {
-            std::cout << "AdaBoostDecisionTree: Caught exception thrown when classifier weights sum to zero indicating defunct classifier." << std::endl;
+            std::cout << "AdaBoostDecisionTree: Caught exception thrown when classifier weights sum to zero indicating defunct classifier."
+                      << std::endl;
         }
         else if (STATUS_CODE_OUT_OF_RANGE == statusCodeException.GetStatusCode())
         {
@@ -260,11 +260,10 @@ AdaBoostDecisionTree::Node::~Node()
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const TiXmlHandle *const pXmlHandle) :
-    m_weight(0.),
-    m_treeId(0)
+AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const TiXmlHandle *const pXmlHandle) : m_weight(0.), m_treeId(0)
 {
-    for (TiXmlElement *pHeadTiXmlElement = pXmlHandle->FirstChildElement().ToElement(); pHeadTiXmlElement != NULL; pHeadTiXmlElement = pHeadTiXmlElement->NextSiblingElement())
+    for (TiXmlElement *pHeadTiXmlElement = pXmlHandle->FirstChildElement().ToElement(); pHeadTiXmlElement != NULL;
+         pHeadTiXmlElement = pHeadTiXmlElement->NextSiblingElement())
     {
         if ("TreeIndex" == pHeadTiXmlElement->ValueStr())
         {
@@ -285,9 +284,7 @@ AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const TiXmlHandle *const pX
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const WeakClassifier &rhs) :
-    m_weight(rhs.m_weight),
-    m_treeId(rhs.m_treeId)
+AdaBoostDecisionTree::WeakClassifier::WeakClassifier(const WeakClassifier &rhs) : m_weight(rhs.m_weight), m_treeId(rhs.m_treeId)
 {
     for (const auto &mapEntry : rhs.m_idToNodeMap)
     {

--- a/larpandoracontent/LArObjects/LArAdaBoostDecisionTree.h
+++ b/larpandoracontent/LArObjects/LArAdaBoostDecisionTree.h
@@ -178,17 +178,17 @@ private:
         bool GetOutcome() const;
 
     private:
-        int       m_nodeId;               ///< Node id
-        int       m_parentNodeId;         ///< Parent node id
-        int       m_leftChildNodeId;      ///< Left child node id
-        int       m_rightChildNodeId;     ///< Right child node id
-        bool      m_isLeaf;               ///< Is node a leaf
-        double    m_threshold;            ///< Threshold used for decision if decision node
-        int       m_variableId;           ///< Variable cut on for decision if decision node
-        bool      m_outcome;              ///< Outcome if leaf node
+        int m_nodeId;           ///< Node id
+        int m_parentNodeId;     ///< Parent node id
+        int m_leftChildNodeId;  ///< Left child node id
+        int m_rightChildNodeId; ///< Right child node id
+        bool m_isLeaf;          ///< Is node a leaf
+        double m_threshold;     ///< Threshold used for decision if decision node
+        int m_variableId;       ///< Variable cut on for decision if decision node
+        bool m_outcome;         ///< Outcome if leaf node
     };
 
-    typedef std::map<int, const Node*> IdToNodeMap;
+    typedef std::map<int, const Node *> IdToNodeMap;
 
     /**
      *  @brief  WeakClassifier class containing a decision tree and a weight
@@ -256,12 +256,12 @@ private:
         int GetTreeId() const;
 
     private:
-        IdToNodeMap     m_idToNodeMap; ///< Decision tree nodes
-        double          m_weight;      ///< Boost weight
-        int             m_treeId;      ///< Decision tree id
+        IdToNodeMap m_idToNodeMap; ///< Decision tree nodes
+        double m_weight;           ///< Boost weight
+        int m_treeId;              ///< Decision tree id
     };
 
-    typedef std::vector<const WeakClassifier*> WeakClassifiers;
+    typedef std::vector<const WeakClassifier *> WeakClassifiers;
 
     /**
      *  @brief  StrongClassifier class used in application of adaptive boost decision tree
@@ -310,7 +310,7 @@ private:
          */
         pandora::StatusCode ReadComponent(pandora::TiXmlElement *pCurrentXmlElement);
 
-        WeakClassifiers     m_weakClassifiers;     ///< Vector of weak classifers
+        WeakClassifiers m_weakClassifiers; ///< Vector of weak classifers
     };
 
     /**
@@ -322,7 +322,7 @@ private:
      */
     double CalculateScore(const LArMvaHelper::MvaFeatureVector &features) const;
 
-    StrongClassifier     *m_pStrongClassifier;           ///< Strong adaptive boost tree classifier
+    StrongClassifier *m_pStrongClassifier; ///< Strong adaptive boost tree classifier
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArObjects/LArCaloHit.h
+++ b/larpandoracontent/LArObjects/LArCaloHit.h
@@ -27,8 +27,8 @@ namespace lar_content
 class LArCaloHitParameters : public object_creation::CaloHit::Parameters
 {
 public:
-    pandora::InputUInt      m_larTPCVolumeId;       ///< The lar tpc volume id
-    pandora::InputUInt      m_daughterVolumeId;     ///< The daughter volume id
+    pandora::InputUInt m_larTPCVolumeId;   ///< The lar tpc volume id
+    pandora::InputUInt m_daughterVolumeId; ///< The daughter volume id
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -53,7 +53,7 @@ public:
      */
     unsigned int GetLArTPCVolumeId() const;
 
-   /**
+    /**
      *  @brief  Get the daughter volume id
      *
      *  @return the daughter volume id
@@ -89,10 +89,10 @@ public:
     void SetShowerProbability(const float probability);
 
 private:
-    unsigned int            m_larTPCVolumeId;       ///< The lar tpc volume id
-    unsigned int            m_daughterVolumeId;     ///< The daughter volume id
-    pandora::InputFloat     m_pTrack;               ///< The probability that the hit is track-like
-    pandora::InputFloat     m_pShower;              ///< The probability that the hit is shower-like
+    unsigned int m_larTPCVolumeId;   ///< The lar tpc volume id
+    unsigned int m_daughterVolumeId; ///< The daughter volume id
+    pandora::InputFloat m_pTrack;    ///< The probability that the hit is track-like
+    pandora::InputFloat m_pShower;   ///< The probability that the hit is shower-like
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -142,7 +142,7 @@ public:
     pandora::StatusCode Create(const Parameters &parameters, const Object *&pObject) const;
 
 private:
-    unsigned int            m_version;              ///< The LArCaloHit version
+    unsigned int m_version; ///< The LArCaloHit version
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -206,8 +206,7 @@ inline void LArCaloHit::SetShowerProbability(const float probability)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline LArCaloHitFactory::LArCaloHitFactory(const unsigned int version) :
-    m_version(version)
+inline LArCaloHitFactory::LArCaloHitFactory(const unsigned int version) : m_version(version)
 {
 }
 
@@ -222,7 +221,7 @@ inline LArCaloHitFactory::Parameters *LArCaloHitFactory::NewParameters() const
 
 inline pandora::StatusCode LArCaloHitFactory::Create(const Parameters &parameters, const Object *&pObject) const
 {
-    const LArCaloHitParameters &larCaloHitParameters(dynamic_cast<const LArCaloHitParameters&>(parameters));
+    const LArCaloHitParameters &larCaloHitParameters(dynamic_cast<const LArCaloHitParameters &>(parameters));
     pObject = new LArCaloHit(larCaloHitParameters);
 
     return pandora::STATUS_CODE_SUCCESS;
@@ -238,22 +237,24 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
 
     if (pandora::BINARY == fileReader.GetFileType())
     {
-        pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader&>(fileReader));
+        pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader &>(fileReader));
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(larTPCVolumeId));
-        if (m_version > 1) PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(daughterVolumeId));
+        if (m_version > 1)
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(daughterVolumeId));
     }
     else if (pandora::XML == fileReader.GetFileType())
     {
-        pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader&>(fileReader));
+        pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader &>(fileReader));
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("LArTPCVolumeId", larTPCVolumeId));
-        if (m_version > 1) PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("DaughterVolumeId", daughterVolumeId));
+        if (m_version > 1)
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("DaughterVolumeId", daughterVolumeId));
     }
     else
     {
         return pandora::STATUS_CODE_INVALID_PARAMETER;
     }
 
-    LArCaloHitParameters &larCaloHitParameters(dynamic_cast<LArCaloHitParameters&>(parameters));
+    LArCaloHitParameters &larCaloHitParameters(dynamic_cast<LArCaloHitParameters &>(parameters));
     larCaloHitParameters.m_larTPCVolumeId = larTPCVolumeId;
     larCaloHitParameters.m_daughterVolumeId = daughterVolumeId;
 
@@ -265,22 +266,25 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
 inline pandora::StatusCode LArCaloHitFactory::Write(const Object *const pObject, pandora::FileWriter &fileWriter) const
 {
     // ATTN: To receive this call-back must have already set file writer mc particle factory to this factory
-    const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit*>(pObject));
+    const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pObject));
 
     if (!pLArCaloHit)
         return pandora::STATUS_CODE_INVALID_PARAMETER;
 
     if (pandora::BINARY == fileWriter.GetFileType())
     {
-        pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter&>(fileWriter));
+        pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter &>(fileWriter));
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetLArTPCVolumeId()));
-        if (m_version > 1) PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetDaughterVolumeId()));
+        if (m_version > 1)
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetDaughterVolumeId()));
     }
     else if (pandora::XML == fileWriter.GetFileType())
     {
-        pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter&>(fileWriter));
+        pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter &>(fileWriter));
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("LArTPCVolumeId", pLArCaloHit->GetLArTPCVolumeId()));
-        if(m_version > 1) PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("DaughterVolumeId", pLArCaloHit->GetDaughterVolumeId()));
+        if (m_version > 1)
+            PANDORA_RETURN_RESULT_IF(
+                pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("DaughterVolumeId", pLArCaloHit->GetDaughterVolumeId()));
     }
     else
     {

--- a/larpandoracontent/LArObjects/LArDiscreteProbabilityVector.cc
+++ b/larpandoracontent/LArObjects/LArDiscreteProbabilityVector.cc
@@ -16,8 +16,7 @@ namespace lar_content
 {
 
 template <typename TX, typename TY>
-DiscreteProbabilityVector::DiscreteProbabilityVector(const InputData<TX, TY> &inputData, const TX xUpperBound, 
-        const bool useWidths) :
+DiscreteProbabilityVector::DiscreteProbabilityVector(const InputData<TX, TY> &inputData, const TX xUpperBound, const bool useWidths) :
     m_xUpperBound(static_cast<float>(xUpperBound)),
     m_useWidths(useWidths),
     m_discreteProbabilityData(this->InitialiseDiscreteProbabilityData(inputData))
@@ -27,8 +26,7 @@ DiscreteProbabilityVector::DiscreteProbabilityVector(const InputData<TX, TY> &in
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-DiscreteProbabilityVector::DiscreteProbabilityVector(const DiscreteProbabilityVector &discreteProbabilityVector,
-        std::mt19937 &randomNumberGenerator) :
+DiscreteProbabilityVector::DiscreteProbabilityVector(const DiscreteProbabilityVector &discreteProbabilityVector, std::mt19937 &randomNumberGenerator) :
     m_xUpperBound(discreteProbabilityVector.m_xUpperBound),
     m_useWidths(discreteProbabilityVector.m_useWidths),
     m_discreteProbabilityData(this->RandomiseDiscreteProbabilityData(discreteProbabilityVector, randomNumberGenerator))
@@ -38,15 +36,13 @@ DiscreteProbabilityVector::DiscreteProbabilityVector(const DiscreteProbabilityVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-DiscreteProbabilityVector::DiscreteProbabilityVector(const DiscreteProbabilityVector &discreteProbabilityVector,
-        const ResamplingPoints &resamplingPoints) :
+DiscreteProbabilityVector::DiscreteProbabilityVector(const DiscreteProbabilityVector &discreteProbabilityVector, const ResamplingPoints &resamplingPoints) :
     m_xUpperBound(discreteProbabilityVector.m_xUpperBound),
     m_useWidths(discreteProbabilityVector.m_useWidths),
     m_discreteProbabilityData(this->ResampleDiscreteProbabilityData(discreteProbabilityVector, resamplingPoints))
 {
     this->VerifyCompleteData();
 }
-
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -71,10 +67,10 @@ float DiscreteProbabilityVector::EvaluateCumulativeProbability(const float x) co
         if (std::fabs(xHigh - xLow) < std::numeric_limits<float>::epsilon())
             throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
 
-        const float m((yHigh - yLow)/(xHigh - xLow));
-        const float c(yLow - m*xLow);
+        const float m((yHigh - yLow) / (xHigh - xLow));
+        const float c(yLow - m * xLow);
 
-        return m*x + c;
+        return m * x + c;
     }
 
     throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
@@ -83,13 +79,12 @@ float DiscreteProbabilityVector::EvaluateCumulativeProbability(const float x) co
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename TX, typename TY>
-DiscreteProbabilityVector::DiscreteProbabilityData DiscreteProbabilityVector::InitialiseDiscreteProbabilityData(
-    InputData<TX, TY> inputData) const
+DiscreteProbabilityVector::DiscreteProbabilityData DiscreteProbabilityVector::InitialiseDiscreteProbabilityData(InputData<TX, TY> inputData) const
 {
     if (2 > inputData.size())
         throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
 
-    std::sort(inputData.begin(), inputData.end(), DiscreteProbabilityVector::SortInputDataByX<TX,TY>);
+    std::sort(inputData.begin(), inputData.end(), DiscreteProbabilityVector::SortInputDataByX<TX, TY>);
 
     if (inputData.back().first - m_xUpperBound > std::numeric_limits<float>::epsilon())
         throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
@@ -133,15 +128,15 @@ DiscreteProbabilityVector::DiscreteProbabilityData DiscreteProbabilityVector::Re
     for (unsigned int iSample = 0; iSample < resamplingPoints.size() - 1; ++iSample)
     {
         const float xResampled(resamplingPoints.at(iSample));
-        const float deltaX(resamplingPoints.at(iSample + 1)-xResampled);
+        const float deltaX(resamplingPoints.at(iSample + 1) - xResampled);
 
         if (deltaX < std::numeric_limits<float>::epsilon())
             throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
 
         const float cumulativeDatumResampled(discreteProbabilityVector.EvaluateCumulativeProbability(xResampled));
         const float densityDatumResampled((cumulativeDatumResampled - prevCumulativeData) / (m_useWidths ? deltaX : 1.f));
-        resampledProbabilityData.emplace_back(DiscreteProbabilityVector::DiscreteProbabilityDatum(xResampled, 
-            densityDatumResampled, cumulativeDatumResampled, deltaX));
+        resampledProbabilityData.emplace_back(
+            DiscreteProbabilityVector::DiscreteProbabilityDatum(xResampled, densityDatumResampled, cumulativeDatumResampled, deltaX));
         prevCumulativeData = cumulativeDatumResampled;
     }
 
@@ -153,8 +148,8 @@ DiscreteProbabilityVector::DiscreteProbabilityData DiscreteProbabilityVector::Re
 
     const float cumulativeDatumResampled(discreteProbabilityVector.EvaluateCumulativeProbability(xResampled));
     const float densityDatumResampled((cumulativeDatumResampled - prevCumulativeData) / (m_useWidths ? deltaX : 1.f));
-    resampledProbabilityData.emplace_back(DiscreteProbabilityVector::DiscreteProbabilityDatum(xResampled, densityDatumResampled, 
-        cumulativeDatumResampled, deltaX));
+    resampledProbabilityData.emplace_back(
+        DiscreteProbabilityVector::DiscreteProbabilityDatum(xResampled, densityDatumResampled, cumulativeDatumResampled, deltaX));
 
     return resampledProbabilityData;
 }
@@ -162,7 +157,7 @@ DiscreteProbabilityVector::DiscreteProbabilityData DiscreteProbabilityVector::Re
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 DiscreteProbabilityVector::DiscreteProbabilityData DiscreteProbabilityVector::RandomiseDiscreteProbabilityData(
-   const DiscreteProbabilityVector &discreteProbabilityVector, std::mt19937 &randomNumberGenerator) const
+    const DiscreteProbabilityVector &discreteProbabilityVector, std::mt19937 &randomNumberGenerator) const
 {
     DiscreteProbabilityData randomisedProbabilityData;
 
@@ -178,8 +173,8 @@ DiscreteProbabilityVector::DiscreteProbabilityData DiscreteProbabilityVector::Ra
         const float deltaX(discreteProbabilityVector.GetWidth(randomElementIndex));
         const float probabilityDensity(discreteProbabilityVector.GetProbabilityDensity(randomElementIndex));
         cumulativeProbability += probabilityDensity * (m_useWidths ? deltaX : 1.f);
-        randomisedProbabilityData.emplace_back(DiscreteProbabilityVector::DiscreteProbabilityDatum(xPos, probabilityDensity, 
-            cumulativeProbability, deltaX));
+        randomisedProbabilityData.emplace_back(
+            DiscreteProbabilityVector::DiscreteProbabilityDatum(xPos, probabilityDensity, cumulativeProbability, deltaX));
         xPos += deltaX;
     }
 
@@ -211,8 +206,8 @@ float DiscreteProbabilityVector::CalculateNormalisation(const InputData<TX, TY> 
     for (unsigned int iDatum = 0; iDatum < inputData.size() - 1; ++iDatum)
     {
         const float y(static_cast<float>(inputData.at(iDatum).second));
-        normalisation += y * (m_useWidths ? 
-            static_cast<float>(inputData.at(iDatum + 1).first) - static_cast<float>(inputData.at(iDatum).first) : 1.f);
+        normalisation +=
+            y * (m_useWidths ? static_cast<float>(inputData.at(iDatum + 1).first) - static_cast<float>(inputData.at(iDatum).first) : 1.f);
     }
     const float y(static_cast<float>(inputData.back().second));
     normalisation += y * (m_useWidths ? m_xUpperBound - static_cast<float>(inputData.back().first) : 1.f);

--- a/larpandoracontent/LArObjects/LArDiscreteProbabilityVector.h
+++ b/larpandoracontent/LArObjects/LArDiscreteProbabilityVector.h
@@ -29,7 +29,7 @@ public:
     using InputDatum = std::pair<TX, TY>;
 
     template <typename TX, typename TY>
-    using InputData = std::vector<InputDatum<TX, TY> >;
+    using InputData = std::vector<InputDatum<TX, TY>>;
 
     typedef InputData<float, float> AllFloatInputData;
 
@@ -179,10 +179,10 @@ private:
         float GetWidth() const;
 
     private:
-        float m_x;                     ///< The x coordinate
-        float m_densityDatum;          ///< The probability density value
-        float m_cumulativeDatum;       ///< The cumulative probability value
-        float m_width;                 ///< The width of the probability bin
+        float m_x;               ///< The x coordinate
+        float m_densityDatum;    ///< The probability density value
+        float m_cumulativeDatum; ///< The cumulative probability value
+        float m_width;           ///< The width of the probability bin
     };
 
     typedef std::vector<DiscreteProbabilityDatum> DiscreteProbabilityData;
@@ -194,7 +194,7 @@ private:
      *
      *  @return a fully-initialised discrete probability data vector
      */
-    template<typename TX, typename TY>
+    template <typename TX, typename TY>
     DiscreteProbabilityData InitialiseDiscreteProbabilityData(InputData<TX, TY> inputData) const;
 
     /**
@@ -205,8 +205,8 @@ private:
      *
      *  @return a resampled probability data vector
      */
-    DiscreteProbabilityData ResampleDiscreteProbabilityData(const DiscreteProbabilityVector &discreteProbabilityVector, 
-        const ResamplingPoints &resamplingPoints) const;
+    DiscreteProbabilityData ResampleDiscreteProbabilityData(
+        const DiscreteProbabilityVector &discreteProbabilityVector, const ResamplingPoints &resamplingPoints) const;
 
     /**
      *  @brief  Get a randomised probability data vector in which the x values are unchanged, the probability density is 
@@ -217,8 +217,8 @@ private:
      *
      *  @return a resampled probability data vector
      */
-    DiscreteProbabilityData RandomiseDiscreteProbabilityData(const DiscreteProbabilityVector &discreteProbabilityVector, 
-        std::mt19937 &randomNumberGenerator) const;
+    DiscreteProbabilityData RandomiseDiscreteProbabilityData(
+        const DiscreteProbabilityVector &discreteProbabilityVector, std::mt19937 &randomNumberGenerator) const;
 
     /**
      *  @brief  Sort the input data according to their x value
@@ -253,9 +253,9 @@ private:
      */
     void VerifyElementRequest(const unsigned int index) const;
 
-    float                   m_xUpperBound;                            ///< the upper bound of the probability vector
-    bool                    m_useWidths;                              ///< controls whether bin widths are used in calculations
-    DiscreteProbabilityData m_discreteProbabilityData;                ///< the probability data
+    float m_xUpperBound;                               ///< the upper bound of the probability vector
+    bool m_useWidths;                                  ///< controls whether bin widths are used in calculations
+    DiscreteProbabilityData m_discreteProbabilityData; ///< the probability data
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -312,8 +312,8 @@ inline float DiscreteProbabilityVector::GetWidth(const unsigned int index) const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline void DiscreteProbabilityVector::GetAllAtIndex(const unsigned int index, float &x, float &probabilityDensity,
-    float &cumulativeProbability, float &width) const
+inline void DiscreteProbabilityVector::GetAllAtIndex(
+    const unsigned int index, float &x, float &probabilityDensity, float &cumulativeProbability, float &width) const
 {
     this->VerifyElementRequest(index);
 
@@ -326,8 +326,8 @@ inline void DiscreteProbabilityVector::GetAllAtIndex(const unsigned int index, f
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline DiscreteProbabilityVector::DiscreteProbabilityDatum::DiscreteProbabilityDatum(const float x,
-        const float densityDatum, const float cumulativeDatum, const float width) :
+inline DiscreteProbabilityVector::DiscreteProbabilityDatum::DiscreteProbabilityDatum(
+    const float x, const float densityDatum, const float cumulativeDatum, const float width) :
     m_x(x),
     m_densityDatum(densityDatum),
     m_cumulativeDatum(cumulativeDatum),
@@ -389,4 +389,3 @@ inline void DiscreteProbabilityVector::VerifyElementRequest(const unsigned int i
 } // namespace lar_content
 
 #endif // #ifndef  LAR_DISCRETE_PROBABILITY_VECTOR_H
-

--- a/larpandoracontent/LArObjects/LArMCParticle.h
+++ b/larpandoracontent/LArObjects/LArMCParticle.h
@@ -27,7 +27,7 @@ namespace lar_content
 class LArMCParticleParameters : public object_creation::MCParticle::Parameters
 {
 public:
-    pandora::InputInt   m_nuanceCode;               ///< The nuance code
+    pandora::InputInt m_nuanceCode; ///< The nuance code
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -53,7 +53,7 @@ public:
     int GetNuanceCode() const;
 
 private:
-    int                 m_nuanceCode;               ///< The nuance code
+    int m_nuanceCode; ///< The nuance code
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -124,7 +124,7 @@ inline LArMCParticleFactory::Parameters *LArMCParticleFactory::NewParameters() c
 
 inline pandora::StatusCode LArMCParticleFactory::Create(const Parameters &parameters, const Object *&pObject) const
 {
-    const LArMCParticleParameters &larMCParticleParameters(dynamic_cast<const LArMCParticleParameters&>(parameters));
+    const LArMCParticleParameters &larMCParticleParameters(dynamic_cast<const LArMCParticleParameters &>(parameters));
     pObject = new LArMCParticle(larMCParticleParameters);
 
     return pandora::STATUS_CODE_SUCCESS;
@@ -139,12 +139,12 @@ inline pandora::StatusCode LArMCParticleFactory::Read(Parameters &parameters, pa
 
     if (pandora::BINARY == fileReader.GetFileType())
     {
-        pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader&>(fileReader));
+        pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader &>(fileReader));
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(nuanceCode));
     }
     else if (pandora::XML == fileReader.GetFileType())
     {
-        pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader&>(fileReader));
+        pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader &>(fileReader));
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("NuanceCode", nuanceCode));
     }
     else
@@ -152,7 +152,7 @@ inline pandora::StatusCode LArMCParticleFactory::Read(Parameters &parameters, pa
         return pandora::STATUS_CODE_INVALID_PARAMETER;
     }
 
-    LArMCParticleParameters &larMCParticleParameters(dynamic_cast<LArMCParticleParameters&>(parameters));
+    LArMCParticleParameters &larMCParticleParameters(dynamic_cast<LArMCParticleParameters &>(parameters));
     larMCParticleParameters.m_nuanceCode = nuanceCode;
 
     return pandora::STATUS_CODE_SUCCESS;
@@ -163,19 +163,19 @@ inline pandora::StatusCode LArMCParticleFactory::Read(Parameters &parameters, pa
 inline pandora::StatusCode LArMCParticleFactory::Write(const Object *const pObject, pandora::FileWriter &fileWriter) const
 {
     // ATTN: To receive this call-back must have already set file writer mc particle factory to this factory
-    const LArMCParticle *const pLArMCParticle(dynamic_cast<const LArMCParticle*>(pObject));
+    const LArMCParticle *const pLArMCParticle(dynamic_cast<const LArMCParticle *>(pObject));
 
     if (!pLArMCParticle)
         return pandora::STATUS_CODE_INVALID_PARAMETER;
 
     if (pandora::BINARY == fileWriter.GetFileType())
     {
-        pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter&>(fileWriter));
+        pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter &>(fileWriter));
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArMCParticle->GetNuanceCode()));
     }
     else if (pandora::XML == fileWriter.GetFileType())
     {
-        pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter&>(fileWriter));
+        pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter &>(fileWriter));
         PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("NuanceCode", pLArMCParticle->GetNuanceCode()));
     }
     else

--- a/larpandoracontent/LArObjects/LArMvaInterface.h
+++ b/larpandoracontent/LArObjects/LArMvaInterface.h
@@ -75,8 +75,8 @@ public:
         bool IsInitialized() const;
 
     private:
-        double m_number;        ///< Number held by class
-        bool   m_isInitialized; ///< Whether the number has been initialized
+        double m_number;      ///< Number held by class
+        bool m_isInitialized; ///< Whether the number has been initialized
     };
 
     typedef InitializedDouble MvaFeature;
@@ -127,17 +127,13 @@ public:
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline MvaTypes::InitializedDouble::InitializedDouble() :
-    m_number(0.),
-    m_isInitialized(false)
+inline MvaTypes::InitializedDouble::InitializedDouble() : m_number(0.), m_isInitialized(false)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline MvaTypes::InitializedDouble::InitializedDouble(const double number) :
-    m_number(number),
-    m_isInitialized(true)
+inline MvaTypes::InitializedDouble::InitializedDouble(const double number) : m_number(number), m_isInitialized(true)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArOverlapMatrix.cc
+++ b/larpandoracontent/LArObjects/LArOverlapMatrix.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/PandoraInputTypes.h"
 
-#include "Pandora/PandoraInternal.h"
 #include "Pandora/PandoraInputTypes.h"
+#include "Pandora/PandoraInternal.h"
 #include "Pandora/StatusCodes.h"
 
 #include "Objects/Cluster.h"
@@ -18,7 +18,6 @@
 
 #include "larpandoracontent/LArObjects/LArOverlapMatrix.h"
 #include "larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.h"
-
 
 #include <algorithm>
 
@@ -61,8 +60,8 @@ void OverlapMatrix<T>::GetUnambiguousElements(const bool ignoreUnavailable, Elem
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-bool OverlapMatrix<T>::DefaultAmbiguityFunction(const ClusterList &clusterList1, const ClusterList &clusterList2, const Cluster *&pCluster1,
-    const Cluster *&pCluster2) const
+bool OverlapMatrix<T>::DefaultAmbiguityFunction(
+    const ClusterList &clusterList1, const ClusterList &clusterList2, const Cluster *&pCluster1, const Cluster *&pCluster2) const
 {
     if ((1 != clusterList1.size()) || (1 != clusterList2.size()))
         return false;
@@ -76,12 +75,13 @@ bool OverlapMatrix<T>::DefaultAmbiguityFunction(const ClusterList &clusterList1,
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-void OverlapMatrix<T>::GetConnectedElements(const pandora::Cluster *const pCluster, const bool ignoreUnavailable, ElementList &elementList,
-    unsigned int &n1, unsigned int &n2) const
+void OverlapMatrix<T>::GetConnectedElements(
+    const pandora::Cluster *const pCluster, const bool ignoreUnavailable, ElementList &elementList, unsigned int &n1, unsigned int &n2) const
 {
     ClusterList clusterList1, clusterList2;
     this->GetConnectedElements(pCluster, ignoreUnavailable, elementList, clusterList1, clusterList2);
-    n1 = clusterList1.size(); n2 = clusterList2.size();
+    n1 = clusterList1.size();
+    n2 = clusterList2.size();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -98,8 +98,7 @@ void OverlapMatrix<T>::GetSortedKeyClusters(ClusterVector &sortedKeyClusters) co
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-void OverlapMatrix<T>::SetOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-    const OverlapResult &overlapResult)
+void OverlapMatrix<T>::SetOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const OverlapResult &overlapResult)
 {
     OverlapList &overlapList = m_overlapMatrix[pCluster1];
     typename OverlapList::const_iterator iter = overlapList.find(pCluster2);
@@ -113,15 +112,16 @@ void OverlapMatrix<T>::SetOverlapResult(const pandora::Cluster *const pCluster1,
     ClusterList &navigation12(m_clusterNavigationMap12[pCluster1]);
     ClusterList &navigation21(m_clusterNavigationMap21[pCluster2]);
 
-    if (navigation12.end() == std::find(navigation12.begin(), navigation12.end(), pCluster2)) navigation12.push_back(pCluster2);
-    if (navigation21.end() == std::find(navigation21.begin(), navigation21.end(), pCluster1)) navigation21.push_back(pCluster1);
+    if (navigation12.end() == std::find(navigation12.begin(), navigation12.end(), pCluster2))
+        navigation12.push_back(pCluster2);
+    if (navigation21.end() == std::find(navigation21.begin(), navigation21.end(), pCluster1))
+        navigation21.push_back(pCluster1);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-void OverlapMatrix<T>::ReplaceOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-    const OverlapResult &overlapResult)
+void OverlapMatrix<T>::ReplaceOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const OverlapResult &overlapResult)
 {
     typename TheMatrix::iterator iter1 = m_overlapMatrix.find(pCluster1);
 
@@ -150,7 +150,7 @@ void OverlapMatrix<T>::RemoveCluster(const pandora::Cluster *const pCluster)
         if (m_overlapMatrix.end() != iter)
             m_overlapMatrix.erase(iter);
 
-        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMap21.begin(); navIter != m_clusterNavigationMap21.end(); )
+        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMap21.begin(); navIter != m_clusterNavigationMap21.end();)
         {
             ClusterNavigationMap::iterator thisIter = navIter++;
             ClusterList::iterator listIter = std::find(thisIter->second.begin(), thisIter->second.end(), pCluster);
@@ -173,7 +173,7 @@ void OverlapMatrix<T>::RemoveCluster(const pandora::Cluster *const pCluster)
                 iter1->second.erase(iter);
         }
 
-        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMap12.begin(); navIter != m_clusterNavigationMap12.end(); )
+        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMap12.begin(); navIter != m_clusterNavigationMap12.end();)
         {
             ClusterNavigationMap::iterator thisIter = navIter++;
             ClusterList::iterator listIter = std::find(thisIter->second.begin(), thisIter->second.end(), pCluster);
@@ -202,7 +202,9 @@ void OverlapMatrix<T>::GetConnectedElements(const Cluster *const pCluster, const
     this->ExploreConnections(pCluster, ignoreUnavailable, localClusterList1, localClusterList2);
 
     // ATTN Now need to check that all clusters received are from fully available matrix elements
-    elementList.clear(); clusterList1.clear(); clusterList2.clear();
+    elementList.clear();
+    clusterList1.clear();
+    clusterList2.clear();
 
     for (typename TheMatrix::const_iterator iter1 = this->begin(), iter1End = this->end(); iter1 != iter1End; ++iter1)
     {
@@ -217,8 +219,10 @@ void OverlapMatrix<T>::GetConnectedElements(const Cluster *const pCluster, const
             Element element(iter1->first, iter2->first, iter2->second);
             elementList.push_back(element);
 
-            if (clusterList1.end() == std::find(clusterList1.begin(), clusterList1.end(), iter1->first)) clusterList1.push_back(iter1->first);
-            if (clusterList2.end() == std::find(clusterList2.begin(), clusterList2.end(), iter2->first)) clusterList2.push_back(iter2->first);
+            if (clusterList1.end() == std::find(clusterList1.begin(), clusterList1.end(), iter1->first))
+                clusterList1.push_back(iter1->first);
+            if (clusterList2.end() == std::find(clusterList2.begin(), clusterList2.end(), iter2->first))
+                clusterList2.push_back(iter2->first);
         }
     }
 
@@ -228,15 +232,17 @@ void OverlapMatrix<T>::GetConnectedElements(const Cluster *const pCluster, const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-void OverlapMatrix<T>::ExploreConnections(const Cluster *const pCluster, const bool ignoreUnavailable, ClusterList &clusterList1,
-    ClusterList &clusterList2) const
+void OverlapMatrix<T>::ExploreConnections(
+    const Cluster *const pCluster, const bool ignoreUnavailable, ClusterList &clusterList1, ClusterList &clusterList2) const
 {
     if (ignoreUnavailable && !pCluster->IsAvailable())
         return;
 
     const HitType hitType(LArClusterHelper::GetClusterHitType(pCluster));
-    const bool clusterFromView1(!m_clusterNavigationMap12.empty() && (LArClusterHelper::GetClusterHitType(m_clusterNavigationMap12.begin()->first) == hitType));
-    const bool clusterFromView2(!m_clusterNavigationMap21.empty() && (LArClusterHelper::GetClusterHitType(m_clusterNavigationMap21.begin()->first) == hitType));
+    const bool clusterFromView1(
+        !m_clusterNavigationMap12.empty() && (LArClusterHelper::GetClusterHitType(m_clusterNavigationMap12.begin()->first) == hitType));
+    const bool clusterFromView2(
+        !m_clusterNavigationMap21.empty() && (LArClusterHelper::GetClusterHitType(m_clusterNavigationMap21.begin()->first) == hitType));
 
     if (clusterFromView1 == clusterFromView2)
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -261,6 +267,5 @@ void OverlapMatrix<T>::ExploreConnections(const Cluster *const pCluster, const b
 
 template class OverlapMatrix<float>;
 template class OverlapMatrix<TwoViewTransverseOverlapResult>;
-
 
 } // namespace lar_content

--- a/larpandoracontent/LArObjects/LArOverlapMatrix.h
+++ b/larpandoracontent/LArObjects/LArOverlapMatrix.h
@@ -69,9 +69,9 @@ public:
         bool operator<(const Element &rhs) const;
 
     private:
-        const pandora::Cluster *m_pCluster1;                    ///< The address of cluster 1
-        const pandora::Cluster *m_pCluster2;                    ///< The address of cluster 2
-        OverlapResult           m_overlapResult;                ///< The overlap result
+        const pandora::Cluster *m_pCluster1; ///< The address of cluster 1
+        const pandora::Cluster *m_pCluster2; ///< The address of cluster 2
+        OverlapResult m_overlapResult;       ///< The overlap result
     };
 
     typedef std::vector<Element> ElementList;
@@ -125,12 +125,12 @@ public:
      *  @param  n1 to receive the number of view 1 connections
      *  @param  n2 to receive the number of view 2 connections
      */
-    void GetConnectedElements(const pandora::Cluster *const pCluster, const bool ignoreUnavailable, ElementList &elementList, unsigned int &n1,
-        unsigned int &n2) const;
+    void GetConnectedElements(const pandora::Cluster *const pCluster, const bool ignoreUnavailable, ElementList &elementList,
+        unsigned int &n1, unsigned int &n2) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterNavigationMap;
-    typedef std::unordered_map<const pandora::Cluster*, OverlapResult> OverlapList;
-    typedef std::unordered_map<const pandora::Cluster*, OverlapList> TheMatrix;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterNavigationMap;
+    typedef std::unordered_map<const pandora::Cluster *, OverlapResult> OverlapList;
+    typedef std::unordered_map<const pandora::Cluster *, OverlapList> TheMatrix;
 
     typedef typename TheMatrix::const_iterator const_iterator;
 
@@ -236,9 +236,9 @@ private:
     void ExploreConnections(const pandora::Cluster *const pCluster, const bool ignoreUnavailable, pandora::ClusterList &clusterList1,
         pandora::ClusterList &clusterList2) const;
 
-    TheMatrix               m_overlapMatrix;                ///< The overlap matrix
-    ClusterNavigationMap    m_clusterNavigationMap12;       ///< The cluster navigation map 1->2
-    ClusterNavigationMap    m_clusterNavigationMap21;       ///< The cluster navigation map 2->1
+    TheMatrix m_overlapMatrix;                     ///< The overlap matrix
+    ClusterNavigationMap m_clusterNavigationMap12; ///< The cluster navigation map 1->2
+    ClusterNavigationMap m_clusterNavigationMap21; ///< The cluster navigation map 2->1
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -278,8 +278,8 @@ inline typename OverlapMatrix<T>::const_iterator OverlapMatrix<T>::end() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-inline const typename OverlapMatrix<T>::OverlapResult &OverlapMatrix<T>::GetOverlapResult(const pandora::Cluster *const pCluster1,
-    const pandora::Cluster *const pCluster2) const
+inline const typename OverlapMatrix<T>::OverlapResult &OverlapMatrix<T>::GetOverlapResult(
+    const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2) const
 {
     const OverlapList &overlapList(this->GetOverlapList(pCluster1));
     typename OverlapList::const_iterator iter = overlapList.find(pCluster2);
@@ -333,7 +333,8 @@ inline void OverlapMatrix<T>::Clear()
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-inline OverlapMatrix<T>::Element::Element(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const OverlapResult &overlapResult) :
+inline OverlapMatrix<T>::Element::Element(
+    const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const OverlapResult &overlapResult) :
     m_pCluster1(pCluster1),
     m_pCluster2(pCluster2),
     m_overlapResult(overlapResult)

--- a/larpandoracontent/LArObjects/LArOverlapTensor.cc
+++ b/larpandoracontent/LArObjects/LArOverlapTensor.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/PandoraInputTypes.h"
 
-#include "Pandora/PandoraInternal.h"
 #include "Pandora/PandoraInputTypes.h"
+#include "Pandora/PandoraInternal.h"
 #include "Pandora/StatusCodes.h"
 
 #include "Objects/Cluster.h"
@@ -65,8 +65,8 @@ void OverlapTensor<T>::GetUnambiguousElements(const bool ignoreUnavailable, Elem
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-bool OverlapTensor<T>::DefaultAmbiguityFunction(const ClusterList &clusterListU, const ClusterList &clusterListV, const ClusterList &clusterListW,
-    const Cluster *&pClusterU, const Cluster *&pClusterV, const Cluster *&pClusterW) const
+bool OverlapTensor<T>::DefaultAmbiguityFunction(const ClusterList &clusterListU, const ClusterList &clusterListV,
+    const ClusterList &clusterListW, const Cluster *&pClusterU, const Cluster *&pClusterV, const Cluster *&pClusterW) const
 {
     if ((1 != clusterListU.size()) || (1 != clusterListV.size()) || (1 != clusterListW.size()))
         return false;
@@ -86,7 +86,9 @@ void OverlapTensor<T>::GetConnectedElements(const pandora::Cluster *const pClust
 {
     ClusterList clusterListU, clusterListV, clusterListW;
     this->GetConnectedElements(pCluster, ignoreUnavailable, elementList, clusterListU, clusterListV, clusterListW);
-    nU = clusterListU.size(); nV = clusterListV.size(); nW = clusterListW.size();
+    nU = clusterListU.size();
+    nV = clusterListV.size();
+    nW = clusterListW.size();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -119,9 +121,12 @@ void OverlapTensor<T>::SetOverlapResult(const pandora::Cluster *const pClusterU,
     ClusterList &navigationVW(m_clusterNavigationMapVW[pClusterV]);
     ClusterList &navigationWU(m_clusterNavigationMapWU[pClusterW]);
 
-    if (navigationUV.end() == std::find(navigationUV.begin(), navigationUV.end(), pClusterV)) navigationUV.push_back(pClusterV);
-    if (navigationVW.end() == std::find(navigationVW.begin(), navigationVW.end(), pClusterW)) navigationVW.push_back(pClusterW);
-    if (navigationWU.end() == std::find(navigationWU.begin(), navigationWU.end(), pClusterU)) navigationWU.push_back(pClusterU);
+    if (navigationUV.end() == std::find(navigationUV.begin(), navigationUV.end(), pClusterV))
+        navigationUV.push_back(pClusterV);
+    if (navigationVW.end() == std::find(navigationVW.begin(), navigationVW.end(), pClusterW))
+        navigationVW.push_back(pClusterW);
+    if (navigationWU.end() == std::find(navigationWU.begin(), navigationWU.end(), pClusterU))
+        navigationWU.push_back(pClusterU);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -162,7 +167,7 @@ void OverlapTensor<T>::RemoveCluster(const pandora::Cluster *const pCluster)
         if (m_overlapTensor.end() != iter)
             m_overlapTensor.erase(iter);
 
-        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMapWU.begin(); navIter != m_clusterNavigationMapWU.end(); )
+        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMapWU.begin(); navIter != m_clusterNavigationMapWU.end();)
         {
             ClusterNavigationMap::iterator thisIter = navIter++;
             ClusterList::iterator listIter = std::find(thisIter->second.begin(), thisIter->second.end(), pCluster);
@@ -185,7 +190,7 @@ void OverlapTensor<T>::RemoveCluster(const pandora::Cluster *const pCluster)
                 iterU->second.erase(iter);
         }
 
-        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMapUV.begin(); navIter != m_clusterNavigationMapUV.end(); )
+        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMapUV.begin(); navIter != m_clusterNavigationMapUV.end();)
         {
             ClusterNavigationMap::iterator thisIter = navIter++;
             ClusterList::iterator listIter = std::find(thisIter->second.begin(), thisIter->second.end(), pCluster);
@@ -211,7 +216,7 @@ void OverlapTensor<T>::RemoveCluster(const pandora::Cluster *const pCluster)
             }
         }
 
-        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMapVW.begin(); navIter != m_clusterNavigationMapVW.end(); )
+        for (ClusterNavigationMap::iterator navIter = m_clusterNavigationMapVW.begin(); navIter != m_clusterNavigationMapVW.end();)
         {
             ClusterNavigationMap::iterator thisIter = navIter++;
             ClusterList::iterator listIter = std::find(thisIter->second.begin(), thisIter->second.end(), pCluster);
@@ -240,7 +245,10 @@ void OverlapTensor<T>::GetConnectedElements(const Cluster *const pCluster, const
     this->ExploreConnections(pCluster, ignoreUnavailable, localClusterListU, localClusterListV, localClusterListW);
 
     // ATTN Now need to check that all clusters received are from fully available tensor elements
-    elementList.clear(); clusterListU.clear(); clusterListV.clear(); clusterListW.clear();
+    elementList.clear();
+    clusterListU.clear();
+    clusterListV.clear();
+    clusterListW.clear();
 
     for (typename TheTensor::const_iterator iterU = this->begin(), iterUEnd = this->end(); iterU != iterUEnd; ++iterU)
     {
@@ -257,9 +265,12 @@ void OverlapTensor<T>::GetConnectedElements(const Cluster *const pCluster, const
                 Element element(iterU->first, iterV->first, iterW->first, iterW->second);
                 elementList.push_back(element);
 
-                if (clusterListU.end() == std::find(clusterListU.begin(), clusterListU.end(), iterU->first)) clusterListU.push_back(iterU->first);
-                if (clusterListV.end() == std::find(clusterListV.begin(), clusterListV.end(), iterV->first)) clusterListV.push_back(iterV->first);
-                if (clusterListW.end() == std::find(clusterListW.begin(), clusterListW.end(), iterW->first)) clusterListW.push_back(iterW->first);
+                if (clusterListU.end() == std::find(clusterListU.begin(), clusterListU.end(), iterU->first))
+                    clusterListU.push_back(iterU->first);
+                if (clusterListV.end() == std::find(clusterListV.begin(), clusterListV.end(), iterV->first))
+                    clusterListV.push_back(iterV->first);
+                if (clusterListW.end() == std::find(clusterListW.begin(), clusterListW.end(), iterW->first))
+                    clusterListW.push_back(iterW->first);
             }
         }
     }
@@ -282,7 +293,8 @@ void OverlapTensor<T>::ExploreConnections(const Cluster *const pCluster, const b
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
     ClusterList &clusterList((TPC_VIEW_U == hitType) ? clusterListU : (TPC_VIEW_V == hitType) ? clusterListV : clusterListW);
-    const ClusterNavigationMap &navigationMap((TPC_VIEW_U == hitType) ? m_clusterNavigationMapUV : (TPC_VIEW_V == hitType) ? m_clusterNavigationMapVW : m_clusterNavigationMapWU);
+    const ClusterNavigationMap &navigationMap(
+        (TPC_VIEW_U == hitType) ? m_clusterNavigationMapUV : (TPC_VIEW_V == hitType) ? m_clusterNavigationMapVW : m_clusterNavigationMapWU);
 
     if (clusterList.end() != std::find(clusterList.begin(), clusterList.end(), pCluster))
         return;

--- a/larpandoracontent/LArObjects/LArOverlapTensor.h
+++ b/larpandoracontent/LArObjects/LArOverlapTensor.h
@@ -39,7 +39,8 @@ public:
          *  @param  pClusterW the address of the w cluster
          *  @param  overlapResult the overlap result
          */
-        Element(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW, const OverlapResult &overlapResult);
+        Element(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW,
+            const OverlapResult &overlapResult);
 
         /**
          *  @brief  Get the address of the u cluster
@@ -77,10 +78,10 @@ public:
         bool operator<(const Element &rhs) const;
 
     private:
-        const pandora::Cluster *m_pClusterU;                    ///< The address of the u cluster
-        const pandora::Cluster *m_pClusterV;                    ///< The address of the v cluster
-        const pandora::Cluster *m_pClusterW;                    ///< The address of the w cluster
-        OverlapResult           m_overlapResult;                ///< The overlap result
+        const pandora::Cluster *m_pClusterU; ///< The address of the u cluster
+        const pandora::Cluster *m_pClusterV; ///< The address of the v cluster
+        const pandora::Cluster *m_pClusterW; ///< The address of the w cluster
+        OverlapResult m_overlapResult;       ///< The overlap result
     };
 
     typedef std::vector<Element> ElementList;
@@ -105,8 +106,9 @@ public:
      *
      *  @return boolean
      */
-    bool DefaultAmbiguityFunction(const pandora::ClusterList &clusterListU, const pandora::ClusterList &clusterListV, const pandora::ClusterList &clusterListW,
-        const pandora::Cluster *&pClusterU, const pandora::Cluster *&pClusterV, const pandora::Cluster *&pClusterW) const;
+    bool DefaultAmbiguityFunction(const pandora::ClusterList &clusterListU, const pandora::ClusterList &clusterListV,
+        const pandora::ClusterList &clusterListW, const pandora::Cluster *&pClusterU, const pandora::Cluster *&pClusterV,
+        const pandora::Cluster *&pClusterW) const;
 
     /**
      *  @brief  Get the number of connections for a specified cluster
@@ -138,13 +140,13 @@ public:
      *  @param  nV to receive the number of v connections
      *  @param  nW to receive the number of w connections
      */
-    void GetConnectedElements(const pandora::Cluster *const pCluster, const bool ignoreUnavailable, ElementList &elementList, unsigned int &nU,
-        unsigned int &nV, unsigned int &nW) const;
+    void GetConnectedElements(const pandora::Cluster *const pCluster, const bool ignoreUnavailable, ElementList &elementList,
+        unsigned int &nU, unsigned int &nV, unsigned int &nW) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterNavigationMap;
-    typedef std::unordered_map<const pandora::Cluster*, OverlapResult> OverlapList;
-    typedef std::unordered_map<const pandora::Cluster*, OverlapList> OverlapMatrix;
-    typedef std::unordered_map<const pandora::Cluster*, OverlapMatrix> TheTensor;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterNavigationMap;
+    typedef std::unordered_map<const pandora::Cluster *, OverlapResult> OverlapList;
+    typedef std::unordered_map<const pandora::Cluster *, OverlapList> OverlapMatrix;
+    typedef std::unordered_map<const pandora::Cluster *, OverlapMatrix> TheTensor;
 
     typedef typename TheTensor::const_iterator const_iterator;
 
@@ -174,7 +176,8 @@ public:
      *
      *  @return the address of the overlap result
      */
-    const OverlapResult &GetOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW) const;
+    const OverlapResult &GetOverlapResult(
+        const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW) const;
 
     /**
      *  @brief  Get the  overlap list for a specified pair of clusters
@@ -224,7 +227,8 @@ public:
      *  @param  pClusterW address of cluster w
      *  @param  overlapResult the overlap result
      */
-    void SetOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW, const OverlapResult &overlapResult);
+    void SetOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV,
+        const pandora::Cluster *const pClusterW, const OverlapResult &overlapResult);
 
     /**
      *  @brief  SetReplace an existing overlap result
@@ -234,7 +238,8 @@ public:
      *  @param  pClusterW address of cluster w
      *  @param  overlapResult the overlap result
      */
-    void ReplaceOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW, const OverlapResult &overlapResult);
+    void ReplaceOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV,
+        const pandora::Cluster *const pClusterW, const OverlapResult &overlapResult);
 
     /**
      *  @brief  Remove entries from tensor corresponding to specified cluster
@@ -272,17 +277,17 @@ private:
     void ExploreConnections(const pandora::Cluster *const pCluster, const bool ignoreUnavailable, pandora::ClusterList &clusterListU,
         pandora::ClusterList &clusterListV, pandora::ClusterList &clusterListW) const;
 
-    TheTensor               m_overlapTensor;                ///< The overlap tensor
-    ClusterNavigationMap    m_clusterNavigationMapUV;       ///< The cluster navigation map U->V
-    ClusterNavigationMap    m_clusterNavigationMapVW;       ///< The cluster navigation map V->W
-    ClusterNavigationMap    m_clusterNavigationMapWU;       ///< The cluster navigation map W->U
+    TheTensor m_overlapTensor;                     ///< The overlap tensor
+    ClusterNavigationMap m_clusterNavigationMapUV; ///< The cluster navigation map U->V
+    ClusterNavigationMap m_clusterNavigationMapVW; ///< The cluster navigation map V->W
+    ClusterNavigationMap m_clusterNavigationMapWU; ///< The cluster navigation map W->U
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-inline void OverlapTensor<T>::GetNConnections(const pandora::Cluster *const pCluster, const bool ignoreUnavailable, unsigned int &nU, unsigned int &nV,
-    unsigned int &nW) const
+inline void OverlapTensor<T>::GetNConnections(
+    const pandora::Cluster *const pCluster, const bool ignoreUnavailable, unsigned int &nU, unsigned int &nV, unsigned int &nW) const
 {
     ElementList elementList;
     this->GetConnectedElements(pCluster, ignoreUnavailable, elementList, nU, nV, nW);
@@ -346,8 +351,7 @@ inline const typename OverlapTensor<T>::OverlapList &OverlapTensor<T>::GetOverla
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-inline const typename OverlapTensor<T>::OverlapMatrix &OverlapTensor<T>::GetOverlapMatrix(
-    const pandora::Cluster *const pClusterU) const
+inline const typename OverlapTensor<T>::OverlapMatrix &OverlapTensor<T>::GetOverlapMatrix(const pandora::Cluster *const pClusterU) const
 {
     typename TheTensor::const_iterator iter = m_overlapTensor.find(pClusterU);
 
@@ -396,8 +400,8 @@ inline void OverlapTensor<T>::Clear()
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-inline OverlapTensor<T>::Element::Element(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW,
-        const OverlapResult &overlapResult) :
+inline OverlapTensor<T>::Element::Element(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV,
+    const pandora::Cluster *const pClusterW, const OverlapResult &overlapResult) :
     m_pClusterU(pClusterU),
     m_pClusterV(pClusterV),
     m_pClusterW(pClusterW),

--- a/larpandoracontent/LArObjects/LArPfoObjects.cc
+++ b/larpandoracontent/LArObjects/LArPfoObjects.cc
@@ -50,15 +50,15 @@ const CaloHit *LArTrackState::GetCaloHit() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArShowerPCA::LArShowerPCA(const CartesianVector &centroid, const CartesianVector &primaryAxis, const CartesianVector &secondaryAxis,
-        const CartesianVector &tertiaryAxis, const CartesianVector &eigenValues) :
+    const CartesianVector &tertiaryAxis, const CartesianVector &eigenValues) :
     m_centroid(centroid),
     m_primaryAxis(primaryAxis),
     m_secondaryAxis(secondaryAxis),
     m_tertiaryAxis(tertiaryAxis),
     m_eigenValues(eigenValues),
     m_axisLengths(((eigenValues.GetX() > std::numeric_limits<float>::epsilon()) ? 6.f * std::sqrt(eigenValues.GetX()) : 0.f),
-                  ((eigenValues.GetY() > std::numeric_limits<float>::epsilon()) ? 6.f * std::sqrt(eigenValues.GetY()) : 0.f),
-                  ((eigenValues.GetZ() > std::numeric_limits<float>::epsilon()) ? 6.f * std::sqrt(eigenValues.GetZ()) : 0.f))
+        ((eigenValues.GetY() > std::numeric_limits<float>::epsilon()) ? 6.f * std::sqrt(eigenValues.GetY()) : 0.f),
+        ((eigenValues.GetZ() > std::numeric_limits<float>::epsilon()) ? 6.f * std::sqrt(eigenValues.GetZ()) : 0.f))
 {
 }
 

--- a/larpandoracontent/LArObjects/LArPfoObjects.h
+++ b/larpandoracontent/LArObjects/LArPfoObjects.h
@@ -8,12 +8,15 @@
 #ifndef LAR_PFO_OBJECTS_H
 #define LAR_PFO_OBJECTS_H 1
 
-#include "Objects/TrackState.h"
 #include "Objects/CartesianVector.h"
+#include "Objects/TrackState.h"
 
 #include <vector>
 
-namespace pandora {class CaloHit;}
+namespace pandora
+{
+class CaloHit;
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -58,7 +61,7 @@ public:
     const pandora::CaloHit *GetCaloHit() const;
 
 private:
-    const pandora::CaloHit  *m_pCaloHit;
+    const pandora::CaloHit *m_pCaloHit;
 };
 
 typedef std::vector<LArTrackState> LArTrackStateVector;
@@ -96,7 +99,7 @@ public:
     int GetIndex() const;
 
 private:
-    int m_index;    ///< The index associated with the trajectory point
+    int m_index; ///< The index associated with the trajectory point
 };
 
 typedef std::vector<LArTrackTrajectoryPoint> LArTrackTrajectory;
@@ -118,8 +121,8 @@ public:
      *  @param  tertiaryAxis  tertiary axis of shower
      *  @param  axisLengths  ordered vector of shower lengths
      */
-    LArShowerPCA(const pandora::CartesianVector &centroid, const pandora::CartesianVector &primaryAxis, const pandora::CartesianVector &secondaryAxis,
-        const pandora::CartesianVector &tertiaryAxis, const pandora::CartesianVector &eigenvalues);
+    LArShowerPCA(const pandora::CartesianVector &centroid, const pandora::CartesianVector &primaryAxis,
+        const pandora::CartesianVector &secondaryAxis, const pandora::CartesianVector &tertiaryAxis, const pandora::CartesianVector &eigenvalues);
 
     /**
      *  @brief  Return centroid
@@ -185,12 +188,12 @@ public:
     float GetTertiaryLength() const;
 
 private:
-    const pandora::CartesianVector  m_centroid;         ///< The centroid
-    const pandora::CartesianVector  m_primaryAxis;      ///< The primary axis
-    const pandora::CartesianVector  m_secondaryAxis;    ///< The secondary axis
-    const pandora::CartesianVector  m_tertiaryAxis;     ///< The tertiary axis
-    const pandora::CartesianVector  m_eigenValues;      ///< The vector of eigenvalues
-    const pandora::CartesianVector  m_axisLengths;      ///< The vector of lengths
+    const pandora::CartesianVector m_centroid;      ///< The centroid
+    const pandora::CartesianVector m_primaryAxis;   ///< The primary axis
+    const pandora::CartesianVector m_secondaryAxis; ///< The secondary axis
+    const pandora::CartesianVector m_tertiaryAxis;  ///< The tertiary axis
+    const pandora::CartesianVector m_eigenValues;   ///< The vector of eigenvalues
+    const pandora::CartesianVector m_axisLengths;   ///< The vector of lengths
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArObjects/LArPointingCluster.cc
+++ b/larpandoracontent/LArObjects/LArPointingCluster.cc
@@ -64,8 +64,8 @@ void LArPointingCluster::BuildPointingCluster(const TwoDSlidingFitResult &slidin
     const Vertex maxVertex(m_pCluster, slidingFitResult.GetGlobalMaxLayerPosition(), slidingFitResult.GetGlobalMaxLayerDirection() * -1.f,
         slidingFitResult.GetMaxLayerRms(), !isInner);
 
-    m_innerVertex = ( isInner ? minVertex : maxVertex);
-    m_outerVertex = ( isInner ? maxVertex : minVertex);
+    m_innerVertex = (isInner ? minVertex : maxVertex);
+    m_outerVertex = (isInner ? maxVertex : minVertex);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ void LArPointingCluster::BuildPointingCluster(const ThreeDSlidingFitResult &slid
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     const bool isInner((slidingFitResult.GetGlobalMinLayerPosition().GetZ() < slidingFitResult.GetGlobalMaxLayerPosition().GetZ()) &&
-        (slidingFitResult.GetMinLayer() < slidingFitResult.GetMaxLayer()));
+                       (slidingFitResult.GetMinLayer() < slidingFitResult.GetMaxLayer()));
 
     m_pCluster = slidingFitResult.GetCluster();
 
@@ -88,8 +88,8 @@ void LArPointingCluster::BuildPointingCluster(const ThreeDSlidingFitResult &slid
     const Vertex maxVertex(m_pCluster, slidingFitResult.GetGlobalMaxLayerPosition(), slidingFitResult.GetGlobalMaxLayerDirection() * -1.f,
         slidingFitResult.GetMaxLayerRms(), !isInner);
 
-    m_innerVertex = ( isInner ? minVertex : maxVertex);
-    m_outerVertex = ( isInner ? maxVertex : minVertex);
+    m_innerVertex = (isInner ? minVertex : maxVertex);
+    m_outerVertex = (isInner ? maxVertex : minVertex);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -106,8 +106,8 @@ LArPointingCluster::Vertex::Vertex() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LArPointingCluster::Vertex::Vertex(const Cluster *const pCluster, const CartesianVector &position, const CartesianVector &direction,
-        const float rms, const bool isInner) :
+LArPointingCluster::Vertex::Vertex(
+    const Cluster *const pCluster, const CartesianVector &position, const CartesianVector &direction, const float rms, const bool isInner) :
     m_pCluster(pCluster),
     m_position(position),
     m_direction(direction),

--- a/larpandoracontent/LArObjects/LArPointingCluster.h
+++ b/larpandoracontent/LArObjects/LArPointingCluster.h
@@ -8,8 +8,8 @@
 #ifndef LAR_POINTING_CLUSTER_H
 #define LAR_POINTING_CLUSTER_H 1
 
-#include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
 #include "larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h"
+#include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
 
 namespace lar_content
 {
@@ -77,7 +77,7 @@ public:
          */
         const pandora::CartesianVector &GetDirection() const;
 
-         /**
+        /**
          *  @brief  Get rms from vertex fit
          *
          *  @return the rms
@@ -106,12 +106,12 @@ public:
         Vertex &operator=(const Vertex &rhs);
 
     private:
-        const pandora::Cluster     *m_pCluster;             ///< The address of the cluster
-        pandora::CartesianVector    m_position;             ///< The vertex position
-        pandora::CartesianVector    m_direction;            ///< The vertex direction
-        float                       m_rms;                  ///< Rms from vertex fit
-        bool                        m_isInner;              ///< Whether this is the inner vertex
-        bool                        m_isInitialized;        ///< Whether the vertex has been initialized
+        const pandora::Cluster *m_pCluster;   ///< The address of the cluster
+        pandora::CartesianVector m_position;  ///< The vertex position
+        pandora::CartesianVector m_direction; ///< The vertex direction
+        float m_rms;                          ///< Rms from vertex fit
+        bool m_isInner;                       ///< Whether this is the inner vertex
+        bool m_isInitialized;                 ///< Whether the vertex has been initialized
     };
 
     /**
@@ -187,14 +187,14 @@ private:
      */
     void BuildPointingCluster(const ThreeDSlidingFitResult &slidingFitResult);
 
-    const pandora::Cluster         *m_pCluster;             ///< The address of the cluster
-    Vertex                          m_innerVertex;          ///< The inner vertex
-    Vertex                          m_outerVertex;          ///< The outer vertex
+    const pandora::Cluster *m_pCluster; ///< The address of the cluster
+    Vertex m_innerVertex;               ///< The inner vertex
+    Vertex m_outerVertex;               ///< The outer vertex
 };
 
 typedef std::vector<LArPointingCluster> LArPointingClusterList;
 typedef std::vector<LArPointingCluster::Vertex> LArPointingClusterVertexList;
-typedef std::unordered_map<const pandora::Cluster*, LArPointingCluster> LArPointingClusterMap;
+typedef std::unordered_map<const pandora::Cluster *, LArPointingCluster> LArPointingClusterMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandoracontent/LArObjects/LArShowerOverlapResult.h
+++ b/larpandoracontent/LArObjects/LArShowerOverlapResult.h
@@ -107,11 +107,11 @@ public:
     ShowerOverlapResult &operator=(const ShowerOverlapResult &rhs);
 
 protected:
-    bool            m_isInitialized;                ///< Whether the track overlap result has been initialized
-    unsigned int    m_nMatchedSamplingPoints;       ///< The number of matched sampling points
-    unsigned int    m_nSamplingPoints;              ///< The number of sampling points
-    float           m_matchedFraction;              ///< The fraction of sampling points resulting in a match
-    XOverlap        m_xOverlap;                     ///< The x overlap object
+    bool m_isInitialized;                  ///< Whether the track overlap result has been initialized
+    unsigned int m_nMatchedSamplingPoints; ///< The number of matched sampling points
+    unsigned int m_nSamplingPoints;        ///< The number of sampling points
+    float m_matchedFraction;               ///< The fraction of sampling points resulting in a match
+    XOverlap m_xOverlap;                   ///< The x overlap object
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArObjects/LArShowerPfo.h
+++ b/larpandoracontent/LArObjects/LArShowerPfo.h
@@ -24,14 +24,14 @@ namespace lar_content
 class LArShowerPfoParameters : public object_creation::ParticleFlowObject::Parameters
 {
 public:
-    pandora::InputCartesianVector   m_showerLength;             ///< Shower length and widths from 3d shower fit
-    pandora::InputCartesianVector   m_showerCentroid;           ///< Shower centroid from 3d shower fit
-    pandora::InputFloat             m_showerOpeningAngle;       ///< Shower opening angle
-    pandora::InputCartesianVector   m_showerDirection;          ///< Shower direction, also the primary eigen vector
-    pandora::InputCartesianVector   m_showerSecondaryVector;    ///< Shower secondary eigen vector
-    pandora::InputCartesianVector   m_showerTertiaryVector;     ///< Shower teriary eigen vector
-    pandora::InputCartesianVector   m_showerEigenValues;        ///< Shower eigenvalues from 3d PCA
-    pandora::InputCartesianVector   m_showerVertex;             ///< Shower starting point
+    pandora::InputCartesianVector m_showerLength;          ///< Shower length and widths from 3d shower fit
+    pandora::InputCartesianVector m_showerCentroid;        ///< Shower centroid from 3d shower fit
+    pandora::InputFloat m_showerOpeningAngle;              ///< Shower opening angle
+    pandora::InputCartesianVector m_showerDirection;       ///< Shower direction, also the primary eigen vector
+    pandora::InputCartesianVector m_showerSecondaryVector; ///< Shower secondary eigen vector
+    pandora::InputCartesianVector m_showerTertiaryVector;  ///< Shower teriary eigen vector
+    pandora::InputCartesianVector m_showerEigenValues;     ///< Shower eigenvalues from 3d PCA
+    pandora::InputCartesianVector m_showerVertex;          ///< Shower starting point
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -106,14 +106,14 @@ public:
     const pandora::CartesianVector &GetShowerVertex() const;
 
 private:
-    pandora::CartesianVector    m_showerLength;             ///< Shower length and widths from 3d shower fit
-    pandora::CartesianVector    m_showerCentroid;           ///< Shower centroid from 3d shower fit
-    float                       m_showerOpeningAngle;       ///< Shower opening angle
-    pandora::CartesianVector    m_showerDirection;          ///< Shower direction, primary eigen vector
-    pandora::CartesianVector    m_showerSecondaryVector;    ///< Shower secondary eigen vector
-    pandora::CartesianVector    m_showerTertiaryVector;     ///< Shower tertiary eigen vector
-    pandora::CartesianVector    m_showerEigenValues;        ///< Shower eigenvalues from 3d PCA
-    pandora::CartesianVector    m_showerVertex;             ///< Shower starting point
+    pandora::CartesianVector m_showerLength;          ///< Shower length and widths from 3d shower fit
+    pandora::CartesianVector m_showerCentroid;        ///< Shower centroid from 3d shower fit
+    float m_showerOpeningAngle;                       ///< Shower opening angle
+    pandora::CartesianVector m_showerDirection;       ///< Shower direction, primary eigen vector
+    pandora::CartesianVector m_showerSecondaryVector; ///< Shower secondary eigen vector
+    pandora::CartesianVector m_showerTertiaryVector;  ///< Shower tertiary eigen vector
+    pandora::CartesianVector m_showerEigenValues;     ///< Shower eigenvalues from 3d PCA
+    pandora::CartesianVector m_showerVertex;          ///< Shower starting point
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -239,7 +239,7 @@ inline LArShowerPfoFactory::Parameters *LArShowerPfoFactory::NewParameters() con
 
 inline pandora::StatusCode LArShowerPfoFactory::Create(const Parameters &parameters, const Object *&pObject) const
 {
-    const LArShowerPfoParameters &larPfoParameters(dynamic_cast<const LArShowerPfoParameters&>(parameters));
+    const LArShowerPfoParameters &larPfoParameters(dynamic_cast<const LArShowerPfoParameters &>(parameters));
     pObject = new LArShowerPfo(larPfoParameters);
 
     return pandora::STATUS_CODE_SUCCESS;
@@ -247,7 +247,7 @@ inline pandora::StatusCode LArShowerPfoFactory::Create(const Parameters &paramet
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArShowerPfoFactory::Read(Parameters&, pandora::FileReader&) const
+inline pandora::StatusCode LArShowerPfoFactory::Read(Parameters &, pandora::FileReader &) const
 {
     // TODO: Provide this functionality if necessary
 
@@ -256,7 +256,7 @@ inline pandora::StatusCode LArShowerPfoFactory::Read(Parameters&, pandora::FileR
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArShowerPfoFactory::Write(const pandora::ParticleFlowObject*, pandora::FileWriter&) const
+inline pandora::StatusCode LArShowerPfoFactory::Write(const pandora::ParticleFlowObject *, pandora::FileWriter &) const
 {
     // TODO: Provide this functionality if necessary
 

--- a/larpandoracontent/LArObjects/LArSupportVectorMachine.cc
+++ b/larpandoracontent/LArObjects/LArSupportVectorMachine.cc
@@ -165,32 +165,26 @@ StatusCode SupportVectorMachine::ReadComponent(TiXmlElement *pCurrentXmlElement)
 StatusCode SupportVectorMachine::ReadMachine(const TiXmlHandle &currentHandle)
 {
     int kernelType(0);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle,
-        "KernelType", kernelType));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle, "KernelType", kernelType));
 
     double bias(0.);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle,
-        "Bias", bias));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle, "Bias", bias));
 
     double scaleFactor(0.);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle,
-        "ScaleFactor", scaleFactor));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle, "ScaleFactor", scaleFactor));
 
     bool standardize(true);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle,
-        "Standardize", standardize));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle, "Standardize", standardize));
 
     bool enableProbability(false);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle,
-        "EnableProbability", enableProbability));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle, "EnableProbability", enableProbability));
 
     double probAParameter(0.);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle,
-        "ProbAParameter", probAParameter));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle, "ProbAParameter", probAParameter));
 
     double probBParameter(0.);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle,
-        "ProbBParameter", probBParameter));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle, "ProbBParameter", probBParameter));
 
     m_kernelType = static_cast<KernelType>(kernelType);
     m_bias = bias;
@@ -210,17 +204,18 @@ StatusCode SupportVectorMachine::ReadMachine(const TiXmlHandle &currentHandle)
 StatusCode SupportVectorMachine::ReadFeatures(const TiXmlHandle &currentHandle)
 {
     std::vector<double> muValues;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(currentHandle,
-        "MuValues", muValues));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(currentHandle, "MuValues", muValues));
 
     std::vector<double> sigmaValues;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(currentHandle,
-        "SigmaValues", sigmaValues));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(currentHandle, "SigmaValues", sigmaValues));
 
     if (muValues.size() != sigmaValues.size())
     {
-        std::cout << "SupportVectorMachine: could not add feature info because the size of mu (" << muValues.size() << ") did not match "
-                     "the size of sigma (" << sigmaValues.size() << ")" << std::endl;
+        std::cout << "SupportVectorMachine: could not add feature info because the size of mu (" << muValues.size()
+                  << ") did not match "
+                     "the size of sigma ("
+                  << sigmaValues.size() << ")" << std::endl;
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
@@ -237,12 +232,10 @@ StatusCode SupportVectorMachine::ReadFeatures(const TiXmlHandle &currentHandle)
 StatusCode SupportVectorMachine::ReadSupportVector(const TiXmlHandle &currentHandle)
 {
     double yAlpha(0.0);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle,
-        "AlphaY", yAlpha));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(currentHandle, "AlphaY", yAlpha));
 
     std::vector<double> values;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(currentHandle,
-        "Values", values));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(currentHandle, "Values", values));
 
     LArMvaHelper::MvaFeatureVector valuesFeatureVector;
     for (const double &value : values)
@@ -264,7 +257,8 @@ double SupportVectorMachine::CalculateClassificationScoreImpl(const LArMvaHelper
 
     if (m_svInfoList.empty())
     {
-        std::cout << "SupportVectorMachine: could not perform classification because the initialized svm had no support vectors in the model" << std::endl;
+        std::cout << "SupportVectorMachine: could not perform classification because the initialized svm had no support vectors in the model"
+                  << std::endl;
         throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
     }
 
@@ -280,8 +274,8 @@ double SupportVectorMachine::CalculateClassificationScoreImpl(const LArMvaHelper
     double classScore(0.);
     for (const SupportVectorInfo &supportVectorInfo : m_svInfoList)
     {
-        classScore += supportVectorInfo.m_yAlpha *
-            m_kernelFunction(supportVectorInfo.m_supportVector, (m_standardizeFeatures ? standardizedFeatures : features), m_scaleFactor);
+        classScore += supportVectorInfo.m_yAlpha * m_kernelFunction(supportVectorInfo.m_supportVector,
+                                                       (m_standardizeFeatures ? standardizedFeatures : features), m_scaleFactor);
     }
 
     return classScore + m_bias;

--- a/larpandoracontent/LArObjects/LArSupportVectorMachine.h
+++ b/larpandoracontent/LArObjects/LArSupportVectorMachine.h
@@ -38,9 +38,9 @@ public:
     enum KernelType
     {
         USER_DEFINED = 0,
-        LINEAR       = 1,
-        QUADRATIC    = 2,
-        CUBIC        = 3,
+        LINEAR = 1,
+        QUADRATIC = 2,
+        CUBIC = 3,
         GAUSSIAN_RBF = 4
     };
 
@@ -122,8 +122,8 @@ private:
          */
         SupportVectorInfo(const double yAlpha, LArMvaHelper::MvaFeatureVector supportVector);
 
-        double                          m_yAlpha;        ///< The alpha-value multiplied by the y-value for the support vector
-        LArMvaHelper::MvaFeatureVector  m_supportVector; ///< The support vector
+        double m_yAlpha;                                ///< The alpha-value multiplied by the y-value for the support vector
+        LArMvaHelper::MvaFeatureVector m_supportVector; ///< The support vector
     };
 
     /**
@@ -154,32 +154,32 @@ private:
          */
         double StandardizeParameter(const double parameter) const;
 
-        double    m_muValue;       ///< The average value of this feature
-        double    m_sigmaValue;    ///< The stddev of this feature
+        double m_muValue;    ///< The average value of this feature
+        double m_sigmaValue; ///< The stddev of this feature
     };
 
     typedef std::vector<SupportVectorInfo> SVInfoList;
-    typedef std::vector<FeatureInfo>       FeatureInfoVector;
+    typedef std::vector<FeatureInfo> FeatureInfoVector;
 
     typedef std::map<KernelType, KernelFunction> KernelMap;
 
-    bool              m_isInitialized;       ///< Whether this svm has been initialized
+    bool m_isInitialized; ///< Whether this svm has been initialized
 
-    bool              m_enableProbability;   ///< Whether to enable probability calculations
-    double            m_probAParameter;      ///< The first-order score coefficient for mapping to a probability using the logistic function
-    double            m_probBParameter;      ///< The score offset parameter for mapping to a probability using the logistic function
+    bool m_enableProbability; ///< Whether to enable probability calculations
+    double m_probAParameter;  ///< The first-order score coefficient for mapping to a probability using the logistic function
+    double m_probBParameter;  ///< The score offset parameter for mapping to a probability using the logistic function
 
-    bool              m_standardizeFeatures; ///< Whether to standardize the features
-    unsigned int      m_nFeatures;           ///< The number of features
-    double            m_bias;                ///< The bias term
-    double            m_scaleFactor;         ///< The kernel scale factor
+    bool m_standardizeFeatures; ///< Whether to standardize the features
+    unsigned int m_nFeatures;   ///< The number of features
+    double m_bias;              ///< The bias term
+    double m_scaleFactor;       ///< The kernel scale factor
 
-    SVInfoList        m_svInfoList;          ///< The list of SupportVectorInfo objects
-    FeatureInfoVector m_featureInfoList;     ///< The list of FeatureInfo objects
+    SVInfoList m_svInfoList;             ///< The list of SupportVectorInfo objects
+    FeatureInfoVector m_featureInfoList; ///< The list of FeatureInfo objects
 
-    KernelType        m_kernelType;          ///< The kernel type
-    KernelFunction    m_kernelFunction;      ///< The kernel function
-    KernelMap         m_kernelMap;           ///< Map from the kernel types to the kernel functions
+    KernelType m_kernelType;         ///< The kernel type
+    KernelFunction m_kernelFunction; ///< The kernel function
+    KernelMap m_kernelMap;           ///< Map from the kernel types to the kernel functions
 
     /**
      *  @brief  Read the svm parameters from an xml file
@@ -243,7 +243,8 @@ private:
      *
      *  @return result of the kernel operation
      */
-    static double QuadraticKernel(const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor = 1.);
+    static double QuadraticKernel(
+        const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor = 1.);
 
     /**
      *  @brief  An inhomogeneous cubic kernel
@@ -254,7 +255,8 @@ private:
      *
      *  @return result of the kernel operation
      */
-    static double CubicKernel(const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor = 1.);
+    static double CubicKernel(
+        const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor = 1.);
 
     /**
      *  @brief  A linear kernel
@@ -265,7 +267,8 @@ private:
      *
      *  @return result of the kernel operation
      */
-    static double LinearKernel(const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor = 1.);
+    static double LinearKernel(
+        const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor = 1.);
 
     /**
      *  @brief  A gaussian RBF kernel
@@ -276,7 +279,8 @@ private:
      *
      *  @return result of the kernel operation
      */
-    static double GaussianRbfKernel(const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor = 1.);
+    static double GaussianRbfKernel(
+        const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor = 1.);
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -333,7 +337,8 @@ inline void SupportVectorMachine::SetKernelFunction(KernelFunction kernelFunctio
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline double SupportVectorMachine::LinearKernel(const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor)
+inline double SupportVectorMachine::LinearKernel(
+    const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor)
 {
     const double denominator(scaleFactor * scaleFactor);
     if (denominator < std::numeric_limits<double>::epsilon())
@@ -348,7 +353,8 @@ inline double SupportVectorMachine::LinearKernel(const LArMvaHelper::MvaFeatureV
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline double SupportVectorMachine::QuadraticKernel(const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor)
+inline double SupportVectorMachine::QuadraticKernel(
+    const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor)
 {
     const double denominator(scaleFactor * scaleFactor);
     if (denominator < std::numeric_limits<double>::epsilon())
@@ -364,7 +370,8 @@ inline double SupportVectorMachine::QuadraticKernel(const LArMvaHelper::MvaFeatu
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline double SupportVectorMachine::CubicKernel(const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor)
+inline double SupportVectorMachine::CubicKernel(
+    const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor)
 {
     const double denominator(scaleFactor * scaleFactor);
     if (denominator < std::numeric_limits<double>::epsilon())
@@ -380,7 +387,8 @@ inline double SupportVectorMachine::CubicKernel(const LArMvaHelper::MvaFeatureVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline double SupportVectorMachine::GaussianRbfKernel(const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor)
+inline double SupportVectorMachine::GaussianRbfKernel(
+    const LArMvaHelper::MvaFeatureVector &supportVector, const LArMvaHelper::MvaFeatureVector &features, const double scaleFactor)
 {
     double total(0.);
     for (unsigned int i = 0; i < features.size(); ++i)
@@ -407,9 +415,7 @@ inline SupportVectorMachine::FeatureInfo::FeatureInfo(const double muValue, cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline SupportVectorMachine::FeatureInfo::FeatureInfo() :
-    m_muValue(0.),
-    m_sigmaValue(0.)
+inline SupportVectorMachine::FeatureInfo::FeatureInfo() : m_muValue(0.), m_sigmaValue(0.)
 {
 }
 

--- a/larpandoracontent/LArObjects/LArThreeDSlidingConeFitResult.cc
+++ b/larpandoracontent/LArObjects/LArThreeDSlidingConeFitResult.cc
@@ -68,8 +68,7 @@ float SimpleCone::GetBoundedHitFraction(const Cluster *const pCluster, const flo
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-ThreeDSlidingConeFitResult::ThreeDSlidingConeFitResult(const T *const pT, const unsigned int slidingFitWindow,
-        const float slidingFitLayerPitch) :
+ThreeDSlidingConeFitResult::ThreeDSlidingConeFitResult(const T *const pT, const unsigned int slidingFitWindow, const float slidingFitLayerPitch) :
     m_slidingFitResult(ThreeDSlidingFitResult(pT, slidingFitWindow, slidingFitLayerPitch))
 {
     const CartesianVector &minLayerPosition3D(m_slidingFitResult.GetGlobalMinLayerPosition());
@@ -100,7 +99,7 @@ ThreeDSlidingConeFitResult::ThreeDSlidingConeFitResult(const T *const pT, const 
             if (!contributionMap1.count(fitResult1.GetLayer(rL)) && !contributionMap2.count(fitResult2.GetLayer(rL)))
                 continue;
 
-            (void) m_trackStateMap.insert(TrackStateMap::value_type(iStep, TrackState(fitPosition3D, fitDirection3D)));
+            (void)m_trackStateMap.insert(TrackStateMap::value_type(iStep, TrackState(fitPosition3D, fitDirection3D)));
         }
         catch (const StatusCodeException &)
         {
@@ -111,8 +110,8 @@ ThreeDSlidingConeFitResult::ThreeDSlidingConeFitResult(const T *const pT, const 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDSlidingConeFitResult::GetSimpleConeList(const unsigned int nLayersForConeFit, const unsigned int nCones, const ConeSelection coneSelection,
-    SimpleConeList &simpleConeList) const
+void ThreeDSlidingConeFitResult::GetSimpleConeList(
+    const unsigned int nLayersForConeFit, const unsigned int nCones, const ConeSelection coneSelection, SimpleConeList &simpleConeList) const
 {
     const TrackStateMap &trackStateMap(this->GetTrackStateMap());
     const unsigned int nLayers(trackStateMap.size());

--- a/larpandoracontent/LArObjects/LArThreeDSlidingConeFitResult.h
+++ b/larpandoracontent/LArObjects/LArThreeDSlidingConeFitResult.h
@@ -104,10 +104,10 @@ public:
     float GetBoundedHitFraction(const pandora::Cluster *const pCluster, const float coneLength, const float coneTanHalfAngle) const;
 
 private:
-    pandora::CartesianVector        m_coneApex;                 ///< The cone apex
-    pandora::CartesianVector        m_coneDirection;            ///< The cone direction
-    float                           m_coneLength;               ///< The cone length
-    float                           m_coneTanHalfAngle;         ///< The tangent of the cone half-angle
+    pandora::CartesianVector m_coneApex;      ///< The cone apex
+    pandora::CartesianVector m_coneDirection; ///< The cone direction
+    float m_coneLength;                       ///< The cone length
+    float m_coneTanHalfAngle;                 ///< The tangent of the cone half-angle
 };
 
 typedef std::vector<SimpleCone> SimpleConeList;
@@ -158,19 +158,20 @@ public:
         SimpleConeList &simpleConeList) const;
 
 private:
-    typedef std::list<pandora::TrackState> TrackStateLinkedList;    ///< The track state linked list typedef
+    typedef std::list<pandora::TrackState> TrackStateLinkedList; ///< The track state linked list typedef
 
-    const ThreeDSlidingFitResult    m_slidingFitResult;             ///< The sliding fit result for the full cluster
-    TrackStateMap                   m_trackStateMap;                ///< The track state map
+    const ThreeDSlidingFitResult m_slidingFitResult; ///< The sliding fit result for the full cluster
+    TrackStateMap m_trackStateMap;                   ///< The track state map
 };
 
 typedef std::vector<ThreeDSlidingConeFitResult> ThreeDSlidingConeFitResultList;
-typedef std::unordered_map<const pandora::Cluster*, ThreeDSlidingConeFitResult> ThreeDSlidingConeFitResultMap;
+typedef std::unordered_map<const pandora::Cluster *, ThreeDSlidingConeFitResult> ThreeDSlidingConeFitResultMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline SimpleCone::SimpleCone(const pandora::CartesianVector &coneApex, const pandora::CartesianVector &coneDirection, const float coneLength, const float coneTanHalfAngle) :
+inline SimpleCone::SimpleCone(const pandora::CartesianVector &coneApex, const pandora::CartesianVector &coneDirection,
+    const float coneLength, const float coneTanHalfAngle) :
     m_coneApex(coneApex),
     m_coneDirection(coneDirection),
     m_coneLength(coneLength),

--- a/larpandoracontent/LArObjects/LArThreeDSlidingFitResult.cc
+++ b/larpandoracontent/LArObjects/LArThreeDSlidingFitResult.cc
@@ -248,17 +248,17 @@ CartesianVector ThreeDSlidingFitResult::GetSeedDirection(const CartesianVector &
     const float py(std::fabs(axisDirection.GetY()));
     const float pz(std::fabs(axisDirection.GetZ()));
 
-    if (px < std::min(py,pz) + std::numeric_limits<float>::epsilon())
+    if (px < std::min(py, pz) + std::numeric_limits<float>::epsilon())
     {
         return CartesianVector(1.f, 0.f, 0.f);
     }
 
-    if (py < std::min(pz,px) + std::numeric_limits<float>::epsilon())
+    if (py < std::min(pz, px) + std::numeric_limits<float>::epsilon())
     {
         return CartesianVector(0.f, 1.f, 0.f);
     }
 
-    if (pz < std::min(px,py) + std::numeric_limits<float>::epsilon())
+    if (pz < std::min(px, py) + std::numeric_limits<float>::epsilon())
     {
         return CartesianVector(0.f, 0.f, 1.f);
     }

--- a/larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h
+++ b/larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h
@@ -211,24 +211,24 @@ private:
      */
     static pandora::CartesianVector GetSeedDirection(const pandora::CartesianVector &axisDirection);
 
-    const pandora::TrackState         m_primaryAxis;            ///< The primary axis position and direction
-    const pandora::CartesianVector    m_axisIntercept;          ///< The axis intercept position
-    const pandora::CartesianVector    m_axisDirection;          ///< The axis direction vector
-    const pandora::CartesianVector    m_firstOrthoDirection;    ///< The orthogonal direction vector
-    const pandora::CartesianVector    m_secondOrthoDirection;   ///< The orthogonal direction vector
-    const TwoDSlidingFitResult        m_firstFitResult;         ///< The first sliding fit result
-    const TwoDSlidingFitResult        m_secondFitResult;        ///< The second sliding fit result
-    const int                         m_minLayer;               ///< The minimum combined layer
-    const int                         m_maxLayer;               ///< The maximum combined layer
+    const pandora::TrackState m_primaryAxis;               ///< The primary axis position and direction
+    const pandora::CartesianVector m_axisIntercept;        ///< The axis intercept position
+    const pandora::CartesianVector m_axisDirection;        ///< The axis direction vector
+    const pandora::CartesianVector m_firstOrthoDirection;  ///< The orthogonal direction vector
+    const pandora::CartesianVector m_secondOrthoDirection; ///< The orthogonal direction vector
+    const TwoDSlidingFitResult m_firstFitResult;           ///< The first sliding fit result
+    const TwoDSlidingFitResult m_secondFitResult;          ///< The second sliding fit result
+    const int m_minLayer;                                  ///< The minimum combined layer
+    const int m_maxLayer;                                  ///< The maximum combined layer
 
-    pandora::CartesianVector          m_minLayerPosition;       ///< The global position at the minimum combined layer
-    pandora::CartesianVector          m_maxLayerPosition;       ///< The global position at the maximum combined layer
-    pandora::CartesianVector          m_minLayerDirection;      ///< The global direction at the minimum combined layer
-    pandora::CartesianVector          m_maxLayerDirection;      ///< The global direction at the maximum combined layer
+    pandora::CartesianVector m_minLayerPosition;  ///< The global position at the minimum combined layer
+    pandora::CartesianVector m_maxLayerPosition;  ///< The global position at the maximum combined layer
+    pandora::CartesianVector m_minLayerDirection; ///< The global direction at the minimum combined layer
+    pandora::CartesianVector m_maxLayerDirection; ///< The global direction at the maximum combined layer
 };
 
 typedef std::vector<ThreeDSlidingFitResult> ThreeDSlidingFitResultList;
-typedef std::unordered_map<const pandora::Cluster*, ThreeDSlidingFitResult> ThreeDSlidingFitResultMap;
+typedef std::unordered_map<const pandora::Cluster *, ThreeDSlidingFitResult> ThreeDSlidingFitResultMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArObjects/LArTrackOverlapResult.cc
+++ b/larpandoracontent/LArObjects/LArTrackOverlapResult.cc
@@ -117,16 +117,14 @@ TrackOverlapResult &TrackOverlapResult::operator=(const TrackOverlapResult &rhs)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TransverseOverlapResult::TransverseOverlapResult() :
-    TrackOverlapResult(),
-    m_xOverlap(XOverlap(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f))
+TransverseOverlapResult::TransverseOverlapResult() : TrackOverlapResult(), m_xOverlap(XOverlap(0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f))
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TransverseOverlapResult::TransverseOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints,
-        const float chi2, const XOverlap &xOverlap) :
+TransverseOverlapResult::TransverseOverlapResult(
+    const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints, const float chi2, const XOverlap &xOverlap) :
     TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2),
     m_xOverlap(xOverlap)
 {
@@ -185,10 +183,7 @@ TransverseOverlapResult operator+(const TransverseOverlapResult &lhs, const Tran
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-LongitudinalOverlapResult::LongitudinalOverlapResult() :
-    TrackOverlapResult(),
-    m_innerChi2(0.f),
-    m_outerChi2(0.f)
+LongitudinalOverlapResult::LongitudinalOverlapResult() : TrackOverlapResult(), m_innerChi2(0.f), m_outerChi2(0.f)
 {
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -198,13 +193,12 @@ LongitudinalOverlapResult::LongitudinalOverlapResult(const TrackOverlapResult tr
     m_innerChi2(innerChi2),
     m_outerChi2(outerChi2)
 {
-
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LongitudinalOverlapResult::LongitudinalOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints,
-        const float chi2, const float innerChi2, const float outerChi2) :
+    const float chi2, const float innerChi2, const float outerChi2) :
     TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2),
     m_innerChi2(innerChi2),
     m_outerChi2(outerChi2)
@@ -240,27 +234,23 @@ LongitudinalOverlapResult &LongitudinalOverlapResult::operator=(const Longitudin
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-FragmentOverlapResult::FragmentOverlapResult() :
-    TrackOverlapResult(),
-    m_caloHitList(),
-    m_clusterList()
+FragmentOverlapResult::FragmentOverlapResult() : TrackOverlapResult(), m_caloHitList(), m_clusterList()
 {
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-FragmentOverlapResult::FragmentOverlapResult(const TrackOverlapResult trackOverlapResult, const pandora::CaloHitList &caloHitList,
-        const pandora::ClusterList &clusterList) :
+FragmentOverlapResult::FragmentOverlapResult(
+    const TrackOverlapResult trackOverlapResult, const pandora::CaloHitList &caloHitList, const pandora::ClusterList &clusterList) :
     TrackOverlapResult(trackOverlapResult),
     m_caloHitList(caloHitList),
     m_clusterList(clusterList)
 {
-
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 FragmentOverlapResult::FragmentOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints,
-        const float chi2, const pandora::CaloHitList &caloHitList, const pandora::ClusterList &clusterList) :
+    const float chi2, const pandora::CaloHitList &caloHitList, const pandora::ClusterList &clusterList) :
     TrackOverlapResult(nMatchedSamplingPoints, nSamplingPoints, chi2),
     m_caloHitList(caloHitList),
     m_clusterList(clusterList)

--- a/larpandoracontent/LArObjects/LArTrackOverlapResult.h
+++ b/larpandoracontent/LArObjects/LArTrackOverlapResult.h
@@ -115,12 +115,12 @@ public:
     TrackOverlapResult &operator=(const TrackOverlapResult &rhs);
 
 protected:
-    bool            m_isInitialized;                ///< Whether the track overlap result has been initialized
-    unsigned int    m_nMatchedSamplingPoints;       ///< The number of matched sampling points
-    unsigned int    m_nSamplingPoints;              ///< The number of sampling points
-    float           m_matchedFraction;              ///< The fraction of sampling points resulting in a match
-    float           m_chi2;                         ///< The absolute chi2 value
-    float           m_reducedChi2;                  ///< The chi2 per samping point value
+    bool m_isInitialized;                  ///< Whether the track overlap result has been initialized
+    unsigned int m_nMatchedSamplingPoints; ///< The number of matched sampling points
+    unsigned int m_nSamplingPoints;        ///< The number of sampling points
+    float m_matchedFraction;               ///< The fraction of sampling points resulting in a match
+    float m_chi2;                          ///< The absolute chi2 value
+    float m_reducedChi2;                   ///< The chi2 per samping point value
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -144,8 +144,7 @@ public:
      *  @param  chi2
      *  @param  xOverlap
      */
-    TransverseOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints, const float chi2,
-        const XOverlap &xOverlap);
+    TransverseOverlapResult(const unsigned int nMatchedSamplingPoints, const unsigned int nSamplingPoints, const float chi2, const XOverlap &xOverlap);
 
     /**
      *  @brief  Copy constructor
@@ -174,7 +173,7 @@ public:
     TransverseOverlapResult &operator=(const TransverseOverlapResult &rhs);
 
 private:
-    XOverlap        m_xOverlap;                     ///< The x overlap object
+    XOverlap m_xOverlap; ///< The x overlap object
 };
 
 typedef std::vector<TransverseOverlapResult> TransverseOverlapResultVector;
@@ -255,8 +254,8 @@ public:
     LongitudinalOverlapResult &operator=(const LongitudinalOverlapResult &rhs);
 
 private:
-    float       m_innerChi2;                        ///< The inner chi squared
-    float       m_outerChi2;                        ///< The outer chi squared
+    float m_innerChi2; ///< The inner chi squared
+    float m_outerChi2; ///< The outer chi squared
 };
 
 typedef std::vector<LongitudinalOverlapResult> LongitudinalOverlapResultVector;
@@ -281,8 +280,7 @@ public:
      *  @param  caloHitList
      *  @param  clusterList
      */
-    FragmentOverlapResult(const TrackOverlapResult trackOverlapResult, const pandora::CaloHitList &caloHitList,
-        const pandora::ClusterList &clusterList);
+    FragmentOverlapResult(const TrackOverlapResult trackOverlapResult, const pandora::CaloHitList &caloHitList, const pandora::ClusterList &clusterList);
 
     /**
      *  @brief  Constructor
@@ -337,8 +335,8 @@ public:
     FragmentOverlapResult &operator=(const FragmentOverlapResult &rhs);
 
 private:
-    pandora::CaloHitList    m_caloHitList;      ///< The list of fragment-associated hits
-    pandora::ClusterList    m_clusterList;      ///< The list of fragment-associated clusters
+    pandora::CaloHitList m_caloHitList; ///< The list of fragment-associated hits
+    pandora::ClusterList m_clusterList; ///< The list of fragment-associated clusters
 };
 
 typedef std::vector<FragmentOverlapResult> FragmentOverlapResultVector;

--- a/larpandoracontent/LArObjects/LArTrackPfo.h
+++ b/larpandoracontent/LArObjects/LArTrackPfo.h
@@ -8,16 +8,19 @@
 #ifndef LAR_TRACK_PFO_H
 #define LAR_TRACK_PFO_H 1
 
-#include "Objects/TrackState.h"
 #include "Objects/CartesianVector.h"
 #include "Objects/ParticleFlowObject.h"
+#include "Objects/TrackState.h"
 
 #include "Pandora/ObjectCreation.h"
 #include "Pandora/ObjectFactory.h"
 
 #include "larpandoracontent/LArObjects/LArPfoObjects.h"
 
-namespace pandora {class CaloHit;}
+namespace pandora
+{
+class CaloHit;
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -30,7 +33,7 @@ namespace lar_content
 class LArTrackPfoParameters : public object_creation::ParticleFlowObject::Parameters
 {
 public:
-    LArTrackStateVector   m_trackStateVector;
+    LArTrackStateVector m_trackStateVector;
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -67,7 +70,7 @@ public:
     const pandora::CartesianVector &GetEndDirection() const;
 
 public:
-    const LArTrackStateVector   m_trackStateVector;      ///< The vector of track states
+    const LArTrackStateVector m_trackStateVector; ///< The vector of track states
 
 private:
     // OTHER MEMBER VARIABLES GO HERE
@@ -125,7 +128,7 @@ inline LArTrackPfoFactory::Parameters *LArTrackPfoFactory::NewParameters() const
 
 inline pandora::StatusCode LArTrackPfoFactory::Create(const Parameters &parameters, const pandora::ParticleFlowObject *&pObject) const
 {
-    const LArTrackPfoParameters &larPfoParameters(dynamic_cast<const LArTrackPfoParameters&>(parameters));
+    const LArTrackPfoParameters &larPfoParameters(dynamic_cast<const LArTrackPfoParameters &>(parameters));
     pObject = new LArTrackPfo(larPfoParameters);
 
     return pandora::STATUS_CODE_SUCCESS;
@@ -133,7 +136,7 @@ inline pandora::StatusCode LArTrackPfoFactory::Create(const Parameters &paramete
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArTrackPfoFactory::Read(Parameters&, pandora::FileReader&) const
+inline pandora::StatusCode LArTrackPfoFactory::Read(Parameters &, pandora::FileReader &) const
 {
     // TODO: Provide this functionality when necessary
 
@@ -142,7 +145,7 @@ inline pandora::StatusCode LArTrackPfoFactory::Read(Parameters&, pandora::FileRe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArTrackPfoFactory::Write(const pandora::ParticleFlowObject*, pandora::FileWriter&) const
+inline pandora::StatusCode LArTrackPfoFactory::Write(const pandora::ParticleFlowObject *, pandora::FileWriter &) const
 {
     // TODO: Provide this functionality when necessary
 

--- a/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.cc
+++ b/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.cc
@@ -13,17 +13,13 @@ using namespace pandora;
 namespace lar_content
 {
 
-TrackTwoViewOverlapResult::TrackTwoViewOverlapResult() :
-    m_isInitialized(false),
-    m_matchingScore(0)
+TrackTwoViewOverlapResult::TrackTwoViewOverlapResult() : m_isInitialized(false), m_matchingScore(0)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TrackTwoViewOverlapResult::TrackTwoViewOverlapResult(const float matchingScore) :
-    m_isInitialized(true),
-    m_matchingScore(matchingScore)
+TrackTwoViewOverlapResult::TrackTwoViewOverlapResult(const float matchingScore) : m_isInitialized(true), m_matchingScore(matchingScore)
 {
 }
 
@@ -98,9 +94,8 @@ TwoViewTransverseOverlapResult::TwoViewTransverseOverlapResult() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TwoViewTransverseOverlapResult::TwoViewTransverseOverlapResult(const float matchingScore, const float downsamplingFactor,
-        const unsigned int nSamplingPoints, const unsigned int nMatchedSamplingPoints, const float correlationCoefficient,
-        const TwoViewXOverlap &twoViewXOverlap) :
+TwoViewTransverseOverlapResult::TwoViewTransverseOverlapResult(const float matchingScore, const float downsamplingFactor, const unsigned int nSamplingPoints,
+    const unsigned int nMatchedSamplingPoints, const float correlationCoefficient, const TwoViewXOverlap &twoViewXOverlap) :
     TrackTwoViewOverlapResult(matchingScore),
     m_downsamplingFactor(downsamplingFactor),
     m_nSamplingPoints(nSamplingPoints),
@@ -148,16 +143,16 @@ bool TwoViewTransverseOverlapResult::operator<(const TwoViewTransverseOverlapRes
         return (m_matchingScore < rhs.m_matchingScore);
 
     if (std::fabs(m_correlationCoefficient - rhs.m_correlationCoefficient) > std::numeric_limits<float>::epsilon())
-	return (m_correlationCoefficient < rhs.m_correlationCoefficient);
+        return (m_correlationCoefficient < rhs.m_correlationCoefficient);
 
     if (m_nMatchedSamplingPoints != rhs.m_nMatchedSamplingPoints)
-	return (m_nMatchedSamplingPoints < rhs.m_nMatchedSamplingPoints);
+        return (m_nMatchedSamplingPoints < rhs.m_nMatchedSamplingPoints);
 
     if (m_nSamplingPoints != rhs.m_nSamplingPoints)
-	return (m_nSamplingPoints < rhs.m_nSamplingPoints);
+        return (m_nSamplingPoints < rhs.m_nSamplingPoints);
 
     if (std::fabs(this->GetLocallyMatchedFraction() - rhs.GetLocallyMatchedFraction()) > std::numeric_limits<float>::epsilon())
-	return (this->GetLocallyMatchedFraction() < rhs.GetLocallyMatchedFraction());
+        return (this->GetLocallyMatchedFraction() < rhs.GetLocallyMatchedFraction());
 
     if (std::fabs(m_twoViewXOverlap.GetTwoViewXOverlapSpan() - rhs.m_twoViewXOverlap.GetTwoViewXOverlapSpan()) > std::numeric_limits<float>::epsilon())
         return (m_twoViewXOverlap.GetTwoViewXOverlapSpan() < rhs.m_twoViewXOverlap.GetTwoViewXOverlapSpan());

--- a/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.h
+++ b/larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.h
@@ -83,8 +83,8 @@ public:
     TrackTwoViewOverlapResult &operator=(const TrackTwoViewOverlapResult &rhs);
 
 protected:
-    bool            m_isInitialized;                ///< Whether the track overlap result has been initialized
-    float           m_matchingScore;                ///< The compatability score for the two objects associated with the overlap result
+    bool m_isInitialized;  ///< Whether the track overlap result has been initialized
+    float m_matchingScore; ///< The compatability score for the two objects associated with the overlap result
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -189,11 +189,11 @@ public:
     TwoViewTransverseOverlapResult &operator=(const TwoViewTransverseOverlapResult &rhs);
 
 private:
-    float                  m_downsamplingFactor;                  ///< The downsampling factor
-    unsigned int           m_nSamplingPoints;                     ///< The number of sampling points
-    unsigned int           m_nMatchedSamplingPoints;              ///< The number of matched sampling points
-    float                  m_correlationCoefficient;              ///< The correlation coefficient
-    TwoViewXOverlap        m_twoViewXOverlap;                     ///< The two view x overlap object
+    float m_downsamplingFactor;            ///< The downsampling factor
+    unsigned int m_nSamplingPoints;        ///< The number of sampling points
+    unsigned int m_nMatchedSamplingPoints; ///< The number of matched sampling points
+    float m_correlationCoefficient;        ///< The correlation coefficient
+    TwoViewXOverlap m_twoViewXOverlap;     ///< The two view x overlap object
 };
 
 typedef std::vector<TwoViewTransverseOverlapResult> TwoViewTransverseOverlapResultVector;

--- a/larpandoracontent/LArObjects/LArTwoDSlidingFitObjects.h
+++ b/larpandoracontent/LArObjects/LArTwoDSlidingFitObjects.h
@@ -75,10 +75,10 @@ public:
     double GetRms() const;
 
 private:
-    double          m_l;                                    ///< The l coordinate
-    double          m_fitT;                                 ///< The fitted t coordinate
-    double          m_gradient;                             ///< The fitted gradient dt/dl
-    double          m_rms;                                  ///< The rms of the fit residuals
+    double m_l;        ///< The l coordinate
+    double m_fitT;     ///< The fitted t coordinate
+    double m_gradient; ///< The fitted gradient dt/dl
+    double m_rms;      ///< The rms of the fit residuals
 };
 
 typedef std::map<int, LayerFitResult> LayerFitResultMap;
@@ -147,12 +147,12 @@ public:
     unsigned int GetNPoints() const;
 
 private:
-    double          m_sumT;                                 ///< The sum t
-    double          m_sumL;                                 ///< The sum l
-    double          m_sumTT;                                ///< The sum t * t
-    double          m_sumLT;                                ///< The sum l * t
-    double          m_sumLL;                                ///< The sum l * l
-    unsigned int    m_nPoints;                              ///< The number of points used
+    double m_sumT;          ///< The sum t
+    double m_sumL;          ///< The sum l
+    double m_sumTT;         ///< The sum t * t
+    double m_sumLT;         ///< The sum l * t
+    double m_sumLL;         ///< The sum l * l
+    unsigned int m_nPoints; ///< The number of points used
 };
 
 typedef std::map<int, LayerFitContribution> LayerFitContributionMap;
@@ -217,11 +217,11 @@ public:
     double GetEndLayerWeight() const;
 
 private:
-    bool                                m_isInitialized;    ///< Whether the object is initialized
-    LayerFitResultMap::const_iterator   m_startLayerIter;   ///< The start layer iterator
-    LayerFitResultMap::const_iterator   m_endLayerIter;     ///< The end layer iterator
-    double                              m_startLayerWeight; ///< The start layer weight
-    double                              m_endLayerWeight;   ///< The end layer weight
+    bool m_isInitialized;                               ///< Whether the object is initialized
+    LayerFitResultMap::const_iterator m_startLayerIter; ///< The start layer iterator
+    LayerFitResultMap::const_iterator m_endLayerIter;   ///< The end layer iterator
+    double m_startLayerWeight;                          ///< The start layer weight
+    double m_endLayerWeight;                            ///< The end layer weight
 };
 
 typedef std::vector<LayerInterpolation> LayerInterpolationList;
@@ -233,7 +233,7 @@ typedef std::vector<LayerInterpolation> LayerInterpolationList;
  */
 class FitSegment
 {
-    public:
+public:
     /**
      *  @brief Constructor
      *
@@ -280,11 +280,11 @@ class FitSegment
     bool IsIncreasingX() const;
 
 private:
-    int             m_startLayer;                           ///< The start layer
-    int             m_endLayer;                             ///< The end layer
-    double          m_minX;                                 ///< The minimum x value
-    double          m_maxX;                                 ///< The maximum x value
-    bool            m_isIncreasingX;                        ///< Whether the x coordinate increases between the start and end layers
+    int m_startLayer;     ///< The start layer
+    int m_endLayer;       ///< The end layer
+    double m_minX;        ///< The minimum x value
+    double m_maxX;        ///< The maximum x value
+    bool m_isIncreasingX; ///< Whether the x coordinate increases between the start and end layers
 };
 
 typedef std::vector<FitSegment> FitSegmentList;
@@ -331,13 +331,7 @@ inline double LayerFitResult::GetRms() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline LayerFitContribution::LayerFitContribution() :
-    m_sumT(0.),
-    m_sumL(0.),
-    m_sumTT(0.),
-    m_sumLT(0.),
-    m_sumLL(0.),
-    m_nPoints(0)
+inline LayerFitContribution::LayerFitContribution() : m_sumT(0.), m_sumL(0.), m_sumTT(0.), m_sumLT(0.), m_sumLL(0.), m_nPoints(0)
 {
 }
 
@@ -401,17 +395,14 @@ inline unsigned int LayerFitContribution::GetNPoints() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline LayerInterpolation::LayerInterpolation() :
-    m_isInitialized(false),
-    m_startLayerWeight(0.f),
-    m_endLayerWeight(0.f)
+inline LayerInterpolation::LayerInterpolation() : m_isInitialized(false), m_startLayerWeight(0.f), m_endLayerWeight(0.f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline LayerInterpolation::LayerInterpolation(const LayerFitResultMap::const_iterator &startLayerIter,
-        const LayerFitResultMap::const_iterator &endLayerIter, const double startLayerWeight, const double endLayerWeight) :
+    const LayerFitResultMap::const_iterator &endLayerIter, const double startLayerWeight, const double endLayerWeight) :
     m_isInitialized(true),
     m_startLayerIter(startLayerIter),
     m_endLayerIter(endLayerIter),

--- a/larpandoracontent/LArObjects/LArTwoDSlidingFitResult.cc
+++ b/larpandoracontent/LArObjects/LArTwoDSlidingFitResult.cc
@@ -24,7 +24,7 @@ namespace lar_content
 
 template <>
 TwoDSlidingFitResult::TwoDSlidingFitResult(const Cluster *const pCluster, const unsigned int layerFitHalfWindow, const float layerPitch,
-        const float axisDeviationLimitForHitDivision) :
+    const float axisDeviationLimitForHitDivision) :
     m_pCluster(pCluster),
     m_layerFitHalfWindow(layerFitHalfWindow),
     m_layerPitch(layerPitch),
@@ -57,8 +57,8 @@ TwoDSlidingFitResult::TwoDSlidingFitResult(const Cluster *const pCluster, const 
 }
 
 template <>
-TwoDSlidingFitResult::TwoDSlidingFitResult(const CartesianPointVector *const pPointVector, const unsigned int layerFitHalfWindow, const float layerPitch,
-        const float /*axisDeviationLimitForHitDivision*/) :
+TwoDSlidingFitResult::TwoDSlidingFitResult(const CartesianPointVector *const pPointVector, const unsigned int layerFitHalfWindow,
+    const float layerPitch, const float /*axisDeviationLimitForHitDivision*/) :
     m_pCluster(nullptr),
     m_layerFitHalfWindow(layerFitHalfWindow),
     m_layerPitch(layerPitch),
@@ -76,7 +76,8 @@ TwoDSlidingFitResult::TwoDSlidingFitResult(const CartesianPointVector *const pPo
 
 template <>
 TwoDSlidingFitResult::TwoDSlidingFitResult(const Cluster *const pCluster, const unsigned int layerFitHalfWindow, const float layerPitch,
-        const CartesianVector &axisIntercept, const CartesianVector &axisDirection, const CartesianVector &orthoDirection, const float axisDeviationLimitForHitDivision) :
+    const CartesianVector &axisIntercept, const CartesianVector &axisDirection, const CartesianVector &orthoDirection,
+    const float axisDeviationLimitForHitDivision) :
     m_pCluster(pCluster),
     m_layerFitHalfWindow(layerFitHalfWindow),
     m_layerPitch(layerPitch),
@@ -106,8 +107,9 @@ TwoDSlidingFitResult::TwoDSlidingFitResult(const Cluster *const pCluster, const 
 }
 
 template <>
-TwoDSlidingFitResult::TwoDSlidingFitResult(const CartesianPointVector *const pPointVector, const unsigned int layerFitHalfWindow, const float layerPitch,
-        const CartesianVector &axisIntercept, const CartesianVector &axisDirection, const CartesianVector &orthoDirection, const float /*axisDeviationLimitForHitDivision*/) :
+TwoDSlidingFitResult::TwoDSlidingFitResult(const CartesianPointVector *const pPointVector, const unsigned int layerFitHalfWindow,
+    const float layerPitch, const CartesianVector &axisIntercept, const CartesianVector &axisDirection,
+    const CartesianVector &orthoDirection, const float /*axisDeviationLimitForHitDivision*/) :
     m_pCluster(nullptr),
     m_layerFitHalfWindow(layerFitHalfWindow),
     m_layerPitch(layerPitch),
@@ -122,9 +124,8 @@ TwoDSlidingFitResult::TwoDSlidingFitResult(const CartesianPointVector *const pPo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TwoDSlidingFitResult::TwoDSlidingFitResult(const unsigned int layerFitHalfWindow, const float layerPitch,
-        const CartesianVector &axisIntercept, const CartesianVector &axisDirection, const CartesianVector &orthoDirection,
-        const LayerFitContributionMap &layerFitContributionMap) :
+TwoDSlidingFitResult::TwoDSlidingFitResult(const unsigned int layerFitHalfWindow, const float layerPitch, const CartesianVector &axisIntercept,
+    const CartesianVector &axisDirection, const CartesianVector &orthoDirection, const LayerFitContributionMap &layerFitContributionMap) :
     m_pCluster(nullptr),
     m_layerFitHalfWindow(layerFitHalfWindow),
     m_layerPitch(layerPitch),
@@ -203,7 +204,7 @@ void TwoDSlidingFitResult::GetLocalPosition(const CartesianVector &position, flo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDSlidingFitResult::GetLocalDirection(const CartesianVector &direction, float&dTdL) const
+void TwoDSlidingFitResult::GetLocalDirection(const CartesianVector &direction, float &dTdL) const
 {
     float pL(0.f), pT(0.f);
     this->GetLocalPosition((direction + m_axisIntercept), pL, pT);
@@ -326,8 +327,8 @@ float TwoDSlidingFitResult::GetCosScatteringAngle(const float rL) const
 {
     const float halfWindowLength(this->GetLayerFitHalfWindowLength());
 
-    CartesianVector firstDirection(0.f,0.f,0.f);
-    CartesianVector secondDirection(0.f,0.f,0.f);
+    CartesianVector firstDirection(0.f, 0.f, 0.f);
+    CartesianVector secondDirection(0.f, 0.f, 0.f);
 
     const StatusCode firstStatusCode(this->GetGlobalFitDirection(rL - halfWindowLength, firstDirection));
     const StatusCode secondStatusCode(this->GetGlobalFitDirection(rL + halfWindowLength, secondDirection));
@@ -422,8 +423,7 @@ StatusCode TwoDSlidingFitResult::GetGlobalFitPositionListAtX(const float x, Cart
     if (STATUS_CODE_SUCCESS != statusCode)
         return statusCode;
 
-    for (LayerInterpolationList::const_iterator iter = layerInterpolationList.begin(), iterEnd = layerInterpolationList.end();
-        iter != iterEnd; ++iter)
+    for (LayerInterpolationList::const_iterator iter = layerInterpolationList.begin(), iterEnd = layerInterpolationList.end(); iter != iterEnd; ++iter)
     {
         positionList.push_back(this->GetGlobalFitPosition(*iter));
     }
@@ -447,8 +447,8 @@ StatusCode TwoDSlidingFitResult::GetTransverseProjection(const float x, const Fi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TwoDSlidingFitResult::GetTransverseProjection(const float x, const FitSegment &fitSegment, CartesianVector &position,
-    CartesianVector &direction) const
+StatusCode TwoDSlidingFitResult::GetTransverseProjection(
+    const float x, const FitSegment &fitSegment, CartesianVector &position, CartesianVector &direction) const
 {
     LayerInterpolation layerInterpolation;
     const StatusCode statusCode(this->TransverseInterpolation(x, fitSegment, layerInterpolation));
@@ -714,8 +714,12 @@ void TwoDSlidingFitResult::PerformSlidingLinearFit()
             continue;
 
         const double gradient((slidingSumLT - slidingSumL * slidingSumT / static_cast<double>(slidingNPoints)) / denominator);
-        const double intercept((slidingSumLL * slidingSumT / static_cast<double>(slidingNPoints) - slidingSumL * slidingSumLT / static_cast<double>(slidingNPoints)) / denominator);
-        double variance((slidingSumTT - 2. * intercept * slidingSumT - 2. * gradient * slidingSumLT + intercept * intercept * static_cast<double>(slidingNPoints) + 2. * gradient * intercept * slidingSumL + gradient * gradient * slidingSumLL) / (1. + gradient * gradient));
+        const double intercept(
+            (slidingSumLL * slidingSumT / static_cast<double>(slidingNPoints) - slidingSumL * slidingSumLT / static_cast<double>(slidingNPoints)) / denominator);
+        double variance((slidingSumTT - 2. * intercept * slidingSumT - 2. * gradient * slidingSumLT +
+                            intercept * intercept * static_cast<double>(slidingNPoints) + 2. * gradient * intercept * slidingSumL +
+                            gradient * gradient * slidingSumLL) /
+                        (1. + gradient * gradient));
 
         if (variance < -std::numeric_limits<float>::epsilon())
             continue;
@@ -728,7 +732,7 @@ void TwoDSlidingFitResult::PerformSlidingLinearFit()
         const double fitT(intercept + gradient * l);
 
         const LayerFitResult layerFitResult(l, fitT, gradient, rms);
-        (void) m_layerFitResultMap.insert(LayerFitResultMap::value_type(iLayer, layerFitResult));
+        (void)m_layerFitResultMap.insert(LayerFitResultMap::value_type(iLayer, layerFitResult));
     }
 
     if (m_layerFitResultMap.empty())
@@ -773,7 +777,8 @@ void TwoDSlidingFitResult::FindSlidingFitSegments()
         else
         {
             if ((POSITIVE_IN_X == sustainedDirection) || (NEGATIVE_IN_X == sustainedDirection))
-                m_fitSegmentList.push_back(FitSegment(sustainedDirectionStartIter->first, sustainedDirectionEndIter->first, sustainedDirectionStartX, sustainedDirectionEndX));
+                m_fitSegmentList.push_back(FitSegment(
+                    sustainedDirectionStartIter->first, sustainedDirectionEndIter->first, sustainedDirectionStartX, sustainedDirectionEndX));
 
             nSustainedSteps = 0;
             sustainedDirection = UNKNOWN;
@@ -786,7 +791,8 @@ void TwoDSlidingFitResult::FindSlidingFitSegments()
     }
 
     if ((POSITIVE_IN_X == sustainedDirection) || (NEGATIVE_IN_X == sustainedDirection))
-        m_fitSegmentList.push_back(FitSegment(sustainedDirectionStartIter->first, sustainedDirectionEndIter->first, sustainedDirectionStartX, sustainedDirectionEndX));
+        m_fitSegmentList.push_back(
+            FitSegment(sustainedDirectionStartIter->first, sustainedDirectionEndIter->first, sustainedDirectionStartX, sustainedDirectionEndX));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -850,14 +856,14 @@ CartesianVector TwoDSlidingFitResult::GetGlobalFitDirection(const LayerInterpola
     if (m_layerFitResultMap.end() == firstLayerIter || m_layerFitResultMap.end() == secondLayerIter)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    CartesianVector firstLayerDirection(0.f,0.f,0.f);
-    this->GetGlobalDirection(firstLayerIter->second.GetGradient(),firstLayerDirection);
+    CartesianVector firstLayerDirection(0.f, 0.f, 0.f);
+    this->GetGlobalDirection(firstLayerIter->second.GetGradient(), firstLayerDirection);
 
     if (firstLayerIter == secondLayerIter)
         return firstLayerDirection;
 
-    CartesianVector secondLayerDirection(0.f,0.f,0.f);
-    this->GetGlobalDirection(secondLayerIter->second.GetGradient(),secondLayerDirection);
+    CartesianVector secondLayerDirection(0.f, 0.f, 0.f);
+    this->GetGlobalDirection(secondLayerIter->second.GetGradient(), secondLayerDirection);
 
     if (firstWeight + secondWeight < std::numeric_limits<float>::epsilon())
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -916,7 +922,8 @@ StatusCode TwoDSlidingFitResult::TransverseInterpolation(const float x, const Fi
     double firstWeight(0.), secondWeight(0.);
     LayerFitResultMap::const_iterator firstLayerIter, secondLayerIter;
 
-    const StatusCode statusCode(this->GetTransverseSurroundingLayers(x, fitSegment.GetStartLayer(), fitSegment.GetEndLayer(), firstLayerIter, secondLayerIter));
+    const StatusCode statusCode(
+        this->GetTransverseSurroundingLayers(x, fitSegment.GetStartLayer(), fitSegment.GetEndLayer(), firstLayerIter, secondLayerIter));
 
     if (STATUS_CODE_SUCCESS != statusCode)
         return statusCode;
@@ -951,8 +958,8 @@ StatusCode TwoDSlidingFitResult::TransverseInterpolation(const float x, LayerInt
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TwoDSlidingFitResult::GetLongitudinalSurroundingLayers(const float rL, LayerFitResultMap::const_iterator &firstLayerIter,
-    LayerFitResultMap::const_iterator &secondLayerIter) const
+StatusCode TwoDSlidingFitResult::GetLongitudinalSurroundingLayers(
+    const float rL, LayerFitResultMap::const_iterator &firstLayerIter, LayerFitResultMap::const_iterator &secondLayerIter) const
 {
     if (m_layerFitResultMap.empty())
         throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);

--- a/larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h
+++ b/larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h
@@ -33,7 +33,8 @@ public:
      *          above which cluster hits are broken into their constituent hits - only used with cluster input
      */
     template <typename T>
-    TwoDSlidingFitResult(const T *const pT, const unsigned int layerFitHalfWindow, const float layerPitch, const float axisDeviationLimitForHitDivision = 0.95f);
+    TwoDSlidingFitResult(const T *const pT, const unsigned int layerFitHalfWindow, const float layerPitch,
+        const float axisDeviationLimitForHitDivision = 0.95f);
 
     /**
      *  @brief  Constructor using specified primary axis. The orthogonal axis must be perpendicular to the primary axis.
@@ -48,8 +49,9 @@ public:
      *          above which cluster hits are broken into their constituent hits - only used with cluster input
      */
     template <typename T>
-    TwoDSlidingFitResult(const T *const pT, const unsigned int layerFitHalfWindow, const float layerPitch, const pandora::CartesianVector &axisIntercept,
-        const pandora::CartesianVector &axisDirection, const pandora::CartesianVector &orthoDirection, const float axisDeviationLimitForHitDivision = 0.95f);
+    TwoDSlidingFitResult(const T *const pT, const unsigned int layerFitHalfWindow, const float layerPitch,
+        const pandora::CartesianVector &axisIntercept, const pandora::CartesianVector &axisDirection,
+        const pandora::CartesianVector &orthoDirection, const float axisDeviationLimitForHitDivision = 0.95f);
 
     /**
      *  @brief  Constructor using specified primary axis and layer fit contribution map. User is responsible for ensuring that
@@ -64,7 +66,8 @@ public:
      *  @param  layerFitContributionMap the layer fit contribution map
      */
     TwoDSlidingFitResult(const unsigned int layerFitHalfWindow, const float layerPitch, const pandora::CartesianVector &axisIntercept,
-        const pandora::CartesianVector &axisDirection, const pandora::CartesianVector &orthoDirection, const LayerFitContributionMap &layerFitContributionMap);
+        const pandora::CartesianVector &axisDirection, const pandora::CartesianVector &orthoDirection,
+        const LayerFitContributionMap &layerFitContributionMap);
 
     /**
      *  @brief  Get the address of the cluster, if originally provided
@@ -124,14 +127,14 @@ public:
      */
     const LayerFitContributionMap &GetLayerFitContributionMap() const;
 
-     /**
+    /**
      *  @brief  Get the fit segment list
      *
      *  @return the fit segment list
      */
     const FitSegmentList &GetFitSegmentList() const;
 
-     /**
+    /**
      *  @brief  Get the layer fit half window length
      *
      *  @return the layer fit half window length
@@ -355,8 +358,8 @@ public:
      *
      *  @return status code, faster than throwing in regular use-cases
      */
-    pandora::StatusCode GetTransverseProjection(const float x, const FitSegment &fitSegment, pandora::CartesianVector &position,
-        pandora::CartesianVector &direction) const;
+    pandora::StatusCode GetTransverseProjection(
+        const float x, const FitSegment &fitSegment, pandora::CartesianVector &position, pandora::CartesianVector &direction) const;
 
     /**
      *  @brief  Get extrapolated position (beyond span) for a given input coordinate
@@ -492,8 +495,8 @@ private:
      *
      *  @return status code, faster than throwing in regular use-cases
      */
-    pandora::StatusCode GetLongitudinalSurroundingLayers(const float rL, LayerFitResultMap::const_iterator &firstLayerIter,
-        LayerFitResultMap::const_iterator &secondLayerIter) const;
+    pandora::StatusCode GetLongitudinalSurroundingLayers(
+        const float rL, LayerFitResultMap::const_iterator &firstLayerIter, LayerFitResultMap::const_iterator &secondLayerIter) const;
 
     /**
      *  @brief  Get iterators for layers surrounding a specified transverse position
@@ -521,7 +524,7 @@ private:
     void GetLongitudinalInterpolationWeights(const float rL, const LayerFitResultMap::const_iterator &firstLayerIter,
         const LayerFitResultMap::const_iterator &secondLayerIter, double &firstWeight, double &secondWeight) const;
 
-   /**
+    /**
      *  @brief  Get interpolation weights for layers surrounding a specified transverse position
      *
      *  @param  x the transverse coordinate
@@ -533,19 +536,19 @@ private:
     void GetTransverseInterpolationWeights(const float x, const LayerFitResultMap::const_iterator &firstLayerIter,
         const LayerFitResultMap::const_iterator &secondLayerIter, double &firstWeight, double &secondWeight) const;
 
-    const pandora::Cluster     *m_pCluster;                 ///< The address of the cluster
-    unsigned int                m_layerFitHalfWindow;       ///< The layer fit half window
-    float                       m_layerPitch;               ///< The layer pitch, units cm
-    pandora::CartesianVector    m_axisIntercept;            ///< The axis intercept position
-    pandora::CartesianVector    m_axisDirection;            ///< The axis direction vector
-    pandora::CartesianVector    m_orthoDirection;           ///< The orthogonal direction vector
-    LayerFitResultMap           m_layerFitResultMap;        ///< The layer fit result map
-    LayerFitContributionMap     m_layerFitContributionMap;  ///< The layer fit contribution map
-    FitSegmentList              m_fitSegmentList;           ///< The fit segment list
+    const pandora::Cluster *m_pCluster;                ///< The address of the cluster
+    unsigned int m_layerFitHalfWindow;                 ///< The layer fit half window
+    float m_layerPitch;                                ///< The layer pitch, units cm
+    pandora::CartesianVector m_axisIntercept;          ///< The axis intercept position
+    pandora::CartesianVector m_axisDirection;          ///< The axis direction vector
+    pandora::CartesianVector m_orthoDirection;         ///< The orthogonal direction vector
+    LayerFitResultMap m_layerFitResultMap;             ///< The layer fit result map
+    LayerFitContributionMap m_layerFitContributionMap; ///< The layer fit contribution map
+    FitSegmentList m_fitSegmentList;                   ///< The fit segment list
 };
 
 typedef std::vector<TwoDSlidingFitResult> TwoDSlidingFitResultList;
-typedef std::unordered_map<const pandora::Cluster*, TwoDSlidingFitResult> TwoDSlidingFitResultMap;
+typedef std::unordered_map<const pandora::Cluster *, TwoDSlidingFitResult> TwoDSlidingFitResultMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArObjects/LArTwoDSlidingShowerFitResult.cc
+++ b/larpandoracontent/LArObjects/LArTwoDSlidingShowerFitResult.cc
@@ -22,8 +22,8 @@ namespace lar_content
 {
 
 template <typename T>
-TwoDSlidingShowerFitResult::TwoDSlidingShowerFitResult(const T *const pT, const unsigned int slidingFitWindow, const float slidingFitLayerPitch,
-        const float showerEdgeMultiplier) :
+TwoDSlidingShowerFitResult::TwoDSlidingShowerFitResult(
+    const T *const pT, const unsigned int slidingFitWindow, const float slidingFitLayerPitch, const float showerEdgeMultiplier) :
     m_showerFitResult(TwoDSlidingFitResult(pT, slidingFitWindow, slidingFitLayerPitch)),
     m_negativeEdgeFitResult(TwoDSlidingShowerFitResult::LArTwoDShowerEdgeFit(pT, m_showerFitResult, NEGATIVE_SHOWER_EDGE, showerEdgeMultiplier)),
     m_positiveEdgeFitResult(TwoDSlidingShowerFitResult::LArTwoDShowerEdgeFit(pT, m_showerFitResult, POSITIVE_SHOWER_EDGE, showerEdgeMultiplier))
@@ -36,8 +36,10 @@ void TwoDSlidingShowerFitResult::GetShowerEdges(const float x, const bool widenI
 {
     edgePositions.clear();
     CartesianPointVector fitPositionVector;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->GetNegativeEdgeFitResult().GetGlobalFitPositionListAtX(x, fitPositionVector));
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->GetPositiveEdgeFitResult().GetGlobalFitPositionListAtX(x, fitPositionVector));
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->GetNegativeEdgeFitResult().GetGlobalFitPositionListAtX(x, fitPositionVector));
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->GetPositiveEdgeFitResult().GetGlobalFitPositionListAtX(x, fitPositionVector));
 
     if (fitPositionVector.size() < 2)
     {
@@ -86,8 +88,8 @@ void TwoDSlidingShowerFitResult::GetShowerEdges(const float x, const bool widenI
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TwoDSlidingFitResult TwoDSlidingShowerFitResult::LArTwoDShowerEdgeFit(const Cluster *const pCluster, const TwoDSlidingFitResult &fullShowerFit,
-    const ShowerEdge showerEdge, const float showerEdgeMultiplier)
+TwoDSlidingFitResult TwoDSlidingShowerFitResult::LArTwoDShowerEdgeFit(
+    const Cluster *const pCluster, const TwoDSlidingFitResult &fullShowerFit, const ShowerEdge showerEdge, const float showerEdgeMultiplier)
 {
     CartesianPointVector pointVector;
     LArClusterHelper::GetCoordinateVector(pCluster, pointVector);
@@ -130,9 +132,8 @@ TwoDSlidingFitResult TwoDSlidingShowerFitResult::LArTwoDShowerEdgeFit(const Cart
     {
         // ATTN Could modify this hit selection, e.g. add inertia to edge positions
         bool bestFitCoordinateFound(false);
-        FitCoordinate bestFitCoordinate = (POSITIVE_SHOWER_EDGE == showerEdge) ?
-            FitCoordinate(0.f, -std::numeric_limits<float>::max()) :
-            FitCoordinate(0.f, +std::numeric_limits<float>::max());
+        FitCoordinate bestFitCoordinate = (POSITIVE_SHOWER_EDGE == showerEdge) ? FitCoordinate(0.f, -std::numeric_limits<float>::max())
+                                                                               : FitCoordinate(0.f, +std::numeric_limits<float>::max());
 
         for (const FitCoordinate &fitCoordinate : mapEntry.second)
         {

--- a/larpandoracontent/LArObjects/LArTwoDSlidingShowerFitResult.h
+++ b/larpandoracontent/LArObjects/LArTwoDSlidingShowerFitResult.h
@@ -43,8 +43,8 @@ public:
      *  @param  showerEdgeMultiplier artificially tune width of shower envelope so as to make it more/less inclusive
      */
     template <typename T>
-    TwoDSlidingShowerFitResult(const T *const pT, const unsigned int slidingFitWindow, const float slidingFitLayerPitch,
-        const float showerEdgeMultiplier = 1.f);
+    TwoDSlidingShowerFitResult(
+        const T *const pT, const unsigned int slidingFitWindow, const float slidingFitLayerPitch, const float showerEdgeMultiplier = 1.f);
 
     /**
      *  @brief  Get the sliding fit result for the full shower cluster
@@ -100,20 +100,20 @@ private:
      *
      *  @return the shower edge fit result
      */
-    static TwoDSlidingFitResult LArTwoDShowerEdgeFit(const pandora::CartesianPointVector *const pPointVector, const TwoDSlidingFitResult &fullShowerFit,
-        const ShowerEdge showerEdge, const float showerEdgeMultiplier);
+    static TwoDSlidingFitResult LArTwoDShowerEdgeFit(const pandora::CartesianPointVector *const pPointVector,
+        const TwoDSlidingFitResult &fullShowerFit, const ShowerEdge showerEdge, const float showerEdgeMultiplier);
 
     typedef std::pair<float, float> FitCoordinate;
     typedef std::vector<FitCoordinate> FitCoordinateList;
     typedef std::map<int, FitCoordinateList> FitCoordinateMap;
 
-    TwoDSlidingFitResult    m_showerFitResult;              ///< The sliding fit result for the full shower cluster
-    TwoDSlidingFitResult    m_negativeEdgeFitResult;        ///< The sliding fit result for the negative shower edge
-    TwoDSlidingFitResult    m_positiveEdgeFitResult;        ///< The sliding fit result for the positive shower edge
+    TwoDSlidingFitResult m_showerFitResult;       ///< The sliding fit result for the full shower cluster
+    TwoDSlidingFitResult m_negativeEdgeFitResult; ///< The sliding fit result for the negative shower edge
+    TwoDSlidingFitResult m_positiveEdgeFitResult; ///< The sliding fit result for the positive shower edge
 };
 
 typedef std::vector<TwoDSlidingShowerFitResult> TwoDSlidingShowerFitResultList;
-typedef std::unordered_map<const pandora::Cluster*, TwoDSlidingShowerFitResult> TwoDSlidingShowerFitResultMap;
+typedef std::unordered_map<const pandora::Cluster *, TwoDSlidingShowerFitResult> TwoDSlidingShowerFitResultMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -154,9 +154,9 @@ public:
     float GetLowEdgeZ() const;
 
 private:
-    float   m_xCoordinate;      ///< The x coordinate
-    float   m_highEdgeZ;        ///< The shower high edge z coordinate
-    float   m_lowEdgeZ;         ///< The shower low edge z coordinate
+    float m_xCoordinate; ///< The x coordinate
+    float m_highEdgeZ;   ///< The shower high edge z coordinate
+    float m_lowEdgeZ;    ///< The shower low edge z coordinate
 };
 
 typedef std::map<int, ShowerExtent> ShowerPositionMap;

--- a/larpandoracontent/LArObjects/LArTwoViewXOverlap.h
+++ b/larpandoracontent/LArObjects/LArTwoViewXOverlap.h
@@ -109,11 +109,11 @@ public:
     float GetXOverlapFraction1() const;
 
 private:
-    float       m_xMin0;                        ///< The min x value in the view 0
-    float       m_xMax0;                        ///< The max x value in the view 0
-    float       m_xMin1;                        ///< The min x value in the view 1
-    float       m_xMax1;                        ///< The max x value in the view 1
-    float       m_xOverlapSpan;                 ///< The x overlap span
+    float m_xMin0;        ///< The min x value in the view 0
+    float m_xMax0;        ///< The max x value in the view 0
+    float m_xMin1;        ///< The min x value in the view 1
+    float m_xMax1;        ///< The max x value in the view 1
+    float m_xOverlapSpan; ///< The x overlap span
 };
 
 /**

--- a/larpandoracontent/LArObjects/LArXOverlap.h
+++ b/larpandoracontent/LArObjects/LArXOverlap.h
@@ -101,13 +101,13 @@ public:
     float GetXOverlapSpan() const;
 
 private:
-    float       m_uMinX;                        ///< The min x value in the u view
-    float       m_uMaxX;                        ///< The max x value in the u view
-    float       m_vMinX;                        ///< The min x value in the v view
-    float       m_vMaxX;                        ///< The max x value in the v view
-    float       m_wMinX;                        ///< The min x value in the w view
-    float       m_wMaxX;                        ///< The max x value in the w view
-    float       m_xOverlapSpan;                 ///< The x overlap span
+    float m_uMinX;        ///< The min x value in the u view
+    float m_uMaxX;        ///< The max x value in the u view
+    float m_vMinX;        ///< The min x value in the v view
+    float m_vMaxX;        ///< The max x value in the v view
+    float m_wMinX;        ///< The min x value in the w view
+    float m_wMaxX;        ///< The max x value in the w view
+    float m_xOverlapSpan; ///< The x overlap span
 };
 
 /**
@@ -120,8 +120,8 @@ XOverlap operator+(const XOverlap &lhs, const XOverlap &rhs);
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline XOverlap::XOverlap(const float uMinX, const float uMaxX, const float vMinX, const float vMaxX,
-        const float wMinX, const float wMaxX, const float xOverlapSpan) :
+inline XOverlap::XOverlap(const float uMinX, const float uMaxX, const float vMinX, const float vMaxX, const float wMinX, const float wMaxX,
+    const float xOverlapSpan) :
     m_uMinX(uMinX),
     m_uMaxX(uMaxX),
     m_vMinX(vMinX),

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
@@ -176,7 +176,7 @@ StatusCode EventReadingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 
     if (this->ExternalParametersPresent())
     {
-        pExternalParameters = dynamic_cast<ExternalEventReadingParameters*>(this->GetExternalParameters());
+        pExternalParameters = dynamic_cast<ExternalEventReadingParameters *>(this->GetExternalParameters());
 
         if (!pExternalParameters)
             return STATUS_CODE_FAILURE;
@@ -188,7 +188,8 @@ StatusCode EventReadingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     }
     else
     {
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "GeometryFileName", m_geometryFileName));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "GeometryFileName", m_geometryFileName));
     }
 
     if (pExternalParameters && !pExternalParameters->m_eventFileNameList.empty())
@@ -197,7 +198,8 @@ StatusCode EventReadingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     }
     else
     {
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "EventFileNameList", m_eventFileNameVector));
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+            XmlHelper::ReadVectorOfValues(xmlHandle, "EventFileNameList", m_eventFileNameVector));
     }
 
     if (!m_eventFileNameVector.empty())
@@ -222,14 +224,13 @@ StatusCode EventReadingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         return STATUS_CODE_NOT_INITIALIZED;
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseLArCaloHits", m_useLArCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArCaloHits", m_useLArCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LArCaloHitVersion", m_larCaloHitVersion));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LArCaloHitVersion", m_larCaloHitVersion));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseLArMCParticles", m_useLArMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArMCParticles", m_useLArMCParticles));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.h
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.h
@@ -14,7 +14,10 @@
 
 #include "Persistency/PandoraIO.h"
 
-namespace pandora {class FileReader;}
+namespace pandora
+{
+class FileReader;
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -43,9 +46,9 @@ public:
     class ExternalEventReadingParameters : public pandora::ExternalParameters
     {
     public:
-        std::string             m_geometryFileName;             ///< Name of the file containing geometry information
-        std::string             m_eventFileNameList;            ///< Colon-separated list of file names to be processed
-        pandora::InputUInt      m_skipToEvent;                  ///< Index of first event to consider in input file
+        std::string m_geometryFileName;   ///< Name of the file containing geometry information
+        std::string m_eventFileNameList;  ///< Colon-separated list of file names to be processed
+        pandora::InputUInt m_skipToEvent; ///< Index of first event to consider in input file
     };
 
 private:
@@ -75,17 +78,17 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string                 m_geometryFileName;             ///< Name of the file containing geometry information
-    std::string                 m_eventFileName;                ///< Name of the current file containing event information
-    pandora::StringVector       m_eventFileNameVector;          ///< Vector of file names to be processed
+    std::string m_geometryFileName;              ///< Name of the file containing geometry information
+    std::string m_eventFileName;                 ///< Name of the current file containing event information
+    pandora::StringVector m_eventFileNameVector; ///< Vector of file names to be processed
 
-    unsigned int                m_skipToEvent;                  ///< Index of first event to consider in first input file
+    unsigned int m_skipToEvent; ///< Index of first event to consider in first input file
 
-    bool                        m_useLArCaloHits;               ///< Whether to read lar calo hits, or standard pandora calo hits
-    unsigned int                m_larCaloHitVersion;            ///< LArCaloHit version for LArCaloHitFactory
-    bool                        m_useLArMCParticles;            ///< Whether to read lar mc particles, or standard pandora mc particles
+    bool m_useLArCaloHits;            ///< Whether to read lar calo hits, or standard pandora calo hits
+    unsigned int m_larCaloHitVersion; ///< LArCaloHit version for LArCaloHitFactory
+    bool m_useLArMCParticles;         ///< Whether to read lar mc particles, or standard pandora mc particles
 
-    pandora::FileReader        *m_pEventFileReader;             ///< Address of the event file reader
+    pandora::FileReader *m_pEventFileReader; ///< Address of the event file reader
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
@@ -146,8 +146,8 @@ StatusCode EventWritingAlgorithm::Run()
         const MCParticleList *pMCParticleList = nullptr;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pMCParticleList));
 
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileWriter->WriteEvent(*pCaloHitList, *pTrackList, *pMCParticleList,
-            m_shouldWriteMCRelationships, m_shouldWriteTrackRelationships));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+            m_pEventFileWriter->WriteEvent(*pCaloHitList, *pTrackList, *pMCParticleList, m_shouldWriteMCRelationships, m_shouldWriteTrackRelationships));
     }
 
     return STATUS_CODE_SUCCESS;
@@ -165,7 +165,7 @@ bool EventWritingAlgorithm::PassNuanceCodeFilter() const
 
     for (const MCParticle *const pMCNeutrino : mcNeutrinoList)
     {
-        const LArMCParticle *const pLArMCNeutrino = dynamic_cast<const LArMCParticle*>(pMCNeutrino);
+        const LArMCParticle *const pLArMCNeutrino = dynamic_cast<const LArMCParticle *>(pMCNeutrino);
 
         if (pLArMCNeutrino && (pLArMCNeutrino->GetNuanceCode() == m_filterNuanceCode))
             return true;
@@ -186,34 +186,44 @@ bool EventWritingAlgorithm::PassMCParticleFilter() const
 
     LArMCParticleHelper::PrimaryParameters parameters;
     LArMCParticleHelper::MCContributionMap mcParticlesToGoodHitsMap;
-    LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, mcParticlesToGoodHitsMap);
+    LArMCParticleHelper::SelectReconstructableMCParticles(
+        pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, mcParticlesToGoodHitsMap);
 
     if (!m_neutrinoInducedOnly)
     {
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamParticle, mcParticlesToGoodHitsMap);
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, mcParticlesToGoodHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamParticle, mcParticlesToGoodHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsCosmicRay, mcParticlesToGoodHitsMap);
     }
 
     unsigned int nNonNeutrons(0), nMuons(0), nElectrons(0), nProtons(0), nPhotons(0), nChargedPions(0);
 
     MCParticleVector mcPrimaryVector;
-    for (const auto &mapEntry : mcParticlesToGoodHitsMap) mcPrimaryVector.push_back(mapEntry.first);
+    for (const auto &mapEntry : mcParticlesToGoodHitsMap)
+        mcPrimaryVector.push_back(mapEntry.first);
     std::sort(mcPrimaryVector.begin(), mcPrimaryVector.end(), LArMCParticleHelper::SortByMomentum);
 
     for (const MCParticle *const pMCPrimary : mcPrimaryVector)
     {
         const unsigned int particleId(std::abs(pMCPrimary->GetParticleId()));
-        if (NEUTRON != particleId) ++nNonNeutrons;
+        if (NEUTRON != particleId)
+            ++nNonNeutrons;
 
-        if (MU_MINUS == particleId) ++nMuons;
-        else if (E_MINUS == particleId) ++nElectrons;
-        else if (PROTON == particleId) ++nProtons;
-        else if (PHOTON == particleId) ++nPhotons;
-        else if (PI_PLUS == particleId) ++nChargedPions;
+        if (MU_MINUS == particleId)
+            ++nMuons;
+        else if (E_MINUS == particleId)
+            ++nElectrons;
+        else if (PROTON == particleId)
+            ++nProtons;
+        else if (PHOTON == particleId)
+            ++nPhotons;
+        else if (PI_PLUS == particleId)
+            ++nChargedPions;
     }
 
-    if ((nNonNeutrons == m_nNonNeutrons) && (nMuons == m_nMuons) && (nElectrons == m_nElectrons) &&
-        (nProtons == m_nProtons) && (nPhotons == m_nPhotons) && (nChargedPions == m_nChargedPions))
+    if ((nNonNeutrons == m_nNonNeutrons) && (nMuons == m_nMuons) && (nElectrons == m_nElectrons) && (nProtons == m_nProtons) &&
+        (nPhotons == m_nPhotons) && (nChargedPions == m_nChargedPions))
     {
         return true;
     }
@@ -235,9 +245,12 @@ bool EventWritingAlgorithm::PassNeutrinoVertexFilter() const
     {
         const CartesianVector &neutrinoInteractionVertex(pMCNeutrino->GetEndpoint());
 
-        if ((neutrinoInteractionVertex.GetX() < (m_detectorHalfLengthX - m_coordinateOffsetX - m_selectedBorderX)) && (neutrinoInteractionVertex.GetX() > (-m_coordinateOffsetX + m_selectedBorderX)) &&
-            (neutrinoInteractionVertex.GetY() < (m_detectorHalfLengthY - m_coordinateOffsetY - m_selectedBorderY)) && (neutrinoInteractionVertex.GetY() > (-m_coordinateOffsetY + m_selectedBorderY)) &&
-            (neutrinoInteractionVertex.GetZ() < (m_detectorHalfLengthZ - m_coordinateOffsetZ - m_selectedBorderZ)) && (neutrinoInteractionVertex.GetZ() > (-m_coordinateOffsetZ + m_selectedBorderZ)) )
+        if ((neutrinoInteractionVertex.GetX() < (m_detectorHalfLengthX - m_coordinateOffsetX - m_selectedBorderX)) &&
+            (neutrinoInteractionVertex.GetX() > (-m_coordinateOffsetX + m_selectedBorderX)) &&
+            (neutrinoInteractionVertex.GetY() < (m_detectorHalfLengthY - m_coordinateOffsetY - m_selectedBorderY)) &&
+            (neutrinoInteractionVertex.GetY() > (-m_coordinateOffsetY + m_selectedBorderY)) &&
+            (neutrinoInteractionVertex.GetZ() < (m_detectorHalfLengthZ - m_coordinateOffsetZ - m_selectedBorderZ)) &&
+            (neutrinoInteractionVertex.GetZ() > (-m_coordinateOffsetZ + m_selectedBorderZ)))
         {
             return true;
         }
@@ -250,13 +263,12 @@ bool EventWritingAlgorithm::PassNeutrinoVertexFilter() const
 
 StatusCode EventWritingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldWriteGeometry", m_shouldWriteGeometry));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShouldWriteGeometry", m_shouldWriteGeometry));
 
     if (m_shouldWriteGeometry)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "GeometryFileName", m_geometryFileName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "GeometryFileName", m_geometryFileName));
 
         std::string fileExtension(m_geometryFileName.substr(m_geometryFileName.find_last_of(".")));
         std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), ::tolower);
@@ -276,13 +288,12 @@ StatusCode EventWritingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         }
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldWriteEvents", m_shouldWriteEvents));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShouldWriteEvents", m_shouldWriteEvents));
 
     if (m_shouldWriteEvents)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-            "EventFileName", m_eventFileName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "EventFileName", m_eventFileName));
 
         std::string fileExtension(m_eventFileName.substr(m_eventFileName.find_last_of(".")));
         std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), ::tolower);
@@ -302,35 +313,34 @@ StatusCode EventWritingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         }
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldWriteMCRelationships", m_shouldWriteMCRelationships));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShouldWriteMCRelationships", m_shouldWriteMCRelationships));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldWriteTrackRelationships", m_shouldWriteTrackRelationships));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShouldWriteTrackRelationships", m_shouldWriteTrackRelationships));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldOverwriteEventFile", m_shouldOverwriteEventFile));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShouldOverwriteEventFile", m_shouldOverwriteEventFile));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldOverwriteGeometryFile", m_shouldOverwriteGeometryFile));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShouldOverwriteGeometryFile", m_shouldOverwriteGeometryFile));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseLArCaloHits", m_useLArCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArCaloHits", m_useLArCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LArCaloHitVersion", m_larCaloHitVersion));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LArCaloHitVersion", m_larCaloHitVersion));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseLArMCParticles", m_useLArMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArMCParticles", m_useLArMCParticles));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldFilterByNuanceCode", m_shouldFilterByNuanceCode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShouldFilterByNuanceCode", m_shouldFilterByNuanceCode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldFilterByMCParticles", m_shouldFilterByMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShouldFilterByMCParticles", m_shouldFilterByMCParticles));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShouldFilterByNeutrinoVertex", m_shouldFilterByNeutrinoVertex));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShouldFilterByNeutrinoVertex", m_shouldFilterByNeutrinoVertex));
 
     if (m_shouldFilterByNuanceCode)
     {

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.h
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.h
@@ -12,7 +12,10 @@
 
 #include "Persistency/PandoraIO.h"
 
-namespace pandora {class FileWriter;}
+namespace pandora
+{
+class FileWriter;
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -62,52 +65,52 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::FileType       m_geometryFileType;             ///< The geometry file type
-    pandora::FileType       m_eventFileType;                ///< The event file type
+    pandora::FileType m_geometryFileType; ///< The geometry file type
+    pandora::FileType m_eventFileType;    ///< The event file type
 
-    pandora::FileWriter    *m_pEventFileWriter;             ///< Address of the event file writer
-    pandora::FileWriter    *m_pGeometryFileWriter;          ///< Address of the geometry file writer
+    pandora::FileWriter *m_pEventFileWriter;    ///< Address of the event file writer
+    pandora::FileWriter *m_pGeometryFileWriter; ///< Address of the geometry file writer
 
-    bool                    m_shouldWriteGeometry;          ///< Whether to write geometry to a specified file
-    bool                    m_writtenGeometry;              ///< Whether geometry has been written
-    std::string             m_geometryFileName;             ///< Name of the output geometry file
+    bool m_shouldWriteGeometry;     ///< Whether to write geometry to a specified file
+    bool m_writtenGeometry;         ///< Whether geometry has been written
+    std::string m_geometryFileName; ///< Name of the output geometry file
 
-    bool                    m_shouldWriteEvents;            ///< Whether to write events to a specified file
-    std::string             m_eventFileName;                ///< Name of the output event file
+    bool m_shouldWriteEvents;    ///< Whether to write events to a specified file
+    std::string m_eventFileName; ///< Name of the output event file
 
-    bool                    m_shouldWriteMCRelationships;   ///< Whether to write mc relationship information to the events file
-    bool                    m_shouldWriteTrackRelationships;///< Whether to write track relationship information to the events file
+    bool m_shouldWriteMCRelationships;    ///< Whether to write mc relationship information to the events file
+    bool m_shouldWriteTrackRelationships; ///< Whether to write track relationship information to the events file
 
-    bool                    m_shouldOverwriteEventFile;     ///< Whether to overwrite existing event file with specified name, or append
-    bool                    m_shouldOverwriteGeometryFile;  ///< Whether to overwrite existing geometry file with specified name, or append
+    bool m_shouldOverwriteEventFile;    ///< Whether to overwrite existing event file with specified name, or append
+    bool m_shouldOverwriteGeometryFile; ///< Whether to overwrite existing geometry file with specified name, or append
 
-    bool                    m_useLArCaloHits;               ///< Whether to write lar calo hits, or standard pandora calo hits
-    unsigned int            m_larCaloHitVersion;            ///< LArCaloHit version for LArCaloHitFactory
-    bool                    m_useLArMCParticles;            ///< Whether to write lar mc particles, or standard pandora mc particles
+    bool m_useLArCaloHits;            ///< Whether to write lar calo hits, or standard pandora calo hits
+    unsigned int m_larCaloHitVersion; ///< LArCaloHit version for LArCaloHitFactory
+    bool m_useLArMCParticles;         ///< Whether to write lar mc particles, or standard pandora mc particles
 
-    bool                    m_shouldFilterByNuanceCode;     ///< Whether to filter output by nuance code
-    int                     m_filterNuanceCode;             ///< The filter nuance code (required if specify filter by nuance code)
+    bool m_shouldFilterByNuanceCode; ///< Whether to filter output by nuance code
+    int m_filterNuanceCode;          ///< The filter nuance code (required if specify filter by nuance code)
 
-    bool                    m_shouldFilterByMCParticles;    ///< Whether to filter output by mc particle constituents
-    bool                    m_neutrinoInducedOnly;          ///< Whether to consider only mc particles that were neutrino induced
-    unsigned int            m_matchingMinPrimaryHits;       ///< The minimum number of mc primary hits used in matching scheme
-    unsigned int            m_nNonNeutrons;                 ///< The requested number of mc primaries that are not neutrons
-    unsigned int            m_nMuons;                       ///< The requested number of mc primaries that are muons
-    unsigned int            m_nElectrons;                   ///< The requested number of mc primaries that are electrons
-    unsigned int            m_nProtons;                     ///< The requested number of mc primaries that are protons
-    unsigned int            m_nPhotons;                     ///< The requested number of mc primaries that are photons
-    unsigned int            m_nChargedPions;                ///< The requested number of mc primaries that are charged pions
+    bool m_shouldFilterByMCParticles;      ///< Whether to filter output by mc particle constituents
+    bool m_neutrinoInducedOnly;            ///< Whether to consider only mc particles that were neutrino induced
+    unsigned int m_matchingMinPrimaryHits; ///< The minimum number of mc primary hits used in matching scheme
+    unsigned int m_nNonNeutrons;           ///< The requested number of mc primaries that are not neutrons
+    unsigned int m_nMuons;                 ///< The requested number of mc primaries that are muons
+    unsigned int m_nElectrons;             ///< The requested number of mc primaries that are electrons
+    unsigned int m_nProtons;               ///< The requested number of mc primaries that are protons
+    unsigned int m_nPhotons;               ///< The requested number of mc primaries that are photons
+    unsigned int m_nChargedPions;          ///< The requested number of mc primaries that are charged pions
 
-    bool                    m_shouldFilterByNeutrinoVertex; ///< Whether to filter output by neutrino vertex position (e.g. fiducial volume cut)
-    float                   m_detectorHalfLengthX;          ///< Half length of detector in x dimension
-    float                   m_detectorHalfLengthY;          ///< Half length of detector in y dimension
-    float                   m_detectorHalfLengthZ;          ///< Half length of detector in z dimension
-    float                   m_coordinateOffsetX;            ///< Origin offset (from detector corner) in x dimension
-    float                   m_coordinateOffsetY;            ///< Origin offset (from detector corner) in y dimension
-    float                   m_coordinateOffsetZ;            ///< Origin offset (from detector corner) in z dimension
-    float                   m_selectedBorderX;              ///< Required distance from detector edge in x dimension
-    float                   m_selectedBorderY;              ///< Required distance from detector edge in y dimension
-    float                   m_selectedBorderZ;              ///< Required distance from detector edge in z dimension
+    bool m_shouldFilterByNeutrinoVertex; ///< Whether to filter output by neutrino vertex position (e.g. fiducial volume cut)
+    float m_detectorHalfLengthX;         ///< Half length of detector in x dimension
+    float m_detectorHalfLengthY;         ///< Half length of detector in y dimension
+    float m_detectorHalfLengthZ;         ///< Half length of detector in z dimension
+    float m_coordinateOffsetX;           ///< Origin offset (from detector corner) in x dimension
+    float m_coordinateOffsetY;           ///< Origin offset (from detector corner) in y dimension
+    float m_coordinateOffsetZ;           ///< Origin offset (from detector corner) in z dimension
+    float m_selectedBorderX;             ///< Required distance from detector edge in x dimension
+    float m_selectedBorderY;             ///< Required distance from detector edge in y dimension
+    float m_selectedBorderZ;             ///< Required distance from detector edge in z dimension
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArPlugins/LArParticleIdPlugins.cc
+++ b/larpandoracontent/LArPlugins/LArParticleIdPlugins.cc
@@ -28,7 +28,7 @@ using namespace pandora;
 
 LArParticleIdPlugins::LArMuonId::LArMuonId() :
     m_layerFitHalfWindow(20),
-    m_minLayerOccupancy (0.75f),
+    m_minLayerOccupancy(0.75f),
     m_maxTrackWidth(0.5f),
     m_trackResidualQuantile(0.8f),
     m_minClustersPassingId(2)
@@ -116,20 +116,19 @@ float LArParticleIdPlugins::LArMuonId::GetMuonTrackWidth(const TwoDSlidingFitRes
 
 StatusCode LArParticleIdPlugins::LArMuonId::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LayerFitHalfWindow", m_layerFitHalfWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LayerFitHalfWindow", m_layerFitHalfWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinLayerOccupancy", m_minLayerOccupancy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinLayerOccupancy", m_minLayerOccupancy));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTrackWidth", m_maxTrackWidth));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxTrackWidth", m_maxTrackWidth));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrackResidualQuantile", m_trackResidualQuantile));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TrackResidualQuantile", m_trackResidualQuantile));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClustersPassingId", m_minClustersPassingId));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClustersPassingId", m_minClustersPassingId));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArPlugins/LArParticleIdPlugins.h
+++ b/larpandoracontent/LArPlugins/LArParticleIdPlugins.h
@@ -49,11 +49,11 @@ public:
 
         pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-        unsigned int    m_layerFitHalfWindow;       ///< Layer fit half window, used for calculating sliding muon track width
-        float           m_minLayerOccupancy;        ///< Min layer occupancy for for muon identification
-        float           m_maxTrackWidth;            ///< Max muon track width estimator for muon identification
-        float           m_trackResidualQuantile;    ///< Track residual quantile, used for calculating muon track width
-        unsigned int    m_minClustersPassingId;     ///< Match pfo if at sufficient clusters in pfo pass the cluster particle id logic
+        unsigned int m_layerFitHalfWindow;   ///< Layer fit half window, used for calculating sliding muon track width
+        float m_minLayerOccupancy;           ///< Min layer occupancy for for muon identification
+        float m_maxTrackWidth;               ///< Max muon track width estimator for muon identification
+        float m_trackResidualQuantile;       ///< Track residual quantile, used for calculating muon track width
+        unsigned int m_minClustersPassingId; ///< Match pfo if at sufficient clusters in pfo pass the cluster particle id logic
     };
 };
 

--- a/larpandoracontent/LArPlugins/LArPseudoLayerPlugin.cc
+++ b/larpandoracontent/LArPlugins/LArPseudoLayerPlugin.cc
@@ -24,10 +24,7 @@ namespace lar_content
 
 using namespace pandora;
 
-LArPseudoLayerPlugin::LArPseudoLayerPlugin() :
-    m_zPitch(std::numeric_limits<float>::max()),
-    m_zOffset(0.01f),
-    m_zerothLayer(5000)
+LArPseudoLayerPlugin::LArPseudoLayerPlugin() : m_zPitch(std::numeric_limits<float>::max()), m_zOffset(0.01f), m_zerothLayer(5000)
 {
 }
 

--- a/larpandoracontent/LArPlugins/LArPseudoLayerPlugin.h
+++ b/larpandoracontent/LArPlugins/LArPseudoLayerPlugin.h
@@ -31,9 +31,9 @@ private:
     pandora::StatusCode Initialize();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float           m_zPitch;       ///< The z pitch
-    float           m_zOffset;      ///< The z offset
-    unsigned int    m_zerothLayer;  ///< The zeroth layer
+    float m_zPitch;             ///< The z pitch
+    float m_zOffset;            ///< The z offset
+    unsigned int m_zerothLayer; ///< The zeroth layer
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -43,6 +43,6 @@ inline unsigned int LArPseudoLayerPlugin::GetPseudoLayerAtIp() const
     return 0;
 }
 
-} // namespace lar
+} // namespace lar_content
 
 #endif // #ifndef LAR_PSEUDO_LAYER_PLUGIN_H

--- a/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.cc
+++ b/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.cc
@@ -131,27 +131,29 @@ double LArRotationalTransformationPlugin::YZtoW(const double y, const double z) 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArRotationalTransformationPlugin::GetMinChiSquaredYZ(const double u, const double v, const double w, const double sigmaU, const double sigmaV,
-    const double sigmaW, double &y, double &z, double &chiSquared) const
+void LArRotationalTransformationPlugin::GetMinChiSquaredYZ(const double u, const double v, const double w, const double sigmaU,
+    const double sigmaV, const double sigmaW, double &y, double &z, double &chiSquared) const
 {
     const double sigmaU2(sigmaU * sigmaU), sigmaV2(sigmaV * sigmaV), sigmaW2(sigmaW * sigmaW);
 
     // Obtain expression for chi2, differentiate wrt y and z, set both results to zero and solve simultaneously. Here just paste-in result.
     y = (sigmaW2 * v * m_cosU * m_cosV * m_sinU - sigmaW2 * u * m_cosV * m_cosV * m_sinU + sigmaV2 * w * m_cosU * m_cosW * m_sinU -
-         sigmaV2 * u * m_cosW * m_cosW * m_sinU - sigmaW2 * v * m_cosU * m_cosU * m_sinV + sigmaW2 * u * m_cosU * m_cosV * m_sinV +
-         sigmaU2 * w * m_cosV * m_cosW * m_sinV - sigmaU2 * v * m_cosW * m_cosW * m_sinV - sigmaV2 * w * m_cosU * m_cosU * m_sinW -
-         sigmaU2 * w * m_cosV * m_cosV * m_sinW + sigmaV2 * u * m_cosU * m_cosW * m_sinW + sigmaU2 * v * m_cosV * m_cosW * m_sinW) /
+            sigmaV2 * u * m_cosW * m_cosW * m_sinU - sigmaW2 * v * m_cosU * m_cosU * m_sinV + sigmaW2 * u * m_cosU * m_cosV * m_sinV +
+            sigmaU2 * w * m_cosV * m_cosW * m_sinV - sigmaU2 * v * m_cosW * m_cosW * m_sinV - sigmaV2 * w * m_cosU * m_cosU * m_sinW -
+            sigmaU2 * w * m_cosV * m_cosV * m_sinW + sigmaV2 * u * m_cosU * m_cosW * m_sinW + sigmaU2 * v * m_cosV * m_cosW * m_sinW) /
         (sigmaW2 * m_cosV * m_cosV * m_sinU * m_sinU + sigmaV2 * m_cosW * m_cosW * m_sinU * m_sinU - 2. * sigmaW2 * m_cosU * m_cosV * m_sinU * m_sinV +
-         sigmaW2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaU2 * m_cosW * m_cosW * m_sinV * m_sinV - 2. * sigmaV2 * m_cosU * m_cosW * m_sinU * m_sinW -
-         2. * sigmaU2 * m_cosV * m_cosW * m_sinV * m_sinW + sigmaV2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaU2 * m_cosV * m_cosV * m_sinW * m_sinW);
+            sigmaW2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaU2 * m_cosW * m_cosW * m_sinV * m_sinV -
+            2. * sigmaV2 * m_cosU * m_cosW * m_sinU * m_sinW - 2. * sigmaU2 * m_cosV * m_cosW * m_sinV * m_sinW +
+            sigmaV2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaU2 * m_cosV * m_cosV * m_sinW * m_sinW);
 
     z = (sigmaW2 * v * m_cosV * m_sinU * m_sinU + sigmaV2 * w * m_cosW * m_sinU * m_sinU - sigmaW2 * v * m_cosU * m_sinU * m_sinV -
-         sigmaW2 * u * m_cosV * m_sinU * m_sinV + sigmaW2 * u * m_cosU * m_sinV * m_sinV + sigmaU2 * w * m_cosW * m_sinV * m_sinV -
-         sigmaV2 * w * m_cosU * m_sinU * m_sinW - sigmaV2 * u * m_cosW * m_sinU * m_sinW - sigmaU2 * w * m_cosV * m_sinV * m_sinW -
-         sigmaU2 * v * m_cosW * m_sinV * m_sinW + sigmaV2 * u * m_cosU * m_sinW * m_sinW + sigmaU2 * v * m_cosV * m_sinW * m_sinW) /
+            sigmaW2 * u * m_cosV * m_sinU * m_sinV + sigmaW2 * u * m_cosU * m_sinV * m_sinV + sigmaU2 * w * m_cosW * m_sinV * m_sinV -
+            sigmaV2 * w * m_cosU * m_sinU * m_sinW - sigmaV2 * u * m_cosW * m_sinU * m_sinW - sigmaU2 * w * m_cosV * m_sinV * m_sinW -
+            sigmaU2 * v * m_cosW * m_sinV * m_sinW + sigmaV2 * u * m_cosU * m_sinW * m_sinW + sigmaU2 * v * m_cosV * m_sinW * m_sinW) /
         (sigmaW2 * m_cosV * m_cosV * m_sinU * m_sinU + sigmaV2 * m_cosW * m_cosW * m_sinU * m_sinU - 2. * sigmaW2 * m_cosU * m_cosV * m_sinU * m_sinV +
-         sigmaW2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaU2 * m_cosW * m_cosW * m_sinV * m_sinV - 2. * sigmaV2 * m_cosU * m_cosW * m_sinU * m_sinW -
-         2. * sigmaU2 * m_cosV * m_cosW * m_sinV * m_sinW + sigmaV2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaU2 * m_cosV * m_cosV * m_sinW * m_sinW);
+            sigmaW2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaU2 * m_cosW * m_cosW * m_sinV * m_sinV -
+            2. * sigmaV2 * m_cosU * m_cosW * m_sinU * m_sinW - 2. * sigmaU2 * m_cosV * m_cosW * m_sinV * m_sinW +
+            sigmaV2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaU2 * m_cosV * m_cosV * m_sinW * m_sinW);
 
     const double deltaU(u - LArRotationalTransformationPlugin::YZtoU(y, z));
     const double deltaV(v - LArRotationalTransformationPlugin::YZtoV(y, z));
@@ -168,90 +170,94 @@ void LArRotationalTransformationPlugin::GetMinChiSquaredYZ(const double u, const
 
     // Obtain expression for chi2, differentiate wrt y and z, set both results to zero and solve simultaneously. Here just paste-in result.
     y = (vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosV * m_sinU + vFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU +
-         sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosU * m_cosV * m_sinU + sigmaW2 * sigmaFit2 * sigmaFit2 * v * m_cosU * m_cosV * m_sinU -
-         uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinU - uFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinU -
-         sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosV * m_cosV * m_sinU - sigmaW2 * sigmaFit2 * sigmaFit2 * u * m_cosV * m_cosV * m_sinU +
-         wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosW * m_sinU + wFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosW * m_sinU +
-         sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosU * m_cosW * m_sinU + sigmaV2 * sigmaFit2 * sigmaFit2 * w * m_cosU * m_cosW * m_sinU -
-         uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinU - uFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinU -
-         sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosW * m_cosW * m_sinU - sigmaV2 * sigmaFit2 * sigmaFit2 * u * m_cosW * m_cosW * m_sinU -
-         vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinV - vFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV -
-         sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosU * m_cosU * m_sinV - sigmaW2 * sigmaFit2 * sigmaFit2 * v * m_cosU * m_cosU * m_sinV +
-         uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosV * m_sinV + uFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinV +
-         sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosU * m_cosV * m_sinV + sigmaW2 * sigmaFit2 * sigmaFit2 * u * m_cosU * m_cosV * m_sinV +
-         wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosW * m_sinV + wFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosW * m_sinV +
-         sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosV * m_cosW * m_sinV + sigmaU2 * sigmaFit2 * sigmaFit2 * w * m_cosV * m_cosW * m_sinV -
-         vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinV - vFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinV -
-         sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosW * m_cosW * m_sinV - sigmaU2 * sigmaFit2 * sigmaFit2 * v * m_cosW * m_cosW * m_sinV -
-         wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinW - wFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinW -
-         sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosU * m_cosU * m_sinW - sigmaV2 * sigmaFit2 * sigmaFit2 * w * m_cosU * m_cosU * m_sinW -
-         wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinW - wFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinW -
-         sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosV * m_cosV * m_sinW - sigmaU2 * sigmaFit2 * sigmaFit2 * w * m_cosV * m_cosV * m_sinW +
-         uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosW * m_sinW + uFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosW * m_sinW +
-         sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosU * m_cosW * m_sinW + sigmaV2 * sigmaFit2 * sigmaFit2 * u * m_cosU * m_cosW * m_sinW +
-         vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosW * m_sinW + vFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosW * m_sinW +
-         sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosV * m_cosW * m_sinW + sigmaU2 * sigmaFit2 * sigmaFit2 * v * m_cosV * m_cosW * m_sinW) /
+            sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosU * m_cosV * m_sinU + sigmaW2 * sigmaFit2 * sigmaFit2 * v * m_cosU * m_cosV * m_sinU -
+            uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinU - uFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinU -
+            sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosV * m_cosV * m_sinU - sigmaW2 * sigmaFit2 * sigmaFit2 * u * m_cosV * m_cosV * m_sinU +
+            wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosW * m_sinU + wFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosW * m_sinU +
+            sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosU * m_cosW * m_sinU + sigmaV2 * sigmaFit2 * sigmaFit2 * w * m_cosU * m_cosW * m_sinU -
+            uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinU - uFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinU -
+            sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosW * m_cosW * m_sinU - sigmaV2 * sigmaFit2 * sigmaFit2 * u * m_cosW * m_cosW * m_sinU -
+            vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinV - vFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV -
+            sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosU * m_cosU * m_sinV - sigmaW2 * sigmaFit2 * sigmaFit2 * v * m_cosU * m_cosU * m_sinV +
+            uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosV * m_sinV + uFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinV +
+            sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosU * m_cosV * m_sinV + sigmaW2 * sigmaFit2 * sigmaFit2 * u * m_cosU * m_cosV * m_sinV +
+            wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosW * m_sinV + wFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosW * m_sinV +
+            sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosV * m_cosW * m_sinV + sigmaU2 * sigmaFit2 * sigmaFit2 * w * m_cosV * m_cosW * m_sinV -
+            vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinV - vFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinV -
+            sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosW * m_cosW * m_sinV - sigmaU2 * sigmaFit2 * sigmaFit2 * v * m_cosW * m_cosW * m_sinV -
+            wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinW - wFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinW -
+            sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosU * m_cosU * m_sinW - sigmaV2 * sigmaFit2 * sigmaFit2 * w * m_cosU * m_cosU * m_sinW -
+            wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinW - wFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinW -
+            sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosV * m_cosV * m_sinW - sigmaU2 * sigmaFit2 * sigmaFit2 * w * m_cosV * m_cosV * m_sinW +
+            uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosW * m_sinW + uFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosW * m_sinW +
+            sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosU * m_cosW * m_sinW + sigmaV2 * sigmaFit2 * sigmaFit2 * u * m_cosU * m_cosW * m_sinW +
+            vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosW * m_sinW + vFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosW * m_sinW +
+            sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosV * m_cosW * m_sinW + sigmaU2 * sigmaFit2 * sigmaFit2 * v * m_cosV * m_cosW * m_sinW) /
         (sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinU * m_sinU + sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU +
-         sigmaV2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU + sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinU * m_sinU + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU +
-         sigmaV2 * sigmaW2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU + sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU -
-         2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosV * m_sinU * m_sinV - 2. * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV -
-         2. * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV - 2. * sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV +
-         sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinV * m_sinV + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV +
-         sigmaU2 * sigmaW2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV + sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV -
-         2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosW * m_sinU * m_sinW - 2. * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW -
-         2. * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW - 2. * sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW -
-         2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosW * m_sinV * m_sinW - 2. * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW -
-         2. * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW - 2. * sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW +
-         sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW +
-         sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW+sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW);
+            sigmaV2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU + sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU +
+            sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinU * m_sinU + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU +
+            sigmaV2 * sigmaW2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU + sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU -
+            2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosV * m_sinU * m_sinV - 2. * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV -
+            2. * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV -
+            2. * sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV + sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinV * m_sinV +
+            sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV +
+            sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinV * m_sinV +
+            sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV + sigmaU2 * sigmaW2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV +
+            sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV - 2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosW * m_sinU * m_sinW -
+            2. * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW - 2. * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW -
+            2. * sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW -
+            2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosW * m_sinV * m_sinW - 2. * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW -
+            2. * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW -
+            2. * sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW +
+            sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW +
+            sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW +
+            sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW +
+            sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW);
 
     z = (vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_sinU * m_sinU + vFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosV * m_sinU * m_sinU +
-         sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosV * m_sinU * m_sinU + sigmaW2 * sigmaFit2 * sigmaFit2 * v * m_cosV * m_sinU * m_sinU +
-         wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_sinU * m_sinU + wFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosW * m_sinU * m_sinU +
-         sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosW * m_sinU * m_sinU + sigmaV2 * sigmaFit2 * sigmaFit2 * w * m_cosW * m_sinU * m_sinU -
-         vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_sinU * m_sinV - vFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_sinU * m_sinV -
-         sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosU * m_sinU * m_sinV - sigmaW2 * sigmaFit2 * sigmaFit2 * v * m_cosU * m_sinU * m_sinV -
-         uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_sinU * m_sinV - uFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_sinU * m_sinV -
-         sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosV * m_sinU * m_sinV - sigmaW2 * sigmaFit2 * sigmaFit2 * u * m_cosV * m_sinU * m_sinV +
-         uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_sinV * m_sinV + uFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_sinV * m_sinV +
-         sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosU * m_sinV * m_sinV + sigmaW2 * sigmaFit2 * sigmaFit2 * u * m_cosU * m_sinV * m_sinV +
-         wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_sinV * m_sinV + wFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosW * m_sinV * m_sinV +
-         sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosW * m_sinV * m_sinV + sigmaU2 * sigmaFit2 * sigmaFit2 * w * m_cosW * m_sinV * m_sinV -
-         wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_sinU * m_sinW - wFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_sinU * m_sinW -
-         sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosU * m_sinU * m_sinW - sigmaV2 * sigmaFit2 * sigmaFit2 * w * m_cosU * m_sinU * m_sinW -
-         uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_sinU * m_sinW - uFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_sinU * m_sinW -
-         sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosW * m_sinU * m_sinW - sigmaV2 * sigmaFit2 * sigmaFit2 * u * m_cosW * m_sinU * m_sinW -
-         wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_sinV * m_sinW - wFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_sinV * m_sinW -
-         sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosV * m_sinV * m_sinW - sigmaU2 * sigmaFit2 * sigmaFit2 * w * m_cosV * m_sinV * m_sinW -
-         vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_sinV * m_sinW - vFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_sinV * m_sinW -
-         sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosW * m_sinV * m_sinW - sigmaU2 * sigmaFit2 * sigmaFit2 * v * m_cosW * m_sinV * m_sinW +
-         uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_sinW * m_sinW + uFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_sinW * m_sinW +
-         sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosU * m_sinW * m_sinW + sigmaV2 * sigmaFit2 * sigmaFit2 * u * m_cosU * m_sinW * m_sinW +
-         vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_sinW * m_sinW + vFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_sinW * m_sinW +
-         sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaFit2 * sigmaFit2 * v * m_cosV * m_sinW * m_sinW) /
+            sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosV * m_sinU * m_sinU + sigmaW2 * sigmaFit2 * sigmaFit2 * v * m_cosV * m_sinU * m_sinU +
+            wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_sinU * m_sinU + wFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosW * m_sinU * m_sinU +
+            sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosW * m_sinU * m_sinU + sigmaV2 * sigmaFit2 * sigmaFit2 * w * m_cosW * m_sinU * m_sinU -
+            vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_sinU * m_sinV - vFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_sinU * m_sinV -
+            sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosU * m_sinU * m_sinV - sigmaW2 * sigmaFit2 * sigmaFit2 * v * m_cosU * m_sinU * m_sinV -
+            uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_sinU * m_sinV - uFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_sinU * m_sinV -
+            sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosV * m_sinU * m_sinV - sigmaW2 * sigmaFit2 * sigmaFit2 * u * m_cosV * m_sinU * m_sinV +
+            uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_sinV * m_sinV + uFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_sinV * m_sinV +
+            sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosU * m_sinV * m_sinV + sigmaW2 * sigmaFit2 * sigmaFit2 * u * m_cosU * m_sinV * m_sinV +
+            wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_sinV * m_sinV + wFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosW * m_sinV * m_sinV +
+            sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosW * m_sinV * m_sinV + sigmaU2 * sigmaFit2 * sigmaFit2 * w * m_cosW * m_sinV * m_sinV -
+            wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_sinU * m_sinW - wFit * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_sinU * m_sinW -
+            sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosU * m_sinU * m_sinW - sigmaV2 * sigmaFit2 * sigmaFit2 * w * m_cosU * m_sinU * m_sinW -
+            uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_sinU * m_sinW - uFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_sinU * m_sinW -
+            sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosW * m_sinU * m_sinW - sigmaV2 * sigmaFit2 * sigmaFit2 * u * m_cosW * m_sinU * m_sinW -
+            wFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_sinV * m_sinW - wFit * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_sinV * m_sinW -
+            sigmaU2 * sigmaV2 * sigmaFit2 * w * m_cosV * m_sinV * m_sinW - sigmaU2 * sigmaFit2 * sigmaFit2 * w * m_cosV * m_sinV * m_sinW -
+            vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_sinV * m_sinW - vFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_sinV * m_sinW -
+            sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosW * m_sinV * m_sinW - sigmaU2 * sigmaFit2 * sigmaFit2 * v * m_cosW * m_sinV * m_sinW +
+            uFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_sinW * m_sinW + uFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_sinW * m_sinW +
+            sigmaV2 * sigmaW2 * sigmaFit2 * u * m_cosU * m_sinW * m_sinW + sigmaV2 * sigmaFit2 * sigmaFit2 * u * m_cosU * m_sinW * m_sinW +
+            vFit * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_sinW * m_sinW + vFit * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_sinW * m_sinW +
+            sigmaU2 * sigmaW2 * sigmaFit2 * v * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaFit2 * sigmaFit2 * v * m_cosV * m_sinW * m_sinW) /
         (sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinU * m_sinU + sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU +
-         sigmaV2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU + sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinU * m_sinU + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU +
-         sigmaV2 * sigmaW2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU + sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU -
-         2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosV * m_sinU * m_sinV-2. * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV -
-         2. * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV-2. * sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV +
-         sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinV * m_sinV + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV +
-         sigmaU2 * sigmaW2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV + sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV -
-         2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosW * m_sinU * m_sinW - 2. * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW -
-         2. * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW - 2. * sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW -
-         2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosW * m_sinV * m_sinW - 2. * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW -
-         2. * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW - 2. * sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW +
-         sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW +
-         sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW +
-         sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW);
+            sigmaV2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU + sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosV * m_sinU * m_sinU +
+            sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinU * m_sinU + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU +
+            sigmaV2 * sigmaW2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU + sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosW * m_cosW * m_sinU * m_sinU -
+            2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosV * m_sinU * m_sinV - 2. * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV -
+            2. * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV -
+            2. * sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosV * m_sinU * m_sinV + sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinV * m_sinV +
+            sigmaU2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV +
+            sigmaW2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosU * m_sinV * m_sinV + sigmaU2 * sigmaV2 * sigmaW2 * m_cosW * m_cosW * m_sinV * m_sinV +
+            sigmaU2 * sigmaV2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV + sigmaU2 * sigmaW2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV +
+            sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosW * m_cosW * m_sinV * m_sinV - 2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosW * m_sinU * m_sinW -
+            2. * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW - 2. * sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW -
+            2. * sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosW * m_sinU * m_sinW -
+            2. * sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosW * m_sinV * m_sinW - 2. * sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW -
+            2. * sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW -
+            2. * sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosW * m_sinV * m_sinW +
+            sigmaU2 * sigmaV2 * sigmaW2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW +
+            sigmaV2 * sigmaW2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW + sigmaV2 * sigmaFit2 * sigmaFit2 * m_cosU * m_cosU * m_sinW * m_sinW +
+            sigmaU2 * sigmaV2 * sigmaW2 * m_cosV * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaV2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW +
+            sigmaU2 * sigmaW2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW + sigmaU2 * sigmaFit2 * sigmaFit2 * m_cosV * m_cosV * m_sinW * m_sinW);
 
     const double outputU(LArRotationalTransformationPlugin::YZtoU(y, z));
     const double outputV(LArRotationalTransformationPlugin::YZtoV(y, z));
@@ -261,9 +267,8 @@ void LArRotationalTransformationPlugin::GetMinChiSquaredYZ(const double u, const
     const double deltaUFit(uFit - outputU), deltaVFit(vFit - outputV), deltaWFit(wFit - outputW);
 
     chiSquared = ((deltaU * deltaU) / sigmaU2) + ((deltaV * deltaV) / sigmaV2) + ((deltaW * deltaW) / sigmaW2) +
-        ((deltaUFit * deltaUFit) / sigmaFit2) + ((deltaVFit * deltaVFit) / sigmaFit2) + ((deltaWFit * deltaWFit) / sigmaFit2);
+                 ((deltaUFit * deltaUFit) / sigmaFit2) + ((deltaVFit * deltaVFit) / sigmaFit2) + ((deltaWFit * deltaWFit) / sigmaFit2);
 }
-
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -294,10 +299,11 @@ StatusCode LArRotationalTransformationPlugin::Initialize()
     m_sinWminusV = std::sin(m_thetaW - m_thetaV);
     m_sinUminusW = std::sin(m_thetaU - m_thetaW);
 
-    if ((std::fabs(m_sinVminusU) < std::numeric_limits<double>::epsilon()) || (std::fabs(m_sinWminusV) < std::numeric_limits<double>::epsilon()) ||
-        (std::fabs(m_sinUminusW) < std::numeric_limits<double>::epsilon()))
+    if ((std::fabs(m_sinVminusU) < std::numeric_limits<double>::epsilon()) ||
+        (std::fabs(m_sinWminusV) < std::numeric_limits<double>::epsilon()) || (std::fabs(m_sinUminusW) < std::numeric_limits<double>::epsilon()))
     {
-        std::cout << "LArRotationalTransformationPlugin::Initialize - Equal wire angles; Plugin does not support provided LArTPC configurations. " << std::endl;
+        std::cout << "LArRotationalTransformationPlugin::Initialize - Equal wire angles; Plugin does not support provided LArTPC configurations. "
+                  << std::endl;
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
@@ -310,7 +316,8 @@ StatusCode LArRotationalTransformationPlugin::Initialize()
             (std::fabs(m_thetaW - pLArTPC->GetWireAngleW()) > m_maxAngularDiscrepancyW) ||
             (std::fabs(sigmaUVW - pLArTPC->GetSigmaUVW()) > m_maxSigmaDiscrepancy))
         {
-            std::cout << "LArRotationalTransformationPlugin::Initialize - Dissimilar drift volumes; Plugin does not support provided LArTPC configurations. " << std::endl;
+            std::cout << "LArRotationalTransformationPlugin::Initialize - Dissimilar drift volumes; Plugin does not support provided LArTPC configurations. "
+                      << std::endl;
             return STATUS_CODE_INVALID_PARAMETER;
         }
     }
@@ -322,17 +329,17 @@ StatusCode LArRotationalTransformationPlugin::Initialize()
 
 pandora::StatusCode LArRotationalTransformationPlugin::ReadSettings(const pandora::TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAngularDiscrepancyU", m_maxAngularDiscrepancyU));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAngularDiscrepancyU", m_maxAngularDiscrepancyU));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAngularDiscrepancyV", m_maxAngularDiscrepancyV));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAngularDiscrepancyV", m_maxAngularDiscrepancyV));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAngularDiscrepancyW", m_maxAngularDiscrepancyW));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAngularDiscrepancyW", m_maxAngularDiscrepancyW));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxSigmaDiscrepancy", m_maxSigmaDiscrepancy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxSigmaDiscrepancy", m_maxSigmaDiscrepancy));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.h
+++ b/larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.h
@@ -39,8 +39,8 @@ public:
     virtual double YZtoV(const double y, const double z) const;
     virtual double YZtoW(const double y, const double z) const;
 
-    virtual void GetMinChiSquaredYZ(const double u, const double v, const double w, const double sigmaU, const double sigmaV, const double sigmaW,
-        double &y, double &z, double &chiSquared) const;
+    virtual void GetMinChiSquaredYZ(const double u, const double v, const double w, const double sigmaU, const double sigmaV,
+        const double sigmaW, double &y, double &z, double &chiSquared) const;
     virtual void GetMinChiSquaredYZ(const double u, const double v, const double w, const double sigmaU, const double sigmaV, const double sigmaW,
         const double uFit, const double vFit, const double wFit, const double sigmaFit, double &y, double &z, double &chiSquared) const;
 
@@ -48,24 +48,24 @@ private:
     pandora::StatusCode Initialize();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    double    m_thetaU;                 ///< inclination of U wires (radians)
-    double    m_thetaV;                 ///< inclination of V wires (radians)
-    double    m_thetaW;                 ///< inclination of W wires (radians)
+    double m_thetaU; ///< inclination of U wires (radians)
+    double m_thetaV; ///< inclination of V wires (radians)
+    double m_thetaW; ///< inclination of W wires (radians)
 
-    double    m_sinU;                   ///< sin(thetaU)
-    double    m_sinV;                   ///< sin(thetaV)
-    double    m_sinW;                   ///< sin(thetaW)
-    double    m_cosU;                   ///< cos(thetaU)
-    double    m_cosV;                   ///< cos(thetaV)
-    double    m_cosW;                   ///< cos(thetaW)
-    double    m_sinVminusU;             ///< sin(thetaV - thetaU)
-    double    m_sinWminusV;             ///< sin(thetaW - thetaV)
-    double    m_sinUminusW;             ///< sin(thetaU - thetaW)
+    double m_sinU;       ///< sin(thetaU)
+    double m_sinV;       ///< sin(thetaV)
+    double m_sinW;       ///< sin(thetaW)
+    double m_cosU;       ///< cos(thetaU)
+    double m_cosV;       ///< cos(thetaV)
+    double m_cosW;       ///< cos(thetaW)
+    double m_sinVminusU; ///< sin(thetaV - thetaU)
+    double m_sinWminusV; ///< sin(thetaW - thetaV)
+    double m_sinUminusW; ///< sin(thetaU - thetaW)
 
-    double    m_maxAngularDiscrepancyU; ///< Maximum allowed difference between u wire angles between LArTPCs
-    double    m_maxAngularDiscrepancyV; ///< Maximum allowed difference between v wire angles between LArTPCs
-    double    m_maxAngularDiscrepancyW; ///< Maximum allowed difference between w wire angles between LArTPCs
-    double    m_maxSigmaDiscrepancy;    ///< Maximum allowed difference between like wire sigma values between LArTPCs
+    double m_maxAngularDiscrepancyU; ///< Maximum allowed difference between u wire angles between LArTPCs
+    double m_maxAngularDiscrepancyV; ///< Maximum allowed difference between v wire angles between LArTPCs
+    double m_maxAngularDiscrepancyW; ///< Maximum allowed difference between w wire angles between LArTPCs
+    double m_maxSigmaDiscrepancy;    ///< Maximum allowed difference between like wire sigma values between LArTPCs
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.cc
@@ -52,8 +52,8 @@ StatusCode CosmicRayBaseMatchingAlgorithm::Run()
 StatusCode CosmicRayBaseMatchingAlgorithm::GetAvailableClusters(const std::string inputClusterListName, ClusterVector &clusterVector) const
 {
     const ClusterList *pClusterList = NULL;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this,
-        inputClusterListName, pClusterList))
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, inputClusterListName, pClusterList))
 
     if (!pClusterList || pClusterList->empty())
     {
@@ -78,8 +78,8 @@ StatusCode CosmicRayBaseMatchingAlgorithm::GetAvailableClusters(const std::strin
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayBaseMatchingAlgorithm::MatchClusters(const ClusterVector &clusterVector1, const ClusterVector &clusterVector2,
-    ClusterAssociationMap &matchedClusters12) const
+void CosmicRayBaseMatchingAlgorithm::MatchClusters(
+    const ClusterVector &clusterVector1, const ClusterVector &clusterVector2, ClusterAssociationMap &matchedClusters12) const
 {
     // Check that there are input clusters from both views
     if (clusterVector1.empty() || clusterVector2.empty())
@@ -109,8 +109,8 @@ void CosmicRayBaseMatchingAlgorithm::MatchClusters(const ClusterVector &clusterV
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayBaseMatchingAlgorithm::MatchThreeViews(const ClusterAssociationMap &matchedClusters12, const ClusterAssociationMap &matchedClusters23,
-    const ClusterAssociationMap &matchedClusters31, ParticleList &matchedParticles) const
+void CosmicRayBaseMatchingAlgorithm::MatchThreeViews(const ClusterAssociationMap &matchedClusters12,
+    const ClusterAssociationMap &matchedClusters23, const ClusterAssociationMap &matchedClusters31, ParticleList &matchedParticles) const
 {
     if (matchedClusters12.empty() || matchedClusters23.empty() || matchedClusters31.empty())
         return;
@@ -118,7 +118,8 @@ void CosmicRayBaseMatchingAlgorithm::MatchThreeViews(const ClusterAssociationMap
     ParticleList candidateParticles;
 
     ClusterList clusterList1;
-    for (const auto &mapEntry : matchedClusters12) clusterList1.push_back(mapEntry.first);
+    for (const auto &mapEntry : matchedClusters12)
+        clusterList1.push_back(mapEntry.first);
     clusterList1.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster1 : clusterList1)
@@ -151,9 +152,12 @@ void CosmicRayBaseMatchingAlgorithm::MatchThreeViews(const ClusterAssociationMap
                 if (!this->CheckMatchedClusters3D(pCluster1, pCluster2, pCluster3))
                     continue;
 
-                const Cluster *const pClusterU((TPC_VIEW_U == hitType1) ? pCluster1 : (TPC_VIEW_U == hitType2) ? pCluster2 : (TPC_VIEW_U == hitType3) ? pCluster3 : NULL);
-                const Cluster *const pClusterV((TPC_VIEW_V == hitType1) ? pCluster1 : (TPC_VIEW_V == hitType2) ? pCluster2 : (TPC_VIEW_V == hitType3) ? pCluster3 : NULL);
-                const Cluster *const pClusterW((TPC_VIEW_W == hitType1) ? pCluster1 : (TPC_VIEW_W == hitType2) ? pCluster2 : (TPC_VIEW_W == hitType3) ? pCluster3 : NULL);
+                const Cluster *const pClusterU(
+                    (TPC_VIEW_U == hitType1) ? pCluster1 : (TPC_VIEW_U == hitType2) ? pCluster2 : (TPC_VIEW_U == hitType3) ? pCluster3 : NULL);
+                const Cluster *const pClusterV(
+                    (TPC_VIEW_V == hitType1) ? pCluster1 : (TPC_VIEW_V == hitType2) ? pCluster2 : (TPC_VIEW_V == hitType3) ? pCluster3 : NULL);
+                const Cluster *const pClusterW(
+                    (TPC_VIEW_W == hitType1) ? pCluster1 : (TPC_VIEW_W == hitType2) ? pCluster2 : (TPC_VIEW_W == hitType3) ? pCluster3 : NULL);
 
                 candidateParticles.push_back(Particle(pClusterU, pClusterV, pClusterW));
             }
@@ -184,7 +188,8 @@ void CosmicRayBaseMatchingAlgorithm::MatchTwoViews(const ClusterAssociationMap &
         return;
 
     ClusterList clusterList1;
-    for (const auto &mapEntry : matchedClusters12) clusterList1.push_back(mapEntry.first);
+    for (const auto &mapEntry : matchedClusters12)
+        clusterList1.push_back(mapEntry.first);
     clusterList1.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster1 : clusterList1)
@@ -245,7 +250,8 @@ void CosmicRayBaseMatchingAlgorithm::BuildParticles(const ParticleList &particle
     if (particleList.empty())
         return;
 
-    const PfoList *pPfoList = NULL; std::string pfoListName;
+    const PfoList *pPfoList = NULL;
+    std::string pfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
     for (const Particle &particle : particleList)
@@ -258,7 +264,7 @@ void CosmicRayBaseMatchingAlgorithm::BuildParticles(const ParticleList &particle
         const bool isAvailableV((NULL != pClusterV) ? pClusterV->IsAvailable() : true);
         const bool isAvailableW((NULL != pClusterW) ? pClusterW->IsAvailable() : true);
 
-        if(!(isAvailableU && isAvailableV && isAvailableW))
+        if (!(isAvailableU && isAvailableV && isAvailableW))
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
         PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayBaseMatchingAlgorithm.h
@@ -40,13 +40,13 @@ protected:
          */
         Particle(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW);
 
-        const pandora::Cluster  *m_pClusterU;    ///< Address of cluster in U view
-        const pandora::Cluster  *m_pClusterV;    ///< Address of cluster in V view
-        const pandora::Cluster  *m_pClusterW;    ///< Address of cluster in W view
+        const pandora::Cluster *m_pClusterU; ///< Address of cluster in U view
+        const pandora::Cluster *m_pClusterV; ///< Address of cluster in V view
+        const pandora::Cluster *m_pClusterW; ///< Address of cluster in W view
     };
 
     typedef std::vector<Particle> ParticleList;
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterAssociationMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterAssociationMap;
     typedef std::set<unsigned int> UIntSet;
 
     /**
@@ -76,8 +76,8 @@ protected:
      *
      *  @return boolean
      */
-    virtual bool CheckMatchedClusters3D(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-        const pandora::Cluster *const pCluster3) const = 0;
+    virtual bool CheckMatchedClusters3D(
+        const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const pandora::Cluster *const pCluster3) const = 0;
 
     /**
      *  @brief  Calculate Pfo properties from proto particle
@@ -116,8 +116,7 @@ private:
      */
     void MatchThreeViews(const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters12,
         const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters23,
-        const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters31,
-        ParticleList &particleList) const;
+        const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters31, ParticleList &particleList) const;
 
     /**
      *  @brief Match clusters from two views and form into particles
@@ -129,8 +128,7 @@ private:
      */
     void MatchTwoViews(const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters12,
         const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters23,
-        const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters31,
-        ParticleList &particleList) const;
+        const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters31, ParticleList &particleList) const;
 
     /**
      *  @brief Match clusters from two views and form into particles
@@ -138,8 +136,7 @@ private:
      *  @param matchedClusters12 the map of matches between the first and second views
      *  @param particleList the output list of particles
      */
-    void MatchTwoViews(const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters12,
-        ParticleList &particleList) const;
+    void MatchTwoViews(const CosmicRayBaseMatchingAlgorithm::ClusterAssociationMap &matchedClusters12, ParticleList &particleList) const;
 
     /**
      *  @brief Remove ambiguities between candidate particles
@@ -156,10 +153,10 @@ private:
      */
     void BuildParticles(const ParticleList &particleList);
 
-    std::string    m_inputClusterListNameU;        ///< The name of the view U cluster list
-    std::string    m_inputClusterListNameV;        ///< The name of the view V cluster list
-    std::string    m_inputClusterListNameW;        ///< The name of the view W cluster list
-    std::string    m_outputPfoListName;            ///< The name of the output PFO list
+    std::string m_inputClusterListNameU; ///< The name of the view U cluster list
+    std::string m_inputClusterListNameV; ///< The name of the view V cluster list
+    std::string m_inputClusterListNameW; ///< The name of the view W cluster list
+    std::string m_outputPfoListName;     ///< The name of the output PFO list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayShowerMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayShowerMatchingAlgorithm.cc
@@ -10,8 +10,8 @@
 
 #include "larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayShowerMatchingAlgorithm.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 using namespace pandora;
 
@@ -61,8 +61,8 @@ bool CosmicRayShowerMatchingAlgorithm::MatchClusters(const Cluster *const pClust
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool CosmicRayShowerMatchingAlgorithm::CheckMatchedClusters3D(const Cluster *const pCluster1, const Cluster *const pCluster2,
-    const Cluster *const pCluster3) const
+bool CosmicRayShowerMatchingAlgorithm::CheckMatchedClusters3D(
+    const Cluster *const pCluster1, const Cluster *const pCluster2, const Cluster *const pCluster3) const
 {
     // Check that three clusters have a consistent 3D position
     const HitType hitType1(LArClusterHelper::GetClusterHitType(pCluster1));
@@ -111,9 +111,12 @@ bool CosmicRayShowerMatchingAlgorithm::CheckMatchedClusters3D(const Cluster *con
 void CosmicRayShowerMatchingAlgorithm::SetPfoParameters(const Particle &particle, PandoraContentApi::ParticleFlowObject::Parameters &pfoParameters) const
 {
     ClusterList clusterList;
-    if (particle.m_pClusterU) clusterList.push_back(particle.m_pClusterU);
-    if (particle.m_pClusterV) clusterList.push_back(particle.m_pClusterV);
-    if (particle.m_pClusterW) clusterList.push_back(particle.m_pClusterW);
+    if (particle.m_pClusterU)
+        clusterList.push_back(particle.m_pClusterU);
+    if (particle.m_pClusterV)
+        clusterList.push_back(particle.m_pClusterV);
+    if (particle.m_pClusterW)
+        clusterList.push_back(particle.m_pClusterW);
 
     // TODO Correct these placeholder parameters
     pfoParameters.m_particleId = E_MINUS; // SHOWER
@@ -128,17 +131,15 @@ void CosmicRayShowerMatchingAlgorithm::SetPfoParameters(const Particle &particle
 
 StatusCode CosmicRayShowerMatchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlap", m_minXOverlap));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlap", m_minXOverlap));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PseudoChi2Cut", m_pseudoChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PseudoChi2Cut", m_pseudoChi2Cut));
 
     return CosmicRayBaseMatchingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayShowerMatchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayShowerMatchingAlgorithm.h
@@ -25,19 +25,18 @@ public:
     CosmicRayShowerMatchingAlgorithm();
 
 private:
-
     void SelectCleanClusters(const pandora::ClusterVector &inputVector, pandora::ClusterVector &outputVector) const;
     bool MatchClusters(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2) const;
-    bool CheckMatchedClusters3D(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-        const pandora::Cluster *const pCluster3) const;
+    bool CheckMatchedClusters3D(
+        const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const pandora::Cluster *const pCluster3) const;
     void SetPfoParameters(const Particle &particle, PandoraContentApi::ParticleFlowObject::Parameters &pfoParameters) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float          m_minCaloHitsPerCluster;        ///< minimum size of clusters for this algorithm
-    float          m_minXOverlap;                  ///< requirement on minimum X overlap for associated clusters
-    float          m_minXOverlapFraction;          ///< requirement on minimum X overlap fraction for associated clusters
-    float          m_pseudoChi2Cut;                ///< The selection cut on the matched chi2
+    float m_minCaloHitsPerCluster; ///< minimum size of clusters for this algorithm
+    float m_minXOverlap;           ///< requirement on minimum X overlap for associated clusters
+    float m_minXOverlapFraction;   ///< requirement on minimum X overlap fraction for associated clusters
+    float m_pseudoChi2Cut;         ///< The selection cut on the matched chi2
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackMatchingAlgorithm.cc
@@ -10,8 +10,8 @@
 
 #include "larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackMatchingAlgorithm.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 using namespace pandora;
 
@@ -46,7 +46,7 @@ void CosmicRayTrackMatchingAlgorithm::SelectCleanClusters(const ClusterVector &i
     for (const Cluster *const pCluster : clusterVector)
     {
         const float lengthSquared(LArClusterHelper::GetLengthSquared(pCluster));
-        CartesianVector innerVertex(0.f,0.f,0.f), outerVertex(0.f,0.f,0.f);
+        CartesianVector innerVertex(0.f, 0.f, 0.f), outerVertex(0.f, 0.f, 0.f);
         LArClusterHelper::GetExtremalCoordinates(pCluster, innerVertex, outerVertex);
 
         bool isDeltaRay(false);
@@ -58,7 +58,7 @@ void CosmicRayTrackMatchingAlgorithm::SelectCleanClusters(const ClusterVector &i
 
             if ((LArClusterHelper::GetLengthSquared(pClusterCheck) > 10.f * lengthSquared) &&
                 (LArClusterHelper::GetClosestDistance(innerVertex, pClusterCheck) < m_vtxXOverlap ||
-                 LArClusterHelper::GetClosestDistance(outerVertex, pClusterCheck) < m_vtxXOverlap))
+                    LArClusterHelper::GetClosestDistance(outerVertex, pClusterCheck) < m_vtxXOverlap))
             {
                 isDeltaRay = true;
                 break;
@@ -75,8 +75,8 @@ void CosmicRayTrackMatchingAlgorithm::SelectCleanClusters(const ClusterVector &i
 bool CosmicRayTrackMatchingAlgorithm::MatchClusters(const Cluster *const pCluster1, const Cluster *const pCluster2) const
 {
     // Use start and end points
-    CartesianVector innerVertex1(0.f,0.f,0.f), outerVertex1(0.f,0.f,0.f);
-    CartesianVector innerVertex2(0.f,0.f,0.f), outerVertex2(0.f,0.f,0.f);
+    CartesianVector innerVertex1(0.f, 0.f, 0.f), outerVertex1(0.f, 0.f, 0.f);
+    CartesianVector innerVertex2(0.f, 0.f, 0.f), outerVertex2(0.f, 0.f, 0.f);
 
     LArClusterHelper::GetExtremalCoordinates(pCluster1, innerVertex1, outerVertex1);
     LArClusterHelper::GetExtremalCoordinates(pCluster2, innerVertex2, outerVertex2);
@@ -97,8 +97,8 @@ bool CosmicRayTrackMatchingAlgorithm::MatchClusters(const Cluster *const pCluste
     pCluster1->GetClusterSpanX(xMin1, xMax1);
     pCluster2->GetClusterSpanX(xMin2, xMax2);
 
-    const float xOverlap(std::min(xMax1,xMax2) - std::max(xMin1,xMin2));
-    const float xSpan(std::max(xMax1,xMax2) - std::min(xMin1,xMin2));
+    const float xOverlap(std::min(xMax1, xMax2) - std::max(xMin1, xMin2));
+    const float xSpan(std::max(xMax1, xMax2) - std::min(xMin1, xMin2));
 
     if (xSpan < std::numeric_limits<float>::epsilon())
         return false;
@@ -111,8 +111,8 @@ bool CosmicRayTrackMatchingAlgorithm::MatchClusters(const Cluster *const pCluste
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool CosmicRayTrackMatchingAlgorithm::CheckMatchedClusters3D(const Cluster *const pCluster1, const Cluster *const pCluster2,
-    const Cluster *const pCluster3) const
+bool CosmicRayTrackMatchingAlgorithm::CheckMatchedClusters3D(
+    const Cluster *const pCluster1, const Cluster *const pCluster2, const Cluster *const pCluster3) const
 {
     // Check that three clusters have a consistent 3D position
     const HitType hitType1(LArClusterHelper::GetClusterHitType(pCluster1));
@@ -122,9 +122,9 @@ bool CosmicRayTrackMatchingAlgorithm::CheckMatchedClusters3D(const Cluster *cons
     if (hitType1 == hitType2 || hitType2 == hitType3 || hitType3 == hitType1)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    CartesianVector innerVertex1(0.f,0.f,0.f), outerVertex1(0.f,0.f,0.f);
-    CartesianVector innerVertex2(0.f,0.f,0.f), outerVertex2(0.f,0.f,0.f);
-    CartesianVector innerVertex3(0.f,0.f,0.f), outerVertex3(0.f,0.f,0.f);
+    CartesianVector innerVertex1(0.f, 0.f, 0.f), outerVertex1(0.f, 0.f, 0.f);
+    CartesianVector innerVertex2(0.f, 0.f, 0.f), outerVertex2(0.f, 0.f, 0.f);
+    CartesianVector innerVertex3(0.f, 0.f, 0.f), outerVertex3(0.f, 0.f, 0.f);
 
     LArClusterHelper::GetExtremalCoordinates(pCluster1, innerVertex1, outerVertex1);
     LArClusterHelper::GetExtremalCoordinates(pCluster2, innerVertex2, outerVertex2);
@@ -149,9 +149,9 @@ bool CosmicRayTrackMatchingAlgorithm::CheckMatchedClusters3D(const Cluster *cons
             std::fabs(end3.GetX() - end1.GetX()) < std::max(m_vtxXOverlap, std::fabs(end3.GetX() - vtx1.GetX())))
         {
             float chi2(0.f);
-            CartesianVector projVtx1(0.f,0.f,0.f), projEnd1(0.f,0.f,0.f);
-            CartesianVector projVtx2(0.f,0.f,0.f), projEnd2(0.f,0.f,0.f);
-            CartesianVector projVtx3(0.f,0.f,0.f), projEnd3(0.f,0.f,0.f);
+            CartesianVector projVtx1(0.f, 0.f, 0.f), projEnd1(0.f, 0.f, 0.f);
+            CartesianVector projVtx2(0.f, 0.f, 0.f), projEnd2(0.f, 0.f, 0.f);
+            CartesianVector projVtx3(0.f, 0.f, 0.f), projEnd3(0.f, 0.f, 0.f);
 
             LArGeometryHelper::MergeTwoPositions(this->GetPandora(), hitType1, hitType2, vtx1, vtx2, projVtx3, chi2);
             LArGeometryHelper::MergeTwoPositions(this->GetPandora(), hitType1, hitType2, end1, end2, projEnd3, chi2);
@@ -187,9 +187,12 @@ bool CosmicRayTrackMatchingAlgorithm::CheckMatchedClusters3D(const Cluster *cons
 void CosmicRayTrackMatchingAlgorithm::SetPfoParameters(const Particle &particle, PandoraContentApi::ParticleFlowObject::Parameters &pfoParameters) const
 {
     ClusterList clusterList;
-    if (particle.m_pClusterU) clusterList.push_back(particle.m_pClusterU);
-    if (particle.m_pClusterV) clusterList.push_back(particle.m_pClusterV);
-    if (particle.m_pClusterW) clusterList.push_back(particle.m_pClusterW);
+    if (particle.m_pClusterU)
+        clusterList.push_back(particle.m_pClusterU);
+    if (particle.m_pClusterV)
+        clusterList.push_back(particle.m_pClusterV);
+    if (particle.m_pClusterW)
+        clusterList.push_back(particle.m_pClusterW);
 
     // TODO Correct these placeholder parameters
     pfoParameters.m_particleId = MU_MINUS; // TRACK
@@ -204,20 +207,17 @@ void CosmicRayTrackMatchingAlgorithm::SetPfoParameters(const Particle &particle,
 
 StatusCode CosmicRayTrackMatchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMinLength", m_clusterMinLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterMinLength", m_clusterMinLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VtxXOverlap", m_vtxXOverlap));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VtxXOverlap", m_vtxXOverlap));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlap", m_minXOverlap));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlap", m_minXOverlap));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxDisplacement", m_maxDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxDisplacement", m_maxDisplacement));
 
     return CosmicRayBaseMatchingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackMatchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackMatchingAlgorithm.h
@@ -25,20 +25,19 @@ public:
     CosmicRayTrackMatchingAlgorithm();
 
 private:
-
     void SelectCleanClusters(const pandora::ClusterVector &inputVector, pandora::ClusterVector &outputVector) const;
     bool MatchClusters(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2) const;
-    bool CheckMatchedClusters3D(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-        const pandora::Cluster *const pCluster3) const;
+    bool CheckMatchedClusters3D(
+        const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const pandora::Cluster *const pCluster3) const;
     void SetPfoParameters(const Particle &protoParticle, PandoraContentApi::ParticleFlowObject::Parameters &pfoParameters) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float          m_clusterMinLength;             ///< minimum length of clusters for this algorithm
-    float          m_vtxXOverlap;                  ///< requirement on X overlap of start/end positions
-    float          m_minXOverlap;                  ///< requirement on minimum X overlap for associated clusters
-    float          m_minXOverlapFraction;          ///< requirement on minimum X overlap fraction for associated clusters
-    float          m_maxDisplacement;              ///< requirement on 3D consistency checks
+    float m_clusterMinLength;    ///< minimum length of clusters for this algorithm
+    float m_vtxXOverlap;         ///< requirement on X overlap of start/end positions
+    float m_minXOverlap;         ///< requirement on minimum X overlap for associated clusters
+    float m_minXOverlapFraction; ///< requirement on minimum X overlap fraction for associated clusters
+    float m_maxDisplacement;     ///< requirement on 3D consistency checks
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.cc
@@ -10,8 +10,8 @@
 
 #include "larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
 
 using namespace pandora;
@@ -59,14 +59,11 @@ StatusCode CosmicRayTrackRecoveryAlgorithm::Run()
     // Create candidate particles using one, two and three primary views
     ParticleList candidateParticles;
 
-    this->MatchThreeViews(cleanClustersU, cleanClustersV, cleanClustersW,
-        matchedClustersUV, matchedClustersVW, matchedClustersWU, candidateParticles);
+    this->MatchThreeViews(cleanClustersU, cleanClustersV, cleanClustersW, matchedClustersUV, matchedClustersVW, matchedClustersWU, candidateParticles);
 
-    this->MatchTwoViews(cleanClustersU, cleanClustersV, cleanClustersW,
-        matchedClustersUV, matchedClustersVW, matchedClustersWU, candidateParticles);
+    this->MatchTwoViews(cleanClustersU, cleanClustersV, cleanClustersW, matchedClustersUV, matchedClustersVW, matchedClustersWU, candidateParticles);
 
-    this->MatchOneView(cleanClustersU, cleanClustersV, cleanClustersW,
-        matchedClustersUV, matchedClustersVW, matchedClustersWU, candidateParticles);
+    this->MatchOneView(cleanClustersU, cleanClustersV, cleanClustersW, matchedClustersUV, matchedClustersVW, matchedClustersWU, candidateParticles);
 
     // Build particle flow objects from candidate particles
     this->BuildParticles(candidateParticles);
@@ -79,8 +76,8 @@ StatusCode CosmicRayTrackRecoveryAlgorithm::Run()
 StatusCode CosmicRayTrackRecoveryAlgorithm::GetAvailableClusters(const std::string &inputClusterListName, ClusterVector &clusterVector) const
 {
     const ClusterList *pClusterList = NULL;
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this,
-        inputClusterListName, pClusterList))
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, inputClusterListName, pClusterList))
 
     if (!pClusterList || pClusterList->empty())
     {
@@ -170,7 +167,7 @@ void CosmicRayTrackRecoveryAlgorithm::MatchViews(const ClusterVector &clusterVec
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTrackRecoveryAlgorithm::MatchClusters(const Cluster* const pSeedCluster, const ClusterVector &targetClusters,
+void CosmicRayTrackRecoveryAlgorithm::MatchClusters(const Cluster *const pSeedCluster, const ClusterVector &targetClusters,
     const TwoDSlidingFitResultMap &slidingFitResultMap, ClusterAssociationMap &clusterAssociationMap) const
 {
     // Match seed cluster to target clusters according to alignment in X position of start/end positions
@@ -226,7 +223,7 @@ void CosmicRayTrackRecoveryAlgorithm::MatchClusters(const Cluster* const pSeedCl
         const float xMax1(std::max(innerVertex1.GetX(), outerVertex1.GetX()));
         const float xMin2(std::min(innerVertex2.GetX(), outerVertex2.GetX()));
         const float xMax2(std::max(innerVertex2.GetX(), outerVertex2.GetX()));
-        const float xOverlap(std::min(xMax1,xMax2) - std::max(xMin1,xMin2));
+        const float xOverlap(std::min(xMax1, xMax2) - std::max(xMin1, xMin2));
 
         if (xOverlap < m_clusterMinOverlapX)
             continue;
@@ -287,8 +284,10 @@ void CosmicRayTrackRecoveryAlgorithm::MatchClusters(const Cluster* const pSeedCl
             return;
         }
 
-        const LArPointingCluster::Vertex pointingEndInner(pointingVertexInner.IsInnerVertex() ? pointingClusterInner.GetOuterVertex() : pointingClusterInner.GetInnerVertex());
-        const LArPointingCluster::Vertex pointingEndOuter(pointingVertexOuter.IsInnerVertex() ? pointingClusterOuter.GetOuterVertex() : pointingClusterOuter.GetInnerVertex());
+        const LArPointingCluster::Vertex pointingEndInner(
+            pointingVertexInner.IsInnerVertex() ? pointingClusterInner.GetOuterVertex() : pointingClusterInner.GetInnerVertex());
+        const LArPointingCluster::Vertex pointingEndOuter(
+            pointingVertexOuter.IsInnerVertex() ? pointingClusterOuter.GetOuterVertex() : pointingClusterOuter.GetInnerVertex());
 
         const float rSpan((pointingEndInner.GetPosition() - pointingEndOuter.GetPosition()).GetMagnitude());
 
@@ -310,7 +309,7 @@ void CosmicRayTrackRecoveryAlgorithm::MatchClusters(const Cluster* const pSeedCl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTrackRecoveryAlgorithm::MatchThreeViews(const ClusterVector &clusterVectorU,  const ClusterVector &clusterVectorV,
+void CosmicRayTrackRecoveryAlgorithm::MatchThreeViews(const ClusterVector &clusterVectorU, const ClusterVector &clusterVectorV,
     const ClusterVector &clusterVectorW, const ClusterAssociationMap &matchedClustersUV, const ClusterAssociationMap &matchedClustersVW,
     const ClusterAssociationMap &matchedClustersWU, ParticleList &particleList) const
 {
@@ -366,23 +365,32 @@ void CosmicRayTrackRecoveryAlgorithm::MatchThreeViews(const ClusterVector &clust
                 const ClusterAssociationMap::const_iterator iter313 = matchedClusters31.find(pCluster3);
                 const ClusterList matchedClusters31_pCluster3(iter313 != matchedClusters31.end() ? iter313->second : ClusterList());
 
-                const bool match12((matchedClusters12_pCluster1.size() +  matchedClusters12_pCluster2.size() > 0) &&
-                    ((matchedClusters12_pCluster1.size() == 1 && std::find(matchedClusters12_pCluster1.begin(), matchedClusters12_pCluster1.end(), pCluster2) != matchedClusters12_pCluster1.end()) ||
-                     (matchedClusters12_pCluster1.size() == 0)) &&
-                    ((matchedClusters12_pCluster2.size() == 1 && std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(), pCluster1) != matchedClusters12_pCluster2.end()) ||
-                     (matchedClusters12_pCluster2.size() == 0)));
+                const bool match12(
+                    (matchedClusters12_pCluster1.size() + matchedClusters12_pCluster2.size() > 0) &&
+                    ((matchedClusters12_pCluster1.size() == 1 && std::find(matchedClusters12_pCluster1.begin(), matchedClusters12_pCluster1.end(),
+                                                                     pCluster2) != matchedClusters12_pCluster1.end()) ||
+                        (matchedClusters12_pCluster1.size() == 0)) &&
+                    ((matchedClusters12_pCluster2.size() == 1 && std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(),
+                                                                     pCluster1) != matchedClusters12_pCluster2.end()) ||
+                        (matchedClusters12_pCluster2.size() == 0)));
 
-                const bool match23((matchedClusters23_pCluster2.size() +  matchedClusters23_pCluster3.size() > 0) &&
-                    ((matchedClusters23_pCluster2.size() == 1 && std::find(matchedClusters23_pCluster2.begin(), matchedClusters23_pCluster2.end(), pCluster3) != matchedClusters23_pCluster2.end()) ||
-                     (matchedClusters23_pCluster2.size() == 0)) &&
-                    ((matchedClusters23_pCluster3.size() == 1 && std::find(matchedClusters23_pCluster3.begin(), matchedClusters23_pCluster3.end(), pCluster2) != matchedClusters23_pCluster3.end()) ||
-                    (matchedClusters23_pCluster3.size() == 0)));
+                const bool match23(
+                    (matchedClusters23_pCluster2.size() + matchedClusters23_pCluster3.size() > 0) &&
+                    ((matchedClusters23_pCluster2.size() == 1 && std::find(matchedClusters23_pCluster2.begin(), matchedClusters23_pCluster2.end(),
+                                                                     pCluster3) != matchedClusters23_pCluster2.end()) ||
+                        (matchedClusters23_pCluster2.size() == 0)) &&
+                    ((matchedClusters23_pCluster3.size() == 1 && std::find(matchedClusters23_pCluster3.begin(), matchedClusters23_pCluster3.end(),
+                                                                     pCluster2) != matchedClusters23_pCluster3.end()) ||
+                        (matchedClusters23_pCluster3.size() == 0)));
 
-                const bool match31((matchedClusters31_pCluster3.size() +  matchedClusters31_pCluster1.size() > 0) &&
-                    ((matchedClusters31_pCluster3.size() == 1 && std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(), pCluster1) != matchedClusters31_pCluster3.end()) ||
-                    (matchedClusters31_pCluster3.size() == 0)) &&
-                    ((matchedClusters31_pCluster1.size() == 1 && std::find(matchedClusters31_pCluster1.begin(), matchedClusters31_pCluster1.end(), pCluster3) != matchedClusters31_pCluster1.end()) ||
-                    (matchedClusters31_pCluster1.size() == 0)));
+                const bool match31(
+                    (matchedClusters31_pCluster3.size() + matchedClusters31_pCluster1.size() > 0) &&
+                    ((matchedClusters31_pCluster3.size() == 1 && std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(),
+                                                                     pCluster1) != matchedClusters31_pCluster3.end()) ||
+                        (matchedClusters31_pCluster3.size() == 0)) &&
+                    ((matchedClusters31_pCluster1.size() == 1 && std::find(matchedClusters31_pCluster1.begin(), matchedClusters31_pCluster1.end(),
+                                                                     pCluster3) != matchedClusters31_pCluster1.end()) ||
+                        (matchedClusters31_pCluster1.size() == 0)));
 
                 if (match12 && match23 && match31)
                 {
@@ -401,7 +409,7 @@ void CosmicRayTrackRecoveryAlgorithm::MatchThreeViews(const ClusterVector &clust
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTrackRecoveryAlgorithm::MatchTwoViews(const ClusterVector &clusterVectorU,  const ClusterVector &clusterVectorV,
+void CosmicRayTrackRecoveryAlgorithm::MatchTwoViews(const ClusterVector &clusterVectorU, const ClusterVector &clusterVectorV,
     const ClusterVector &clusterVectorW, const ClusterAssociationMap &matchedClustersUV, const ClusterAssociationMap &matchedClustersVW,
     const ClusterAssociationMap &matchedClustersWU, ParticleList &particleList) const
 {
@@ -446,12 +454,15 @@ void CosmicRayTrackRecoveryAlgorithm::MatchTwoViews(const ClusterVector &cluster
                 const ClusterAssociationMap::const_iterator iter232 = matchedClusters23.find(pCluster2);
                 const ClusterList matchedClusters23_pCluster2(iter232 != matchedClusters23.end() ? iter232->second : ClusterList());
 
-                const bool match12((matchedClusters12_pCluster1.size() == 1 && std::find(matchedClusters12_pCluster1.begin(), matchedClusters12_pCluster1.end(), pCluster2) != matchedClusters12_pCluster1.end()) &&
-                    (matchedClusters12_pCluster2.size() == 1 && std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(), pCluster1) != matchedClusters12_pCluster2.end()) &&
+                const bool match12(
+                    (matchedClusters12_pCluster1.size() == 1 && std::find(matchedClusters12_pCluster1.begin(), matchedClusters12_pCluster1.end(),
+                                                                    pCluster2) != matchedClusters12_pCluster1.end()) &&
+                    (matchedClusters12_pCluster2.size() == 1 && std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(),
+                                                                    pCluster1) != matchedClusters12_pCluster2.end()) &&
                     (matchedClusters23_pCluster2.size() == 0 && matchedClusters31_pCluster1.size() == 0));
 
                 if (!match12)
-                continue;
+                    continue;
 
                 Particle newParticle;
                 newParticle.m_clusterList.push_back(pCluster1);
@@ -470,11 +481,15 @@ void CosmicRayTrackRecoveryAlgorithm::MatchTwoViews(const ClusterVector &cluster
                     const ClusterAssociationMap::const_iterator iter313 = matchedClusters31.find(pCluster3);
                     const ClusterList matchedClusters31_pCluster3(iter313 != matchedClusters31.end() ? iter313->second : ClusterList());
 
-                    const bool match3((matchedClusters31_pCluster3.size() +  matchedClusters23_pCluster3.size() > 0) &&
-                        ((matchedClusters31_pCluster3.size() == 1 && std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(), pCluster1) != matchedClusters31_pCluster3.end()) ||
-                        (matchedClusters31_pCluster3.size() == 0)) &&
-                        ((matchedClusters23_pCluster3.size() == 1 && std::find(matchedClusters23_pCluster3.begin(), matchedClusters23_pCluster3.end(), pCluster2) != matchedClusters23_pCluster3.end()) ||
-                        (matchedClusters23_pCluster3.size() == 0)));
+                    const bool match3((matchedClusters31_pCluster3.size() + matchedClusters23_pCluster3.size() > 0) &&
+                                      ((matchedClusters31_pCluster3.size() == 1 &&
+                                           std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(), pCluster1) !=
+                                               matchedClusters31_pCluster3.end()) ||
+                                          (matchedClusters31_pCluster3.size() == 0)) &&
+                                      ((matchedClusters23_pCluster3.size() == 1 &&
+                                           std::find(matchedClusters23_pCluster3.begin(), matchedClusters23_pCluster3.end(), pCluster2) !=
+                                               matchedClusters23_pCluster3.end()) ||
+                                          (matchedClusters23_pCluster3.size() == 0)));
 
                     if (match3)
                         newParticle.m_clusterList.push_back(pCluster3);
@@ -490,7 +505,7 @@ void CosmicRayTrackRecoveryAlgorithm::MatchTwoViews(const ClusterVector &cluster
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayTrackRecoveryAlgorithm::MatchOneView(const ClusterVector &clusterVectorU,  const ClusterVector &clusterVectorV,
+void CosmicRayTrackRecoveryAlgorithm::MatchOneView(const ClusterVector &clusterVectorU, const ClusterVector &clusterVectorV,
     const ClusterVector &clusterVectorW, const ClusterAssociationMap &matchedClustersUV, const ClusterAssociationMap &matchedClustersVW,
     const ClusterAssociationMap &matchedClustersWU, ParticleList &particleList) const
 {
@@ -541,7 +556,9 @@ void CosmicRayTrackRecoveryAlgorithm::MatchOneView(const ClusterVector &clusterV
                 const ClusterAssociationMap::const_iterator iter232 = matchedClusters23.find(pCluster2);
                 const ClusterList matchedClusters23_pCluster2(iter232 != matchedClusters23.end() ? iter232->second : ClusterList());
 
-                if (matchedClusters12_pCluster2.size() == 1 && std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(), pCluster1) != matchedClusters12_pCluster2.end() &&
+                if (matchedClusters12_pCluster2.size() == 1 &&
+                    std::find(matchedClusters12_pCluster2.begin(), matchedClusters12_pCluster2.end(), pCluster1) !=
+                        matchedClusters12_pCluster2.end() &&
                     matchedClusters23_pCluster2.size() == 0)
                     newParticle.m_clusterList.push_back(pCluster2);
             }
@@ -559,7 +576,9 @@ void CosmicRayTrackRecoveryAlgorithm::MatchOneView(const ClusterVector &clusterV
                 const ClusterAssociationMap::const_iterator iter313 = matchedClusters31.find(pCluster3);
                 const ClusterList matchedClusters31_pCluster3(iter313 != matchedClusters31.end() ? iter313->second : ClusterList());
 
-                if (matchedClusters31_pCluster3.size() == 1 && std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(), pCluster1) != matchedClusters31_pCluster3.end() &&
+                if (matchedClusters31_pCluster3.size() == 1 &&
+                    std::find(matchedClusters31_pCluster3.begin(), matchedClusters31_pCluster3.end(), pCluster1) !=
+                        matchedClusters31_pCluster3.end() &&
                     matchedClusters23_pCluster3.size() == 0)
                     newParticle.m_clusterList.push_back(pCluster3);
             }
@@ -637,7 +656,8 @@ void CosmicRayTrackRecoveryAlgorithm::BuildParticles(const ParticleList &particl
     if (particleList.empty())
         return;
 
-    const PfoList *pPfoList(nullptr); std::string pfoListName;
+    const PfoList *pPfoList(nullptr);
+    std::string pfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
     for (const Particle &particle : particleList)
@@ -678,7 +698,7 @@ void CosmicRayTrackRecoveryAlgorithm::MergeClusters(const ClusterList &inputClus
 
     for (unsigned int iView = 0; iView < 3; ++iView)
     {
-        const ClusterList clusterList((0 == iView) ? clusterListU : (1 == iView) ?  clusterListV : clusterListW);
+        const ClusterList clusterList((0 == iView) ? clusterListU : (1 == iView) ? clusterListV : clusterListW);
         const std::string inputClusterListName((0 == iView) ? m_inputClusterListNameU : (1 == iView) ? m_inputClusterListNameV : m_inputClusterListNameW);
 
         if (clusterList.empty())
@@ -697,8 +717,8 @@ void CosmicRayTrackRecoveryAlgorithm::MergeClusters(const ClusterList &inputClus
             if (!PandoraContentApi::IsAvailable(*this, pAssociatedCluster))
                 continue;
 
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pSeedCluster, pAssociatedCluster,
-                inputClusterListName, inputClusterListName));
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::MergeAndDeleteClusters(*this, pSeedCluster, pAssociatedCluster, inputClusterListName, inputClusterListName));
         }
 
         outputClusterList.push_back(pSeedCluster);
@@ -709,20 +729,18 @@ void CosmicRayTrackRecoveryAlgorithm::MergeClusters(const ClusterList &inputClus
 
 StatusCode CosmicRayTrackRecoveryAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMinLength", m_clusterMinLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterMinLength", m_clusterMinLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMinSpanZ", m_clusterMinSpanZ));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterMinSpanZ", m_clusterMinSpanZ));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMinOverlapX", m_clusterMinOverlapX));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterMinOverlapX", m_clusterMinOverlapX));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMaxDeltaX", m_clusterMaxDeltaX));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterMaxDeltaX", m_clusterMaxDeltaX));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMinHits", m_clusterMinHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterMinHits", m_clusterMinHits));
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputClusterListNameU", m_inputClusterListNameU));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputClusterListNameV", m_inputClusterListNameV));

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayTrackRecoveryAlgorithm.h
@@ -41,7 +41,7 @@ private:
     };
 
     typedef std::vector<Particle> ParticleList;
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterAssociationMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterAssociationMap;
     typedef std::set<unsigned int> UIntSet;
 
     /**
@@ -87,7 +87,7 @@ private:
      *  @param slidingFitResultMap the input map of sliding linear fit results
      *  @param clusterAssociationMap the output map of cluster associations
      */
-    void MatchClusters(const pandora::Cluster* const pSeedCluster, const pandora::ClusterVector &targetClusters,
+    void MatchClusters(const pandora::Cluster *const pSeedCluster, const pandora::ClusterVector &targetClusters,
         const TwoDSlidingFitResultMap &slidingFitResultMap, ClusterAssociationMap &clusterAssociationMap) const;
 
     /**
@@ -103,8 +103,7 @@ private:
      */
     void MatchThreeViews(const pandora::ClusterVector &clusterVectorU, const pandora::ClusterVector &clusterVectorV,
         const pandora::ClusterVector &clusterVectorW, const ClusterAssociationMap &clusterAssociationMapUV,
-        const ClusterAssociationMap &clusterAssociationMapVW, const ClusterAssociationMap &clusterAssociationMapWU,
-        ParticleList &particleList) const;
+        const ClusterAssociationMap &clusterAssociationMapVW, const ClusterAssociationMap &clusterAssociationMapWU, ParticleList &particleList) const;
 
     /**
      *  @brief  Create candidate particles using two primary clusters and one pair of broken clusters
@@ -117,10 +116,9 @@ private:
      *  @param clusterAssociationMapWU map of cluster associations between the W and U views
      *  @param particleList the output list of candidate particles
      */
-    void MatchTwoViews(const pandora::ClusterVector &clusterVectorU,  const pandora::ClusterVector &clusterVectorV,
+    void MatchTwoViews(const pandora::ClusterVector &clusterVectorU, const pandora::ClusterVector &clusterVectorV,
         const pandora::ClusterVector &clusterVectorW, const ClusterAssociationMap &clusterAssociationMapUV,
-        const ClusterAssociationMap &clusterAssociationMapVW, const ClusterAssociationMap &clusterAssociationMapWU,
-        ParticleList &particleList) const;
+        const ClusterAssociationMap &clusterAssociationMapVW, const ClusterAssociationMap &clusterAssociationMapWU, ParticleList &particleList) const;
 
     /**
      *  @brief  Create candidate particles using one primary cluster and one pair of broken clusters
@@ -133,10 +131,9 @@ private:
      *  @param clusterAssociationMapWU map of cluster associations between the W and U views
      *  @param particleList the output list of candidate particles
      */
-    void MatchOneView(const pandora::ClusterVector &clusterVectorU,  const pandora::ClusterVector &clusterVectorV,
+    void MatchOneView(const pandora::ClusterVector &clusterVectorU, const pandora::ClusterVector &clusterVectorV,
         const pandora::ClusterVector &clusterVectorW, const ClusterAssociationMap &clusterAssociationMapUV,
-        const ClusterAssociationMap &clusterAssociationMapVW, const ClusterAssociationMap &clusterAssociationMapWU,
-        ParticleList &particleList) const;
+        const ClusterAssociationMap &clusterAssociationMapVW, const ClusterAssociationMap &clusterAssociationMapWU, ParticleList &particleList) const;
 
     /**
      *  @brief Build the list of clusters already used to create particles
@@ -169,16 +166,16 @@ private:
      */
     void BuildParticles(const ParticleList &particleList);
 
-    float          m_clusterMinLength;          ///<
-    float          m_clusterMinSpanZ;           ///<
-    float          m_clusterMinOverlapX;        ///<
-    float          m_clusterMaxDeltaX;          ///<
-    unsigned int   m_clusterMinHits;            ///<
+    float m_clusterMinLength;      ///<
+    float m_clusterMinSpanZ;       ///<
+    float m_clusterMinOverlapX;    ///<
+    float m_clusterMaxDeltaX;      ///<
+    unsigned int m_clusterMinHits; ///<
 
-    std::string    m_inputClusterListNameU;     ///<
-    std::string    m_inputClusterListNameV;     ///<
-    std::string    m_inputClusterListNameW;     ///<
-    std::string    m_outputPfoListName;         ///<
+    std::string m_inputClusterListNameU; ///<
+    std::string m_inputClusterListNameV; ///<
+    std::string m_inputClusterListNameW; ///<
+    std::string m_outputPfoListName;     ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayVertexBuildingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayVertexBuildingAlgorithm.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayVertexBuildingAlgorithm.h"
@@ -31,8 +31,8 @@ CosmicRayVertexBuildingAlgorithm::CosmicRayVertexBuildingAlgorithm() :
 StatusCode CosmicRayVertexBuildingAlgorithm::Run()
 {
     const PfoList *pPfoList = NULL;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_parentPfoListName,
-        pPfoList));
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_parentPfoListName, pPfoList));
 
     if (NULL == pPfoList)
     {
@@ -158,8 +158,8 @@ void CosmicRayVertexBuildingAlgorithm::BuildCosmicRayParent(const LArPointingClu
 
         try
         {
-            CartesianVector minPosition(0.f, 0.f, 0.f), maxPosition(0.f,0.f,0.f);
-            CartesianVector minDirection(0.f, 0.f, 0.f), maxDirection(0.f,0.f,0.f);
+            CartesianVector minPosition(0.f, 0.f, 0.f), maxPosition(0.f, 0.f, 0.f);
+            CartesianVector minDirection(0.f, 0.f, 0.f), maxDirection(0.f, 0.f, 0.f);
 
             LArPointingClusterMap::const_iterator cIter2 = pointingClusterMap.find(pCluster);
 
@@ -216,7 +216,7 @@ void CosmicRayVertexBuildingAlgorithm::BuildCosmicRayParent(const LArPointingClu
                 endDirection = maxDirection;
             }
         }
-        catch(StatusCodeException &statusCodeException)
+        catch (StatusCodeException &statusCodeException)
         {
             if (STATUS_CODE_FAILURE == statusCodeException.GetStatusCode())
                 throw statusCodeException;
@@ -281,8 +281,8 @@ void CosmicRayVertexBuildingAlgorithm::BuildCosmicRayDaughter(const ParticleFlow
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayVertexBuildingAlgorithm::SetParticleParameters(const CartesianVector &vtxPosition, const CartesianVector &vtxDirection,
-    const ParticleFlowObject *const pPfo) const
+void CosmicRayVertexBuildingAlgorithm::SetParticleParameters(
+    const CartesianVector &vtxPosition, const CartesianVector &vtxDirection, const ParticleFlowObject *const pPfo) const
 {
     if (!pPfo->GetVertexList().empty())
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -291,7 +291,8 @@ void CosmicRayVertexBuildingAlgorithm::SetParticleParameters(const CartesianVect
     metadata.m_momentum = vtxDirection;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pPfo, metadata));
 
-    const VertexList *pVertexList = NULL; std::string vertexListName;
+    const VertexList *pVertexList = NULL;
+    std::string vertexListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pVertexList, vertexListName));
 
     PandoraContentApi::Vertex::Parameters parameters;
@@ -317,14 +318,13 @@ StatusCode CosmicRayVertexBuildingAlgorithm::ReadSettings(const TiXmlHandle xmlH
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_vertexListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseParentForShowerVertex", m_useParentShowerVertex));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseParentForShowerVertex", m_useParentShowerVertex));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_halfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-	"IsDualPhase", m_isDualPhase));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IsDualPhase", m_isDualPhase));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayVertexBuildingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/CosmicRayVertexBuildingAlgorithm.h
@@ -78,11 +78,11 @@ private:
     void SetParticleParameters(const pandora::CartesianVector &vtxPosition, const pandora::CartesianVector &vtxDirection,
         const pandora::ParticleFlowObject *const pPfo) const;
 
-    bool                    m_useParentShowerVertex;    ///< use the parent pfo for the shower vertices
-    bool                    m_isDualPhase;              ///< type of geometry
-    unsigned int            m_halfWindowLayers;         ///< number of layers to use for half-window of sliding fit
-    std::string             m_parentPfoListName;        ///< The name of the input pfo list
-    std::string             m_vertexListName;           ///< The name of the output vertex list
+    bool m_useParentShowerVertex;    ///< use the parent pfo for the shower vertices
+    bool m_isDualPhase;              ///< type of geometry
+    unsigned int m_halfWindowLayers; ///< number of layers to use for half-window of sliding fit
+    std::string m_parentPfoListName; ///< The name of the input pfo list
+    std::string m_vertexListName;    ///< The name of the output vertex list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayIdentificationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayIdentificationAlgorithm.cc
@@ -50,8 +50,8 @@ StatusCode DeltaRayIdentificationAlgorithm::Run()
 
     if (!newDaughterPfoList.empty())
     {
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, m_parentPfoListName, m_daughterPfoListName,
-            newDaughterPfoList));
+        PANDORA_THROW_RESULT_IF(
+            STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, m_parentPfoListName, m_daughterPfoListName, newDaughterPfoList));
     }
 
     return STATUS_CODE_SUCCESS;
@@ -62,8 +62,7 @@ StatusCode DeltaRayIdentificationAlgorithm::Run()
 void DeltaRayIdentificationAlgorithm::GetPfos(const std::string &inputPfoListName, PfoVector &outputPfoVector) const
 {
     const PfoList *pPfoList = NULL;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this,
-        inputPfoListName, pPfoList));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, inputPfoListName, pPfoList));
 
     if (NULL == pPfoList)
         return;
@@ -74,8 +73,7 @@ void DeltaRayIdentificationAlgorithm::GetPfos(const std::string &inputPfoListNam
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void DeltaRayIdentificationAlgorithm::BuildAssociationMap(const PfoVector &parentPfos, const PfoVector &daughterPfos,
-    PfoAssociationMap &pfoAssociationMap) const
+void DeltaRayIdentificationAlgorithm::BuildAssociationMap(const PfoVector &parentPfos, const PfoVector &daughterPfos, PfoAssociationMap &pfoAssociationMap) const
 {
     PfoSet parentPfoList, daughterPfoList;
     parentPfoList.insert(parentPfos.begin(), parentPfos.end());
@@ -148,8 +146,8 @@ void DeltaRayIdentificationAlgorithm::BuildAssociationMap(const PfoVector &paren
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool DeltaRayIdentificationAlgorithm::IsAssociated(const ParticleFlowObject *const pDaughterPfo, const ParticleFlowObject *const pParentPfo,
-    float &displacement) const
+bool DeltaRayIdentificationAlgorithm::IsAssociated(
+    const ParticleFlowObject *const pDaughterPfo, const ParticleFlowObject *const pParentPfo, float &displacement) const
 {
     displacement = std::numeric_limits<float>::max();
 
@@ -159,19 +157,19 @@ bool DeltaRayIdentificationAlgorithm::IsAssociated(const ParticleFlowObject *con
     const float daughterLengthSquared(LArPfoHelper::GetTwoDLengthSquared(pDaughterPfo));
     const float parentLengthSquared(LArPfoHelper::GetTwoDLengthSquared(pParentPfo));
 
-    if (daughterLengthSquared > m_maxDaughterLengthSquared || parentLengthSquared < m_minParentLengthSquared ||
-        daughterLengthSquared > 0.5 * parentLengthSquared)
+    if (daughterLengthSquared > m_maxDaughterLengthSquared || parentLengthSquared < m_minParentLengthSquared || daughterLengthSquared > 0.5 * parentLengthSquared)
         return false;
 
     const float transitionLengthSquared(125.f);
-    const float displacementCut((daughterLengthSquared > transitionLengthSquared) ? m_distanceForMatching :
-        m_distanceForMatching * (2.f - daughterLengthSquared / transitionLengthSquared));
+    const float displacementCut((daughterLengthSquared > transitionLengthSquared)
+                                    ? m_distanceForMatching
+                                    : m_distanceForMatching * (2.f - daughterLengthSquared / transitionLengthSquared));
 
     try
     {
         displacement = this->GetTwoDSeparation(pDaughterPfo, pParentPfo);
     }
-    catch(StatusCodeException &statusCodeException)
+    catch (StatusCodeException &statusCodeException)
     {
         if (STATUS_CODE_FAILURE == statusCodeException.GetStatusCode())
             throw statusCodeException;
@@ -238,7 +236,7 @@ void DeltaRayIdentificationAlgorithm::GetTwoDVertices(const ParticleFlowObject *
     {
         const Cluster *const pCluster = *iter;
 
-        CartesianVector firstCoordinate(0.f,0.f,0.f), secondCoordinate(0.f,0.f,0.f);
+        CartesianVector firstCoordinate(0.f, 0.f, 0.f), secondCoordinate(0.f, 0.f, 0.f);
         LArClusterHelper::GetExtremalCoordinates(pCluster, firstCoordinate, secondCoordinate);
 
         vertexVector.push_back(firstCoordinate);
@@ -277,7 +275,8 @@ float DeltaRayIdentificationAlgorithm::GetClosestDistance(const CartesianPointVe
 void DeltaRayIdentificationAlgorithm::BuildParentDaughterLinks(const PfoAssociationMap &pfoAssociationMap, PfoList &daughterPfoList) const
 {
     PfoList pfoList;
-    for (const auto &mapEntry : pfoAssociationMap) pfoList.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoAssociationMap)
+        pfoList.push_back(mapEntry.first);
     pfoList.sort(LArPfoHelper::SortByNHits);
 
     for (const ParticleFlowObject *const pDaughterPfo : pfoList)
@@ -302,13 +301,12 @@ void DeltaRayIdentificationAlgorithm::BuildParentDaughterLinks(const PfoAssociat
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const ParticleFlowObject *DeltaRayIdentificationAlgorithm::GetParent(const PfoAssociationMap &pfoAssociationMap,
-    const ParticleFlowObject *const pPfo) const
+const ParticleFlowObject *DeltaRayIdentificationAlgorithm::GetParent(const PfoAssociationMap &pfoAssociationMap, const ParticleFlowObject *const pPfo) const
 {
     const ParticleFlowObject *pParentPfo = nullptr;
     const ParticleFlowObject *pDaughterPfo = pPfo;
 
-    while(1)
+    while (1)
     {
         PfoAssociationMap::const_iterator iter = pfoAssociationMap.find(pDaughterPfo);
         if (pfoAssociationMap.end() == iter)
@@ -328,17 +326,16 @@ StatusCode DeltaRayIdentificationAlgorithm::ReadSettings(const TiXmlHandle xmlHa
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ParentPfoListName", m_parentPfoListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "DaughterPfoListName", m_daughterPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DistanceForMatching", m_distanceForMatching));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DistanceForMatching", m_distanceForMatching));
 
     float minParentLength = std::sqrt(m_minParentLengthSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinParentLength", minParentLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinParentLength", minParentLength));
     m_minParentLengthSquared = minParentLength * minParentLength;
 
     float maxDaughterLength = std::sqrt(m_maxDaughterLengthSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxDaughterLength", maxDaughterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxDaughterLength", maxDaughterLength));
     m_maxDaughterLengthSquared = maxDaughterLength * maxDaughterLength;
 
     return STATUS_CODE_SUCCESS;

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayIdentificationAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayIdentificationAlgorithm.h
@@ -29,7 +29,7 @@ public:
 private:
     pandora::StatusCode Run();
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, const pandora::ParticleFlowObject*> PfoAssociationMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::ParticleFlowObject *> PfoAssociationMap;
 
     /**
      *  @brief Get the vector of Pfos, given the input list name
@@ -46,8 +46,7 @@ private:
      *  @param outputPfos the input vector of current daughter Pfos
      *  @param pfoAssociationMap the output map of parent/daughter associations
      */
-    void BuildAssociationMap(const pandora::PfoVector &inputPfos, const pandora::PfoVector &outputPfos,
-        PfoAssociationMap &pfoAssociationMap) const;
+    void BuildAssociationMap(const pandora::PfoVector &inputPfos, const pandora::PfoVector &outputPfos, PfoAssociationMap &pfoAssociationMap) const;
 
     /**
      *  @brief Determine if a given pair of Pfos have a parent/daughter association
@@ -58,8 +57,7 @@ private:
      *
      *  @return boolean
      */
-    bool IsAssociated(const pandora::ParticleFlowObject *const pDaughterPfo, const pandora::ParticleFlowObject *const pParentPfo,
-        float &displacement) const;
+    bool IsAssociated(const pandora::ParticleFlowObject *const pDaughterPfo, const pandora::ParticleFlowObject *const pParentPfo, float &displacement) const;
 
     /**
      *  @brief Calculate 2D separation between two Pfos
@@ -78,8 +76,7 @@ private:
      *  @param hitType the hit type
      *  @param vertexVector the vector of possible vertex positions
      */
-    void GetTwoDVertices(const pandora::ParticleFlowObject *const pPfo, const pandora::HitType &hitType,
-        pandora::CartesianPointVector &vertexVector) const;
+    void GetTwoDVertices(const pandora::ParticleFlowObject *const pPfo, const pandora::HitType &hitType, pandora::CartesianPointVector &vertexVector) const;
 
     /**
      *  @brief Calculate closest 2D separation between a set of vertices and a set of clusters
@@ -109,12 +106,12 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string  m_parentPfoListName;          ///< The parent pfo list name
-    std::string  m_daughterPfoListName;        ///< The daughter pfo list name
+    std::string m_parentPfoListName;   ///< The parent pfo list name
+    std::string m_daughterPfoListName; ///< The daughter pfo list name
 
-    float        m_distanceForMatching;        ///< Maximum allowed distance of delta ray from parent cosmic ray
-    float        m_minParentLengthSquared;     ///< Minimum allowed length of parent cosmic ray
-    float        m_maxDaughterLengthSquared;   ///< Maximum allowed length of daughter delta ray
+    float m_distanceForMatching;      ///< Maximum allowed distance of delta ray from parent cosmic ray
+    float m_minParentLengthSquared;   ///< Minimum allowed length of parent cosmic ray
+    float m_maxDaughterLengthSquared; ///< Maximum allowed length of daughter delta ray
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMatchingAlgorithm.cc
@@ -72,8 +72,7 @@ void DeltaRayMatchingAlgorithm::InitializeNearbyClusterMaps()
 void DeltaRayMatchingAlgorithm::InitializeNearbyClusterMap(const std::string &clusterListName, ClusterToClustersMap &nearbyClusters)
 {
     const ClusterList *pClusterList = NULL;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this,
-        clusterListName, pClusterList))
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList))
 
     if ((NULL == pClusterList) || pClusterList->empty())
         return;
@@ -88,7 +87,7 @@ void DeltaRayMatchingAlgorithm::InitializeNearbyClusterMap(const std::string &cl
         allCaloHits.insert(allCaloHits.end(), daughterHits.begin(), daughterHits.end());
 
         for (const CaloHit *const pCaloHit : daughterHits)
-            (void) hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHit, pCluster));
+            (void)hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHit, pCluster));
     }
 
     HitKDTree2D kdTree;
@@ -111,7 +110,7 @@ void DeltaRayMatchingAlgorithm::InitializeNearbyClusterMap(const std::string &cl
 
             for (const auto &hit : found)
             {
-                ClusterList  &nearbyClusterList(nearbyClusters[pCluster]);
+                ClusterList &nearbyClusterList(nearbyClusters[pCluster]);
                 const Cluster *const pNearbyCluster(hitToClusterMap.at(hit.data));
 
                 if (nearbyClusterList.end() == std::find(nearbyClusterList.begin(), nearbyClusterList.end(), pNearbyCluster))
@@ -135,8 +134,7 @@ void DeltaRayMatchingAlgorithm::ClearNearbyClusterMaps()
 void DeltaRayMatchingAlgorithm::GetAllPfos(const std::string &inputPfoListName, PfoVector &pfoVector) const
 {
     const PfoList *pPfoList = NULL;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this,
-        inputPfoListName, pPfoList));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, inputPfoListName, pPfoList));
 
     if (NULL == pPfoList)
         return;
@@ -172,8 +170,8 @@ void DeltaRayMatchingAlgorithm::GetTrackPfos(const std::string &inputPfoListName
 void DeltaRayMatchingAlgorithm::GetClusters(const std::string &inputClusterListName, pandora::ClusterVector &clusterVector) const
 {
     const ClusterList *pClusterList = NULL;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this,
-        inputClusterListName, pClusterList))
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, inputClusterListName, pClusterList))
 
     if (NULL == pClusterList)
         return;
@@ -246,8 +244,8 @@ void DeltaRayMatchingAlgorithm::OneViewMatching(ClusterLengthMap &clusterLengthM
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void DeltaRayMatchingAlgorithm::ThreeViewMatching(const ClusterVector &clusters1, const ClusterVector &clusters2, const ClusterVector &clusters3,
-    ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, ParticleList &particleList) const
+void DeltaRayMatchingAlgorithm::ThreeViewMatching(const ClusterVector &clusters1, const ClusterVector &clusters2,
+    const ClusterVector &clusters3, ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, ParticleList &particleList) const
 {
     if (clusters1.empty() || clusters2.empty() || clusters3.empty())
         return;
@@ -282,8 +280,8 @@ void DeltaRayMatchingAlgorithm::ThreeViewMatching(const ClusterVector &clusters1
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void DeltaRayMatchingAlgorithm::TwoViewMatching(const ClusterVector &clusters1, const ClusterVector &clusters2, ClusterLengthMap &clusterLengthMap,
-    PfoLengthMap &pfoLengthMap, ParticleList &particleList) const
+void DeltaRayMatchingAlgorithm::TwoViewMatching(const ClusterVector &clusters1, const ClusterVector &clusters2,
+    ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, ParticleList &particleList) const
 {
     if (clusters1.empty() || clusters2.empty())
         return;
@@ -314,8 +312,8 @@ void DeltaRayMatchingAlgorithm::TwoViewMatching(const ClusterVector &clusters1, 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void DeltaRayMatchingAlgorithm::OneViewMatching(const ClusterVector &clusters, ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap,
-    ParticleList &particleList) const
+void DeltaRayMatchingAlgorithm::OneViewMatching(
+    const ClusterVector &clusters, ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, ParticleList &particleList) const
 {
     if (clusters.empty())
         return;
@@ -365,9 +363,10 @@ void DeltaRayMatchingAlgorithm::SelectParticles(const ParticleList &initialParti
                 else if (particle2.GetNViews() == particle1.GetNViews() && NULL != particle2.GetParentPfo())
                 {
                     if ((NULL == particle1.GetParentPfo()) || (particle2.GetNCaloHits() > particle1.GetNCaloHits()) ||
-                        (particle2.GetNCaloHits() == particle1.GetNCaloHits() && this->GetLength(particle2, clusterLengthMap) >= this->GetLength(particle1, clusterLengthMap)) )
+                        (particle2.GetNCaloHits() == particle1.GetNCaloHits() &&
+                            this->GetLength(particle2, clusterLengthMap) >= this->GetLength(particle1, clusterLengthMap)))
                     {
-                            isGoodParticle = false;
+                        isGoodParticle = false;
                     }
                 }
 
@@ -434,8 +433,7 @@ void DeltaRayMatchingAlgorithm::CreateParticles(const ParticleList &particleList
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool DeltaRayMatchingAlgorithm::AreClustersMatched(const Cluster *const pCluster1, const Cluster *const pCluster2,
-    const Cluster *const pCluster3) const
+bool DeltaRayMatchingAlgorithm::AreClustersMatched(const Cluster *const pCluster1, const Cluster *const pCluster2, const Cluster *const pCluster3) const
 {
     if (nullptr == pCluster1 && nullptr == pCluster2 && nullptr == pCluster3)
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -470,7 +468,7 @@ bool DeltaRayMatchingAlgorithm::AreClustersMatched(const Cluster *const pCluster
     const HitType hitType2(LArClusterHelper::GetClusterHitType(pCluster2));
     const HitType hitType3(LArClusterHelper::GetClusterHitType(pCluster3));
 
-    if (hitType1 == hitType2 ||  hitType2 == hitType3 || hitType3 == hitType1)
+    if (hitType1 == hitType2 || hitType2 == hitType3 || hitType3 == hitType1)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
     const unsigned int nSamplingPoints(1 + static_cast<unsigned int>(xOverlap / xPitch));
@@ -508,7 +506,7 @@ bool DeltaRayMatchingAlgorithm::AreClustersMatched(const Cluster *const pCluster
             if (pseudoChi2 < m_pseudoChi2Cut)
                 return true;
         }
-        catch(StatusCodeException &statusCodeException)
+        catch (StatusCodeException &statusCodeException)
         {
             if (STATUS_CODE_NOT_FOUND != statusCodeException.GetStatusCode())
                 throw statusCodeException;
@@ -520,8 +518,8 @@ bool DeltaRayMatchingAlgorithm::AreClustersMatched(const Cluster *const pCluster
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void DeltaRayMatchingAlgorithm::FindBestParentPfo(const Cluster *const pCluster1, const Cluster *const pCluster2, const Cluster *const pCluster3,
-    ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, const ParticleFlowObject *&pBestPfo) const
+void DeltaRayMatchingAlgorithm::FindBestParentPfo(const Cluster *const pCluster1, const Cluster *const pCluster2,
+    const Cluster *const pCluster3, ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, const ParticleFlowObject *&pBestPfo) const
 {
     PfoVector pfoVector;
     this->GetTrackPfos(m_parentPfoListName, pfoVector);
@@ -595,7 +593,7 @@ float DeltaRayMatchingAlgorithm::GetLengthFromCache(const Cluster *const pCluste
         return iter->second;
 
     const float lengthSquared(LArClusterHelper::GetLengthSquared(pCluster));
-    (void) clusterLengthMap.insert(ClusterLengthMap::value_type(pCluster, lengthSquared));
+    (void)clusterLengthMap.insert(ClusterLengthMap::value_type(pCluster, lengthSquared));
     return lengthSquared;
 }
 
@@ -609,7 +607,7 @@ float DeltaRayMatchingAlgorithm::GetLengthFromCache(const ParticleFlowObject *co
         return iter->second;
 
     const float lengthSquared(LArPfoHelper::GetTwoDLengthSquared(pPfo));
-    (void) pfoLengthMap.insert(PfoLengthMap::value_type(pPfo, lengthSquared));
+    (void)pfoLengthMap.insert(PfoLengthMap::value_type(pPfo, lengthSquared));
     return lengthSquared;
 }
 
@@ -670,7 +668,8 @@ float DeltaRayMatchingAlgorithm::GetDistanceSquaredToPfo(const Cluster *const pC
 
 void DeltaRayMatchingAlgorithm::CreateDaughterPfo(const ClusterList &clusterList, const ParticleFlowObject *const pParentPfo) const
 {
-    const PfoList *pPfoList = NULL; std::string pfoListName;
+    const PfoList *pPfoList = NULL;
+    std::string pfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
     // TODO Correct these placeholder parameters
@@ -699,8 +698,8 @@ void DeltaRayMatchingAlgorithm::AddToDaughterPfo(const ClusterList &clusterList,
     for (const Cluster *const pDaughterCluster : clusterList)
     {
         const HitType hitType(LArClusterHelper::GetClusterHitType(pDaughterCluster));
-        const std::string clusterListName((TPC_VIEW_U == hitType) ? m_inputClusterListNameU :
-                                          (TPC_VIEW_V == hitType) ? m_inputClusterListNameV : m_inputClusterListNameW);
+        const std::string clusterListName(
+            (TPC_VIEW_U == hitType) ? m_inputClusterListNameU : (TPC_VIEW_V == hitType) ? m_inputClusterListNameV : m_inputClusterListNameW);
 
         ClusterList pfoClusters;
         LArPfoHelper::GetClusters(pParentPfo, hitType, pfoClusters);
@@ -710,16 +709,16 @@ void DeltaRayMatchingAlgorithm::AddToDaughterPfo(const ClusterList &clusterList,
 
         const Cluster *const pParentCluster = *(pfoClusters.begin());
 
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pDaughterCluster,
-            clusterListName, clusterListName));
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+            PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pDaughterCluster, clusterListName, clusterListName));
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-DeltaRayMatchingAlgorithm::Particle::Particle(const Cluster *const pCluster1, const Cluster *const pCluster2, const Cluster *const pCluster3,
-        const ParticleFlowObject *const pPfo) :
+DeltaRayMatchingAlgorithm::Particle::Particle(
+    const Cluster *const pCluster1, const Cluster *const pCluster2, const Cluster *const pCluster3, const ParticleFlowObject *const pPfo) :
     m_pClusterU(NULL),
     m_pClusterV(NULL),
     m_pClusterW(NULL),
@@ -785,20 +784,17 @@ StatusCode DeltaRayMatchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputClusterListNameV", m_inputClusterListNameV));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputClusterListNameW", m_inputClusterListNameW));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "OverlapWindow", m_xOverlapWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "OverlapWindow", m_xOverlapWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DistanceForMatching", m_distanceForMatching));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DistanceForMatching", m_distanceForMatching));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PseudoChi2Cut", m_pseudoChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PseudoChi2Cut", m_pseudoChi2Cut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SearchRegion1D", m_searchRegion1D));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SearchRegion1D", m_searchRegion1D));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMatchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/DeltaRayMatchingAlgorithm.h
@@ -15,8 +15,10 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -82,20 +84,20 @@ private:
         unsigned int GetNCaloHits() const;
 
     private:
-        const pandora::Cluster             *m_pClusterU;    ///< Address of cluster in U view
-        const pandora::Cluster             *m_pClusterV;    ///< Address of cluster in V view
-        const pandora::Cluster             *m_pClusterW;    ///< Address of cluster in W view
-        const pandora::ParticleFlowObject  *m_pParentPfo;   ///< Address of parent Pfo
+        const pandora::Cluster *m_pClusterU;             ///< Address of cluster in U view
+        const pandora::Cluster *m_pClusterV;             ///< Address of cluster in V view
+        const pandora::Cluster *m_pClusterW;             ///< Address of cluster in W view
+        const pandora::ParticleFlowObject *m_pParentPfo; ///< Address of parent Pfo
     };
 
     typedef std::vector<Particle> ParticleList;
 
-    typedef KDTreeLinkerAlgo<const pandora::CaloHit*, 2> HitKDTree2D;
-    typedef KDTreeNodeInfoT<const pandora::CaloHit*, 2> HitKDNode2D;
+    typedef KDTreeLinkerAlgo<const pandora::CaloHit *, 2> HitKDTree2D;
+    typedef KDTreeNodeInfoT<const pandora::CaloHit *, 2> HitKDNode2D;
     typedef std::vector<HitKDNode2D> HitKDNode2DList;
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterToClustersMap;
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::Cluster*> HitToClusterMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterToClustersMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterMap;
 
     /**
      *  @brief  Initialize nearby cluster maps
@@ -140,8 +142,8 @@ private:
      */
     void GetClusters(const std::string &clusterListName, pandora::ClusterVector &clusterVector) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, float> ClusterLengthMap;
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, float> PfoLengthMap;
+    typedef std::unordered_map<const pandora::Cluster *, float> ClusterLengthMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoLengthMap;
 
     /**
      *  @brief  Match clusters using all three views
@@ -174,8 +176,8 @@ private:
      *  @param  pfoLengthMap the pfo length map
      *  @param  particleList the output list of particles
      */
-    void ThreeViewMatching(const pandora::ClusterVector &clusters1, const pandora::ClusterVector &clusters2, const pandora::ClusterVector &clusters3,
-        ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, ParticleList &particleList) const;
+    void ThreeViewMatching(const pandora::ClusterVector &clusters1, const pandora::ClusterVector &clusters2,
+        const pandora::ClusterVector &clusters3, ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, ParticleList &particleList) const;
 
     /**
      *  @brief  Match clusters using a pair of views
@@ -186,8 +188,8 @@ private:
      *  @param  pfoLengthMap the pfo length map
      *  @param  particleList the output list of particles
      */
-    void TwoViewMatching(const pandora::ClusterVector &clusters1, const pandora::ClusterVector &clusters2, ClusterLengthMap &clusterLengthMap,
-        PfoLengthMap &pfoLengthMap, ParticleList &particleList) const;
+    void TwoViewMatching(const pandora::ClusterVector &clusters1, const pandora::ClusterVector &clusters2,
+        ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, ParticleList &particleList) const;
 
     /**
      *  @brief  Match clusters using a single view
@@ -197,7 +199,8 @@ private:
      *  @param  pfoLengthMap the pfo length map
      *  @param  particleList the output list of particles
      */
-    void OneViewMatching(const pandora::ClusterVector &clusters, ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap, ParticleList &particleList) const;
+    void OneViewMatching(const pandora::ClusterVector &clusters, ClusterLengthMap &clusterLengthMap, PfoLengthMap &pfoLengthMap,
+        ParticleList &particleList) const;
 
     /**
      *  @brief Resolve any ambiguities between candidate particles
@@ -265,8 +268,7 @@ private:
      *  @param  pCluster2 pointer to second cluster
      *  @param  pCluster3 pointer to third cluster
      */
-    bool AreClustersMatched(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-        const pandora::Cluster *const pCluster3) const;
+    bool AreClustersMatched(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const pandora::Cluster *const pCluster3) const;
 
     /**
      *  @brief Get displacementr between cluster and particle flow object
@@ -294,22 +296,22 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string             m_parentPfoListName;          ///< The parent pfo list name
-    std::string             m_daughterPfoListName;        ///< The daughter pfo list name for new daughter particles
+    std::string m_parentPfoListName;   ///< The parent pfo list name
+    std::string m_daughterPfoListName; ///< The daughter pfo list name for new daughter particles
 
-    std::string             m_inputClusterListNameU;      ///< The input cluster list name for the u view
-    std::string             m_inputClusterListNameV;      ///< The input cluster list name for the v view
-    std::string             m_inputClusterListNameW;      ///< The input cluster list name for the w view
+    std::string m_inputClusterListNameU; ///< The input cluster list name for the u view
+    std::string m_inputClusterListNameV; ///< The input cluster list name for the v view
+    std::string m_inputClusterListNameW; ///< The input cluster list name for the w view
 
-    unsigned int            m_minCaloHitsPerCluster;      ///< The min number of calo hits per candidate cluster
-    float                   m_xOverlapWindow;             ///< The maximum allowed displacement in x position
-    float                   m_distanceForMatching;        ///< The maximum allowed distance between tracks and delta rays
-    float                   m_pseudoChi2Cut;              ///< Pseudo chi2 cut for three view matching
+    unsigned int m_minCaloHitsPerCluster; ///< The min number of calo hits per candidate cluster
+    float m_xOverlapWindow;               ///< The maximum allowed displacement in x position
+    float m_distanceForMatching;          ///< The maximum allowed distance between tracks and delta rays
+    float m_pseudoChi2Cut;                ///< Pseudo chi2 cut for three view matching
 
-    float                   m_searchRegion1D;             ///< Search region, applied to each dimension, for look-up from kd-trees
-    ClusterToClustersMap    m_nearbyClustersU;            ///< The nearby clusters map for the u view
-    ClusterToClustersMap    m_nearbyClustersV;            ///< The nearby clusters map for the v view
-    ClusterToClustersMap    m_nearbyClustersW;            ///< The nearby clusters map for the w view
+    float m_searchRegion1D;                 ///< Search region, applied to each dimension, for look-up from kd-trees
+    ClusterToClustersMap m_nearbyClustersU; ///< The nearby clusters map for the u view
+    ClusterToClustersMap m_nearbyClustersV; ///< The nearby clusters map for the v view
+    ClusterToClustersMap m_nearbyClustersW; ///< The nearby clusters map for the w view
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArCosmicRay/UnattachedDeltaRaysAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArCosmicRay/UnattachedDeltaRaysAlgorithm.h
@@ -22,7 +22,7 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string     m_pfoListName;                ///< The pfo list name
+    std::string m_pfoListName; ///< The pfo list name
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.cc
@@ -36,7 +36,7 @@ BranchAssociatedPfosTool::BranchAssociatedPfosTool() :
 void BranchAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     bool associationsMade(true);
 
@@ -61,8 +61,8 @@ void BranchAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgo
             const ThreeDSlidingFitResult &parentFitResult(*(pParentPfoInfo->GetSlidingFitResult3D()));
 
             const float parentLength3D((parentFitResult.GetGlobalMinLayerPosition() - parentFitResult.GetGlobalMaxLayerPosition()).GetMagnitude());
-            const CartesianVector &parentVertexPosition(pParentPfoInfo->IsInnerLayerAssociated() ? parentFitResult.GetGlobalMinLayerPosition() :
-                parentFitResult.GetGlobalMaxLayerPosition());
+            const CartesianVector &parentVertexPosition(pParentPfoInfo->IsInnerLayerAssociated() ? parentFitResult.GetGlobalMinLayerPosition()
+                                                                                                 : parentFitResult.GetGlobalMaxLayerPosition());
 
             for (const ParticleFlowObject *const pPfo : unassignedPfos)
             {
@@ -104,14 +104,14 @@ void BranchAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgo
 
 StatusCode BranchAssociatedPfosTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinNeutrinoVertexDistance", m_minNeutrinoVertexDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinNeutrinoVertexDistance", m_minNeutrinoVertexDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrackBranchAdditionFraction", m_trackBranchAdditionFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "TrackBranchAdditionFraction", m_trackBranchAdditionFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxParentClusterDistance", m_maxParentClusterDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxParentClusterDistance", m_maxParentClusterDistance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/BranchAssociatedPfosTool.h
@@ -24,14 +24,15 @@ public:
      */
     BranchAssociatedPfosTool();
 
-    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
+    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex,
+        NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float       m_minNeutrinoVertexDistance;        ///< Branch association: min distance from branch vertex to neutrino vertex
-    float       m_trackBranchAdditionFraction;      ///< Branch association: min fraction of length along parent track before association allowed
-    float       m_maxParentClusterDistance;         ///< Branch association: max distance from branch vertex to a hit in parent 3D cluster
+    float m_minNeutrinoVertexDistance;   ///< Branch association: min distance from branch vertex to neutrino vertex
+    float m_trackBranchAdditionFraction; ///< Branch association: min fraction of length along parent track before association allowed
+    float m_maxParentClusterDistance;    ///< Branch association: max distance from branch vertex to a hit in parent 3D cluster
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.cc
@@ -38,7 +38,7 @@ EndAssociatedPfosTool::EndAssociatedPfosTool() :
 void EndAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     bool associationsMade(true);
 
@@ -59,7 +59,8 @@ void EndAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorit
             PfoInfo *const pParentPfoInfo(pfoInfoMap.at(pParentPfo));
             const LArPointingCluster parentPointingCluster(*(pParentPfoInfo->GetSlidingFitResult3D()));
 
-            const LArPointingCluster::Vertex &parentEndpoint(pParentPfoInfo->IsInnerLayerAssociated() ? parentPointingCluster.GetOuterVertex() : parentPointingCluster.GetInnerVertex());
+            const LArPointingCluster::Vertex &parentEndpoint(
+                pParentPfoInfo->IsInnerLayerAssociated() ? parentPointingCluster.GetOuterVertex() : parentPointingCluster.GetInnerVertex());
             const float neutrinoVertexDistance((parentEndpoint.GetPosition() - pNeutrinoVertex->GetPosition()).GetMagnitude());
 
             if (neutrinoVertexDistance < m_minNeutrinoVertexDistance)
@@ -74,15 +75,17 @@ void EndAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorit
 
                 const LArPointingCluster pointingCluster(*(pPfoInfo->GetSlidingFitResult3D()));
                 const bool useInner((pointingCluster.GetInnerVertex().GetPosition() - parentEndpoint.GetPosition()).GetMagnitudeSquared() <
-                    (pointingCluster.GetOuterVertex().GetPosition() - parentEndpoint.GetPosition()).GetMagnitudeSquared());
+                                    (pointingCluster.GetOuterVertex().GetPosition() - parentEndpoint.GetPosition()).GetMagnitudeSquared());
 
                 const LArPointingCluster::Vertex &daughterVertex(useInner ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
 
                 if (LArPointingClusterHelper::IsNode(parentEndpoint.GetPosition(), daughterVertex, m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
                     LArPointingClusterHelper::IsNode(daughterVertex.GetPosition(), parentEndpoint, m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-                    LArPointingClusterHelper::IsEmission(parentEndpoint.GetPosition(), daughterVertex, m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-                    LArPointingClusterHelper::IsEmission(daughterVertex.GetPosition(), parentEndpoint, m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-                    this->IsCloseToParentEndpoint(parentEndpoint.GetPosition(), pParentPfoInfo->GetCluster3D(), pPfoInfo->GetCluster3D()) )
+                    LArPointingClusterHelper::IsEmission(parentEndpoint.GetPosition(), daughterVertex, m_minVertexLongitudinalDistance,
+                        m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+                    LArPointingClusterHelper::IsEmission(daughterVertex.GetPosition(), parentEndpoint, m_minVertexLongitudinalDistance,
+                        m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+                    this->IsCloseToParentEndpoint(parentEndpoint.GetPosition(), pParentPfoInfo->GetCluster3D(), pPfoInfo->GetCluster3D()))
                 {
                     associationsMade = true;
                     pParentPfoInfo->AddDaughterPfo(pPfoInfo->GetThisPfo());
@@ -97,15 +100,16 @@ void EndAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool EndAssociatedPfosTool::IsCloseToParentEndpoint(const CartesianVector &parentEndpoint, const Cluster *const pParentCluster3D,
-    const Cluster *const pDaughterCluster3D) const
+bool EndAssociatedPfosTool::IsCloseToParentEndpoint(
+    const CartesianVector &parentEndpoint, const Cluster *const pParentCluster3D, const Cluster *const pDaughterCluster3D) const
 {
     try
     {
         CartesianVector parentPosition3D(0.f, 0.f, 0.f), daughterPosition3D(0.f, 0.f, 0.f);
         LArClusterHelper::GetClosestPositions(pParentCluster3D, pDaughterCluster3D, parentPosition3D, daughterPosition3D);
 
-        if (((parentPosition3D - parentEndpoint).GetMagnitude() < m_maxParentEndpointDistance) && ((parentPosition3D - daughterPosition3D).GetMagnitude() < m_maxParentEndpointDistance))
+        if (((parentPosition3D - parentEndpoint).GetMagnitude() < m_maxParentEndpointDistance) &&
+            ((parentPosition3D - daughterPosition3D).GetMagnitude() < m_maxParentEndpointDistance))
             return true;
     }
     catch (const StatusCodeException &)
@@ -119,23 +123,23 @@ bool EndAssociatedPfosTool::IsCloseToParentEndpoint(const CartesianVector &paren
 
 StatusCode EndAssociatedPfosTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinNeutrinoVertexDistance", m_minNeutrinoVertexDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinNeutrinoVertexDistance", m_minNeutrinoVertexDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexAngularAllowance", m_vertexAngularAllowance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexAngularAllowance", m_vertexAngularAllowance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxParentEndpointDistance", m_maxParentEndpointDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxParentEndpointDistance", m_maxParentEndpointDistance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EndAssociatedPfosTool.h
@@ -26,7 +26,8 @@ public:
      */
     EndAssociatedPfosTool();
 
-    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
+    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex,
+        NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
 
 private:
     /**
@@ -43,12 +44,12 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float       m_minNeutrinoVertexDistance;            ///< Min distance between candidate parent endpoint and neutrino vertex
-    float       m_minVertexLongitudinalDistance;        ///< Vertex association check: min longitudinal distance cut
-    float       m_maxVertexLongitudinalDistance;        ///< Vertex association check: max longitudinal distance cut
-    float       m_maxVertexTransverseDistance;          ///< Vertex association check: max transverse distance cut
-    float       m_vertexAngularAllowance;               ///< Vertex association check: pointing angular allowance in degrees
-    float       m_maxParentEndpointDistance;            ///< Max distance between candidate parent endpoint and candidate daughter
+    float m_minNeutrinoVertexDistance;     ///< Min distance between candidate parent endpoint and neutrino vertex
+    float m_minVertexLongitudinalDistance; ///< Vertex association check: min longitudinal distance cut
+    float m_maxVertexLongitudinalDistance; ///< Vertex association check: max longitudinal distance cut
+    float m_maxVertexTransverseDistance;   ///< Vertex association check: max transverse distance cut
+    float m_vertexAngularAllowance;        ///< Vertex association check: pointing angular allowance in degrees
+    float m_maxParentEndpointDistance;     ///< Max distance between candidate parent endpoint and candidate daughter
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.cc
@@ -13,8 +13,8 @@
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 #include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
 
-#include "larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h"
 #include "larpandoracontent/LArObjects/LArThreeDSlidingConeFitResult.h"
+#include "larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h"
 
 #include "larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.h"
 
@@ -59,11 +59,11 @@ EventSlicingTool::EventSlicingTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventSlicingTool::RunSlicing(const Algorithm *const pAlgorithm, const HitTypeToNameMap &caloHitListNames, const HitTypeToNameMap &clusterListNames,
-    SliceList &sliceList)
+void EventSlicingTool::RunSlicing(const Algorithm *const pAlgorithm, const HitTypeToNameMap &caloHitListNames,
+    const HitTypeToNameMap &clusterListNames, SliceList &sliceList)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ClusterToPfoMap clusterToPfoMap;
 
@@ -103,32 +103,35 @@ void EventSlicingTool::CopyAllHitsToSingleSlice(const Algorithm *const pAlgorith
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
     const CaloHitList *pCaloHitListU(nullptr);
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*pAlgorithm,
-        caloHitListNames.at(TPC_VIEW_U), pCaloHitListU));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+        PandoraContentApi::GetList(*pAlgorithm, caloHitListNames.at(TPC_VIEW_U), pCaloHitListU));
 
     const CaloHitList *pCaloHitListV(nullptr);
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*pAlgorithm,
-        caloHitListNames.at(TPC_VIEW_V), pCaloHitListV));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+        PandoraContentApi::GetList(*pAlgorithm, caloHitListNames.at(TPC_VIEW_V), pCaloHitListV));
 
     const CaloHitList *pCaloHitListW(nullptr);
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*pAlgorithm,
-        caloHitListNames.at(TPC_VIEW_W), pCaloHitListW));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+        PandoraContentApi::GetList(*pAlgorithm, caloHitListNames.at(TPC_VIEW_W), pCaloHitListW));
 
     if (pCaloHitListU || pCaloHitListV || pCaloHitListW)
     {
         sliceList.push_back(Slice());
         Slice &slice(sliceList.at(0));
 
-        if (pCaloHitListU) slice.m_caloHitListU = *pCaloHitListU;
-        if (pCaloHitListV) slice.m_caloHitListV = *pCaloHitListV;
-        if (pCaloHitListW) slice.m_caloHitListW = *pCaloHitListW;
+        if (pCaloHitListU)
+            slice.m_caloHitListU = *pCaloHitListU;
+        if (pCaloHitListV)
+            slice.m_caloHitListV = *pCaloHitListV;
+        if (pCaloHitListW)
+            slice.m_caloHitListW = *pCaloHitListW;
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventSlicingTool::GetThreeDClusters(const Algorithm *const pAlgorithm, const std::string &pfoListName, ClusterList &clusters3D,
-    ClusterToPfoMap &clusterToPfoMap) const
+void EventSlicingTool::GetThreeDClusters(
+    const Algorithm *const pAlgorithm, const std::string &pfoListName, ClusterList &clusters3D, ClusterToPfoMap &clusterToPfoMap) const
 {
     const PfoList *pPfoList(nullptr);
     PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*pAlgorithm, pfoListName, pPfoList));
@@ -164,8 +167,7 @@ void EventSlicingTool::GetThreeDClusters(const Algorithm *const pAlgorithm, cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventSlicingTool::GetClusterSliceList(const ClusterList &trackClusters3D, const ClusterList &showerClusters3D,
-    ClusterSliceList &clusterSliceList) const
+void EventSlicingTool::GetClusterSliceList(const ClusterList &trackClusters3D, const ClusterList &showerClusters3D, ClusterSliceList &clusterSliceList) const
 {
     const float layerPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
@@ -173,16 +175,30 @@ void EventSlicingTool::GetClusterSliceList(const ClusterList &trackClusters3D, c
 
     for (const Cluster *const pCluster3D : trackClusters3D)
     {
-        try {trackFitResults.insert(ThreeDSlidingFitResultMap::value_type(pCluster3D, ThreeDSlidingFitResult(pCluster3D, m_halfWindowLayers, layerPitch)));}
-        catch (StatusCodeException &) {std::cout << "EventSlicingTool: ThreeDSlidingFitResult failure for track cluster." << std::endl;}
+        try
+        {
+            trackFitResults.insert(
+                ThreeDSlidingFitResultMap::value_type(pCluster3D, ThreeDSlidingFitResult(pCluster3D, m_halfWindowLayers, layerPitch)));
+        }
+        catch (StatusCodeException &)
+        {
+            std::cout << "EventSlicingTool: ThreeDSlidingFitResult failure for track cluster." << std::endl;
+        }
     }
 
     ThreeDSlidingConeFitResultMap showerConeFitResults;
 
     for (const Cluster *const pCluster3D : showerClusters3D)
     {
-        try {showerConeFitResults.insert(ThreeDSlidingConeFitResultMap::value_type(pCluster3D, ThreeDSlidingConeFitResult(pCluster3D, m_halfWindowLayers, layerPitch)));}
-        catch (StatusCodeException &) {std::cout << "EventSlicingTool: ThreeDSlidingConeFitResult failure for shower cluster." << std::endl;}
+        try
+        {
+            showerConeFitResults.insert(
+                ThreeDSlidingConeFitResultMap::value_type(pCluster3D, ThreeDSlidingConeFitResult(pCluster3D, m_halfWindowLayers, layerPitch)));
+        }
+        catch (StatusCodeException &)
+        {
+            std::cout << "EventSlicingTool: ThreeDSlidingConeFitResult failure for shower cluster." << std::endl;
+        }
     }
 
     ClusterVector sortedClusters3D(trackClusters3D.begin(), trackClusters3D.end());
@@ -210,8 +226,8 @@ void EventSlicingTool::GetClusterSliceList(const ClusterList &trackClusters3D, c
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void EventSlicingTool::CollectAssociatedClusters(const Cluster *const pClusterInSlice, const ClusterVector &candidateClusters,
-    const ThreeDSlidingFitResultMap &trackFitResults, const ThreeDSlidingConeFitResultMap &showerConeFitResults, ClusterVector &clusterSlice,
-    ClusterSet &usedClusters) const
+    const ThreeDSlidingFitResultMap &trackFitResults, const ThreeDSlidingConeFitResultMap &showerConeFitResults,
+    ClusterVector &clusterSlice, ClusterSet &usedClusters) const
 {
     ClusterVector addedClusters;
 
@@ -222,10 +238,11 @@ void EventSlicingTool::CollectAssociatedClusters(const Cluster *const pClusterIn
 
         if ((m_usePointingAssociation && this->PassPointing(pClusterInSlice, pCandidateCluster, trackFitResults)) ||
             (m_useProximityAssociation && this->PassProximity(pClusterInSlice, pCandidateCluster)) ||
-            (m_useShowerConeAssociation && (this->PassShowerCone(pClusterInSlice, pCandidateCluster, showerConeFitResults) || this->PassShowerCone(pCandidateCluster, pClusterInSlice, showerConeFitResults))) )
+            (m_useShowerConeAssociation && (this->PassShowerCone(pClusterInSlice, pCandidateCluster, showerConeFitResults) ||
+                                               this->PassShowerCone(pCandidateCluster, pClusterInSlice, showerConeFitResults))))
         {
             addedClusters.push_back(pCandidateCluster);
-            (void) usedClusters.insert(pCandidateCluster);
+            (void)usedClusters.insert(pCandidateCluster);
         }
     }
 
@@ -237,7 +254,8 @@ void EventSlicingTool::CollectAssociatedClusters(const Cluster *const pClusterIn
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool EventSlicingTool::PassPointing(const Cluster *const pClusterInSlice, const Cluster *const pCandidateCluster, const ThreeDSlidingFitResultMap &trackFitResults) const
+bool EventSlicingTool::PassPointing(
+    const Cluster *const pClusterInSlice, const Cluster *const pCandidateCluster, const ThreeDSlidingFitResultMap &trackFitResults) const
 {
     ThreeDSlidingFitResultMap::const_iterator inSliceIter = trackFitResults.find(pClusterInSlice);
     ThreeDSlidingFitResultMap::const_iterator candidateIter = trackFitResults.find(pCandidateCluster);
@@ -249,8 +267,7 @@ bool EventSlicingTool::PassPointing(const Cluster *const pClusterInSlice, const 
     const LArPointingCluster candidatePointingCluster(candidateIter->second);
 
     if (this->CheckClosestApproach(inSlicePointingCluster, candidatePointingCluster) ||
-        this->IsEmission(inSlicePointingCluster, candidatePointingCluster) ||
-        this->IsNode(inSlicePointingCluster, candidatePointingCluster))
+        this->IsEmission(inSlicePointingCluster, candidatePointingCluster) || this->IsNode(inSlicePointingCluster, candidatePointingCluster))
     {
         return true;
     }
@@ -284,7 +301,8 @@ bool EventSlicingTool::PassProximity(const Cluster *const pClusterInSlice, const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool EventSlicingTool::PassShowerCone(const Cluster *const pConeCluster, const Cluster *const pNearbyCluster, const ThreeDSlidingConeFitResultMap &showerConeFitResults) const
+bool EventSlicingTool::PassShowerCone(
+    const Cluster *const pConeCluster, const Cluster *const pNearbyCluster, const ThreeDSlidingConeFitResultMap &showerConeFitResults) const
 {
     ThreeDSlidingConeFitResultMap::const_iterator fitIter = showerConeFitResults.find(pConeCluster);
 
@@ -327,9 +345,9 @@ bool EventSlicingTool::PassShowerCone(const Cluster *const pConeCluster, const C
 bool EventSlicingTool::CheckClosestApproach(const LArPointingCluster &cluster1, const LArPointingCluster &cluster2) const
 {
     return (this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetInnerVertex()) ||
-        this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetInnerVertex()) ||
-        this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetOuterVertex()) ||
-        this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetOuterVertex()));
+            this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetInnerVertex()) ||
+            this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetOuterVertex()) ||
+            this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetOuterVertex()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -352,35 +370,52 @@ bool EventSlicingTool::CheckClosestApproach(const LArPointingCluster::Vertex &ve
     const CartesianVector approach2(vertex2.GetPosition() + vertex2.GetDirection() * displacement2);
     const float closestApproach((approach1 - approach2).GetMagnitude());
 
-    return ((closestApproach < m_maxClosestApproach) && (std::fabs(displacement1) < m_maxInterceptDistance) && (std::fabs(displacement2) < m_maxInterceptDistance));
+    return ((closestApproach < m_maxClosestApproach) && (std::fabs(displacement1) < m_maxInterceptDistance) &&
+            (std::fabs(displacement2) < m_maxInterceptDistance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 bool EventSlicingTool::IsNode(const LArPointingCluster &cluster1, const LArPointingCluster &cluster2) const
 {
-    return (LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
+    return (LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetInnerVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 bool EventSlicingTool::IsEmission(const LArPointingCluster &cluster1, const LArPointingCluster &cluster2) const
 {
-    return (LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
+    return (LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetInnerVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
+                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -411,7 +446,8 @@ void EventSlicingTool::CopyPfoHitsToSlices(const ClusterToSliceIndexMap &cluster
     SliceList &sliceList, ClusterSet &assignedClusters) const
 {
     ClusterList clusterList;
-    for (const auto &mapEntry : clusterToSliceIndexMap) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterToSliceIndexMap)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster3D : clusterList)
@@ -458,7 +494,8 @@ void EventSlicingTool::GetRemainingClusters(const Algorithm *const pAlgorithm, c
     const ClusterSet &assignedClusters, ClusterList &remainingClusters) const
 {
     const ClusterList *pClusterList(nullptr);
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*pAlgorithm, clusterListName, pClusterList));
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*pAlgorithm, clusterListName, pClusterList));
 
     if (!pClusterList || pClusterList->empty())
     {
@@ -487,8 +524,8 @@ void EventSlicingTool::GetRemainingClusters(const Algorithm *const pAlgorithm, c
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventSlicingTool::AssignRemainingHitsToSlices(const ClusterList &remainingClusters, const ClusterToSliceIndexMap &clusterToSliceIndexMap,
-    SliceList &sliceList) const
+void EventSlicingTool::AssignRemainingHitsToSlices(
+    const ClusterList &remainingClusters, const ClusterToSliceIndexMap &clusterToSliceIndexMap, SliceList &sliceList) const
 {
     PointToSliceIndexMap pointToSliceIndexMap;
 
@@ -540,17 +577,19 @@ void EventSlicingTool::AssignRemainingHitsToSlices(const ClusterList &remainingC
     catch (...)
     {
         std::cout << "EventSlicingTool::AssignRemainingHitsToSlices - exception " << std::endl;
-        for (const auto &pointMap : pointToSliceIndexMap) delete pointMap.first;
+        for (const auto &pointMap : pointToSliceIndexMap)
+            delete pointMap.first;
         throw;
     }
 
-    for (const auto &pointMap : pointToSliceIndexMap) delete pointMap.first;
+    for (const auto &pointMap : pointToSliceIndexMap)
+        delete pointMap.first;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EventSlicingTool::GetKDTreeEntries2D(const SliceList &sliceList, PointList &pointsU, PointList &pointsV,
-    PointList &pointsW, PointToSliceIndexMap &pointToSliceIndexMap) const
+void EventSlicingTool::GetKDTreeEntries2D(
+    const SliceList &sliceList, PointList &pointsU, PointList &pointsV, PointList &pointsW, PointToSliceIndexMap &pointToSliceIndexMap) const
 {
     unsigned int sliceIndex(0);
 
@@ -587,7 +626,8 @@ void EventSlicingTool::GetKDTreeEntries3D(const ClusterToSliceIndexMap &clusterT
     PointList &pointsW, PointToSliceIndexMap &pointToSliceIndexMap) const
 {
     ClusterList clusterList;
-    for (const auto &mapEntry : clusterToSliceIndexMap) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterToSliceIndexMap)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster3D : clusterList)
@@ -604,9 +644,12 @@ void EventSlicingTool::GetKDTreeEntries3D(const ClusterToSliceIndexMap &clusterT
 
             const CartesianVector &position3D(pCaloHit3D->GetPositionVector());
 
-            const CartesianVector *const pProjectionU(new CartesianVector(LArGeometryHelper::ProjectPosition(this->GetPandora(), position3D, TPC_VIEW_U)));
-            const CartesianVector *const pProjectionV(new CartesianVector(LArGeometryHelper::ProjectPosition(this->GetPandora(), position3D, TPC_VIEW_V)));
-            const CartesianVector *const pProjectionW(new CartesianVector(LArGeometryHelper::ProjectPosition(this->GetPandora(), position3D, TPC_VIEW_W)));
+            const CartesianVector *const pProjectionU(
+                new CartesianVector(LArGeometryHelper::ProjectPosition(this->GetPandora(), position3D, TPC_VIEW_U)));
+            const CartesianVector *const pProjectionV(
+                new CartesianVector(LArGeometryHelper::ProjectPosition(this->GetPandora(), position3D, TPC_VIEW_V)));
+            const CartesianVector *const pProjectionW(
+                new CartesianVector(LArGeometryHelper::ProjectPosition(this->GetPandora(), position3D, TPC_VIEW_W)));
 
             pointsU.push_back(pProjectionU);
             pointsV.push_back(pProjectionV);
@@ -630,7 +673,8 @@ const EventSlicingTool::PointKDNode2D *EventSlicingTool::MatchClusterToSlice(con
     {
         clusterPointList.push_back(new CartesianVector(pCluster2D->GetCentroid(pCluster2D->GetInnerPseudoLayer())));
         clusterPointList.push_back(new CartesianVector(pCluster2D->GetCentroid(pCluster2D->GetOuterPseudoLayer())));
-        clusterPointList.push_back(new CartesianVector((pCluster2D->GetCentroid(pCluster2D->GetInnerPseudoLayer()) + pCluster2D->GetCentroid(pCluster2D->GetOuterPseudoLayer())) * 0.5f));
+        clusterPointList.push_back(new CartesianVector(
+            (pCluster2D->GetCentroid(pCluster2D->GetInnerPseudoLayer()) + pCluster2D->GetCentroid(pCluster2D->GetOuterPseudoLayer())) * 0.5f));
 
         float bestDistance(std::numeric_limits<float>::max());
 
@@ -651,11 +695,13 @@ const EventSlicingTool::PointKDNode2D *EventSlicingTool::MatchClusterToSlice(con
     catch (...)
     {
         std::cout << "EventSlicingTool::MatchClusterToSlice - exception " << std::endl;
-        for (const CartesianVector *const pPoint : clusterPointList) delete pPoint;
+        for (const CartesianVector *const pPoint : clusterPointList)
+            delete pPoint;
         throw;
     }
 
-    for (const CartesianVector *const pPoint : clusterPointList) delete pPoint;
+    for (const CartesianVector *const pPoint : clusterPointList)
+        delete pPoint;
 
     return pBestResultPoint;
 }
@@ -679,79 +725,73 @@ bool EventSlicingTool::SortPoints(const CartesianVector *const pLhs, const Carte
 
 StatusCode EventSlicingTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrackPfoListName", m_trackPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "TrackPfoListName", m_trackPfoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerPfoListName", m_showerPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ShowerPfoListName", m_showerPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsPer3DCluster", m_minHitsPer3DCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinHitsPer3DCluster", m_minHitsPer3DCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "Min3DHitsToSeedNewSlice", m_min3DHitsToSeedNewSlice));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "Min3DHitsToSeedNewSlice", m_min3DHitsToSeedNewSlice));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_halfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UsePointingAssociation", m_usePointingAssociation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UsePointingAssociation", m_usePointingAssociation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexAngularAllowance", m_vertexAngularAllowance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexAngularAllowance", m_vertexAngularAllowance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClosestApproach", m_maxClosestApproach));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClosestApproach", m_maxClosestApproach));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxInterceptDistance", m_maxInterceptDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxInterceptDistance", m_maxInterceptDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseProximityAssociation", m_useProximityAssociation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseProximityAssociation", m_useProximityAssociation));
 
     float maxHitSeparation = std::sqrt(m_maxHitSeparationSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxHitSeparation", maxHitSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxHitSeparation", maxHitSeparation));
     m_maxHitSeparationSquared = maxHitSeparation * maxHitSeparation;
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseShowerConeAssociation", m_useShowerConeAssociation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseShowerConeAssociation", m_useShowerConeAssociation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NConeFitLayers", m_nConeFitLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NConeFitLayers", m_nConeFitLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NConeFits", m_nConeFits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NConeFits", m_nConeFits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeLengthMultiplier", m_coneLengthMultiplier));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeLengthMultiplier", m_coneLengthMultiplier));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxConeLength", m_maxConeLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxConeLength", m_maxConeLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeTanHalfAngle1", m_coneTanHalfAngle1));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeTanHalfAngle1", m_coneTanHalfAngle1));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeBoundedFraction1", m_coneBoundedFraction1));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeBoundedFraction1", m_coneBoundedFraction1));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeTanHalfAngle2", m_coneTanHalfAngle2));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeTanHalfAngle2", m_coneTanHalfAngle2));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeBoundedFraction2", m_coneBoundedFraction2));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeBoundedFraction2", m_coneBoundedFraction2));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "Use3DProjectionsInHitPickUp", m_use3DProjectionsInHitPickUp));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "Use3DProjectionsInHitPickUp", m_use3DProjectionsInHitPickUp));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.h
@@ -17,8 +17,10 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 class SimpleCone;
 
@@ -49,7 +51,7 @@ private:
     void CopyAllHitsToSingleSlice(const pandora::Algorithm *const pAlgorithm, const SlicingAlgorithm::HitTypeToNameMap &caloHitListNames,
         SlicingAlgorithm::SliceList &sliceList) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, const pandora::ParticleFlowObject*> ClusterToPfoMap;
+    typedef std::unordered_map<const pandora::Cluster *, const pandora::ParticleFlowObject *> ClusterToPfoMap;
 
     /**
      *  @brief  Get the 3D clusters from a specified list of pfos, storing the 3D clusters in the provided list and populating
@@ -72,8 +74,8 @@ private:
      *  @param  showerClusters3D the list of 3D shower clusters
      *  @param  clusterSliceList to receive the list of 3D clusters, divided into slices (one 3D cluster list per slice)
      */
-    void GetClusterSliceList(const pandora::ClusterList &trackClusters3D, const pandora::ClusterList &showerClusters3D,
-        ClusterSliceList &clusterSliceList) const;
+    void GetClusterSliceList(
+        const pandora::ClusterList &trackClusters3D, const pandora::ClusterList &showerClusters3D, ClusterSliceList &clusterSliceList) const;
 
     /**
      *  @brief  Collect all clusters associated with a provided cluster
@@ -85,8 +87,9 @@ private:
      *  @param  clusterSlice the cluster slice
      *  @param  usedClusters the list of clusters already added to slices
      */
-    void CollectAssociatedClusters(const pandora::Cluster *const pClusterInSlice, const pandora::ClusterVector &candidateClusters, const ThreeDSlidingFitResultMap &trackFitResults,
-        const ThreeDSlidingConeFitResultMap &showerConeFitResults, pandora::ClusterVector &clusterSlice, pandora::ClusterSet &usedClusters) const;
+    void CollectAssociatedClusters(const pandora::Cluster *const pClusterInSlice, const pandora::ClusterVector &candidateClusters,
+        const ThreeDSlidingFitResultMap &trackFitResults, const ThreeDSlidingConeFitResultMap &showerConeFitResults,
+        pandora::ClusterVector &clusterSlice, pandora::ClusterSet &usedClusters) const;
 
     /**
      *  @brief  Compare the provided clusters to assess whether they are associated via pointing (checks association "both ways")
@@ -97,7 +100,8 @@ private:
      *
      *  @return whether an addition to the cluster slice should be made
      */
-    bool PassPointing(const pandora::Cluster *const pClusterInSlice, const pandora::Cluster *const pCandidateCluster, const ThreeDSlidingFitResultMap &trackFitResults) const;
+    bool PassPointing(const pandora::Cluster *const pClusterInSlice, const pandora::Cluster *const pCandidateCluster,
+        const ThreeDSlidingFitResultMap &trackFitResults) const;
 
     /**
      *  @brief  Compare the provided clusters to assess whether they are associated via pointing
@@ -118,7 +122,8 @@ private:
      *
      *  @return whether an addition to the cluster slice should be made
      */
-    bool PassShowerCone(const pandora::Cluster *const pConeCluster, const pandora::Cluster *const pNearbyCluster, const ThreeDSlidingConeFitResultMap &showerConeFitResults) const;
+    bool PassShowerCone(const pandora::Cluster *const pConeCluster, const pandora::Cluster *const pNearbyCluster,
+        const ThreeDSlidingConeFitResultMap &showerConeFitResults) const;
 
     /**
      *  @brief  Check closest approach metrics for a pair of pointing clusters
@@ -160,7 +165,7 @@ private:
      */
     bool IsEmission(const LArPointingCluster &cluster1, const LArPointingCluster &cluster2) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, unsigned int> ClusterToSliceIndexMap;
+    typedef std::unordered_map<const pandora::Cluster *, unsigned int> ClusterToSliceIndexMap;
 
     /**
      *  @brief  Create new slices for each of the groupings of 3D clusters in the provided cluster slice list
@@ -180,8 +185,8 @@ private:
      *  @param  sliceList the list containing slices to be populated with 2D hits
      *  @param  assignedClusters to receive the list of 2D clusters with hits assigned to slices
      */
-    void CopyPfoHitsToSlices(const ClusterToSliceIndexMap &clusterToSliceIndexMap, const ClusterToPfoMap &clusterToPfoMap, SlicingAlgorithm::SliceList &sliceList,
-        pandora::ClusterSet &assignedClusters) const;
+    void CopyPfoHitsToSlices(const ClusterToSliceIndexMap &clusterToSliceIndexMap, const ClusterToPfoMap &clusterToPfoMap,
+        SlicingAlgorithm::SliceList &sliceList, pandora::ClusterSet &assignedClusters) const;
 
     /**
      *  @brief  Get the list of 2D clusters with hits yets to be assigned to slices
@@ -215,12 +220,12 @@ private:
     void AssignRemainingHitsToSlices(const pandora::ClusterList &remainingClusters, const ClusterToSliceIndexMap &clusterToSliceIndexMap,
         SlicingAlgorithm::SliceList &sliceList) const;
 
-    typedef KDTreeLinkerAlgo<const pandora::CartesianVector*, 2> PointKDTree2D;
-    typedef KDTreeNodeInfoT<const pandora::CartesianVector*, 2> PointKDNode2D;
+    typedef KDTreeLinkerAlgo<const pandora::CartesianVector *, 2> PointKDTree2D;
+    typedef KDTreeNodeInfoT<const pandora::CartesianVector *, 2> PointKDNode2D;
     typedef std::vector<PointKDNode2D> PointKDNode2DList;
 
-    typedef std::list<const pandora::CartesianVector*> PointList;
-    typedef std::unordered_map<const pandora::CartesianVector*, unsigned int> PointToSliceIndexMap;
+    typedef std::list<const pandora::CartesianVector *> PointList;
+    typedef std::unordered_map<const pandora::CartesianVector *, unsigned int> PointToSliceIndexMap;
 
     /**
      *  @brief  Use projections of 3D hits already assigned to slices to populate kd trees to aid assignment of remaining clusters
@@ -266,35 +271,35 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string     m_trackPfoListName;                 ///< The name of the input track pfo list
-    std::string     m_showerPfoListName;                ///< The name of the input shower pfo list
+    std::string m_trackPfoListName;  ///< The name of the input track pfo list
+    std::string m_showerPfoListName; ///< The name of the input shower pfo list
 
-    unsigned int    m_minHitsPer3DCluster;              ///< The minimum number of hits in a 3D cluster to warrant consideration in slicing
-    unsigned int    m_min3DHitsToSeedNewSlice;          ///< The minimum number of hits in a 3D cluster to seed a new slice
-    unsigned int    m_halfWindowLayers;                 ///< The number of layers to use for half-window of sliding fit
+    unsigned int m_minHitsPer3DCluster;     ///< The minimum number of hits in a 3D cluster to warrant consideration in slicing
+    unsigned int m_min3DHitsToSeedNewSlice; ///< The minimum number of hits in a 3D cluster to seed a new slice
+    unsigned int m_halfWindowLayers;        ///< The number of layers to use for half-window of sliding fit
 
-    bool            m_usePointingAssociation;           ///< Whether to use pointing association
-    float           m_minVertexLongitudinalDistance;    ///< Pointing association check: min longitudinal distance cut
-    float           m_maxVertexLongitudinalDistance;    ///< Pointing association check: max longitudinal distance cut
-    float           m_maxVertexTransverseDistance;      ///< Pointing association check: max transverse distance cut
-    float           m_vertexAngularAllowance;           ///< Pointing association check: pointing angular allowance in degrees
-    float           m_maxClosestApproach;               ///< Pointing association: max distance of closest approach between straight line fits
-    float           m_maxInterceptDistance;             ///< Pointing association: max distance from cluster vertex to point of closest approach
+    bool m_usePointingAssociation;         ///< Whether to use pointing association
+    float m_minVertexLongitudinalDistance; ///< Pointing association check: min longitudinal distance cut
+    float m_maxVertexLongitudinalDistance; ///< Pointing association check: max longitudinal distance cut
+    float m_maxVertexTransverseDistance;   ///< Pointing association check: max transverse distance cut
+    float m_vertexAngularAllowance;        ///< Pointing association check: pointing angular allowance in degrees
+    float m_maxClosestApproach;            ///< Pointing association: max distance of closest approach between straight line fits
+    float m_maxInterceptDistance;          ///< Pointing association: max distance from cluster vertex to point of closest approach
 
-    bool            m_useProximityAssociation;          ///< Whether to use proximity association
-    float           m_maxHitSeparationSquared;          ///< Proximity association: max distance allowed between the closest pair of hits
+    bool m_useProximityAssociation;  ///< Whether to use proximity association
+    float m_maxHitSeparationSquared; ///< Proximity association: max distance allowed between the closest pair of hits
 
-    bool            m_useShowerConeAssociation;         ///< Whether to use shower cone association
-    unsigned int    m_nConeFitLayers;                   ///< The number of layers over which to sum fitted direction to obtain cone fit
-    unsigned int    m_nConeFits;                        ///< The number of cone fits to perform, spread roughly uniformly along the shower length
-    float           m_coneLengthMultiplier;             ///< The cone length multiplier to use when calculating bounded cluster fractions
-    float           m_maxConeLength;                    ///< The maximum allowed cone length to use when calculating bounded cluster fractions
-    float           m_coneTanHalfAngle1;                ///< The cone tan half angle to use when calculating bounded cluster fractions 1
-    float           m_coneBoundedFraction1;             ///< The minimum cluster bounded fraction for association 1
-    float           m_coneTanHalfAngle2;                ///< The cone tan half angle to use when calculating bounded cluster fractions 2
-    float           m_coneBoundedFraction2;             ///< The minimum cluster bounded fraction for association 2
+    bool m_useShowerConeAssociation; ///< Whether to use shower cone association
+    unsigned int m_nConeFitLayers;   ///< The number of layers over which to sum fitted direction to obtain cone fit
+    unsigned int m_nConeFits;        ///< The number of cone fits to perform, spread roughly uniformly along the shower length
+    float m_coneLengthMultiplier;    ///< The cone length multiplier to use when calculating bounded cluster fractions
+    float m_maxConeLength;           ///< The maximum allowed cone length to use when calculating bounded cluster fractions
+    float m_coneTanHalfAngle1;       ///< The cone tan half angle to use when calculating bounded cluster fractions 1
+    float m_coneBoundedFraction1;    ///< The minimum cluster bounded fraction for association 1
+    float m_coneTanHalfAngle2;       ///< The cone tan half angle to use when calculating bounded cluster fractions 2
+    float m_coneBoundedFraction2;    ///< The minimum cluster bounded fraction for association 2
 
-    bool            m_use3DProjectionsInHitPickUp;      ///< Whether to include 3D cluster projections when assigning remaining clusters to slices
+    bool m_use3DProjectionsInHitPickUp; ///< Whether to include 3D cluster projections when assigning remaining clusters to slices
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoCreationAlgorithm.cc
@@ -19,8 +19,7 @@ namespace lar_content
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-NeutrinoCreationAlgorithm::NeutrinoCreationAlgorithm() :
-    m_forceSingleEmptyNeutrino(false)
+NeutrinoCreationAlgorithm::NeutrinoCreationAlgorithm() : m_forceSingleEmptyNeutrino(false)
 {
 }
 
@@ -32,8 +31,8 @@ StatusCode NeutrinoCreationAlgorithm::Run()
         return this->ForceSingleEmptyNeutrino();
 
     const VertexList *pVertexList(nullptr);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_vertexListName,
-        pVertexList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_vertexListName, pVertexList));
 
     if (!pVertexList || pVertexList->empty())
     {
@@ -45,8 +44,7 @@ StatusCode NeutrinoCreationAlgorithm::Run()
 
     std::string neutrinoPfoListName;
     const PfoList *pNeutrinoPfoList(nullptr);
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pNeutrinoPfoList,
-        neutrinoPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pNeutrinoPfoList, neutrinoPfoListName));
 
     for (VertexList::const_iterator vIter = pVertexList->begin(), vIterEnd = pVertexList->end(); vIter != vIterEnd; ++vIter)
     {
@@ -79,8 +77,7 @@ StatusCode NeutrinoCreationAlgorithm::ForceSingleEmptyNeutrino() const
 {
     std::string neutrinoPfoListName;
     const PfoList *pNeutrinoPfoList(nullptr);
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pNeutrinoPfoList,
-        neutrinoPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pNeutrinoPfoList, neutrinoPfoListName));
 
     PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
     this->FillDefaultNeutrinoParameters(pfoParameters);
@@ -113,14 +110,12 @@ void NeutrinoCreationAlgorithm::FillDefaultNeutrinoParameters(PandoraContentApi:
 
 StatusCode NeutrinoCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputVertexListName", m_vertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputVertexListName", m_vertexListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "NeutrinoPfoListName", m_neutrinoPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "NeutrinoPfoListName", m_neutrinoPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ForceSingleEmptyNeutrino", m_forceSingleEmptyNeutrino));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ForceSingleEmptyNeutrino", m_forceSingleEmptyNeutrino));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoCreationAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoCreationAlgorithm.h
@@ -41,10 +41,10 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string     m_vertexListName;               ///< The name of the neutrino vertex list
-    std::string     m_neutrinoPfoListName;          ///< The name of the neutrino pfo list
+    std::string m_vertexListName;      ///< The name of the neutrino vertex list
+    std::string m_neutrinoPfoListName; ///< The name of the neutrino pfo list
 
-    bool            m_forceSingleEmptyNeutrino;     ///< Whether to force creation of a single neutrino, with no vertex, regardless of number of input vertices
+    bool m_forceSingleEmptyNeutrino; ///< Whether to force creation of a single neutrino, with no vertex, regardless of number of input vertices
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoDaughterVerticesAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoDaughterVerticesAlgorithm.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoDaughterVerticesAlgorithm.h"
@@ -19,9 +19,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-NeutrinoDaughterVerticesAlgorithm::NeutrinoDaughterVerticesAlgorithm() :
-    m_useParentShowerVertex(false),
-    m_halfWindowLayers(20)
+NeutrinoDaughterVerticesAlgorithm::NeutrinoDaughterVerticesAlgorithm() : m_useParentShowerVertex(false), m_halfWindowLayers(20)
 {
 }
 
@@ -30,8 +28,7 @@ NeutrinoDaughterVerticesAlgorithm::NeutrinoDaughterVerticesAlgorithm() :
 StatusCode NeutrinoDaughterVerticesAlgorithm::Run()
 {
     const PfoList *pPfoList = NULL;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_neutrinoListName,
-        pPfoList));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_neutrinoListName, pPfoList));
 
     if (!pPfoList || pPfoList->empty())
     {
@@ -157,8 +154,8 @@ void NeutrinoDaughterVerticesAlgorithm::BuildDaughterTrack(const LArPointingClus
     {
         const Cluster *const pDaughterCluster = *dIter;
 
-        CartesianVector minPosition(0.f, 0.f, 0.f), maxPosition(0.f,0.f,0.f);
-        CartesianVector minDirection(0.f, 0.f, 0.f), maxDirection(0.f,0.f,0.f);
+        CartesianVector minPosition(0.f, 0.f, 0.f), maxPosition(0.f, 0.f, 0.f);
+        CartesianVector minDirection(0.f, 0.f, 0.f), maxDirection(0.f, 0.f, 0.f);
         bool foundDirection(false);
 
         LArPointingClusterMap::const_iterator cIter = pointingClusterMap.find(pDaughterCluster);
@@ -249,8 +246,8 @@ void NeutrinoDaughterVerticesAlgorithm::BuildDaughterShower(const ParticleFlowOb
     if (LArPfoHelper::IsNeutrino(pParentPfo))
     {
         const Vertex *const pVertex = *(pParentPfo->GetVertexList().begin());
-        const CartesianVector vtxPosition(m_useParentShowerVertex ? pVertex->GetPosition() :
-            LArClusterHelper::GetClosestPosition(pVertex->GetPosition(), daughterList));
+        const CartesianVector vtxPosition(
+            m_useParentShowerVertex ? pVertex->GetPosition() : LArClusterHelper::GetClosestPosition(pVertex->GetPosition(), daughterList));
 
         return this->SetParticleParameters(vtxPosition, CartesianVector(0.f, 0.f, 0.f), pDaughterPfo);
     }
@@ -292,8 +289,8 @@ void NeutrinoDaughterVerticesAlgorithm::BuildDaughterShower(const ParticleFlowOb
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void NeutrinoDaughterVerticesAlgorithm::SetParticleParameters(const CartesianVector &vtxPosition, const CartesianVector &vtxDirection,
-    const ParticleFlowObject *const pPfo) const
+void NeutrinoDaughterVerticesAlgorithm::SetParticleParameters(
+    const CartesianVector &vtxPosition, const CartesianVector &vtxDirection, const ParticleFlowObject *const pPfo) const
 {
     if (!pPfo->GetVertexList().empty())
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -302,7 +299,8 @@ void NeutrinoDaughterVerticesAlgorithm::SetParticleParameters(const CartesianVec
     metadata.m_momentum = vtxDirection;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pPfo, metadata));
 
-    const VertexList *pVertexList = NULL; std::string vertexListName;
+    const VertexList *pVertexList = NULL;
+    std::string vertexListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pVertexList, vertexListName));
 
     PandoraContentApi::Vertex::Parameters parameters;
@@ -324,17 +322,15 @@ void NeutrinoDaughterVerticesAlgorithm::SetParticleParameters(const CartesianVec
 
 StatusCode NeutrinoDaughterVerticesAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "NeutrinoPfoListName", m_neutrinoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "NeutrinoPfoListName", m_neutrinoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputVertexListName", m_vertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_vertexListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseParentForShowerVertex", m_useParentShowerVertex));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseParentForShowerVertex", m_useParentShowerVertex));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_halfWindowLayers));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoDaughterVerticesAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoDaughterVerticesAlgorithm.h
@@ -79,10 +79,10 @@ private:
     void SetParticleParameters(const pandora::CartesianVector &vtxPosition, const pandora::CartesianVector &vtxDirection,
         const pandora::ParticleFlowObject *const pPfo) const;
 
-    bool                    m_useParentShowerVertex;    ///< use the parent pfo for the shower vertices
-    unsigned int            m_halfWindowLayers;         ///< number of layers to use for half-window of sliding fit
-    std::string             m_neutrinoListName;         ///< The input list of pfo list names
-    std::string             m_vertexListName;           ///< The name of the output cosmic-ray vertex list
+    bool m_useParentShowerVertex;    ///< use the parent pfo for the shower vertices
+    unsigned int m_halfWindowLayers; ///< number of layers to use for half-window of sliding fit
+    std::string m_neutrinoListName;  ///< The input list of pfo list names
+    std::string m_vertexListName;    ///< The name of the output cosmic-ray vertex list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.cc
@@ -19,9 +19,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-NeutrinoHierarchyAlgorithm::NeutrinoHierarchyAlgorithm() :
-    m_halfWindowLayers(20),
-    m_displayPfoInfoMap(false)
+NeutrinoHierarchyAlgorithm::NeutrinoHierarchyAlgorithm() : m_halfWindowLayers(20), m_displayPfoInfoMap(false)
 {
 }
 
@@ -30,7 +28,8 @@ NeutrinoHierarchyAlgorithm::NeutrinoHierarchyAlgorithm() :
 void NeutrinoHierarchyAlgorithm::SeparatePfos(const PfoInfoMap &pfoInfoMap, PfoVector &assignedPfos, PfoVector &unassignedPfos) const
 {
     PfoVector sortedPfos;
-    for (const auto &mapEntry : pfoInfoMap) sortedPfos.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoInfoMap)
+        sortedPfos.push_back(mapEntry.first);
     std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
 
     for (const Pfo *const pPfo : sortedPfos)
@@ -105,7 +104,8 @@ StatusCode NeutrinoHierarchyAlgorithm::Run()
 void NeutrinoHierarchyAlgorithm::GetNeutrinoPfo(const ParticleFlowObject *&pNeutrinoPfo) const
 {
     const PfoList *pPfoList = nullptr;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_neutrinoPfoListName, pPfoList));
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_neutrinoPfoListName, pPfoList));
 
     if (!pPfoList || pPfoList->empty())
     {
@@ -157,7 +157,7 @@ void NeutrinoHierarchyAlgorithm::GetInitialPfoInfoMap(const PfoList &pfoList, Pf
         try
         {
             pPfoInfo = new PfoInfo(pPfo, m_halfWindowLayers, layerPitch);
-            (void) pfoInfoMap.insert(PfoInfoMap::value_type(pPfo, pPfoInfo));
+            (void)pfoInfoMap.insert(PfoInfoMap::value_type(pPfo, pPfoInfo));
         }
         catch (StatusCodeException &)
         {
@@ -195,7 +195,8 @@ void NeutrinoHierarchyAlgorithm::ProcessPfoInfoMap(const ParticleFlowObject *con
 
     // Add primary pfo->daughter pfo links
     PfoVector sortedPfos;
-    for (const auto &mapEntry : pfoInfoMap) sortedPfos.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoInfoMap)
+        sortedPfos.push_back(mapEntry.first);
     std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
 
     for (const Pfo *const pPfo : sortedPfos)
@@ -206,7 +207,8 @@ void NeutrinoHierarchyAlgorithm::ProcessPfoInfoMap(const ParticleFlowObject *con
         std::sort(daughterPfos.begin(), daughterPfos.end(), LArPfoHelper::SortByNHits);
 
         for (const ParticleFlowObject *const pDaughterPfo : daughterPfos)
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPfoInfo->GetThisPfo(), pDaughterPfo));
+            PANDORA_THROW_RESULT_IF(
+                STATUS_CODE_SUCCESS, !=, PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPfoInfo->GetThisPfo(), pDaughterPfo));
     }
 
     // Deal with any remaining parent-less pfos
@@ -222,8 +224,8 @@ void NeutrinoHierarchyAlgorithm::ProcessPfoInfoMap(const ParticleFlowObject *con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void NeutrinoHierarchyAlgorithm::AdjustVertexAndPfoInfo(const ParticleFlowObject *const pNeutrinoPfo, const PfoList &candidateDaughterPfoList,
-    PfoInfoMap &pfoInfoMap) const
+void NeutrinoHierarchyAlgorithm::AdjustVertexAndPfoInfo(
+    const ParticleFlowObject *const pNeutrinoPfo, const PfoList &candidateDaughterPfoList, PfoInfoMap &pfoInfoMap) const
 {
     PfoVector candidateDaughterPfoVector(candidateDaughterPfoList.begin(), candidateDaughterPfoList.end());
     std::sort(candidateDaughterPfoVector.begin(), candidateDaughterPfoVector.end(), LArPfoHelper::SortByNHits);
@@ -256,7 +258,8 @@ void NeutrinoHierarchyAlgorithm::AdjustVertexAndPfoInfo(const ParticleFlowObject
     std::string temporaryVertexListName;
     const VertexList *pTemporaryVertexList(nullptr);
     const Vertex *pNewNeutrinoVertex(nullptr);
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pTemporaryVertexList, temporaryVertexListName));
+    PANDORA_THROW_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pTemporaryVertexList, temporaryVertexListName));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Vertex::Create(*this, parameters, pNewNeutrinoVertex));
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Vertex>(*this, neutrinoVertexListName));
 
@@ -279,20 +282,23 @@ void NeutrinoHierarchyAlgorithm::DisplayPfoInfoMap(const ParticleFlowObject *con
 {
     bool display(false);
     PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1.f, -1.f, 1.f));
-    std::cout << "-Neutrino Pfo, nDaughters " << pNeutrinoPfo->GetDaughterPfoList().size() << ", nVertices " << pNeutrinoPfo->GetVertexList().size() << std::endl;
+    std::cout << "-Neutrino Pfo, nDaughters " << pNeutrinoPfo->GetDaughterPfoList().size() << ", nVertices "
+              << pNeutrinoPfo->GetVertexList().size() << std::endl;
 
     PfoVector sortedPfos;
-    for (const auto &mapEntry : pfoInfoMap) sortedPfos.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoInfoMap)
+        sortedPfos.push_back(mapEntry.first);
     std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
 
     for (const Pfo *const pPfo : sortedPfos)
     {
         const PfoInfo *const pPfoInfo(pfoInfoMap.at(pPfo));
 
-        std::cout << "Pfo " << pPfoInfo->GetThisPfo() << ", vtxAssoc " << pPfoInfo->IsNeutrinoVertexAssociated()
-                  << ", parent " << pPfoInfo->GetParentPfo() << ", nDaughters " << pPfoInfo->GetDaughterPfoList().size() << " (";
+        std::cout << "Pfo " << pPfoInfo->GetThisPfo() << ", vtxAssoc " << pPfoInfo->IsNeutrinoVertexAssociated() << ", parent "
+                  << pPfoInfo->GetParentPfo() << ", nDaughters " << pPfoInfo->GetDaughterPfoList().size() << " (";
 
-        for (const ParticleFlowObject *const pDaughterPfo : pPfoInfo->GetDaughterPfoList()) std::cout << pDaughterPfo << " ";
+        for (const ParticleFlowObject *const pDaughterPfo : pPfoInfo->GetDaughterPfoList())
+            std::cout << pDaughterPfo << " ";
         std::cout << ") " << std::endl;
 
         if (pPfoInfo->IsNeutrinoVertexAssociated())
@@ -319,7 +325,8 @@ void NeutrinoHierarchyAlgorithm::DisplayPfoInfoMap(const ParticleFlowObject *con
             display = true;
             const PfoList tempPfoList(1, pPfoInfo->GetThisPfo());
             PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &tempPfoList, "ParentPfo", RED, true, false));
-            PANDORA_MONITORING_API(VisualizeParticleFlowObjects(this->GetPandora(), &(pPfoInfo->GetDaughterPfoList()), "DaughterPfos", BLUE, true, false));
+            PANDORA_MONITORING_API(
+                VisualizeParticleFlowObjects(this->GetPandora(), &(pPfoInfo->GetDaughterPfoList()), "DaughterPfos", BLUE, true, false));
             PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
         }
     }
@@ -328,8 +335,7 @@ void NeutrinoHierarchyAlgorithm::DisplayPfoInfoMap(const ParticleFlowObject *con
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-NeutrinoHierarchyAlgorithm::PfoInfo::PfoInfo(const pandora::ParticleFlowObject *const pPfo, const unsigned int halfWindowLayers,
-        const float layerPitch) :
+NeutrinoHierarchyAlgorithm::PfoInfo::PfoInfo(const pandora::ParticleFlowObject *const pPfo, const unsigned int halfWindowLayers, const float layerPitch) :
     m_pThisPfo(pPfo),
     m_pCluster3D(nullptr),
     m_pVertex3D(nullptr),
@@ -461,12 +467,11 @@ void NeutrinoHierarchyAlgorithm::PfoInfo::RemoveDaughterPfo(const pandora::Parti
 StatusCode NeutrinoHierarchyAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     AlgorithmToolVector algorithmToolVector;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle,
-        "PfoRelationTools", algorithmToolVector));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "PfoRelationTools", algorithmToolVector));
 
     for (AlgorithmToolVector::const_iterator iter = algorithmToolVector.begin(), iterEnd = algorithmToolVector.end(); iter != iterEnd; ++iter)
     {
-        PfoRelationTool *const pPfoRelationTool(dynamic_cast<PfoRelationTool*>(*iter));
+        PfoRelationTool *const pPfoRelationTool(dynamic_cast<PfoRelationTool *>(*iter));
 
         if (!pPfoRelationTool)
             return STATUS_CODE_INVALID_PARAMETER;
@@ -474,20 +479,18 @@ StatusCode NeutrinoHierarchyAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         m_algorithmToolVector.push_back(pPfoRelationTool);
     }
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "NeutrinoPfoListName", m_neutrinoPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "NeutrinoPfoListName", m_neutrinoPfoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "DaughterPfoListNames", m_daughterPfoListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "DaughterPfoListNames", m_daughterPfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NeutrinoVertexListName", m_neutrinoVertexListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NeutrinoVertexListName", m_neutrinoVertexListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_halfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DisplayPfoInfoMap", m_displayPfoInfoMap));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DisplayPfoInfoMap", m_displayPfoInfoMap));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoHierarchyAlgorithm.h
@@ -156,18 +156,18 @@ public:
         void RemoveDaughterPfo(const pandora::ParticleFlowObject *const pDaughterPfo);
 
     private:
-        const pandora::ParticleFlowObject  *m_pThisPfo;                     ///< The address of the pfo
-        const pandora::Cluster             *m_pCluster3D;                   ///< The address of the three dimensional cluster
-        const pandora::Vertex              *m_pVertex3D;                    ///< The address of the three dimensional vertex
-        ThreeDSlidingFitResult             *m_pSlidingFitResult3D;          ///< The three dimensional sliding fit result
+        const pandora::ParticleFlowObject *m_pThisPfo; ///< The address of the pfo
+        const pandora::Cluster *m_pCluster3D;          ///< The address of the three dimensional cluster
+        const pandora::Vertex *m_pVertex3D;            ///< The address of the three dimensional vertex
+        ThreeDSlidingFitResult *m_pSlidingFitResult3D; ///< The three dimensional sliding fit result
 
-        bool                                m_isNeutrinoVertexAssociated;   ///< Whether the pfo is associated with the neutrino vertex
-        bool                                m_isInnerLayerAssociated;       ///< If associated, whether association to parent (vtx or pfo) is at sliding fit inner layer
-        const pandora::ParticleFlowObject  *m_pParentPfo;                   ///< The address of the parent pfo
-        pandora::PfoList                    m_daughterPfoList;              ///< The daughter pfo list
+        bool m_isNeutrinoVertexAssociated; ///< Whether the pfo is associated with the neutrino vertex
+        bool m_isInnerLayerAssociated;     ///< If associated, whether association to parent (vtx or pfo) is at sliding fit inner layer
+        const pandora::ParticleFlowObject *m_pParentPfo; ///< The address of the parent pfo
+        pandora::PfoList m_daughterPfoList;              ///< The daughter pfo list
     };
 
-    typedef std::unordered_map<const pandora::ParticleFlowObject*, PfoInfo*> PfoInfoMap;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, PfoInfo *> PfoInfoMap;
 
     /**
      *  @brief  Query the pfo info map and separate/extract pfos currently either acting as parents or associated with the neutrino vertex
@@ -234,16 +234,16 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::vector<PfoRelationTool*> PfoRelationToolVector;
-    PfoRelationToolVector           m_algorithmToolVector;      ///< The algorithm tool vector
+    typedef std::vector<PfoRelationTool *> PfoRelationToolVector;
+    PfoRelationToolVector m_algorithmToolVector; ///< The algorithm tool vector
 
-    std::string                     m_neutrinoPfoListName;      ///< The neutrino pfo list name
-    pandora::StringVector           m_daughterPfoListNames;     ///< The list of daughter pfo list names
+    std::string m_neutrinoPfoListName;            ///< The neutrino pfo list name
+    pandora::StringVector m_daughterPfoListNames; ///< The list of daughter pfo list names
 
-    std::string                     m_neutrinoVertexListName;   ///< The neutrino vertex list name - if not specified will assume current list
+    std::string m_neutrinoVertexListName; ///< The neutrino vertex list name - if not specified will assume current list
 
-    unsigned int                    m_halfWindowLayers;         ///< The number of layers to use for half-window of sliding fit
-    bool                            m_displayPfoInfoMap;        ///< Whether to display the pfo info map (if monitoring is enabled)
+    unsigned int m_halfWindowLayers; ///< The number of layers to use for half-window of sliding fit
+    bool m_displayPfoInfoMap;        ///< Whether to display the pfo info map (if monitoring is enabled)
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -261,7 +261,8 @@ public:
      *  @param  pNeutrinoVertex the address of the three dimensional neutrino interaction vertex
      *  @param  pfoInfoMap mapping from pfos to three dimensional clusters, sliding fits, vertices, etc.
      */
-    virtual void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap) = 0;
+    virtual void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex,
+        NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap) = 0;
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoPropertiesAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoPropertiesAlgorithm.cc
@@ -18,8 +18,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-NeutrinoPropertiesAlgorithm::NeutrinoPropertiesAlgorithm() :
-    m_includeIsolatedHits(false)
+NeutrinoPropertiesAlgorithm::NeutrinoPropertiesAlgorithm() : m_includeIsolatedHits(false)
 {
 }
 
@@ -28,7 +27,8 @@ NeutrinoPropertiesAlgorithm::NeutrinoPropertiesAlgorithm() :
 StatusCode NeutrinoPropertiesAlgorithm::Run()
 {
     const PfoList *pPfoList(nullptr);
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_neutrinoPfoListName, pPfoList));
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_neutrinoPfoListName, pPfoList));
 
     if (!pPfoList || pPfoList->empty())
     {
@@ -131,11 +131,10 @@ unsigned int NeutrinoPropertiesAlgorithm::GetNTwoDHitsInPfoChain(const ParticleF
 
 StatusCode NeutrinoPropertiesAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "NeutrinoPfoListName", m_neutrinoPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "NeutrinoPfoListName", m_neutrinoPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IncludeIsolatedHits", m_includeIsolatedHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IncludeIsolatedHits", m_includeIsolatedHits));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoPropertiesAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/NeutrinoPropertiesAlgorithm.h
@@ -45,9 +45,9 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string     m_neutrinoPfoListName;      ///< The name of the output neutrino pfo list
+    std::string m_neutrinoPfoListName; ///< The name of the output neutrino pfo list
 
-    bool            m_includeIsolatedHits;      ///< Whether to include isolated hits when counting 2d hits in pfo chain
+    bool m_includeIsolatedHits; ///< Whether to include isolated hits when counting 2d hits in pfo chain
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.cc
@@ -83,12 +83,14 @@ StatusCode TestBeamParticleCreationAlgorithm::SetupTestBeamPfo(const Pfo *const 
 
     // Move test beam pfo to parent list from its initial track or shower list
     const std::string &originalListName(LArPfoHelper::IsTrack(pTestBeamPfo) ? m_trackPfoListName : m_showerPfoListName);
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, originalListName, m_parentPfoListName, PfoList(1, pTestBeamPfo)));
+    PANDORA_RETURN_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, originalListName, m_parentPfoListName, PfoList(1, pTestBeamPfo)));
 
     // Alter metadata: test beam score (1, if not previously set) and particle id (electron if primary pfo shower-like, else charged pion)
     PandoraContentApi::ParticleFlowObject::Metadata pfoMetadata;
     pfoMetadata.m_propertiesToAdd["IsTestBeam"] = 1.f;
-    pfoMetadata.m_propertiesToAdd["TestBeamScore"] = (pNuPfo->GetPropertiesMap().count("TestBeamScore")) ? pNuPfo->GetPropertiesMap().at("TestBeamScore") : 1.f;
+    pfoMetadata.m_propertiesToAdd["TestBeamScore"] =
+        (pNuPfo->GetPropertiesMap().count("TestBeamScore")) ? pNuPfo->GetPropertiesMap().at("TestBeamScore") : 1.f;
     pfoMetadata.m_particleId = (std::fabs(pTestBeamPfo->GetParticleId()) == E_MINUS) ? E_MINUS : PI_PLUS;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pTestBeamPfo, pfoMetadata));
 
@@ -97,7 +99,8 @@ StatusCode TestBeamParticleCreationAlgorithm::SetupTestBeamPfo(const Pfo *const 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TestBeamParticleCreationAlgorithm::SetupTestBeamVertex(const Pfo *const pNuPfo, const Pfo *const pTestBeamPfo, const CartesianVector &testBeamStartVertex) const
+StatusCode TestBeamParticleCreationAlgorithm::SetupTestBeamVertex(
+    const Pfo *const pNuPfo, const Pfo *const pTestBeamPfo, const CartesianVector &testBeamStartVertex) const
 {
     try
     {
@@ -145,20 +148,15 @@ StatusCode TestBeamParticleCreationAlgorithm::SetupTestBeamVertex(const Pfo *con
 
 StatusCode TestBeamParticleCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "ParentPfoListName", m_parentPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ParentPfoListName", m_parentPfoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrackPfoListName", m_trackPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "TrackPfoListName", m_trackPfoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerPfoListName", m_showerPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ShowerPfoListName", m_showerPfoListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "ParentVertexListName", m_parentVertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ParentVertexListName", m_parentVertexListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "DaughterVertexListName", m_daughterVertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "DaughterVertexListName", m_daughterVertexListName));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/TestBeamParticleCreationAlgorithm.h
@@ -30,7 +30,8 @@ private:
      *
      *  @return status code
      */
-    pandora::StatusCode SetupTestBeamPfo(const pandora::Pfo *const pNuPfo, const pandora::Pfo *&pTestBeamPfo, pandora::CartesianVector &testBeamStartVertex) const;
+    pandora::StatusCode SetupTestBeamPfo(
+        const pandora::Pfo *const pNuPfo, const pandora::Pfo *&pTestBeamPfo, pandora::CartesianVector &testBeamStartVertex) const;
 
     /**
      *  @brief  Set up the test beam vertex
@@ -41,16 +42,17 @@ private:
      *
      *  @return status code
      */
-    pandora::StatusCode SetupTestBeamVertex(const pandora::Pfo *const pNuPfo, const pandora::Pfo *const pTestBeamPfo, const pandora::CartesianVector &testBeamStartVertex) const;
+    pandora::StatusCode SetupTestBeamVertex(
+        const pandora::Pfo *const pNuPfo, const pandora::Pfo *const pTestBeamPfo, const pandora::CartesianVector &testBeamStartVertex) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string    m_parentPfoListName;         ///< The parent pfo list name
-    std::string    m_trackPfoListName;          ///< The track pfo list name
-    std::string    m_showerPfoListName;         ///< The shower pfo list name
+    std::string m_parentPfoListName; ///< The parent pfo list name
+    std::string m_trackPfoListName;  ///< The track pfo list name
+    std::string m_showerPfoListName; ///< The shower pfo list name
 
-    std::string    m_parentVertexListName;      ///< The parent vertex list name
-    std::string    m_daughterVertexListName;    ///< The daughter vertex list name
+    std::string m_parentVertexListName;   ///< The parent vertex list name
+    std::string m_daughterVertexListName; ///< The daughter vertex list name
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.cc
@@ -37,12 +37,13 @@ VertexAssociatedPfosTool::VertexAssociatedPfosTool() :
 void VertexAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const Vertex *const pNeutrinoVertex, PfoInfoMap &pfoInfoMap)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     const CartesianVector &neutrinoVertex(pNeutrinoVertex->GetPosition());
 
     PfoVector sortedPfos;
-    for (const auto &mapEntry : pfoInfoMap) sortedPfos.push_back(mapEntry.first);
+    for (const auto &mapEntry : pfoInfoMap)
+        sortedPfos.push_back(mapEntry.first);
     std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
 
     for (const Pfo *const pPfo : sortedPfos)
@@ -54,12 +55,13 @@ void VertexAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgo
 
         const LArPointingCluster pointingCluster(*(pPfoInfo->GetSlidingFitResult3D()));
         const bool useInner((pointingCluster.GetInnerVertex().GetPosition() - neutrinoVertex).GetMagnitudeSquared() <
-            (pointingCluster.GetOuterVertex().GetPosition() - neutrinoVertex).GetMagnitudeSquared());
+                            (pointingCluster.GetOuterVertex().GetPosition() - neutrinoVertex).GetMagnitudeSquared());
 
         const LArPointingCluster::Vertex &daughterVertex(useInner ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
 
         if (LArPointingClusterHelper::IsNode(neutrinoVertex, daughterVertex, m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsEmission(neutrinoVertex, daughterVertex,  m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance))
+            LArPointingClusterHelper::IsEmission(neutrinoVertex, daughterVertex, m_minVertexLongitudinalDistance,
+                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance))
         {
             pPfoInfo->SetNeutrinoVertexAssociation(true);
             pPfoInfo->SetInnerLayerAssociation(useInner);
@@ -71,17 +73,17 @@ void VertexAssociatedPfosTool::Run(const NeutrinoHierarchyAlgorithm *const pAlgo
 
 StatusCode VertexAssociatedPfosTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexAngularAllowance", m_vertexAngularAllowance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexAngularAllowance", m_vertexAngularAllowance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/VertexAssociatedPfosTool.h
@@ -24,15 +24,16 @@ public:
      */
     VertexAssociatedPfosTool();
 
-    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex, NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
+    void Run(const NeutrinoHierarchyAlgorithm *const pAlgorithm, const pandora::Vertex *const pNeutrinoVertex,
+        NeutrinoHierarchyAlgorithm::PfoInfoMap &pfoInfoMap);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float       m_minVertexLongitudinalDistance;        ///< Vertex association check: min longitudinal distance cut
-    float       m_maxVertexLongitudinalDistance;        ///< Vertex association check: max longitudinal distance cut
-    float       m_maxVertexTransverseDistance;          ///< Vertex association check: max transverse distance cut
-    float       m_vertexAngularAllowance;               ///< Vertex association check: pointing angular allowance in degrees
+    float m_minVertexLongitudinalDistance; ///< Vertex association check: min longitudinal distance cut
+    float m_maxVertexLongitudinalDistance; ///< Vertex association check: max longitudinal distance cut
+    float m_maxVertexTransverseDistance;   ///< Vertex association check: max transverse distance cut
+    float m_vertexAngularAllowance;        ///< Vertex association check: pointing angular allowance in degrees
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ClearLongitudinalTrackHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ClearLongitudinalTrackHitsTool.cc
@@ -17,8 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-void ClearLongitudinalTrackHitsTool::GetLongitudinalTrackHit3D(const MatchedSlidingFitMap &matchedSlidingFitMap, const CartesianVector &vtx3D,
-    const CartesianVector &end3D, ProtoHit &protoHit) const
+void ClearLongitudinalTrackHitsTool::GetLongitudinalTrackHit3D(
+    const MatchedSlidingFitMap &matchedSlidingFitMap, const CartesianVector &vtx3D, const CartesianVector &end3D, ProtoHit &protoHit) const
 {
     const CaloHit *const pCaloHit2D(protoHit.GetParentCaloHit2D());
     const HitType hitType(pCaloHit2D->GetHitType());
@@ -73,8 +73,10 @@ void ClearLongitudinalTrackHitsTool::GetLongitudinalTrackHit3D(const MatchedSlid
     }
 
     unsigned int nViews(1);
-    if (fitPositionList1.size() > 0) ++nViews;
-    if (fitPositionList2.size() > 0) ++nViews;
+    if (fitPositionList1.size() > 0)
+        ++nViews;
+    if (fitPositionList2.size() > 0)
+        ++nViews;
 
     if (nViews < m_minViews)
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ClearTransverseTrackHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ClearTransverseTrackHitsTool.cc
@@ -53,8 +53,10 @@ void ClearTransverseTrackHitsTool::GetTransverseTrackHit3D(const MatchedSlidingF
     }
 
     unsigned int nViews(1);
-    if (fitPositionList1.size() > 0) ++nViews;
-    if (fitPositionList2.size() > 0) ++nViews;
+    if (fitPositionList1.size() > 0)
+        ++nViews;
+    if (fitPositionList2.size() > 0)
+        ++nViews;
 
     if (nViews < m_minViews)
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/DeltaRayShowerHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/DeltaRayShowerHitsTool.cc
@@ -24,7 +24,7 @@ void DeltaRayShowerHitsTool::Run(ThreeDHitCreationAlgorithm *const pAlgorithm, c
     const CaloHitVector &inputTwoDHits, ProtoHitVector &protoHitVector)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     try
     {
@@ -51,8 +51,8 @@ void DeltaRayShowerHitsTool::Run(ThreeDHitCreationAlgorithm *const pAlgorithm, c
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void DeltaRayShowerHitsTool::CreateDeltaRayShowerHits3D(const CaloHitVector &inputTwoDHits, const CaloHitVector &parentHits3D,
-    ProtoHitVector &protoHitVector) const
+void DeltaRayShowerHitsTool::CreateDeltaRayShowerHits3D(
+    const CaloHitVector &inputTwoDHits, const CaloHitVector &parentHits3D, ProtoHitVector &protoHitVector) const
 {
     for (const CaloHit *const pCaloHit2D : inputTwoDHits)
     {
@@ -72,7 +72,7 @@ void DeltaRayShowerHitsTool::CreateDeltaRayShowerHits3D(const CaloHitVector &inp
                 const CartesianVector thisPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), thisPosition3D, hitType));
                 const float thisDistanceSquared((pCaloHit2D->GetPositionVector() - thisPosition2D).GetMagnitudeSquared());
 
-                if (thisDistanceSquared <  closestDistanceSquared)
+                if (thisDistanceSquared < closestDistanceSquared)
                 {
                     foundClosestPosition = true;
                     closestDistanceSquared = thisDistanceSquared;

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/DeltaRayShowerHitsTool.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/DeltaRayShowerHitsTool.h
@@ -23,15 +23,15 @@ public:
         const pandora::CaloHitVector &inputTwoDHits, ProtoHitVector &protoHitVector);
 
 private:
-     /**
+    /**
      *  @brief  Create three dimensional hits, using a list of input two dimensional hits and the 3D hits from the parent particle
      *
      *  @param  inputTwoDHits the vector of input two dimensional hits
      *  @param  parentHits3D the vector of 3D hits from the parent particle
      *  @param  protoHitVector to receive the new three dimensional proto hits
      */
-    void CreateDeltaRayShowerHits3D(const pandora::CaloHitVector &inputTwoDHits, const pandora::CaloHitVector &parentHits3D,
-        ProtoHitVector &protoHitVector) const;
+    void CreateDeltaRayShowerHits3D(
+        const pandora::CaloHitVector &inputTwoDHits, const pandora::CaloHitVector &parentHits3D, ProtoHitVector &protoHitVector) const;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.cc
@@ -17,9 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-HitCreationBaseTool::HitCreationBaseTool() :
-    m_sigmaX2(1.),
-    m_chiSquaredCut(1.)
+HitCreationBaseTool::HitCreationBaseTool() : m_sigmaX2(1.), m_chiSquaredCut(1.)
 {
 }
 
@@ -85,9 +83,12 @@ void HitCreationBaseTool::GetBestPosition3D(const HitType hitType1, const HitTyp
     CartesianVector position3D(0.f, 0.f, 0.f);
     double chi2(std::numeric_limits<double>::max());
 
-    const double u((TPC_VIEW_U == hitType) ? pCaloHit2D->GetPositionVector().GetZ() : (TPC_VIEW_U == hitType1) ? fitPosition1.GetZ() : fitPosition2.GetZ());
-    const double v((TPC_VIEW_V == hitType) ? pCaloHit2D->GetPositionVector().GetZ() : (TPC_VIEW_V == hitType1) ? fitPosition1.GetZ() : fitPosition2.GetZ());
-    const double w((TPC_VIEW_W == hitType) ? pCaloHit2D->GetPositionVector().GetZ() : (TPC_VIEW_W == hitType1) ? fitPosition1.GetZ() : fitPosition2.GetZ());
+    const double u((TPC_VIEW_U == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+                                           : (TPC_VIEW_U == hitType1) ? fitPosition1.GetZ() : fitPosition2.GetZ());
+    const double v((TPC_VIEW_V == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+                                           : (TPC_VIEW_V == hitType1) ? fitPosition1.GetZ() : fitPosition2.GetZ());
+    const double w((TPC_VIEW_W == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+                                           : (TPC_VIEW_W == hitType1) ? fitPosition1.GetZ() : fitPosition2.GetZ());
 
     const double sigmaU((TPC_VIEW_U == hitType) ? sigmaHit : sigmaFit);
     const double sigmaV((TPC_VIEW_V == hitType) ? sigmaHit : sigmaFit);
@@ -119,8 +120,8 @@ void HitCreationBaseTool::GetBestPosition3D(const HitType hitType, const Cartesi
 
     CartesianVector position3D(0.f, 0.f, 0.f);
     float chi2(std::numeric_limits<float>::max());
-    LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), pCaloHit2D->GetHitType(), hitType, pCaloHit2D->GetPositionVector(),
-        fitPosition, position3D, chi2);
+    LArGeometryHelper::MergeTwoPositions3D(
+        this->GetPandora(), pCaloHit2D->GetHitType(), hitType, pCaloHit2D->GetPositionVector(), fitPosition, position3D, chi2);
 
     // ATTN Replace chi2 from LArGeometryHelper for consistency with three-view treatment (purely a measure of delta x)
     const double deltaX(pCaloHit2D->GetPositionVector().GetX() - fitPosition.GetX());
@@ -136,8 +137,7 @@ StatusCode HitCreationBaseTool::ReadSettings(const pandora::TiXmlHandle xmlHandl
 {
     double sigmaX(std::sqrt(m_sigmaX2));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SigmaX", sigmaX));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SigmaX", sigmaX));
 
     m_sigmaX2 = sigmaX * sigmaX;
 
@@ -147,8 +147,7 @@ StatusCode HitCreationBaseTool::ReadSettings(const pandora::TiXmlHandle xmlHandl
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ChiSquaredCut", m_chiSquaredCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ChiSquaredCut", m_chiSquaredCut));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.h
@@ -56,8 +56,8 @@ protected:
      *  @param  fitPositionList2 the candidate sliding fit position in the second view
      *  @param  protoHit to receive the populated proto hit
      */
-    virtual void GetBestPosition3D(const pandora::HitType hitType1, const pandora::HitType hitType2, const pandora::CartesianPointVector &fitPositionList1,
-        const pandora::CartesianPointVector &fitPositionList2, ProtoHit &protoHit) const;
+    virtual void GetBestPosition3D(const pandora::HitType hitType1, const pandora::HitType hitType2,
+        const pandora::CartesianPointVector &fitPositionList1, const pandora::CartesianPointVector &fitPositionList2, ProtoHit &protoHit) const;
 
     /**
      *  @brief  Get the three dimensional position using a provided two dimensional calo hit and candidate fit positions from the other two views
@@ -68,8 +68,8 @@ protected:
      *  @param  fitPosition2 the candidate sliding fit position in the second view
      *  @param  protoHit to receive the populated proto hit
      */
-    virtual void GetBestPosition3D(const pandora::HitType hitType1, const pandora::HitType hitType2, const pandora::CartesianVector &fitPosition1,
-        const pandora::CartesianVector &fitPosition2, ProtoHit &protoHit) const;
+    virtual void GetBestPosition3D(const pandora::HitType hitType1, const pandora::HitType hitType2,
+        const pandora::CartesianVector &fitPosition1, const pandora::CartesianVector &fitPosition2, ProtoHit &protoHit) const;
 
     /**
      *  @brief  Get the three dimensional position using a provided two dimensional calo hit and a candidate fit position from another view
@@ -82,8 +82,8 @@ protected:
 
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    double      m_sigmaX2;              ///< The sigmaX squared value, for calculation of chi2 deltaX term
-    double      m_chiSquaredCut;        ///< The chi squared cut (accept only values below the cut value)
+    double m_sigmaX2;       ///< The sigmaX squared value, for calculation of chi2 deltaX term
+    double m_chiSquaredCut; ///< The chi squared cut (accept only values below the cut value)
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/LongitudinalTrackHitsBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/LongitudinalTrackHitsBaseTool.cc
@@ -26,8 +26,8 @@ LongitudinalTrackHitsBaseTool::LongitudinalTrackHitsBaseTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LongitudinalTrackHitsBaseTool::GetTrackHits3D(const CaloHitVector &inputTwoDHits, const MatchedSlidingFitMap &inputSlidingFitMap,
-    ProtoHitVector &protoHitVector) const
+void LongitudinalTrackHitsBaseTool::GetTrackHits3D(
+    const CaloHitVector &inputTwoDHits, const MatchedSlidingFitMap &inputSlidingFitMap, ProtoHitVector &protoHitVector) const
 {
     MatchedSlidingFitMap matchedSlidingFitMap;
     CartesianVector vtx3D(0.f, 0.f, 0.f), end3D(0.f, 0.f, 0.f);
@@ -127,11 +127,12 @@ void LongitudinalTrackHitsBaseTool::GetVertexAndEndPositions(const MatchedSlidin
             const CartesianVector projVtxU(LArGeometryHelper::ProjectPosition(this->GetPandora(), vtx3D, TPC_VIEW_U));
             const CartesianVector projEndU(LArGeometryHelper::ProjectPosition(this->GetPandora(), end3D, TPC_VIEW_U));
 
-            if((endU - vtxU).GetMagnitudeSquared() > m_minTrackLengthSquared &&
-               (projVtxU - vtxU).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projVtxU - endU).GetMagnitudeSquared()) &&
-               (projEndU - endU).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projEndU - vtxU).GetMagnitudeSquared()))
+            if ((endU - vtxU).GetMagnitudeSquared() > m_minTrackLengthSquared &&
+                (projVtxU - vtxU).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projVtxU - endU).GetMagnitudeSquared()) &&
+                (projEndU - endU).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projEndU - vtxU).GetMagnitudeSquared()))
             {
-                matchedU = true;  ++matchedViews;
+                matchedU = true;
+                ++matchedViews;
             }
         }
 
@@ -140,11 +141,12 @@ void LongitudinalTrackHitsBaseTool::GetVertexAndEndPositions(const MatchedSlidin
             const CartesianVector projVtxV(LArGeometryHelper::ProjectPosition(this->GetPandora(), vtx3D, TPC_VIEW_V));
             const CartesianVector projEndV(LArGeometryHelper::ProjectPosition(this->GetPandora(), end3D, TPC_VIEW_V));
 
-            if((endV - vtxV).GetMagnitudeSquared() > m_minTrackLengthSquared &&
-               (projVtxV - vtxV).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projVtxV - endV).GetMagnitudeSquared()) &&
-               (projEndV - endV).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projEndV - vtxV).GetMagnitudeSquared()))
+            if ((endV - vtxV).GetMagnitudeSquared() > m_minTrackLengthSquared &&
+                (projVtxV - vtxV).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projVtxV - endV).GetMagnitudeSquared()) &&
+                (projEndV - endV).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projEndV - vtxV).GetMagnitudeSquared()))
             {
-                matchedV = true;  ++matchedViews;
+                matchedV = true;
+                ++matchedViews;
             }
         }
 
@@ -153,11 +155,12 @@ void LongitudinalTrackHitsBaseTool::GetVertexAndEndPositions(const MatchedSlidin
             const CartesianVector projVtxW(LArGeometryHelper::ProjectPosition(this->GetPandora(), vtx3D, TPC_VIEW_W));
             const CartesianVector projEndW(LArGeometryHelper::ProjectPosition(this->GetPandora(), end3D, TPC_VIEW_W));
 
-            if((endW - vtxW).GetMagnitudeSquared() > m_minTrackLengthSquared &&
-               (projVtxW - vtxW).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projVtxW - endW).GetMagnitudeSquared()) &&
-               (projEndW - endW).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projEndW - vtxW).GetMagnitudeSquared()))
+            if ((endW - vtxW).GetMagnitudeSquared() > m_minTrackLengthSquared &&
+                (projVtxW - vtxW).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projVtxW - endW).GetMagnitudeSquared()) &&
+                (projEndW - endW).GetMagnitudeSquared() < std::min(m_vtxDisplacementCutSquared, (projEndW - vtxW).GetMagnitudeSquared()))
             {
-                matchedW = true;  ++matchedViews;
+                matchedW = true;
+                ++matchedViews;
             }
         }
 
@@ -211,14 +214,13 @@ void LongitudinalTrackHitsBaseTool::UpdateBestPosition(const HitType hitType1, c
 StatusCode LongitudinalTrackHitsBaseTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
     float vtxDisplacementCut = std::sqrt(m_vtxDisplacementCutSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexDisplacementCut", vtxDisplacementCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexDisplacementCut", vtxDisplacementCut));
     m_vtxDisplacementCutSquared = vtxDisplacementCut * vtxDisplacementCut;
 
     float minTrackLength = std::sqrt(m_minTrackLengthSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinTrackLength", minTrackLength));
-    m_minTrackLengthSquared =  minTrackLength * minTrackLength;
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinTrackLength", minTrackLength));
+    m_minTrackLengthSquared = minTrackLength * minTrackLength;
 
     return TrackHitsBaseTool::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/LongitudinalTrackHitsBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/LongitudinalTrackHitsBaseTool.h
@@ -36,8 +36,8 @@ protected:
     virtual void GetLongitudinalTrackHit3D(const MatchedSlidingFitMap &matchedSlidingFitMap, const pandora::CartesianVector &vtx3D,
         const pandora::CartesianVector &end3D, ProtoHit &protoHit) const = 0;
 
-    virtual void GetTrackHits3D(const pandora::CaloHitVector &inputTwoDHits, const MatchedSlidingFitMap &matchedSlidingFitMap,
-        ProtoHitVector &protoHitVector) const;
+    virtual void GetTrackHits3D(
+        const pandora::CaloHitVector &inputTwoDHits, const MatchedSlidingFitMap &matchedSlidingFitMap, ProtoHitVector &protoHitVector) const;
 
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
@@ -66,8 +66,8 @@ private:
     void UpdateBestPosition(const pandora::HitType hitType1, const pandora::HitType hitType2, const pandora::CartesianVector &vtx1,
         const pandora::CartesianVector &vtx2, pandora::CartesianVector &bestVtx, float &bestChi2) const;
 
-    float  m_vtxDisplacementCutSquared;   ///<
-    float  m_minTrackLengthSquared;       ///<
+    float m_vtxDisplacementCutSquared; ///<
+    float m_minTrackLengthSquared;     ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedLongitudinalTrackHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedLongitudinalTrackHitsTool.cc
@@ -17,8 +17,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-void MultiValuedLongitudinalTrackHitsTool::GetLongitudinalTrackHit3D(const MatchedSlidingFitMap &matchedSlidingFitMap, const CartesianVector &vtx3D,
-    const CartesianVector &end3D, ProtoHit &protoHit) const
+void MultiValuedLongitudinalTrackHitsTool::GetLongitudinalTrackHit3D(
+    const MatchedSlidingFitMap &matchedSlidingFitMap, const CartesianVector &vtx3D, const CartesianVector &end3D, ProtoHit &protoHit) const
 {
     const CaloHit *const pCaloHit2D(protoHit.GetParentCaloHit2D());
     const HitType hitType(pCaloHit2D->GetHitType());
@@ -69,8 +69,10 @@ void MultiValuedLongitudinalTrackHitsTool::GetLongitudinalTrackHit3D(const Match
     }
 
     unsigned int nViews(1);
-    if (fitPositionList1.size() > 0) ++nViews;
-    if (fitPositionList2.size() > 0) ++nViews;
+    if (fitPositionList1.size() > 0)
+        ++nViews;
+    if (fitPositionList2.size() > 0)
+        ++nViews;
 
     if (nViews < m_minViews)
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedTransverseTrackHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedTransverseTrackHitsTool.cc
@@ -29,7 +29,8 @@ void MultiValuedTransverseTrackHitsTool::GetTransverseTrackHit3D(const MatchedSl
     if (matchedSlidingFitMap.end() != iter1)
     {
         const TwoDSlidingFitResult &fitResult1 = iter1->second;
-        PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, fitResult1.GetGlobalFitPositionListAtX(pCaloHit2D->GetPositionVector().GetX(), fitPositionList1));
+        PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+            fitResult1.GetGlobalFitPositionListAtX(pCaloHit2D->GetPositionVector().GetX(), fitPositionList1));
     }
 
     MatchedSlidingFitMap::const_iterator iter2 = matchedSlidingFitMap.find(hitType2);
@@ -37,12 +38,15 @@ void MultiValuedTransverseTrackHitsTool::GetTransverseTrackHit3D(const MatchedSl
     if (matchedSlidingFitMap.end() != iter2)
     {
         const TwoDSlidingFitResult &fitResult2 = iter2->second;
-        PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, fitResult2.GetGlobalFitPositionListAtX(pCaloHit2D->GetPositionVector().GetX(), fitPositionList2));
+        PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+            fitResult2.GetGlobalFitPositionListAtX(pCaloHit2D->GetPositionVector().GetX(), fitPositionList2));
     }
 
     unsigned int nViews(1);
-    if (fitPositionList1.size() > 0) ++nViews;
-    if (fitPositionList2.size() > 0) ++nViews;
+    if (fitPositionList1.size() > 0)
+        ++nViews;
+    if (fitPositionList2.size() > 0)
+        ++nViews;
 
     if (nViews < m_minViews)
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ShowerHitsBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ShowerHitsBaseTool.cc
@@ -18,8 +18,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ShowerHitsBaseTool::ShowerHitsBaseTool() :
-    m_xTolerance(1.f)
+ShowerHitsBaseTool::ShowerHitsBaseTool() : m_xTolerance(1.f)
 {
 }
 
@@ -29,7 +28,7 @@ void ShowerHitsBaseTool::Run(ThreeDHitCreationAlgorithm *const pAlgorithm, const
     const CaloHitVector &inputTwoDHits, ProtoHitVector &protoHitVector)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     try
     {
@@ -77,8 +76,7 @@ void ShowerHitsBaseTool::GetShowerHits3D(const CaloHitVector &inputTwoDHits, con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ShowerHitsBaseTool::FilterCaloHits(const float x, const float xTolerance, const CaloHitVector &inputCaloHitVector,
-    CaloHitVector &outputCaloHitVector) const
+void ShowerHitsBaseTool::FilterCaloHits(const float x, const float xTolerance, const CaloHitVector &inputCaloHitVector, CaloHitVector &outputCaloHitVector) const
 {
     for (const CaloHit *const pCaloHit : inputCaloHitVector)
     {
@@ -93,8 +91,7 @@ void ShowerHitsBaseTool::FilterCaloHits(const float x, const float xTolerance, c
 
 StatusCode ShowerHitsBaseTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "XTolerance", m_xTolerance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "XTolerance", m_xTolerance));
 
     return HitCreationBaseTool::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ShowerHitsBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ShowerHitsBaseTool.h
@@ -36,8 +36,7 @@ protected:
      *  @param  caloHitVector2 the vector of candidate hits in view 2
      *  @param  protoHit to receive the populated proto hit
      */
-    virtual void GetShowerHit3D(const pandora::CaloHitVector &caloHitVector1, const pandora::CaloHitVector &caloHitVector2,
-        ProtoHit &protoHit) const = 0;
+    virtual void GetShowerHit3D(const pandora::CaloHitVector &caloHitVector1, const pandora::CaloHitVector &caloHitVector2, ProtoHit &protoHit) const = 0;
 
     /**
      *  @brief  Create three dimensional hits, using a list of input two dimensional hits and the hits (contained in the same particle)
@@ -65,7 +64,7 @@ private:
     void FilterCaloHits(const float x, const float xTolerance, const pandora::CaloHitVector &inputCaloHitVector,
         pandora::CaloHitVector &outputCaloHitVector) const;
 
-    float       m_xTolerance;           ///< The x tolerance to use when looking for associated calo hits between views
+    float m_xTolerance; ///< The x tolerance to use when looking for associated calo hits between views
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.cc
@@ -50,7 +50,8 @@ void ThreeDHitCreationAlgorithm::FilterCaloHitsByType(const CaloHitVector &input
 StatusCode ThreeDHitCreationAlgorithm::Run()
 {
     const PfoList *pPfoList(nullptr);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
 
     if (!pPfoList || pPfoList->empty())
     {
@@ -101,7 +102,8 @@ StatusCode ThreeDHitCreationAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDHitCreationAlgorithm::SeparateTwoDHits(const ParticleFlowObject *const pPfo, const ProtoHitVector &protoHitVector, CaloHitVector &remainingHitVector) const
+void ThreeDHitCreationAlgorithm::SeparateTwoDHits(
+    const ParticleFlowObject *const pPfo, const ProtoHitVector &protoHitVector, CaloHitVector &remainingHitVector) const
 {
     ClusterList twoDClusterList;
     LArPfoHelper::GetTwoDClusterList(pPfo, twoDClusterList);
@@ -208,12 +210,16 @@ double ThreeDHitCreationAlgorithm::GetChi2WrtFit(const ThreeDSlidingFitResult &s
         const double vFit(PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoV(pointOnFit.GetY(), pointOnFit.GetZ()));
         const double wFit(PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoW(pointOnFit.GetY(), pointOnFit.GetZ()));
 
-        const double outputU(PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoU(protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ()));
-        const double outputV(PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoV(protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ()));
-        const double outputW(PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoW(protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ()));
+        const double outputU(PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoU(
+            protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ()));
+        const double outputV(PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoV(
+            protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ()));
+        const double outputW(PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoW(
+            protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ()));
 
         const double deltaUFit(uFit - outputU), deltaVFit(vFit - outputV), deltaWFit(wFit - outputW);
-        chi2WrtFit += ((deltaUFit * deltaUFit) / (sigma3DFit * sigma3DFit)) + ((deltaVFit * deltaVFit) / (sigma3DFit * sigma3DFit)) + ((deltaWFit * deltaWFit) / (sigma3DFit * sigma3DFit));
+        chi2WrtFit += ((deltaUFit * deltaUFit) / (sigma3DFit * sigma3DFit)) + ((deltaVFit * deltaVFit) / (sigma3DFit * sigma3DFit)) +
+                      ((deltaWFit * deltaWFit) / (sigma3DFit * sigma3DFit));
     }
 
     return chi2WrtFit;
@@ -274,15 +280,27 @@ void ThreeDHitCreationAlgorithm::RefineHitPositions(const ThreeDSlidingFitResult
 
         if (protoHit.GetNTrajectorySamples() == 2)
         {
-            u = (TPC_VIEW_U == hitType) ? pCaloHit2D->GetPositionVector().GetZ() : (TPC_VIEW_U == protoHit.GetFirstTrajectorySample().GetHitType()) ? protoHit.GetFirstTrajectorySample().GetPosition().GetZ() : protoHit.GetLastTrajectorySample().GetPosition().GetZ();
-            v = (TPC_VIEW_V == hitType) ? pCaloHit2D->GetPositionVector().GetZ() : (TPC_VIEW_V == protoHit.GetFirstTrajectorySample().GetHitType()) ? protoHit.GetFirstTrajectorySample().GetPosition().GetZ() : protoHit.GetLastTrajectorySample().GetPosition().GetZ();
-            w = (TPC_VIEW_W == hitType) ? pCaloHit2D->GetPositionVector().GetZ() : (TPC_VIEW_W == protoHit.GetFirstTrajectorySample().GetHitType()) ? protoHit.GetFirstTrajectorySample().GetPosition().GetZ() : protoHit.GetLastTrajectorySample().GetPosition().GetZ();
+            u = (TPC_VIEW_U == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+                                        : (TPC_VIEW_U == protoHit.GetFirstTrajectorySample().GetHitType())
+                                              ? protoHit.GetFirstTrajectorySample().GetPosition().GetZ()
+                                              : protoHit.GetLastTrajectorySample().GetPosition().GetZ();
+            v = (TPC_VIEW_V == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+                                        : (TPC_VIEW_V == protoHit.GetFirstTrajectorySample().GetHitType())
+                                              ? protoHit.GetFirstTrajectorySample().GetPosition().GetZ()
+                                              : protoHit.GetLastTrajectorySample().GetPosition().GetZ();
+            w = (TPC_VIEW_W == hitType) ? pCaloHit2D->GetPositionVector().GetZ()
+                                        : (TPC_VIEW_W == protoHit.GetFirstTrajectorySample().GetHitType())
+                                              ? protoHit.GetFirstTrajectorySample().GetPosition().GetZ()
+                                              : protoHit.GetLastTrajectorySample().GetPosition().GetZ();
         }
         else if (protoHit.GetNTrajectorySamples() == 1)
         {
-            u = PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoU(protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ());
-            v = PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoV(protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ());
-            w = PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoW(protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ());
+            u = PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoU(
+                protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ());
+            v = PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoV(
+                protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ());
+            w = PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->YZtoW(
+                protoHit.GetPosition3D().GetY(), protoHit.GetPosition3D().GetZ());
         }
         else
         {
@@ -291,7 +309,8 @@ void ThreeDHitCreationAlgorithm::RefineHitPositions(const ThreeDSlidingFitResult
         }
 
         double bestY(std::numeric_limits<double>::max()), bestZ(std::numeric_limits<double>::max());
-        PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->GetMinChiSquaredYZ(u, v, w, sigmaU, sigmaV, sigmaW, uFit, vFit, wFit, sigma3DFit, bestY, bestZ, chi2);
+        PandoraContentApi::GetPlugins(*this)->GetLArTransformationPlugin()->GetMinChiSquaredYZ(
+            u, v, w, sigmaU, sigmaV, sigmaW, uFit, vFit, wFit, sigma3DFit, bestY, bestZ, chi2);
         position3D.SetValues(pCaloHit2D->GetPositionVector().GetX(), static_cast<float>(bestY), static_cast<float>(bestZ));
 
         protoHit.SetPosition3D(position3D, chi2);
@@ -326,7 +345,7 @@ void ThreeDHitCreationAlgorithm::CreateThreeDHit(const ProtoHit &protoHit, const
     parameters.m_hitType = TPC_3D;
 
     const CaloHit *const pCaloHit2D(protoHit.GetParentCaloHit2D());
-    parameters.m_pParentAddress = static_cast<const void*>(pCaloHit2D);
+    parameters.m_pParentAddress = static_cast<const void *>(pCaloHit2D);
 
     // TODO Check these parameters, especially new cell dimensions
     parameters.m_cellThickness = pCaloHit2D->GetCellThickness();
@@ -356,7 +375,7 @@ bool ThreeDHitCreationAlgorithm::CheckThreeDHit(const ProtoHit &protoHit) const
     try
     {
         // Check that corresponding pseudo layer is within range - TODO use full LArTPC geometry here
-        (void) PandoraContentApi::GetPlugins(*this)->GetPseudoLayerPlugin()->GetPseudoLayer(protoHit.GetPosition3D());
+        (void)PandoraContentApi::GetPlugins(*this)->GetPseudoLayerPlugin()->GetPseudoLayer(protoHit.GetPosition3D());
     }
     catch (StatusCodeException &)
     {
@@ -380,7 +399,8 @@ void ThreeDHitCreationAlgorithm::AddThreeDHitsToPfo(const ParticleFlowObject *co
     if (!threeDClusterList.empty())
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    const ClusterList *pClusterList(nullptr); std::string clusterListName;
+    const ClusterList *pClusterList(nullptr);
+    std::string clusterListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, clusterListName));
 
     PandoraContentApi::Cluster::Parameters parameters;
@@ -443,12 +463,11 @@ const ThreeDHitCreationAlgorithm::TrajectorySample &ThreeDHitCreationAlgorithm::
 StatusCode ThreeDHitCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     AlgorithmToolVector algorithmToolVector;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle,
-        "HitCreationTools", algorithmToolVector));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "HitCreationTools", algorithmToolVector));
 
     for (AlgorithmToolVector::const_iterator iter = algorithmToolVector.begin(), iterEnd = algorithmToolVector.end(); iter != iterEnd; ++iter)
     {
-        HitCreationBaseTool *const pHitCreationTool(dynamic_cast<HitCreationBaseTool*>(*iter));
+        HitCreationBaseTool *const pHitCreationTool(dynamic_cast<HitCreationBaseTool *>(*iter));
 
         if (!pHitCreationTool)
             return STATUS_CODE_INVALID_PARAMETER;
@@ -460,23 +479,23 @@ StatusCode ThreeDHitCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputCaloHitListName", m_outputCaloHitListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputClusterListName", m_outputClusterListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IterateTrackHits", m_iterateTrackHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IterateTrackHits", m_iterateTrackHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IterateShowerHits", m_iterateShowerHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IterateShowerHits", m_iterateShowerHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_slidingFitHalfWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_slidingFitHalfWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NHitRefinementIterations", m_nHitRefinementIterations));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "NHitRefinementIterations", m_nHitRefinementIterations));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "Sigma3DFitMultiplier", m_sigma3DFitMultiplier));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "Sigma3DFitMultiplier", m_sigma3DFitMultiplier));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IterationMaxChi2Ratio", m_iterationMaxChi2Ratio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IterationMaxChi2Ratio", m_iterationMaxChi2Ratio));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.h
@@ -60,9 +60,9 @@ public:
         double GetSigma() const;
 
     private:
-        pandora::CartesianVector    m_position;             ///< The sampling position
-        pandora::HitType            m_hitType;              ///< The sampling hit type
-        double                      m_sigma;                ///< The sampling sigma
+        pandora::CartesianVector m_position; ///< The sampling position
+        pandora::HitType m_hitType;          ///< The sampling hit type
+        double m_sigma;                      ///< The sampling sigma
     };
 
     typedef std::vector<TrajectorySample> TrajectorySampleVector;
@@ -153,11 +153,11 @@ public:
         void AddTrajectorySample(const TrajectorySample &trajectorySample);
 
     private:
-        const pandora::CaloHit     *m_pParentCaloHit2D;         ///< The address of the parent 2D calo hit
-        bool                        m_isPositionSet;            ///< Whether the output 3D position has been set
-        pandora::CartesianVector    m_position3D;               ///< The output 3D position
-        double                      m_chi2;                     ///< The output chi squared value
-        TrajectorySampleVector      m_trajectorySampleVector;   ///< The trajectory sample vector
+        const pandora::CaloHit *m_pParentCaloHit2D;      ///< The address of the parent 2D calo hit
+        bool m_isPositionSet;                            ///< Whether the output 3D position has been set
+        pandora::CartesianVector m_position3D;           ///< The output 3D position
+        double m_chi2;                                   ///< The output chi squared value
+        TrajectorySampleVector m_trajectorySampleVector; ///< The trajectory sample vector
     };
 
     typedef std::vector<ProtoHit> ProtoHitVector;
@@ -174,8 +174,8 @@ public:
      *  @param  hitType the hit type to filter upon
      *  @param  outputCaloHitVector to receive the output calo hit vector
      */
-    void FilterCaloHitsByType(const pandora::CaloHitVector &inputCaloHitVector, const pandora::HitType hitType,
-        pandora::CaloHitVector &outputCaloHitVector) const;
+    void FilterCaloHitsByType(
+        const pandora::CaloHitVector &inputCaloHitVector, const pandora::HitType hitType, pandora::CaloHitVector &outputCaloHitVector) const;
 
 private:
     pandora::StatusCode Run();
@@ -268,24 +268,25 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::vector<HitCreationBaseTool*> HitCreationToolVector;
-    HitCreationToolVector   m_algorithmToolVector;      ///< The algorithm tool vector
+    typedef std::vector<HitCreationBaseTool *> HitCreationToolVector;
+    HitCreationToolVector m_algorithmToolVector; ///< The algorithm tool vector
 
-    std::string             m_inputPfoListName;         ///< The name of the input pfo list
-    std::string             m_outputCaloHitListName;    ///< The name of the output calo hit list
-    std::string             m_outputClusterListName;    ///< The name of the output cluster list
+    std::string m_inputPfoListName;      ///< The name of the input pfo list
+    std::string m_outputCaloHitListName; ///< The name of the output calo hit list
+    std::string m_outputClusterListName; ///< The name of the output cluster list
 
-    bool                    m_iterateTrackHits;         ///< Whether to enable iterative improvement of 3D hits for track trajectories
-    bool                    m_iterateShowerHits;        ///< Whether to enable iterative improvement of 3D hits for showers
-    unsigned int            m_slidingFitHalfWindow;     ///< The sliding linear fit half window
-    unsigned int            m_nHitRefinementIterations; ///< The maximum number of hit refinement iterations
-    double                  m_sigma3DFitMultiplier;     ///< Multiplicative factor: sigmaUVW (same as sigmaHit and sigma2DFit) to sigma3DFit
-    double                  m_iterationMaxChi2Ratio;    ///< Max ratio between current and previous chi2 values to cease iterations
+    bool m_iterateTrackHits;                 ///< Whether to enable iterative improvement of 3D hits for track trajectories
+    bool m_iterateShowerHits;                ///< Whether to enable iterative improvement of 3D hits for showers
+    unsigned int m_slidingFitHalfWindow;     ///< The sliding linear fit half window
+    unsigned int m_nHitRefinementIterations; ///< The maximum number of hit refinement iterations
+    double m_sigma3DFitMultiplier;           ///< Multiplicative factor: sigmaUVW (same as sigmaHit and sigma2DFit) to sigma3DFit
+    double m_iterationMaxChi2Ratio;          ///< Max ratio between current and previous chi2 values to cease iterations
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline ThreeDHitCreationAlgorithm::TrajectorySample::TrajectorySample(const pandora::CartesianVector &position, const pandora::HitType hitType, const double sigma) :
+inline ThreeDHitCreationAlgorithm::TrajectorySample::TrajectorySample(
+    const pandora::CartesianVector &position, const pandora::HitType hitType, const double sigma) :
     m_position(position),
     m_hitType(hitType),
     m_sigma(sigma)

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.cc
@@ -17,8 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ThreeViewShowerHitsTool::ThreeViewShowerHitsTool() :
-    m_zTolerance(1.f)
+ThreeViewShowerHitsTool::ThreeViewShowerHitsTool() : m_zTolerance(1.f)
 {
 }
 
@@ -61,8 +60,7 @@ void ThreeViewShowerHitsTool::GetShowerHit3D(const CaloHitVector &caloHitVector1
 
 StatusCode ThreeViewShowerHitsTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ZTolerance", m_zTolerance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ZTolerance", m_zTolerance));
 
     return ShowerHitsBaseTool::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.h
@@ -29,7 +29,7 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float     m_zTolerance;          ///< The z tolerance to use when looking for associated calo hits between views
+    float m_zTolerance; ///< The z tolerance to use when looking for associated calo hits between views
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/TrackHitsBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/TrackHitsBaseTool.cc
@@ -8,9 +8,9 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
-#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/TrackHitsBaseTool.h"
@@ -20,9 +20,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-TrackHitsBaseTool::TrackHitsBaseTool() :
-    m_minViews(2),
-    m_slidingFitWindow(20)
+TrackHitsBaseTool::TrackHitsBaseTool() : m_minViews(2), m_slidingFitWindow(20)
 {
 }
 
@@ -32,7 +30,7 @@ void TrackHitsBaseTool::Run(ThreeDHitCreationAlgorithm *const pAlgorithm, const 
     const CaloHitVector &inputTwoDHits, ProtoHitVector &protoHitVector)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     try
     {
@@ -92,11 +90,10 @@ void TrackHitsBaseTool::BuildSlidingFitMap(const ParticleFlowObject *const pPfo,
 
 StatusCode TrackHitsBaseTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinViews", m_minViews));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinViews", m_minViews));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
     return HitCreationBaseTool::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/TrackHitsBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/TrackHitsBaseTool.h
@@ -55,8 +55,8 @@ protected:
 
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_minViews;                 ///< The minimum number of views required for building hits
-    unsigned int    m_slidingFitWindow;         ///< The layer window for the sliding linear fits
+    unsigned int m_minViews;         ///< The minimum number of views required for building hits
+    unsigned int m_slidingFitWindow; ///< The layer window for the sliding linear fits
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/TransverseTrackHitsBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/TransverseTrackHitsBaseTool.cc
@@ -18,8 +18,8 @@ using namespace pandora;
 namespace lar_content
 {
 
-void TransverseTrackHitsBaseTool::GetTrackHits3D(const CaloHitVector &inputTwoDHits, const MatchedSlidingFitMap &matchedSlidingFitMap,
-    ProtoHitVector &protoHitVector) const
+void TransverseTrackHitsBaseTool::GetTrackHits3D(
+    const CaloHitVector &inputTwoDHits, const MatchedSlidingFitMap &matchedSlidingFitMap, ProtoHitVector &protoHitVector) const
 {
     for (const CaloHit *const pCaloHit2D : inputTwoDHits)
     {
@@ -69,8 +69,7 @@ double TransverseTrackHitsBaseTool::GetTransverseChi2(const CartesianVector &pos
     const float minX(std::min(minLayerX, maxLayerX));
     const float maxX(std::max(minLayerX, maxLayerX));
 
-    if (((position2D.GetX() - minX) > -std::numeric_limits<float>::epsilon()) &&
-        ((position2D.GetX() - maxX) < +std::numeric_limits<float>::epsilon()))
+    if (((position2D.GetX() - minX) > -std::numeric_limits<float>::epsilon()) && ((position2D.GetX() - maxX) < +std::numeric_limits<float>::epsilon()))
         return 0.;
 
     const float minLayerDistanceSquared((position2D - fitResult.GetGlobalMinLayerPosition()).GetMagnitudeSquared());

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/TransverseTrackHitsBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/TransverseTrackHitsBaseTool.h
@@ -27,8 +27,8 @@ protected:
      */
     virtual void GetTransverseTrackHit3D(const MatchedSlidingFitMap &matchedSlidingFitMap, ProtoHit &protoHit) const = 0;
 
-    virtual void GetTrackHits3D(const pandora::CaloHitVector &inputTwoDHits, const MatchedSlidingFitMap &matchedSlidingFitMap,
-        ProtoHitVector &protoHitVector) const;
+    virtual void GetTrackHits3D(
+        const pandora::CaloHitVector &inputTwoDHits, const MatchedSlidingFitMap &matchedSlidingFitMap, ProtoHitVector &protoHitVector) const;
 
     /**
      *  @brief  Calculate an additional contribution to the chi-squared based on the steepness of the track

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/TwoViewShowerHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/TwoViewShowerHitsTool.cc
@@ -50,7 +50,7 @@ void TwoViewShowerHitsTool::GetShowerHit3D(const CaloHitVector &caloHitVector, P
     {
         Sqx += pCaloHit->GetMipEquivalentEnergy() * pCaloHit->GetPositionVector().GetX();
         Sqz += pCaloHit->GetMipEquivalentEnergy() * pCaloHit->GetPositionVector().GetZ();
-        Sq  += pCaloHit->GetMipEquivalentEnergy();
+        Sq += pCaloHit->GetMipEquivalentEnergy();
     }
 
     if (Sq < std::numeric_limits<double>::epsilon())

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ClearLongitudinalTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ClearLongitudinalTracksTool.cc
@@ -15,8 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClearLongitudinalTracksTool::ClearLongitudinalTracksTool() :
-    m_minMatchedFraction(0.8f)
+ClearLongitudinalTracksTool::ClearLongitudinalTracksTool() : m_minMatchedFraction(0.8f)
 {
 }
 
@@ -25,7 +24,7 @@ ClearLongitudinalTracksTool::ClearLongitudinalTracksTool() :
 bool ClearLongitudinalTracksTool::Run(ThreeViewLongitudinalTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     bool particlesMade(false);
 
@@ -38,8 +37,8 @@ bool ClearLongitudinalTracksTool::Run(ThreeViewLongitudinalTracksAlgorithm *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClearLongitudinalTracksTool::CreateThreeDParticles(ThreeViewLongitudinalTracksAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList,
-    bool &particlesMade) const
+void ClearLongitudinalTracksTool::CreateThreeDParticles(
+    ThreeViewLongitudinalTracksAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList, bool &particlesMade) const
 {
     ProtoParticleVector protoParticleVector;
 
@@ -62,8 +61,8 @@ void ClearLongitudinalTracksTool::CreateThreeDParticles(ThreeViewLongitudinalTra
 
 StatusCode ClearLongitudinalTracksTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ClearLongitudinalTracksTool.h
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ClearLongitudinalTracksTool.h
@@ -36,9 +36,10 @@ private:
      *  @param  elementList the tensor element list
      *  @param  particlesMade receive boolean indicating whether particles have been made
      */
-    void CreateThreeDParticles(ThreeViewLongitudinalTracksAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList, bool &particlesMade) const;
+    void CreateThreeDParticles(
+        ThreeViewLongitudinalTracksAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList, bool &particlesMade) const;
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
+    float m_minMatchedFraction; ///< The min matched sampling point fraction for particle creation
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/MatchedEndPointsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/MatchedEndPointsTool.cc
@@ -15,9 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-MatchedEndPointsTool::MatchedEndPointsTool() :
-    m_minMatchedFraction(0.8f),
-    m_maxEndPointChi2(3.f)
+MatchedEndPointsTool::MatchedEndPointsTool() : m_minMatchedFraction(0.8f), m_maxEndPointChi2(3.f)
 {
 }
 
@@ -26,7 +24,7 @@ MatchedEndPointsTool::MatchedEndPointsTool() :
 bool MatchedEndPointsTool::Run(ThreeViewLongitudinalTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ProtoParticleVector protoParticleVector;
     this->FindMatchedTracks(overlapTensor, protoParticleVector);
@@ -65,7 +63,7 @@ void MatchedEndPointsTool::FindMatchedTracks(const TensorType &overlapTensor, Pr
             if (iter->GetOverlapResult().GetMatchedFraction() < m_minMatchedFraction)
                 continue;
 
-            if (std::max(iter->GetOverlapResult().GetInnerChi2(),iter->GetOverlapResult().GetOuterChi2()) > m_maxEndPointChi2)
+            if (std::max(iter->GetOverlapResult().GetInnerChi2(), iter->GetOverlapResult().GetOuterChi2()) > m_maxEndPointChi2)
                 continue;
 
             ProtoParticle protoParticle;
@@ -86,18 +84,17 @@ void MatchedEndPointsTool::FindMatchedTracks(const TensorType &overlapTensor, Pr
 bool MatchedEndPointsTool::SortByChiSquared(const TensorType::Element &lhs, const TensorType::Element &rhs)
 {
     return (lhs.GetOverlapResult().GetInnerChi2() + lhs.GetOverlapResult().GetOuterChi2() <
-        rhs.GetOverlapResult().GetInnerChi2() + rhs.GetOverlapResult().GetOuterChi2());
+            rhs.GetOverlapResult().GetInnerChi2() + rhs.GetOverlapResult().GetOuterChi2());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode MatchedEndPointsTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxEndPointChi2", m_maxEndPointChi2));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxEndPointChi2", m_maxEndPointChi2));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/MatchedEndPointsTool.h
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/MatchedEndPointsTool.h
@@ -47,8 +47,8 @@ private:
      */
     static bool SortByChiSquared(const TensorType::Element &lhs, const TensorType::Element &rhs);
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    float           m_maxEndPointChi2;                    ///< The max chi2 of matched vertex and end points for particle creation
+    float m_minMatchedFraction; ///< The min matched sampling point fraction for particle creation
+    float m_maxEndPointChi2;    ///< The max chi2 of matched vertex and end points for particle creation
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.cc
@@ -28,7 +28,8 @@ ThreeViewLongitudinalTracksAlgorithm::ThreeViewLongitudinalTracksAlgorithm() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW)
+void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(
+    const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW)
 {
     LongitudinalOverlapResult overlapResult;
     this->CalculateOverlapResult(pClusterU, pClusterV, pClusterW, overlapResult);
@@ -39,8 +40,8 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW,
-    LongitudinalOverlapResult &longitudinalOverlapResult)
+void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster *const pClusterU, const Cluster *const pClusterV,
+    const Cluster *const pClusterW, LongitudinalOverlapResult &longitudinalOverlapResult)
 {
     const TwoDSlidingFitResult &slidingFitResultU(this->GetCachedSlidingFitResult(pClusterU));
     const TwoDSlidingFitResult &slidingFitResultV(this->GetCachedSlidingFitResult(pClusterV));
@@ -56,28 +57,28 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster 
         const bool isForwardW((3 == iPermutation) ? false : true);
 
         // Get 2D start and end positions from each sliding fit for this permutation
-        const CartesianVector vtxU((isForwardU)  ? slidingFitResultU.GetGlobalMinLayerPosition() : slidingFitResultU.GetGlobalMaxLayerPosition());
+        const CartesianVector vtxU((isForwardU) ? slidingFitResultU.GetGlobalMinLayerPosition() : slidingFitResultU.GetGlobalMaxLayerPosition());
         const CartesianVector endU((!isForwardU) ? slidingFitResultU.GetGlobalMinLayerPosition() : slidingFitResultU.GetGlobalMaxLayerPosition());
 
-        const CartesianVector vtxV((isForwardV)  ? slidingFitResultV.GetGlobalMinLayerPosition() : slidingFitResultV.GetGlobalMaxLayerPosition());
+        const CartesianVector vtxV((isForwardV) ? slidingFitResultV.GetGlobalMinLayerPosition() : slidingFitResultV.GetGlobalMaxLayerPosition());
         const CartesianVector endV((!isForwardV) ? slidingFitResultV.GetGlobalMinLayerPosition() : slidingFitResultV.GetGlobalMaxLayerPosition());
 
-        const CartesianVector vtxW((isForwardW)  ? slidingFitResultW.GetGlobalMinLayerPosition() : slidingFitResultW.GetGlobalMaxLayerPosition());
+        const CartesianVector vtxW((isForwardW) ? slidingFitResultW.GetGlobalMinLayerPosition() : slidingFitResultW.GetGlobalMaxLayerPosition());
         const CartesianVector endW((!isForwardW) ? slidingFitResultW.GetGlobalMinLayerPosition() : slidingFitResultW.GetGlobalMaxLayerPosition());
 
         // Merge start and end positions (three views)
-        const float halfLengthSquaredU(0.25*(vtxU - endU).GetMagnitudeSquared());
-        const float halfLengthSquaredV(0.25*(vtxV - endV).GetMagnitudeSquared());
-        const float halfLengthSquaredW(0.25*(vtxW - endW).GetMagnitudeSquared());
+        const float halfLengthSquaredU(0.25 * (vtxU - endU).GetMagnitudeSquared());
+        const float halfLengthSquaredV(0.25 * (vtxV - endV).GetMagnitudeSquared());
+        const float halfLengthSquaredW(0.25 * (vtxW - endW).GetMagnitudeSquared());
 
-        CartesianVector vtxMergedU(0.f,0.f,0.f), vtxMergedV(0.f,0.f,0.f), vtxMergedW(0.f,0.f,0.f);
-        CartesianVector endMergedU(0.f,0.f,0.f), endMergedV(0.f,0.f,0.f), endMergedW(0.f,0.f,0.f);
+        CartesianVector vtxMergedU(0.f, 0.f, 0.f), vtxMergedV(0.f, 0.f, 0.f), vtxMergedW(0.f, 0.f, 0.f);
+        CartesianVector endMergedU(0.f, 0.f, 0.f), endMergedV(0.f, 0.f, 0.f), endMergedW(0.f, 0.f, 0.f);
 
         float vtxChi2(std::numeric_limits<float>::max());
         float endChi2(std::numeric_limits<float>::max());
 
-        LArGeometryHelper::MergeThreePositions(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, vtxU, vtxV, vtxW, vtxMergedU,
-            vtxMergedV, vtxMergedW, vtxChi2);
+        LArGeometryHelper::MergeThreePositions(
+            this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, vtxU, vtxV, vtxW, vtxMergedU, vtxMergedV, vtxMergedW, vtxChi2);
 
         if (vtxChi2 > m_vertexChi2Cut)
             continue;
@@ -87,8 +88,8 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster 
             ((vtxMergedW - vtxW).GetMagnitudeSquared() > std::min(halfLengthSquaredW, (vtxMergedW - endW).GetMagnitudeSquared())))
             continue;
 
-        LArGeometryHelper::MergeThreePositions(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, endU, endV, endW, endMergedU,
-            endMergedV, endMergedW, endChi2);
+        LArGeometryHelper::MergeThreePositions(
+            this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, endU, endV, endW, endMergedU, endMergedV, endMergedW, endChi2);
 
         if (endChi2 > m_vertexChi2Cut)
             continue;
@@ -100,7 +101,7 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster 
 
         // Merge start and end positions (two views)
         float chi2(0.f);
-        CartesianVector position3D(0.f,0.f,0.f);
+        CartesianVector position3D(0.f, 0.f, 0.f);
         CartesianPointVector vtxList3D, endList3D;
 
         LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, vtxU, vtxV, position3D, chi2);
@@ -131,8 +132,7 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster 
                 const CartesianVector &endMerged3D(*iterJ);
 
                 TrackOverlapResult overlapResult;
-                this->CalculateOverlapResult(slidingFitResultU, slidingFitResultV, slidingFitResultW,
-                    vtxMerged3D, endMerged3D, overlapResult);
+                this->CalculateOverlapResult(slidingFitResultU, slidingFitResultV, slidingFitResultW, vtxMerged3D, endMerged3D, overlapResult);
 
                 if (overlapResult.IsInitialized() && (overlapResult.GetNMatchedSamplingPoints() > 0) && (overlapResult > bestOverlapResult))
                 {
@@ -146,8 +146,9 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const Cluster 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const TwoDSlidingFitResult &slidingFitResultU, const TwoDSlidingFitResult &slidingFitResultV,
-    const TwoDSlidingFitResult &slidingFitResultW, const CartesianVector &vtxMerged3D, const CartesianVector &endMerged3D, TrackOverlapResult &overlapResult) const
+void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const TwoDSlidingFitResult &slidingFitResultU,
+    const TwoDSlidingFitResult &slidingFitResultV, const TwoDSlidingFitResult &slidingFitResultW, const CartesianVector &vtxMerged3D,
+    const CartesianVector &endMerged3D, TrackOverlapResult &overlapResult) const
 {
     // Calculate start and end positions of linear trajectory
     const CartesianVector vtxMergedU(LArGeometryHelper::ProjectPosition(this->GetPandora(), vtxMerged3D, TPC_VIEW_U));
@@ -158,9 +159,9 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const TwoDSlid
     const CartesianVector endMergedV(LArGeometryHelper::ProjectPosition(this->GetPandora(), endMerged3D, TPC_VIEW_V));
     const CartesianVector endMergedW(LArGeometryHelper::ProjectPosition(this->GetPandora(), endMerged3D, TPC_VIEW_W));
 
-    const unsigned int nSamplingPoints = static_cast<unsigned int>((endMerged3D - vtxMerged3D).GetMagnitude()/ m_samplingPitch);
+    const unsigned int nSamplingPoints = static_cast<unsigned int>((endMerged3D - vtxMerged3D).GetMagnitude() / m_samplingPitch);
 
-    if(0 == nSamplingPoints)
+    if (0 == nSamplingPoints)
         return;
 
     // Loop over sampling points and calculate track overlap result
@@ -174,7 +175,7 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const TwoDSlid
         const CartesianVector linearV(vtxMergedV + (endMergedV - vtxMergedV) * alpha);
         const CartesianVector linearW(vtxMergedW + (endMergedW - vtxMergedW) * alpha);
 
-        CartesianVector posU(0.f,0.f,0.f), posV(0.f,0.f,0.f), posW(0.f,0.f,0.f);
+        CartesianVector posU(0.f, 0.f, 0.f), posV(0.f, 0.f, 0.f), posW(0.f, 0.f, 0.f);
         if ((STATUS_CODE_SUCCESS != slidingFitResultU.GetGlobalFitProjection(linearU, posU)) ||
             (STATUS_CODE_SUCCESS != slidingFitResultV.GetGlobalFitProjection(linearV, posV)) ||
             (STATUS_CODE_SUCCESS != slidingFitResultW.GetGlobalFitProjection(linearW, posW)))
@@ -182,7 +183,7 @@ void ThreeViewLongitudinalTracksAlgorithm::CalculateOverlapResult(const TwoDSlid
             continue;
         }
 
-        CartesianVector mergedU(0.f,0.f,0.f), mergedV(0.f,0.f,0.f), mergedW(0.f,0.f,0.f);
+        CartesianVector mergedU(0.f, 0.f, 0.f), mergedV(0.f, 0.f, 0.f), mergedW(0.f, 0.f, 0.f);
         LArGeometryHelper::MergeThreePositions(this->GetPandora(), posU, posV, posW, mergedU, mergedV, mergedW, deltaChi2);
 
         if (deltaChi2 < m_reducedChi2Cut)
@@ -201,7 +202,7 @@ void ThreeViewLongitudinalTracksAlgorithm::ExamineOverlapContainer()
 {
     unsigned int repeatCounter(0);
 
-    for (TensorToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd; )
+    for (TensorToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd;)
     {
         if ((*iter)->Run(this, this->GetMatchingControl().GetOverlapTensor()))
         {
@@ -222,12 +223,11 @@ void ThreeViewLongitudinalTracksAlgorithm::ExamineOverlapContainer()
 StatusCode ThreeViewLongitudinalTracksAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     AlgorithmToolVector algorithmToolVector;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle,
-        "TrackTools", algorithmToolVector));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "TrackTools", algorithmToolVector));
 
     for (AlgorithmToolVector::const_iterator iter = algorithmToolVector.begin(), iterEnd = algorithmToolVector.end(); iter != iterEnd; ++iter)
     {
-        LongitudinalTensorTool *const pLongitudinalTensorTool(dynamic_cast<LongitudinalTensorTool*>(*iter));
+        LongitudinalTensorTool *const pLongitudinalTensorTool(dynamic_cast<LongitudinalTensorTool *>(*iter));
 
         if (!pLongitudinalTensorTool)
             return STATUS_CODE_INVALID_PARAMETER;
@@ -235,17 +235,14 @@ StatusCode ThreeViewLongitudinalTracksAlgorithm::ReadSettings(const TiXmlHandle 
         m_algorithmToolVector.push_back(pLongitudinalTensorTool);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NMaxTensorToolRepeats", m_nMaxTensorToolRepeats));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NMaxTensorToolRepeats", m_nMaxTensorToolRepeats));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexChi2Cut", m_vertexChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexChi2Cut", m_vertexChi2Cut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ReducedChi2Cut", m_reducedChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ReducedChi2Cut", m_reducedChi2Cut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SamplingPitch", m_samplingPitch));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SamplingPitch", m_samplingPitch));
 
     if (m_samplingPitch < std::numeric_limits<float>::epsilon())
         return STATUS_CODE_INVALID_PARAMETER;

--- a/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.h
@@ -26,10 +26,10 @@ class LongitudinalTensorTool;
 /**
  *  @brief  ThreeViewLongitudinalTracksAlgorithm class
  */
-class ThreeViewLongitudinalTracksAlgorithm : public NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<LongitudinalOverlapResult> >
+class ThreeViewLongitudinalTracksAlgorithm : public NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<LongitudinalOverlapResult>>
 {
 public:
-    typedef NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<LongitudinalOverlapResult> > BaseAlgorithm;
+    typedef NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<LongitudinalOverlapResult>> BaseAlgorithm;
 
     /**
      *  @brief  Default constructor
@@ -47,8 +47,8 @@ private:
      *  @param  pClusterW the cluster from the W view
      *  @param  overlapResult to receive the overlap result
      */
-    void CalculateOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW,
-        LongitudinalOverlapResult &overlapResult);
+    void CalculateOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV,
+        const pandora::Cluster *const pClusterW, LongitudinalOverlapResult &overlapResult);
 
     /**
      *  @brief  Calculate the overlap result for given 3D vertex and end positions
@@ -61,20 +61,20 @@ private:
      *  @param  overlapResult to receive the overlap result
      */
     void CalculateOverlapResult(const TwoDSlidingFitResult &slidingFitResultU, const TwoDSlidingFitResult &slidingFitResultV,
-        const TwoDSlidingFitResult &slidingFitResultW, const pandora::CartesianVector &vtxMerged3D, const pandora::CartesianVector &endMerged3D,
-        TrackOverlapResult &overlapResult) const;
+        const TwoDSlidingFitResult &slidingFitResultW, const pandora::CartesianVector &vtxMerged3D,
+        const pandora::CartesianVector &endMerged3D, TrackOverlapResult &overlapResult) const;
 
     void ExamineOverlapContainer();
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::vector<LongitudinalTensorTool*> TensorToolVector;
-    TensorToolVector    m_algorithmToolVector;              ///< The algorithm tool vector
+    typedef std::vector<LongitudinalTensorTool *> TensorToolVector;
+    TensorToolVector m_algorithmToolVector; ///< The algorithm tool vector
 
-    unsigned int        m_nMaxTensorToolRepeats;            ///< The maximum number of repeat loops over tensor tools
-    float               m_vertexChi2Cut;                    ///< The maximum allowed chi2 for associating end points from three views
-    float               m_reducedChi2Cut;                   ///< The maximum allowed chi2 for associating hit positions from three views
-    float               m_samplingPitch;                    ///< Pitch used to generate sampling points along tracks
+    unsigned int m_nMaxTensorToolRepeats; ///< The maximum number of repeat loops over tensor tools
+    float m_vertexChi2Cut;                ///< The maximum allowed chi2 for associating end points from three views
+    float m_reducedChi2Cut;               ///< The maximum allowed chi2 for associating hit positions from three views
+    float m_samplingPitch;                ///< Pitch used to generate sampling points along tracks
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.cc
@@ -40,28 +40,31 @@ ShowerPfoMopUpAlgorithm::ShowerPfoMopUpAlgorithm() :
 bool ShowerPfoMopUpAlgorithm::IsVertexAssociated(const CartesianVector &vertex2D, const LArPointingCluster &pointingCluster) const
 {
     return (LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetInnerVertex(),  m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetOuterVertex(),  m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
+            LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance,
+                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance,
+                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ShowerPfoMopUpAlgorithm::PfoAssociation ShowerPfoMopUpAlgorithm::GetPfoAssociation(const Pfo *const pVertexPfo, const Pfo *const pDaughterPfo,
-    HitTypeToAssociationMap &hitTypeToAssociationMap) const
+ShowerPfoMopUpAlgorithm::PfoAssociation ShowerPfoMopUpAlgorithm::GetPfoAssociation(
+    const Pfo *const pVertexPfo, const Pfo *const pDaughterPfo, HitTypeToAssociationMap &hitTypeToAssociationMap) const
 {
-    return PfoAssociation(pVertexPfo, pDaughterPfo, hitTypeToAssociationMap[TPC_VIEW_U], hitTypeToAssociationMap[TPC_VIEW_V], hitTypeToAssociationMap[TPC_VIEW_W]);
+    return PfoAssociation(pVertexPfo, pDaughterPfo, hitTypeToAssociationMap[TPC_VIEW_U], hitTypeToAssociationMap[TPC_VIEW_V],
+        hitTypeToAssociationMap[TPC_VIEW_W]);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode ShowerPfoMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexAngularAllowance", m_vertexAngularAllowance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexAngularAllowance", m_vertexAngularAllowance));
 
     return VertexBasedPfoMopUpAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.h
@@ -26,11 +26,12 @@ public:
 
 private:
     bool IsVertexAssociated(const pandora::CartesianVector &vertex2D, const LArPointingCluster &pointingCluster) const;
-    PfoAssociation GetPfoAssociation(const pandora::Pfo *const pVertexPfo, const pandora::Pfo *const pDaughterPfo, HitTypeToAssociationMap &hitTypeToAssociationMap) const;
+    PfoAssociation GetPfoAssociation(const pandora::Pfo *const pVertexPfo, const pandora::Pfo *const pDaughterPfo,
+        HitTypeToAssociationMap &hitTypeToAssociationMap) const;
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float                   m_maxVertexLongitudinalDistance;    ///< Vertex association check: max longitudinal distance cut
-    float                   m_vertexAngularAllowance;           ///< Vertex association check: pointing angular allowance in degrees
+    float m_maxVertexLongitudinalDistance; ///< Vertex association check: max longitudinal distance cut
+    float m_vertexAngularAllowance;        ///< Vertex association check: pointing angular allowance in degrees
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.cc
@@ -83,7 +83,8 @@ void SlidingConePfoMopUpAlgorithm::GetInteractionVertex(const Vertex *&pVertex) 
     const VertexList *pVertexList = nullptr;
     PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetCurrentList(*this, pVertexList));
 
-    pVertex = ((pVertexList && (pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
+    pVertex =
+        ((pVertexList && (pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -145,12 +146,17 @@ void SlidingConePfoMopUpAlgorithm::GetClusterMergeMap(const Vertex *const pVerte
 
             const float vertexToMinLayer(!pVertex ? 0.f : (pVertex->GetPosition() - minLayerPosition).GetMagnitude());
             const float vertexToMaxLayer(!pVertex ? 0.f : (pVertex->GetPosition() - maxLayerPosition).GetMagnitude());
-            const ConeSelection coneSelection(!pVertex ? CONE_BOTH_DIRECTIONS : (vertexToMaxLayer > vertexToMinLayer) ? CONE_FORWARD_ONLY : CONE_BACKWARD_ONLY);
+            const ConeSelection coneSelection(
+                !pVertex ? CONE_BOTH_DIRECTIONS : (vertexToMaxLayer > vertexToMinLayer) ? CONE_FORWARD_ONLY : CONE_BACKWARD_ONLY);
 
             slidingConeFitResult3D.GetSimpleConeList(m_nConeFitLayers, m_nConeFits, coneSelection, simpleConeList);
-            isShowerVertexAssociated = this->IsVertexAssociated(pShowerCluster, pVertex, vertexAssociationMap, &(slidingConeFitResult3D.GetSlidingFitResult()));
+            isShowerVertexAssociated =
+                this->IsVertexAssociated(pShowerCluster, pVertex, vertexAssociationMap, &(slidingConeFitResult3D.GetSlidingFitResult()));
         }
-        catch (const StatusCodeException &) {continue;}
+        catch (const StatusCodeException &)
+        {
+            continue;
+        }
 
         for (const Cluster *const pNearbyCluster : clusters3D)
         {
@@ -172,7 +178,8 @@ void SlidingConePfoMopUpAlgorithm::GetClusterMergeMap(const Vertex *const pVerte
             if (isShowerVertexAssociated && this->IsVertexAssociated(pNearbyCluster, pVertex, vertexAssociationMap))
                 continue;
 
-            if (bestClusterMerge.GetParentCluster() && (bestClusterMerge.GetBoundedFraction1() > m_coneBoundedFraction1) && (bestClusterMerge.GetBoundedFraction2() > m_coneBoundedFraction2))
+            if (bestClusterMerge.GetParentCluster() && (bestClusterMerge.GetBoundedFraction1() > m_coneBoundedFraction1) &&
+                (bestClusterMerge.GetBoundedFraction2() > m_coneBoundedFraction2))
                 clusterMergeMap[pNearbyCluster].push_back(bestClusterMerge);
         }
     }
@@ -195,23 +202,24 @@ bool SlidingConePfoMopUpAlgorithm::IsVertexAssociated(const Cluster *const pClus
         return iter->second;
 
     const bool isVertexAssociated(this->IsVertexAssociated(pCluster, pVertex->GetPosition(), pSlidingFitResult));
-    (void) vertexAssociationMap.insert(VertexAssociationMap::value_type(pCluster, isVertexAssociated));
+    (void)vertexAssociationMap.insert(VertexAssociationMap::value_type(pCluster, isVertexAssociated));
 
     return isVertexAssociated;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool SlidingConePfoMopUpAlgorithm::IsVertexAssociated(const Cluster *const pCluster, const CartesianVector &vertexPosition,
-    const ThreeDSlidingFitResult *const pSlidingFitResult) const
+bool SlidingConePfoMopUpAlgorithm::IsVertexAssociated(
+    const Cluster *const pCluster, const CartesianVector &vertexPosition, const ThreeDSlidingFitResult *const pSlidingFitResult) const
 {
     try
     {
         const float layerPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
-        const LArPointingCluster pointingCluster(pSlidingFitResult ? LArPointingCluster(*pSlidingFitResult) : LArPointingCluster(pCluster, m_halfWindowLayers, layerPitch));
+        const LArPointingCluster pointingCluster(
+            pSlidingFitResult ? LArPointingCluster(*pSlidingFitResult) : LArPointingCluster(pCluster, m_halfWindowLayers, layerPitch));
 
         const bool useInner((pointingCluster.GetInnerVertex().GetPosition() - vertexPosition).GetMagnitudeSquared() <
-            (pointingCluster.GetOuterVertex().GetPosition() - vertexPosition).GetMagnitudeSquared());
+                            (pointingCluster.GetOuterVertex().GetPosition() - vertexPosition).GetMagnitudeSquared());
 
         const LArPointingCluster::Vertex &daughterVertex(useInner ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
         return LArPointingClusterHelper::IsNode(vertexPosition, daughterVertex, m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance);
@@ -228,7 +236,8 @@ bool SlidingConePfoMopUpAlgorithm::IsVertexAssociated(const Cluster *const pClus
 bool SlidingConePfoMopUpAlgorithm::MakePfoMerges(const ClusterToPfoMap &clusterToPfoMap, const ClusterMergeMap &clusterMergeMap) const
 {
     ClusterVector daughterClusters;
-    for (const ClusterMergeMap::value_type &mapEntry : clusterMergeMap) daughterClusters.push_back(mapEntry.first);
+    for (const ClusterMergeMap::value_type &mapEntry : clusterMergeMap)
+        daughterClusters.push_back(mapEntry.first);
     std::sort(daughterClusters.begin(), daughterClusters.end(), LArClusterHelper::SortByNHits);
 
     bool pfosMerged(false);
@@ -297,53 +306,48 @@ bool SlidingConePfoMopUpAlgorithm::ClusterMerge::operator<(const ClusterMerge &r
 
 StatusCode SlidingConePfoMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputPfoListNames", m_inputPfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputPfoListNames", m_inputPfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseVertex", m_useVertex));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseVertex", m_useVertex));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxIterations", m_maxIterations));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxIterations", m_maxIterations));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxHitsToConsider3DTrack", m_maxHitsToConsider3DTrack));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxHitsToConsider3DTrack", m_maxHitsToConsider3DTrack));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsToConsider3DShower", m_minHitsToConsider3DShower));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitsToConsider3DShower", m_minHitsToConsider3DShower));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_halfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NConeFitLayers", m_nConeFitLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NConeFitLayers", m_nConeFitLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NConeFits", m_nConeFits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NConeFits", m_nConeFits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeLengthMultiplier", m_coneLengthMultiplier));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeLengthMultiplier", m_coneLengthMultiplier));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxConeLength", m_maxConeLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxConeLength", m_maxConeLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeTanHalfAngle1", m_coneTanHalfAngle1));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeTanHalfAngle1", m_coneTanHalfAngle1));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeBoundedFraction1", m_coneBoundedFraction1));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeBoundedFraction1", m_coneBoundedFraction1));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeTanHalfAngle2", m_coneTanHalfAngle2));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeTanHalfAngle2", m_coneTanHalfAngle2));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeBoundedFraction2", m_coneBoundedFraction2));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeBoundedFraction2", m_coneBoundedFraction2));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
 
     m_daughterListNames.insert(m_daughterListNames.end(), m_inputPfoListNames.begin(), m_inputPfoListNames.end());
 

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.h
@@ -73,9 +73,9 @@ private:
         bool operator<(const ClusterMerge &rhs) const;
 
     private:
-        const pandora::Cluster *m_pParentCluster;       ///< The address of the candidate parent (shower) cluster
-        float                   m_boundedFraction1;     ///< The bounded fraction for algorithm-specified cone angle 1
-        float                   m_boundedFraction2;     ///< The bounded fraction for algorithm-specified cone angle 2
+        const pandora::Cluster *m_pParentCluster; ///< The address of the candidate parent (shower) cluster
+        float m_boundedFraction1;                 ///< The bounded fraction for algorithm-specified cone angle 1
+        float m_boundedFraction2;                 ///< The bounded fraction for algorithm-specified cone angle 2
     };
 
     typedef std::vector<ClusterMerge> ClusterMergeList;
@@ -89,7 +89,7 @@ private:
      */
     void GetInteractionVertex(const pandora::Vertex *&pVertex) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, const pandora::ParticleFlowObject*> ClusterToPfoMap;
+    typedef std::unordered_map<const pandora::Cluster *, const pandora::ParticleFlowObject *> ClusterToPfoMap;
 
     /**
      *  @brief  Get all 3d clusters contained in the input pfo lists and a mapping from clusters to pfos
@@ -99,7 +99,7 @@ private:
      */
     void GetThreeDClusters(pandora::ClusterVector &clusters3D, ClusterToPfoMap &clusterToPfoMap) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, ClusterMergeList> ClusterMergeMap;
+    typedef std::unordered_map<const pandora::Cluster *, ClusterMergeList> ClusterMergeMap;
 
     /**
      *  @brief  Get the cluster merge map describing all potential 3d cluster merges
@@ -109,10 +109,10 @@ private:
      *  @param  clusterToPfoMap the mapping from 3d cluster to pfo
      *  @param  clusterMergeMap to receive the populated cluster merge map
      */
-    void GetClusterMergeMap(const pandora::Vertex *const pVertex, const pandora::ClusterVector &clusters3D, const ClusterToPfoMap &clusterToPfoMap,
-        ClusterMergeMap &clusterMergeMap) const;
+    void GetClusterMergeMap(const pandora::Vertex *const pVertex, const pandora::ClusterVector &clusters3D,
+        const ClusterToPfoMap &clusterToPfoMap, ClusterMergeMap &clusterMergeMap) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, bool> VertexAssociationMap;
+    typedef std::unordered_map<const pandora::Cluster *, bool> VertexAssociationMap;
 
     /**
      *  @brief  Whether a 3D cluster is nodally associated with a provided vertex
@@ -151,29 +151,30 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::Cluster*, const pandora::Cluster*> ClusterReplacementMap;
+    typedef std::unordered_map<const pandora::Cluster *, const pandora::Cluster *> ClusterReplacementMap;
 
-    pandora::StringVector   m_inputPfoListNames;                ///< The input pfo list names
-    bool                    m_useVertex;                        ///< Whether to use the interaction vertex to select useful cone directions
-    unsigned int            m_maxIterations;                    ///< The maximum allowed number of algorithm iterations
-    unsigned int            m_maxHitsToConsider3DTrack;         ///< The maximum number of hits in a 3d track cluster to warrant inclusion in algorithm
-    unsigned int            m_minHitsToConsider3DShower;        ///< The minimum number of hits in a 3d shower cluster to attempt cone fits
-    unsigned int            m_halfWindowLayers;                 ///< The number of layers to use for half-window of sliding fit
-    unsigned int            m_nConeFitLayers;                   ///< The number of layers over which to sum fitted direction to obtain cone fit
-    unsigned int            m_nConeFits;                        ///< The number of cone fits to perform, spread roughly uniformly along the shower length
-    float                   m_coneLengthMultiplier;             ///< The cone length multiplier to use when calculating bounded cluster fractions
-    float                   m_maxConeLength;                    ///< The maximum allowed cone length to use when calculating bounded cluster fractions
-    float                   m_coneTanHalfAngle1;                ///< The cone tan half angle to use when calculating bounded cluster fractions 1
-    float                   m_coneBoundedFraction1;             ///< The minimum cluster bounded fraction for association 1
-    float                   m_coneTanHalfAngle2;                ///< The cone tan half angle to use when calculating bounded cluster fractions 2
-    float                   m_coneBoundedFraction2;             ///< The minimum cluster bounded fraction for association 2
-    float                   m_minVertexLongitudinalDistance;    ///< Vertex association check: min longitudinal distance cut
-    float                   m_maxVertexTransverseDistance;      ///< Vertex association check: max transverse distance cut
+    pandora::StringVector m_inputPfoListNames; ///< The input pfo list names
+    bool m_useVertex;                          ///< Whether to use the interaction vertex to select useful cone directions
+    unsigned int m_maxIterations;              ///< The maximum allowed number of algorithm iterations
+    unsigned int m_maxHitsToConsider3DTrack;   ///< The maximum number of hits in a 3d track cluster to warrant inclusion in algorithm
+    unsigned int m_minHitsToConsider3DShower;  ///< The minimum number of hits in a 3d shower cluster to attempt cone fits
+    unsigned int m_halfWindowLayers;           ///< The number of layers to use for half-window of sliding fit
+    unsigned int m_nConeFitLayers;             ///< The number of layers over which to sum fitted direction to obtain cone fit
+    unsigned int m_nConeFits;                  ///< The number of cone fits to perform, spread roughly uniformly along the shower length
+    float m_coneLengthMultiplier;              ///< The cone length multiplier to use when calculating bounded cluster fractions
+    float m_maxConeLength;                     ///< The maximum allowed cone length to use when calculating bounded cluster fractions
+    float m_coneTanHalfAngle1;                 ///< The cone tan half angle to use when calculating bounded cluster fractions 1
+    float m_coneBoundedFraction1;              ///< The minimum cluster bounded fraction for association 1
+    float m_coneTanHalfAngle2;                 ///< The cone tan half angle to use when calculating bounded cluster fractions 2
+    float m_coneBoundedFraction2;              ///< The minimum cluster bounded fraction for association 2
+    float m_minVertexLongitudinalDistance;     ///< Vertex association check: min longitudinal distance cut
+    float m_maxVertexTransverseDistance;       ///< Vertex association check: max transverse distance cut
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline SlidingConePfoMopUpAlgorithm::ClusterMerge::ClusterMerge(const pandora::Cluster *const pParentCluster, const float boundedFraction1, const float boundedFraction2) :
+inline SlidingConePfoMopUpAlgorithm::ClusterMerge::ClusterMerge(
+    const pandora::Cluster *const pParentCluster, const float boundedFraction1, const float boundedFraction2) :
     m_pParentCluster(pParentCluster),
     m_boundedFraction1(boundedFraction1),
     m_boundedFraction2(boundedFraction2)

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.cc
@@ -10,8 +10,8 @@
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
-#include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArVertexHelper.h"
 
 #include "larpandoracontent/LArObjects/LArPointingCluster.h"
@@ -47,7 +47,8 @@ StatusCode VertexBasedPfoMopUpAlgorithm::Run()
     const VertexList *pVertexList = nullptr;
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetCurrentList(*this, pVertexList));
 
-    const Vertex *const pSelectedVertex((pVertexList && (pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
+    const Vertex *const pSelectedVertex(
+        (pVertexList && (pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
 
     if (!pSelectedVertex)
     {
@@ -80,18 +81,19 @@ StatusCode VertexBasedPfoMopUpAlgorithm::Run()
 bool VertexBasedPfoMopUpAlgorithm::IsVertexAssociated(const CartesianVector &vertex2D, const LArPointingCluster &pointingCluster) const
 {
     return (LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
+            LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-VertexBasedPfoMopUpAlgorithm::PfoAssociation VertexBasedPfoMopUpAlgorithm::GetPfoAssociation(const Pfo *const pVertexPfo, const Pfo *const pDaughterPfo,
-    HitTypeToAssociationMap &hitTypeToAssociationMap) const
+VertexBasedPfoMopUpAlgorithm::PfoAssociation VertexBasedPfoMopUpAlgorithm::GetPfoAssociation(
+    const Pfo *const pVertexPfo, const Pfo *const pDaughterPfo, HitTypeToAssociationMap &hitTypeToAssociationMap) const
 {
     if ((pVertexPfo->GetClusterList().size() != pDaughterPfo->GetClusterList().size()) || (3 != pVertexPfo->GetClusterList().size()))
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-    return PfoAssociation(pVertexPfo, pDaughterPfo, hitTypeToAssociationMap.at(TPC_VIEW_U), hitTypeToAssociationMap.at(TPC_VIEW_V), hitTypeToAssociationMap.at(TPC_VIEW_W));
+    return PfoAssociation(pVertexPfo, pDaughterPfo, hitTypeToAssociationMap.at(TPC_VIEW_U), hitTypeToAssociationMap.at(TPC_VIEW_V),
+        hitTypeToAssociationMap.at(TPC_VIEW_W));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -142,7 +144,9 @@ bool VertexBasedPfoMopUpAlgorithm::IsVertexAssociated(const Pfo *const pPfo, con
             if (this->IsVertexAssociated(vertex2D, pointingCluster))
                 hitTypeSet.insert(hitType);
         }
-        catch (StatusCodeException &) {}
+        catch (StatusCodeException &)
+        {
+        }
     }
 
     const unsigned int nVertexAssociatedHitTypes(hitTypeSet.size());
@@ -151,8 +155,8 @@ bool VertexBasedPfoMopUpAlgorithm::IsVertexAssociated(const Pfo *const pPfo, con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void VertexBasedPfoMopUpAlgorithm::GetPfoAssociations(const Vertex *const pVertex, const PfoList &vertexPfos, const PfoList &nonVertexPfos,
-    PfoAssociationList &pfoAssociationList) const
+void VertexBasedPfoMopUpAlgorithm::GetPfoAssociations(
+    const Vertex *const pVertex, const PfoList &vertexPfos, const PfoList &nonVertexPfos, PfoAssociationList &pfoAssociationList) const
 {
     for (const Pfo *const pVertexPfo : vertexPfos)
     {
@@ -163,15 +167,17 @@ void VertexBasedPfoMopUpAlgorithm::GetPfoAssociations(const Vertex *const pVerte
                 const PfoAssociation pfoAssociation(this->GetPfoAssociation(pVertex, pVertexPfo, pDaughterPfo));
                 pfoAssociationList.push_back(pfoAssociation);
             }
-            catch (StatusCodeException &) {}
+            catch (StatusCodeException &)
+            {
+            }
         }
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-VertexBasedPfoMopUpAlgorithm::PfoAssociation VertexBasedPfoMopUpAlgorithm::GetPfoAssociation(const Vertex *const pVertex, const Pfo *const pVertexPfo,
-    const Pfo *const pDaughterPfo) const
+VertexBasedPfoMopUpAlgorithm::PfoAssociation VertexBasedPfoMopUpAlgorithm::GetPfoAssociation(
+    const Vertex *const pVertex, const Pfo *const pVertexPfo, const Pfo *const pDaughterPfo) const
 {
     if (pVertexPfo->GetClusterList().empty() || pDaughterPfo->GetClusterList().empty())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -199,8 +205,8 @@ VertexBasedPfoMopUpAlgorithm::PfoAssociation VertexBasedPfoMopUpAlgorithm::GetPf
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-VertexBasedPfoMopUpAlgorithm::ClusterAssociation VertexBasedPfoMopUpAlgorithm::GetClusterAssociation(const Vertex *const pVertex,
-    const Cluster *const pVertexCluster, const Cluster *const pDaughterCluster) const
+VertexBasedPfoMopUpAlgorithm::ClusterAssociation VertexBasedPfoMopUpAlgorithm::GetClusterAssociation(
+    const Vertex *const pVertex, const Cluster *const pVertexCluster, const Cluster *const pDaughterCluster) const
 {
     const HitType vertexHitType(LArClusterHelper::GetClusterHitType(pVertexCluster));
     const CartesianVector vertexPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), vertexHitType));
@@ -208,10 +214,10 @@ VertexBasedPfoMopUpAlgorithm::ClusterAssociation VertexBasedPfoMopUpAlgorithm::G
     const ConeParameters coneParameters(pVertexCluster, vertexPosition2D, m_coneAngleCentile, m_maxConeCosHalfAngle);
     const float boundedFraction(coneParameters.GetBoundedFraction(pDaughterCluster, m_maxConeLengthMultiplier));
 
-    const LArVertexHelper::ClusterDirection vertexClusterDirection(LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex,
-        pVertexCluster, m_directionTanAngle, m_directionApexShift));
-    const LArVertexHelper::ClusterDirection daughterClusterDirection(LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex,
-        pDaughterCluster, m_directionTanAngle, m_directionApexShift));
+    const LArVertexHelper::ClusterDirection vertexClusterDirection(
+        LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex, pVertexCluster, m_directionTanAngle, m_directionApexShift));
+    const LArVertexHelper::ClusterDirection daughterClusterDirection(
+        LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex, pDaughterCluster, m_directionTanAngle, m_directionApexShift));
     const bool isConsistentDirection(vertexClusterDirection == daughterClusterDirection);
 
     return ClusterAssociation(pVertexCluster, pDaughterCluster, boundedFraction, isConsistentDirection);
@@ -222,13 +228,12 @@ VertexBasedPfoMopUpAlgorithm::ClusterAssociation VertexBasedPfoMopUpAlgorithm::G
 bool VertexBasedPfoMopUpAlgorithm::ProcessPfoAssociations(const PfoAssociationList &pfoAssociationList) const
 {
     const PfoList *pTrackPfoList(nullptr);
-    (void) PandoraContentApi::GetList(*this, m_trackPfoListName, pTrackPfoList);
+    (void)PandoraContentApi::GetList(*this, m_trackPfoListName, pTrackPfoList);
 
     for (const PfoAssociation &pfoAssociation : pfoAssociationList)
     {
         if ((pfoAssociation.GetMeanBoundedFraction() < m_meanBoundedFractionCut) ||
-            (pfoAssociation.GetMaxBoundedFraction() < m_maxBoundedFractionCut) ||
-            (pfoAssociation.GetMinBoundedFraction() < m_minBoundedFractionCut) ||
+            (pfoAssociation.GetMaxBoundedFraction() < m_maxBoundedFractionCut) || (pfoAssociation.GetMinBoundedFraction() < m_minBoundedFractionCut) ||
             (pfoAssociation.GetNConsistentDirections() < m_minConsistentDirections))
         {
             continue;
@@ -243,7 +248,7 @@ bool VertexBasedPfoMopUpAlgorithm::ProcessPfoAssociations(const PfoAssociationLi
             }
 
             if (((pTrackPfoList->end() != std::find(pTrackPfoList->begin(), pTrackPfoList->end(), pfoAssociation.GetVertexPfo())) ||
-                (pTrackPfoList->end() != std::find(pTrackPfoList->begin(), pTrackPfoList->end(), pfoAssociation.GetDaughterPfo()))) &&
+                    (pTrackPfoList->end() != std::find(pTrackPfoList->begin(), pTrackPfoList->end(), pfoAssociation.GetDaughterPfo()))) &&
                 (pfoAssociation.GetNConsistentDirections() < m_minConsistentDirectionsTrack))
             {
                 continue;
@@ -262,8 +267,8 @@ bool VertexBasedPfoMopUpAlgorithm::ProcessPfoAssociations(const PfoAssociationLi
 void VertexBasedPfoMopUpAlgorithm::MergePfos(const PfoAssociation &pfoAssociation) const
 {
     const PfoList *pTrackPfoList(nullptr), *pShowerPfoList(nullptr);
-    (void) PandoraContentApi::GetList(*this, m_trackPfoListName, pTrackPfoList);
-    (void) PandoraContentApi::GetList(*this, m_showerPfoListName, pShowerPfoList);
+    (void)PandoraContentApi::GetList(*this, m_trackPfoListName, pTrackPfoList);
+    (void)PandoraContentApi::GetList(*this, m_showerPfoListName, pShowerPfoList);
 
     if (!pTrackPfoList && !pShowerPfoList)
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -300,8 +305,8 @@ VertexBasedPfoMopUpAlgorithm::ClusterAssociation::ClusterAssociation() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-VertexBasedPfoMopUpAlgorithm::ClusterAssociation::ClusterAssociation(const Cluster *const pVertexCluster, const Cluster *const pDaughterCluster,
-        const float boundedFraction, const bool isConsistentDirection) :
+VertexBasedPfoMopUpAlgorithm::ClusterAssociation::ClusterAssociation(const Cluster *const pVertexCluster,
+    const Cluster *const pDaughterCluster, const float boundedFraction, const bool isConsistentDirection) :
     m_pVertexCluster(pVertexCluster),
     m_pDaughterCluster(pDaughterCluster),
     m_boundedFraction(boundedFraction),
@@ -312,8 +317,8 @@ VertexBasedPfoMopUpAlgorithm::ClusterAssociation::ClusterAssociation(const Clust
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-VertexBasedPfoMopUpAlgorithm::PfoAssociation::PfoAssociation(const Pfo *const pVertexPfo, const Pfo *const pDaughterPfo, const ClusterAssociation &clusterAssociationU,
-        const ClusterAssociation &clusterAssociationV, const ClusterAssociation &clusterAssociationW) :
+VertexBasedPfoMopUpAlgorithm::PfoAssociation::PfoAssociation(const Pfo *const pVertexPfo, const Pfo *const pDaughterPfo,
+    const ClusterAssociation &clusterAssociationU, const ClusterAssociation &clusterAssociationV, const ClusterAssociation &clusterAssociationW) :
     m_pVertexPfo(pVertexPfo),
     m_pDaughterPfo(pDaughterPfo),
     m_clusterAssociationU(clusterAssociationU),
@@ -326,21 +331,25 @@ VertexBasedPfoMopUpAlgorithm::PfoAssociation::PfoAssociation(const Pfo *const pV
 
 float VertexBasedPfoMopUpAlgorithm::PfoAssociation::GetMeanBoundedFraction() const
 {
-    return ((this->GetClusterAssociationU().GetBoundedFraction() + this->GetClusterAssociationV().GetBoundedFraction() + this->GetClusterAssociationW().GetBoundedFraction()) / 3.f);
+    return ((this->GetClusterAssociationU().GetBoundedFraction() + this->GetClusterAssociationV().GetBoundedFraction() +
+                this->GetClusterAssociationW().GetBoundedFraction()) /
+            3.f);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 float VertexBasedPfoMopUpAlgorithm::PfoAssociation::GetMaxBoundedFraction() const
 {
-    return std::max(this->GetClusterAssociationU().GetBoundedFraction(), std::max(this->GetClusterAssociationV().GetBoundedFraction(), this->GetClusterAssociationW().GetBoundedFraction()));
+    return std::max(this->GetClusterAssociationU().GetBoundedFraction(),
+        std::max(this->GetClusterAssociationV().GetBoundedFraction(), this->GetClusterAssociationW().GetBoundedFraction()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 float VertexBasedPfoMopUpAlgorithm::PfoAssociation::GetMinBoundedFraction() const
 {
-    return std::min(this->GetClusterAssociationU().GetBoundedFraction(), std::min(this->GetClusterAssociationV().GetBoundedFraction(), this->GetClusterAssociationW().GetBoundedFraction()));
+    return std::min(this->GetClusterAssociationU().GetBoundedFraction(),
+        std::min(this->GetClusterAssociationV().GetBoundedFraction(), this->GetClusterAssociationW().GetBoundedFraction()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -363,7 +372,7 @@ unsigned int VertexBasedPfoMopUpAlgorithm::PfoAssociation::GetNConsistentDirecti
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool VertexBasedPfoMopUpAlgorithm::PfoAssociation::operator< (const PfoAssociation &rhs) const
+bool VertexBasedPfoMopUpAlgorithm::PfoAssociation::operator<(const PfoAssociation &rhs) const
 {
     if (std::fabs(this->GetMeanBoundedFraction() - rhs.GetMeanBoundedFraction()) > std::numeric_limits<float>::epsilon())
         return (this->GetMeanBoundedFraction() > rhs.GetMeanBoundedFraction());
@@ -377,8 +386,8 @@ bool VertexBasedPfoMopUpAlgorithm::PfoAssociation::operator< (const PfoAssociati
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-VertexBasedPfoMopUpAlgorithm::ConeParameters::ConeParameters(const Cluster *const pCluster, const CartesianVector &vertexPosition2D,
-        const float coneAngleCentile, const float maxCosHalfAngle) :
+VertexBasedPfoMopUpAlgorithm::ConeParameters::ConeParameters(
+    const Cluster *const pCluster, const CartesianVector &vertexPosition2D, const float coneAngleCentile, const float maxCosHalfAngle) :
     m_pCluster(pCluster),
     m_apex(vertexPosition2D),
     m_direction(0.f, 0.f, 0.f),
@@ -498,50 +507,50 @@ float VertexBasedPfoMopUpAlgorithm::ConeParameters::GetCosHalfAngleEstimate(cons
 
 StatusCode VertexBasedPfoMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrackPfoListName", m_trackPfoListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TrackPfoListName", m_trackPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerPfoListName", m_showerPfoListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowerPfoListName", m_showerPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexAssociatedHitTypes", m_minVertexAssociatedHitTypes));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexAssociatedHitTypes", m_minVertexAssociatedHitTypes));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeAngleCentile", m_coneAngleCentile));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeAngleCentile", m_coneAngleCentile));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxConeCosHalfAngle", m_maxConeCosHalfAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxConeCosHalfAngle", m_maxConeCosHalfAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxConeLengthMultiplier", m_maxConeLengthMultiplier));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxConeLengthMultiplier", m_maxConeLengthMultiplier));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DirectionTanAngle", m_directionTanAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DirectionTanAngle", m_directionTanAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DirectionApexShift", m_directionApexShift));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DirectionApexShift", m_directionApexShift));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MeanBoundedFractionCut", m_meanBoundedFractionCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MeanBoundedFractionCut", m_meanBoundedFractionCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxBoundedFractionCut", m_maxBoundedFractionCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxBoundedFractionCut", m_maxBoundedFractionCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinBoundedFractionCut", m_minBoundedFractionCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinBoundedFractionCut", m_minBoundedFractionCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinConsistentDirections", m_minConsistentDirections));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinConsistentDirections", m_minConsistentDirections));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinConsistentDirectionsTrack", m_minConsistentDirectionsTrack));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinConsistentDirectionsTrack", m_minConsistentDirectionsTrack));
 
     m_daughterListNames.push_back(m_trackPfoListName);
     m_daughterListNames.push_back(m_showerPfoListName);

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.h
@@ -46,8 +46,8 @@ protected:
          *  @param  boundedFraction the fraction of daughter hits bounded by the cone defined by the vertex cluster
          *  @param  isConsistentDirection whether clusters have consistent directions
          */
-        ClusterAssociation(const pandora::Cluster *const pVertexCluster, const pandora::Cluster *const pDaughterCluster, const float boundedFraction,
-            const bool isConsistentDirection);
+        ClusterAssociation(const pandora::Cluster *const pVertexCluster, const pandora::Cluster *const pDaughterCluster,
+            const float boundedFraction, const bool isConsistentDirection);
 
         /**
          *  @brief  Get the address of the vertex cluster
@@ -78,10 +78,10 @@ protected:
         bool IsConsistentDirection() const;
 
     private:
-        const pandora::Cluster *m_pVertexCluster;           ///< The address of the vertex cluster
-        const pandora::Cluster *m_pDaughterCluster;         ///< The address of the daughter cluster
-        float                   m_boundedFraction;          ///< The fraction of daughter hits bounded by the cone defined by the vertex cluster
-        bool                    m_isConsistentDirection;    ///< Whether the vertex and daughter clusters have consistent directions
+        const pandora::Cluster *m_pVertexCluster;   ///< The address of the vertex cluster
+        const pandora::Cluster *m_pDaughterCluster; ///< The address of the daughter cluster
+        float m_boundedFraction;                    ///< The fraction of daughter hits bounded by the cone defined by the vertex cluster
+        bool m_isConsistentDirection;               ///< Whether the vertex and daughter clusters have consistent directions
     };
 
     /**
@@ -172,15 +172,15 @@ protected:
          *
          *  @return boolean
          */
-        bool operator< (const PfoAssociation &rhs) const;
+        bool operator<(const PfoAssociation &rhs) const;
 
     private:
-        const pandora::Pfo     *m_pVertexPfo;               ///< The address of the vertex-associated pfo
-        const pandora::Pfo     *m_pDaughterPfo;             ///< The address of the non-vertex-associated candidate daughter pfo
+        const pandora::Pfo *m_pVertexPfo;   ///< The address of the vertex-associated pfo
+        const pandora::Pfo *m_pDaughterPfo; ///< The address of the non-vertex-associated candidate daughter pfo
 
-        ClusterAssociation      m_clusterAssociationU;      ///< The cluster association in the u view
-        ClusterAssociation      m_clusterAssociationV;      ///< The cluster association in the v view
-        ClusterAssociation      m_clusterAssociationW;      ///< The cluster association in the w view
+        ClusterAssociation m_clusterAssociationU; ///< The cluster association in the u view
+        ClusterAssociation m_clusterAssociationV; ///< The cluster association in the v view
+        ClusterAssociation m_clusterAssociationW; ///< The cluster association in the w view
     };
 
     typedef std::vector<PfoAssociation> PfoAssociationList;
@@ -199,8 +199,8 @@ protected:
          *  @param  coneAngleCentile the cone angle centile
          *  @param  maxConeCosHalfAngle the maximum value for cosine of cone half angle
          */
-        ConeParameters(const pandora::Cluster *const pCluster, const pandora::CartesianVector &vertexPosition2D, const float coneAngleCentile,
-            const float maxConeCosHalfAngle);
+        ConeParameters(const pandora::Cluster *const pCluster, const pandora::CartesianVector &vertexPosition2D,
+            const float coneAngleCentile, const float maxConeCosHalfAngle);
 
         /**
          *  @brief  Get the fraction of hits in a candidate daughter cluster bounded by the cone
@@ -236,11 +236,11 @@ protected:
          */
         float GetCosHalfAngleEstimate(const float coneAngleCentile) const;
 
-        const pandora::Cluster     *m_pCluster;             ///< The parent cluster
-        pandora::CartesianVector    m_apex;                 ///< The cone apex
-        pandora::CartesianVector    m_direction;            ///< The cone direction
-        float                       m_coneLength;           ///< The cone length
-        float                       m_coneCosHalfAngle;     ///< The cone cos half angle
+        const pandora::Cluster *m_pCluster;   ///< The parent cluster
+        pandora::CartesianVector m_apex;      ///< The cone apex
+        pandora::CartesianVector m_direction; ///< The cone direction
+        float m_coneLength;                   ///< The cone length
+        float m_coneCosHalfAngle;             ///< The cone cos half angle
     };
 
     pandora::StatusCode Run();
@@ -308,7 +308,8 @@ protected:
      *
      *  @return the pfo association details
      */
-    PfoAssociation GetPfoAssociation(const pandora::Vertex *const pVertex, const pandora::Pfo *const pVertexPfo, const pandora::Pfo *const pDaughterPfo) const;
+    PfoAssociation GetPfoAssociation(
+        const pandora::Vertex *const pVertex, const pandora::Pfo *const pVertexPfo, const pandora::Pfo *const pDaughterPfo) const;
 
     /**
      *  @brief  Get cluster association details between a vertex-associated cluster and a non-vertex associated daughter candidate cluster
@@ -341,28 +342,28 @@ protected:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     typedef std::set<pandora::HitType> HitTypeSet;
-    typedef std::map<pandora::HitType, const pandora::Cluster*> HitTypeToClusterMap;
+    typedef std::map<pandora::HitType, const pandora::Cluster *> HitTypeToClusterMap;
 
-    std::string             m_trackPfoListName;                 ///< The input track pfo list name
-    std::string             m_showerPfoListName;                ///< The input shower pfo list name
+    std::string m_trackPfoListName;  ///< The input track pfo list name
+    std::string m_showerPfoListName; ///< The input shower pfo list name
 
-    float                   m_minVertexLongitudinalDistance;    ///< Vertex association check: min longitudinal distance cut
-    float                   m_maxVertexTransverseDistance;      ///< Vertex association check: max transverse distance cut
-    unsigned int            m_minVertexAssociatedHitTypes;      ///< The min number of vertex associated hit types for a vertex associated pfo
+    float m_minVertexLongitudinalDistance;      ///< Vertex association check: min longitudinal distance cut
+    float m_maxVertexTransverseDistance;        ///< Vertex association check: max transverse distance cut
+    unsigned int m_minVertexAssociatedHitTypes; ///< The min number of vertex associated hit types for a vertex associated pfo
 
-    float                   m_coneAngleCentile;                 ///< Cluster cone angle is defined using specified centile of distribution of hit half angles
-    float                   m_maxConeCosHalfAngle;              ///< Maximum value for cosine of cone half angle
-    float                   m_maxConeLengthMultiplier;          ///< Consider hits as bound if inside cone, with projected distance less than N times cone length
+    float m_coneAngleCentile;        ///< Cluster cone angle is defined using specified centile of distribution of hit half angles
+    float m_maxConeCosHalfAngle;     ///< Maximum value for cosine of cone half angle
+    float m_maxConeLengthMultiplier; ///< Consider hits as bound if inside cone, with projected distance less than N times cone length
 
-    float                   m_directionTanAngle;                ///< Direction determination, look for vertex inside triangle with apex shifted along the cluster length
-    float                   m_directionApexShift;               ///< Direction determination, look for vertex inside triangle with apex shifted along the cluster length
+    float m_directionTanAngle;  ///< Direction determination, look for vertex inside triangle with apex shifted along the cluster length
+    float m_directionApexShift; ///< Direction determination, look for vertex inside triangle with apex shifted along the cluster length
 
-    float                   m_meanBoundedFractionCut;           ///< Cut on association info (mean bounded fraction) for determining pfo merges
-    float                   m_maxBoundedFractionCut;            ///< Cut on association info (max bounded fraction) for determining pfo merges
-    float                   m_minBoundedFractionCut;            ///< Cut on association info (min bounded fraction) for determining pfo merges
+    float m_meanBoundedFractionCut; ///< Cut on association info (mean bounded fraction) for determining pfo merges
+    float m_maxBoundedFractionCut;  ///< Cut on association info (max bounded fraction) for determining pfo merges
+    float m_minBoundedFractionCut;  ///< Cut on association info (min bounded fraction) for determining pfo merges
 
-    unsigned int            m_minConsistentDirections;          ///< The minimum number of consistent cluster directions to allow a pfo merge
-    unsigned int            m_minConsistentDirectionsTrack;     ///< The minimum number of consistent cluster directions to allow a merge involving a track pfo
+    unsigned int m_minConsistentDirections;      ///< The minimum number of consistent cluster directions to allow a pfo merge
+    unsigned int m_minConsistentDirectionsTrack; ///< The minimum number of consistent cluster directions to allow a merge involving a track pfo
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.cc
@@ -151,7 +151,9 @@ void ParticleRecoveryAlgorithm::VertexClusterSelection(const ClusterList &inputC
                 vertexList.push_back(pointingCluster.GetOuterVertex().GetPosition());
             }
         }
-        catch (StatusCodeException &) {}
+        catch (StatusCodeException &)
+        {
+        }
     }
 
     for (ClusterList::const_iterator iter = inputClusterList.begin(), iterEnd = inputClusterList.end(); iter != iterEnd; ++iter)
@@ -175,7 +177,9 @@ void ParticleRecoveryAlgorithm::VertexClusterSelection(const ClusterList &inputC
                 }
             }
         }
-        catch (StatusCodeException &) {}
+        catch (StatusCodeException &)
+        {
+        }
     }
 }
 
@@ -252,7 +256,8 @@ void ParticleRecoveryAlgorithm::CalculateEffectiveOverlapFractions(const Cluster
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ParticleRecoveryAlgorithm::CalculateEffectiveSpan(const pandora::Cluster *const pCluster, const float xMin, const float xMax, float &xMinEff, float &xMaxEff) const
+void ParticleRecoveryAlgorithm::CalculateEffectiveSpan(
+    const pandora::Cluster *const pCluster, const float xMin, const float xMax, float &xMinEff, float &xMaxEff) const
 {
     // TODO cache sliding linear fit results and optimise protection against exceptions from TwoDSlidingFitResult and IsXSamplingPointInGap
     try
@@ -288,7 +293,9 @@ void ParticleRecoveryAlgorithm::CalculateEffectiveSpan(const pandora::Cluster *c
         xMinEff = xMinEff - dxMin;
         xMaxEff = xMaxEff + dxMax;
     }
-    catch (StatusCodeException &) {}
+    catch (StatusCodeException &)
+    {
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -375,7 +382,8 @@ void ParticleRecoveryAlgorithm::CreateTrackParticle(const ClusterList &clusterLi
     if (clusterList.size() < 2)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-    const PfoList *pPfoList = NULL; std::string pfoListName;
+    const PfoList *pPfoList = NULL;
+    std::string pfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
     // TODO Correct these placeholder parameters
@@ -450,7 +458,8 @@ void ParticleRecoveryAlgorithm::SimpleOverlapTensor::GetConnectedElements(const 
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
     ClusterList &clusterList((TPC_VIEW_U == hitType) ? clusterListU : (TPC_VIEW_V == hitType) ? clusterListV : clusterListW);
-    const ClusterNavigationMap &navigationMap((TPC_VIEW_U == hitType) ? m_clusterNavigationMapUV : (TPC_VIEW_V == hitType) ? m_clusterNavigationMapVW : m_clusterNavigationMapWU);
+    const ClusterNavigationMap &navigationMap(
+        (TPC_VIEW_U == hitType) ? m_clusterNavigationMapUV : (TPC_VIEW_V == hitType) ? m_clusterNavigationMapVW : m_clusterNavigationMapWU);
 
     if (clusterList.end() != std::find(clusterList.begin(), clusterList.end(), pCluster))
         return;
@@ -474,37 +483,33 @@ StatusCode ParticleRecoveryAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputPfoListName", m_outputPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterCaloHits", m_minClusterCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterCaloHits", m_minClusterCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CheckGaps", m_checkGaps));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CheckGaps", m_checkGaps));
 
     float minClusterLength = std::sqrt(m_minClusterLengthSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", minClusterLength));
     m_minClusterLengthSquared = minClusterLength * minClusterLength;
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterXSpan", m_minClusterXSpan));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterXSpan", m_minClusterXSpan));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexClusterMode", m_vertexClusterMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexClusterMode", m_vertexClusterMode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFractionGaps", m_minXOverlapFractionGaps));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinXOverlapFractionGaps", m_minXOverlapFractionGaps));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SampleStepSize", m_sampleStepSize));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SampleStepSize", m_sampleStepSize));
 
     if (m_sampleStepSize < std::numeric_limits<float>::epsilon())
     {
@@ -512,11 +517,10 @@ StatusCode ParticleRecoveryAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_slidingFitHalfWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_slidingFitHalfWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PseudoChi2Cut", m_pseudoChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PseudoChi2Cut", m_pseudoChi2Cut));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.h
@@ -61,12 +61,12 @@ private:
         const pandora::ClusterList &GetKeyClusters() const;
 
     private:
-        typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterNavigationMap;
+        typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterNavigationMap;
 
-        pandora::ClusterList    m_keyClusters;                  ///< The list of key clusters
-        ClusterNavigationMap    m_clusterNavigationMapUV;       ///< The cluster navigation map U->V
-        ClusterNavigationMap    m_clusterNavigationMapVW;       ///< The cluster navigation map V->W
-        ClusterNavigationMap    m_clusterNavigationMapWU;       ///< The cluster navigation map W->U
+        pandora::ClusterList m_keyClusters;            ///< The list of key clusters
+        ClusterNavigationMap m_clusterNavigationMapUV; ///< The cluster navigation map U->V
+        ClusterNavigationMap m_clusterNavigationMapVW; ///< The cluster navigation map V->W
+        ClusterNavigationMap m_clusterNavigationMapWU; ///< The cluster navigation map W->U
     };
 
     pandora::StatusCode Run();
@@ -174,24 +174,24 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector       m_inputClusterListNames;        ///< The list of cluster list names
-    std::string                 m_outputPfoListName;            ///< The output pfo list name
+    pandora::StringVector m_inputClusterListNames; ///< The list of cluster list names
+    std::string m_outputPfoListName;               ///< The output pfo list name
 
-    bool                        m_checkGaps;                    ///< Whether to check for gaps in the calculation of the overlap
+    bool m_checkGaps; ///< Whether to check for gaps in the calculation of the overlap
 
-    unsigned int                m_minClusterCaloHits;           ///< The min number of hits in base cluster selection method
-    float                       m_minClusterLengthSquared;      ///< The min length (squared) in base cluster selection method
-    float                       m_minClusterXSpan;              ///< The min x span required in order to consider a cluster
+    unsigned int m_minClusterCaloHits; ///< The min number of hits in base cluster selection method
+    float m_minClusterLengthSquared;   ///< The min length (squared) in base cluster selection method
+    float m_minClusterXSpan;           ///< The min x span required in order to consider a cluster
 
-    bool                        m_vertexClusterMode;            ///< Whether to demand clusters are associated with vertices of existing particles
-    float                       m_minVertexLongitudinalDistance;///< Vertex association check: min longitudinal distance cut
-    float                       m_maxVertexTransverseDistance;  ///< Vertex association check: max transverse distance cut
+    bool m_vertexClusterMode;              ///< Whether to demand clusters are associated with vertices of existing particles
+    float m_minVertexLongitudinalDistance; ///< Vertex association check: min longitudinal distance cut
+    float m_maxVertexTransverseDistance;   ///< Vertex association check: max transverse distance cut
 
-    float                       m_minXOverlapFraction;          ///< The min x overlap fraction required in order to id overlapping clusters
-    float                       m_minXOverlapFractionGaps;      ///< The min x overlap fraction when there are gaps involved
-    float                       m_sampleStepSize;               ///< The sampling step size used in association checks, units cm
-    unsigned int                m_slidingFitHalfWindow;         ///< The half window for the fit sliding result constructor
-    float                       m_pseudoChi2Cut;                ///< The selection cut on the matched chi2
+    float m_minXOverlapFraction;         ///< The min x overlap fraction required in order to id overlapping clusters
+    float m_minXOverlapFractionGaps;     ///< The min x overlap fraction when there are gaps involved
+    float m_sampleStepSize;              ///< The sampling step size used in association checks, units cm
+    unsigned int m_slidingFitHalfWindow; ///< The half window for the fit sliding result constructor
+    float m_pseudoChi2Cut;               ///< The selection cut on the matched chi2
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.cc
@@ -10,8 +10,8 @@
 
 #include "larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
 
 using namespace pandora;
@@ -35,7 +35,8 @@ StatusCode VertexBasedPfoRecoveryAlgorithm::Run()
     const VertexList *pVertexList = NULL;
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetCurrentList(*this, pVertexList));
 
-    const Vertex *const pSelectedVertex((pVertexList && (pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : NULL);
+    const Vertex *const pSelectedVertex(
+        (pVertexList && (pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : NULL);
 
     if (!pSelectedVertex)
     {
@@ -92,7 +93,7 @@ StatusCode VertexBasedPfoRecoveryAlgorithm::GetAvailableClusters(const StringVec
             if (!pCluster->IsAvailable())
                 continue;
 
-            if (pCluster->GetNCaloHits() <=1)
+            if (pCluster->GetNCaloHits() <= 1)
                 continue;
 
             if (TPC_3D == LArClusterHelper::GetClusterHitType(pCluster))
@@ -108,8 +109,7 @@ StatusCode VertexBasedPfoRecoveryAlgorithm::GetAvailableClusters(const StringVec
 }
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void VertexBasedPfoRecoveryAlgorithm::BuildSlidingFitResultMap(const ClusterVector &clusterVector,
-    TwoDSlidingFitResultMap &slidingFitResultMap) const
+void VertexBasedPfoRecoveryAlgorithm::BuildSlidingFitResultMap(const ClusterVector &clusterVector, TwoDSlidingFitResultMap &slidingFitResultMap) const
 {
     const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
@@ -206,12 +206,12 @@ void VertexBasedPfoRecoveryAlgorithm::MatchThreeViews(const Vertex *const pVerte
         const HitType hitType2(LArClusterHelper::GetClusterHitType(pCluster2));
         const HitType hitType3(LArClusterHelper::GetClusterHitType(pCluster3));
 
-        const Cluster *const pClusterU((TPC_VIEW_U == hitType1) ? pCluster1 : (TPC_VIEW_U == hitType2) ? pCluster2 :
-                                       (TPC_VIEW_U == hitType3) ? pCluster3 : NULL);
-        const Cluster *const pClusterV((TPC_VIEW_V == hitType1) ? pCluster1 : (TPC_VIEW_V == hitType2) ? pCluster2 :
-                                       (TPC_VIEW_V == hitType3) ? pCluster3 : NULL);
-        const Cluster *const pClusterW((TPC_VIEW_W == hitType1) ? pCluster1 : (TPC_VIEW_W == hitType2) ? pCluster2 :
-                                       (TPC_VIEW_W == hitType3) ? pCluster3 : NULL);
+        const Cluster *const pClusterU(
+            (TPC_VIEW_U == hitType1) ? pCluster1 : (TPC_VIEW_U == hitType2) ? pCluster2 : (TPC_VIEW_U == hitType3) ? pCluster3 : NULL);
+        const Cluster *const pClusterV(
+            (TPC_VIEW_V == hitType1) ? pCluster1 : (TPC_VIEW_V == hitType2) ? pCluster2 : (TPC_VIEW_V == hitType3) ? pCluster3 : NULL);
+        const Cluster *const pClusterW(
+            (TPC_VIEW_W == hitType1) ? pCluster1 : (TPC_VIEW_W == hitType2) ? pCluster2 : (TPC_VIEW_W == hitType3) ? pCluster3 : NULL);
 
         particleList.push_back(Particle(pClusterU, pClusterV, pClusterW));
 
@@ -262,8 +262,8 @@ void VertexBasedPfoRecoveryAlgorithm::MatchTwoViews(const Vertex *const pVertex,
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void VertexBasedPfoRecoveryAlgorithm::GetBestChi2(const Vertex *const pVertex, const TwoDSlidingFitResultMap &slidingFitResultMap,
-    const ClusterVector &clusters1, const ClusterVector &clusters2, const ClusterVector &clusters3,
-    const Cluster *&pBestCluster1, const Cluster *&pBestCluster2, const Cluster *&pBestCluster3, float &bestChi2) const
+    const ClusterVector &clusters1, const ClusterVector &clusters2, const ClusterVector &clusters3, const Cluster *&pBestCluster1,
+    const Cluster *&pBestCluster2, const Cluster *&pBestCluster3, float &bestChi2) const
 {
     if (clusters1.empty() || clusters2.empty() || clusters3.empty())
         return;
@@ -295,25 +295,25 @@ void VertexBasedPfoRecoveryAlgorithm::GetBestChi2(const Vertex *const pVertex, c
             // Third loop
             for (ClusterVector::const_iterator cIter3 = clusters3.begin(), cIterEnd3 = clusters3.end(); cIter3 != cIterEnd3; ++cIter3)
             {
-                 const Cluster *const pCluster3 = *cIter3;
+                const Cluster *const pCluster3 = *cIter3;
 
-                 TwoDSlidingFitResultMap::const_iterator sIter3 = slidingFitResultMap.find(pCluster3);
-                 if (slidingFitResultMap.end() == sIter3)
-                     continue;
+                TwoDSlidingFitResultMap::const_iterator sIter3 = slidingFitResultMap.find(pCluster3);
+                if (slidingFitResultMap.end() == sIter3)
+                    continue;
 
-                 const TwoDSlidingFitResult &slidingFitResult3 = sIter3->second;
-                 const LArPointingCluster pointingCluster3(slidingFitResult3);
+                const TwoDSlidingFitResult &slidingFitResult3 = sIter3->second;
+                const LArPointingCluster pointingCluster3(slidingFitResult3);
 
-                 // Calculate chi-squared
-                 const float thisChi2(this->GetChi2(pVertex, pointingCluster1, pointingCluster2, pointingCluster3));
+                // Calculate chi-squared
+                const float thisChi2(this->GetChi2(pVertex, pointingCluster1, pointingCluster2, pointingCluster3));
 
-                 if (thisChi2 < bestChi2)
-                 {
-                     bestChi2 = thisChi2;
-                     pBestCluster1 = pCluster1;
-                     pBestCluster2 = pCluster2;
-                     pBestCluster3 = pCluster3;
-                 }
+                if (thisChi2 < bestChi2)
+                {
+                    bestChi2 = thisChi2;
+                    pBestCluster1 = pCluster1;
+                    pBestCluster2 = pCluster2;
+                    pBestCluster3 = pCluster3;
+                }
             }
         }
     }
@@ -366,8 +366,8 @@ void VertexBasedPfoRecoveryAlgorithm::GetBestChi2(const Vertex *const pVertex, c
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float VertexBasedPfoRecoveryAlgorithm::GetChi2(const Vertex *const pVertex, const LArPointingCluster &pointingCluster1,
-    const LArPointingCluster &pointingCluster2) const
+float VertexBasedPfoRecoveryAlgorithm::GetChi2(
+    const Vertex *const pVertex, const LArPointingCluster &pointingCluster1, const LArPointingCluster &pointingCluster2) const
 {
     const HitType hitType1(LArClusterHelper::GetClusterHitType(pointingCluster1.GetCluster()));
     const HitType hitType2(LArClusterHelper::GetClusterHitType(pointingCluster2.GetCluster()));
@@ -383,8 +383,8 @@ float VertexBasedPfoRecoveryAlgorithm::GetChi2(const Vertex *const pVertex, cons
 
     float chi2(0.f);
     CartesianVector mergedPosition(0.f, 0.f, 0.f);
-    LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), hitType1, hitType2,
-        pointingVertex1.GetPosition(), pointingVertex2.GetPosition(), mergedPosition, chi2);
+    LArGeometryHelper::MergeTwoPositions3D(
+        this->GetPandora(), hitType1, hitType2, pointingVertex1.GetPosition(), pointingVertex2.GetPosition(), mergedPosition, chi2);
 
     return chi2;
 }
@@ -411,16 +411,15 @@ float VertexBasedPfoRecoveryAlgorithm::GetChi2(const Vertex *const pVertex, cons
 
     float chi2(0.f);
     CartesianVector mergedPosition(0.f, 0.f, 0.f);
-    LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), hitType1, hitType2, hitType3,
-        pointingVertex1.GetPosition(), pointingVertex2.GetPosition(), pointingVertex3.GetPosition(), mergedPosition, chi2);
+    LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), hitType1, hitType2, hitType3, pointingVertex1.GetPosition(),
+        pointingVertex2.GetPosition(), pointingVertex3.GetPosition(), mergedPosition, chi2);
 
     return chi2;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void VertexBasedPfoRecoveryAlgorithm::SelectAvailableClusters(const ClusterSet &vetoList, const ClusterVector &inputVector,
-    ClusterVector &outputVector) const
+void VertexBasedPfoRecoveryAlgorithm::SelectAvailableClusters(const ClusterSet &vetoList, const ClusterVector &inputVector, ClusterVector &outputVector) const
 {
     for (ClusterVector::const_iterator iter = inputVector.begin(), iterEnd = inputVector.end(); iter != iterEnd; ++iter)
     {
@@ -442,8 +441,7 @@ void VertexBasedPfoRecoveryAlgorithm::SelectClusters(const HitType hitType, cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const LArPointingCluster::Vertex &VertexBasedPfoRecoveryAlgorithm::GetInnerVertex(const CartesianVector &vertex,
-    const LArPointingCluster &cluster) const
+const LArPointingCluster::Vertex &VertexBasedPfoRecoveryAlgorithm::GetInnerVertex(const CartesianVector &vertex, const LArPointingCluster &cluster) const
 {
     const float innerDistance((vertex - cluster.GetInnerVertex().GetPosition()).GetMagnitudeSquared());
     const float outerDistance((vertex - cluster.GetOuterVertex().GetPosition()).GetMagnitudeSquared());
@@ -456,8 +454,7 @@ const LArPointingCluster::Vertex &VertexBasedPfoRecoveryAlgorithm::GetInnerVerte
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const LArPointingCluster::Vertex &VertexBasedPfoRecoveryAlgorithm::GetOuterVertex(const CartesianVector &vertex,
-    const LArPointingCluster &cluster) const
+const LArPointingCluster::Vertex &VertexBasedPfoRecoveryAlgorithm::GetOuterVertex(const CartesianVector &vertex, const LArPointingCluster &cluster) const
 {
     const LArPointingCluster::Vertex &innerVertex = this->GetInnerVertex(vertex, cluster);
 
@@ -474,7 +471,8 @@ void VertexBasedPfoRecoveryAlgorithm::BuildParticles(const ParticleList &particl
     if (particleList.empty())
         return;
 
-    const PfoList *pPfoList = NULL; std::string pfoListName;
+    const PfoList *pPfoList = NULL;
+    std::string pfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
     for (ParticleList::const_iterator iter = particleList.begin(), iterEnd = particleList.end(); iter != iterEnd; ++iter)
@@ -490,12 +488,15 @@ void VertexBasedPfoRecoveryAlgorithm::BuildParticles(const ParticleList &particl
         const bool isAvailableV((NULL != pClusterV) ? pClusterV->IsAvailable() : true);
         const bool isAvailableW((NULL != pClusterW) ? pClusterW->IsAvailable() : true);
 
-        if(!(isAvailableU && isAvailableV && isAvailableW))
+        if (!(isAvailableU && isAvailableV && isAvailableW))
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
-        if (pClusterU) clusterList.push_back(pClusterU);
-        if (pClusterV) clusterList.push_back(pClusterV);
-        if (pClusterW) clusterList.push_back(pClusterW);
+        if (pClusterU)
+            clusterList.push_back(pClusterU);
+        if (pClusterV)
+            clusterList.push_back(pClusterV);
+        if (pClusterW)
+            clusterList.push_back(pClusterW);
 
         // TODO Correct these placeholder parameters
         PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
@@ -536,26 +537,23 @@ VertexBasedPfoRecoveryAlgorithm::Particle::Particle(const Cluster *const pCluste
 
 StatusCode VertexBasedPfoRecoveryAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputClusterListNames", m_inputClusterListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputPfoListName", m_outputPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputPfoListName", m_outputPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_slidingFitHalfWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_slidingFitHalfWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TwoViewChi2Cut", m_twoViewChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TwoViewChi2Cut", m_twoViewChi2Cut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ThreeViewChi2Cut", m_threeViewChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ThreeViewChi2Cut", m_threeViewChi2Cut));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.h
@@ -10,8 +10,8 @@
 
 #include "Pandora/Algorithm.h"
 
-#include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
 #include "larpandoracontent/LArObjects/LArPointingCluster.h"
+#include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
 
 namespace lar_content
 {
@@ -45,9 +45,9 @@ private:
          */
         Particle(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW);
 
-        const pandora::Cluster  *m_pClusterU;    ///< Address of cluster in U view
-        const pandora::Cluster  *m_pClusterV;    ///< Address of cluster in V view
-        const pandora::Cluster  *m_pClusterW;    ///< Address of cluster in W view
+        const pandora::Cluster *m_pClusterU; ///< Address of cluster in U view
+        const pandora::Cluster *m_pClusterV; ///< Address of cluster in V view
+        const pandora::Cluster *m_pClusterW; ///< Address of cluster in W view
     };
 
     typedef std::vector<Particle> ParticleList;
@@ -119,8 +119,7 @@ private:
      */
     void GetBestChi2(const pandora::Vertex *const pVertex, const TwoDSlidingFitResultMap &slidingFitResultMap,
         const pandora::ClusterVector &clusters1, const pandora::ClusterVector &clusters2, const pandora::ClusterVector &clusters3,
-        const pandora::Cluster *&pBestCluster1, const pandora::Cluster *&pBestCluster2, const pandora::Cluster *&pBestCluster3,
-        float &chi2) const;
+        const pandora::Cluster *&pBestCluster1, const pandora::Cluster *&pBestCluster2, const pandora::Cluster *&pBestCluster3, float &chi2) const;
 
     /**
      *  @brief  Get best-matched pair of clusters from a set of input cluster vectors
@@ -133,9 +132,8 @@ private:
      *  @param  pBestCluster2 the best-matched cluster from the second view
      *  @param  chi2 the chi-squared metric from the best match
      */
-    void GetBestChi2(const pandora::Vertex *const pVertex, const TwoDSlidingFitResultMap &slidingFitResultMap,
-        const pandora::ClusterVector &clusters1, const pandora::ClusterVector &clusters2,
-        const pandora::Cluster *&pBestCluster1, const pandora::Cluster *&pBestCluster2, float &chi2) const;
+    void GetBestChi2(const pandora::Vertex *const pVertex, const TwoDSlidingFitResultMap &slidingFitResultMap, const pandora::ClusterVector &clusters1,
+        const pandora::ClusterVector &clusters2, const pandora::Cluster *&pBestCluster1, const pandora::Cluster *&pBestCluster2, float &chi2) const;
 
     /**
      *  @brief  Merge two pointing clusters and return chi-squared metric giving consistency of matching
@@ -144,8 +142,7 @@ private:
      *  @param  pointingCluster1  the first pointing cluster
      *  @param  pointingCluster2  the second pointing cluster
      */
-    float GetChi2(const pandora::Vertex *const pVertex, const LArPointingCluster &pointingCluster1,
-        const LArPointingCluster &pointingCluster2) const;
+    float GetChi2(const pandora::Vertex *const pVertex, const LArPointingCluster &pointingCluster1, const LArPointingCluster &pointingCluster2) const;
 
     /**
      *  @brief  Merge three clusters between views and return chi-squared metric giving consistency of matching
@@ -165,8 +162,7 @@ private:
      *  @param  inputVector  the input vector of clusters
      *  @param  outputVector  the output vector of clusters
      */
-    void SelectAvailableClusters(const pandora::ClusterSet &vetoList, const pandora::ClusterVector &inputVector,
-        pandora::ClusterVector &outputVector) const;
+    void SelectAvailableClusters(const pandora::ClusterSet &vetoList, const pandora::ClusterVector &inputVector, pandora::ClusterVector &outputVector) const;
 
     /**
      *  @brief  Select clusters of a specified hit type
@@ -175,8 +171,7 @@ private:
      *  @param  inputVector  the input vector of clusters
      *  @param  outputVector  the output vector of clusters
      */
-    void SelectClusters(const pandora::HitType hitType, const pandora::ClusterVector &inputVector,
-        pandora::ClusterVector &outputVector) const;
+    void SelectClusters(const pandora::HitType hitType, const pandora::ClusterVector &inputVector, pandora::ClusterVector &outputVector) const;
 
     /**
      *  @brief  Find nearest end of pointing cluster to a specified position vector
@@ -203,14 +198,14 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector m_inputClusterListNames;        ///< The list of input cluster list names
-    std::string           m_outputPfoListName;            ///< The name of the output pfo list
+    pandora::StringVector m_inputClusterListNames; ///< The list of input cluster list names
+    std::string m_outputPfoListName;               ///< The name of the output pfo list
 
-    unsigned int          m_slidingFitHalfWindow;         ///<
-    float                 m_maxLongitudinalDisplacement;  ///<
-    float                 m_maxTransverseDisplacement;    ///<
-    float                 m_twoViewChi2Cut;               ///<
-    float                 m_threeViewChi2Cut;             ///<
+    unsigned int m_slidingFitHalfWindow; ///<
+    float m_maxLongitudinalDisplacement; ///<
+    float m_maxTransverseDisplacement;   ///<
+    float m_twoViewChi2Cut;              ///<
+    float m_threeViewChi2Cut;            ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArShowerFragments/ClearRemnantsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerFragments/ClearRemnantsTool.cc
@@ -18,7 +18,7 @@ namespace lar_content
 bool ClearRemnantsTool::Run(ThreeViewRemnantsAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     bool particlesMade(false);
 
@@ -31,8 +31,7 @@ bool ClearRemnantsTool::Run(ThreeViewRemnantsAlgorithm *const pAlgorithm, Tensor
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClearRemnantsTool::CreateThreeDParticles(ThreeViewRemnantsAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList,
-    bool &particlesMade) const
+void ClearRemnantsTool::CreateThreeDParticles(ThreeViewRemnantsAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList, bool &particlesMade) const
 {
     ProtoParticleVector protoParticleVector;
 

--- a/larpandoracontent/LArThreeDReco/LArShowerFragments/ConnectedRemnantsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerFragments/ConnectedRemnantsTool.cc
@@ -17,8 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ConnectedRemnantsTool::ConnectedRemnantsTool() :
-    m_maxClusterSeparation(10.f)
+ConnectedRemnantsTool::ConnectedRemnantsTool() : m_maxClusterSeparation(10.f)
 {
 }
 
@@ -27,21 +26,22 @@ ConnectedRemnantsTool::ConnectedRemnantsTool() :
 bool ConnectedRemnantsTool::Run(ThreeViewRemnantsAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    ProtoParticleVector protoParticleVector; ClusterMergeMap clusterMergeMap;
+    ProtoParticleVector protoParticleVector;
+    ClusterMergeMap clusterMergeMap;
     this->FindConnectedShowers(overlapTensor, protoParticleVector, clusterMergeMap);
 
     const bool particlesMade(pAlgorithm->CreateThreeDParticles(protoParticleVector));
     const bool mergesMade(pAlgorithm->MakeClusterMerges(clusterMergeMap));
 
-    return (particlesMade||mergesMade);
+    return (particlesMade || mergesMade);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ConnectedRemnantsTool::FindConnectedShowers(const TensorType &overlapTensor, ProtoParticleVector &protoParticleVector,
-    ClusterMergeMap &clusterMergeMap) const
+void ConnectedRemnantsTool::FindConnectedShowers(
+    const TensorType &overlapTensor, ProtoParticleVector &protoParticleVector, ClusterMergeMap &clusterMergeMap) const
 {
     ClusterSet usedClusters;
     ClusterVector sortedKeyClusters;
@@ -142,8 +142,8 @@ bool ConnectedRemnantsTool::IsConnected(const ClusterVector &clusterVector) cons
 
 StatusCode ConnectedRemnantsTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClusterSeparation", m_maxClusterSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClusterSeparation", m_maxClusterSeparation));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArShowerFragments/ConnectedRemnantsTool.h
+++ b/larpandoracontent/LArThreeDReco/LArShowerFragments/ConnectedRemnantsTool.h
@@ -65,7 +65,7 @@ private:
      */
     bool IsConnected(const pandora::ClusterVector &clusterVector) const;
 
-    float m_maxClusterSeparation;       ///<
+    float m_maxClusterSeparation; ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArShowerFragments/MopUpRemnantsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerFragments/MopUpRemnantsTool.cc
@@ -24,7 +24,7 @@ MopUpRemnantsTool::MopUpRemnantsTool()
 bool MopUpRemnantsTool::Run(ThreeViewRemnantsAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ProtoParticleVector protoParticleVector;
     this->FindBestShowers(overlapTensor, protoParticleVector);
@@ -78,8 +78,8 @@ void MopUpRemnantsTool::GetUsedClusters(const TensorType::ElementList &elementLi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MopUpRemnantsTool::SelectBestElement(const TensorType::ElementList &elementList, const ClusterSet &usedClusters,
-    TensorType::ElementList::const_iterator &bestIter) const
+void MopUpRemnantsTool::SelectBestElement(
+    const TensorType::ElementList &elementList, const ClusterSet &usedClusters, TensorType::ElementList::const_iterator &bestIter) const
 {
     float bestFigureOfMerit(0.f);
 

--- a/larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.cc
@@ -10,8 +10,8 @@
 
 #include "larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 using namespace pandora;
 
@@ -81,7 +81,8 @@ void ThreeViewRemnantsAlgorithm::CalculateOverlapResult(const Cluster *const pCl
         return;
 
     // ATTN Essentially a boolean result; actual value matters only so as to ensure that overlap results can be sorted
-    const float hackValue(pseudoChi2 + pClusterU->GetElectromagneticEnergy() + pClusterV->GetElectromagneticEnergy() + pClusterW->GetElectromagneticEnergy());
+    const float hackValue(
+        pseudoChi2 + pClusterU->GetElectromagneticEnergy() + pClusterV->GetElectromagneticEnergy() + pClusterW->GetElectromagneticEnergy());
     this->GetMatchingControl().GetOverlapTensor().SetOverlapResult(pClusterU, pClusterV, pClusterW, hackValue);
 }
 
@@ -91,7 +92,7 @@ void ThreeViewRemnantsAlgorithm::ExamineOverlapContainer()
 {
     unsigned int repeatCounter(0);
 
-    for (RemnantTensorToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd; )
+    for (RemnantTensorToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd;)
     {
         if ((*iter)->Run(this, this->GetMatchingControl().GetOverlapTensor()))
         {
@@ -112,12 +113,11 @@ void ThreeViewRemnantsAlgorithm::ExamineOverlapContainer()
 StatusCode ThreeViewRemnantsAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     AlgorithmToolVector algorithmToolVector;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle,
-        "TrackTools", algorithmToolVector));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "TrackTools", algorithmToolVector));
 
     for (AlgorithmToolVector::const_iterator iter = algorithmToolVector.begin(), iterEnd = algorithmToolVector.end(); iter != iterEnd; ++iter)
     {
-        RemnantTensorTool *const pRemnantTensorTool(dynamic_cast<RemnantTensorTool*>(*iter));
+        RemnantTensorTool *const pRemnantTensorTool(dynamic_cast<RemnantTensorTool *>(*iter));
 
         if (!pRemnantTensorTool)
             return STATUS_CODE_INVALID_PARAMETER;
@@ -125,17 +125,15 @@ StatusCode ThreeViewRemnantsAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         m_algorithmToolVector.push_back(pRemnantTensorTool);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NMaxTensorToolRepeats", m_nMaxTensorToolRepeats));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NMaxTensorToolRepeats", m_nMaxTensorToolRepeats));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterCaloHits", m_minClusterCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterCaloHits", m_minClusterCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "OverlapWindow", m_xOverlapWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "OverlapWindow", m_xOverlapWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PseudoChi2Cut", m_pseudoChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PseudoChi2Cut", m_pseudoChi2Cut));
 
     return BaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArShowerFragments/ThreeViewRemnantsAlgorithm.h
@@ -24,10 +24,10 @@ class RemnantTensorTool;
 /**
  *  @brief  ThreeViewRemnantsAlgorithm class
  */
-class ThreeViewRemnantsAlgorithm : public NViewMatchingAlgorithm<ThreeViewMatchingControl<float> >
+class ThreeViewRemnantsAlgorithm : public NViewMatchingAlgorithm<ThreeViewMatchingControl<float>>
 {
 public:
-    typedef NViewMatchingAlgorithm<ThreeViewMatchingControl<float> > BaseAlgorithm;
+    typedef NViewMatchingAlgorithm<ThreeViewMatchingControl<float>> BaseAlgorithm;
 
     /**
      *  @brief  Default constructor
@@ -42,13 +42,13 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::vector<RemnantTensorTool*> RemnantTensorToolVector;
-    RemnantTensorToolVector     m_algorithmToolVector;      ///< The algorithm tool list
+    typedef std::vector<RemnantTensorTool *> RemnantTensorToolVector;
+    RemnantTensorToolVector m_algorithmToolVector; ///< The algorithm tool list
 
-    unsigned int                m_nMaxTensorToolRepeats;    ///< The maximum number of repeat loops over tensor tools
-    unsigned int                m_minClusterCaloHits;       ///< The selection cut on the number of cluster calo hits
-    float                       m_xOverlapWindow;           ///< The sampling pitch in the x coordinate
-    float                       m_pseudoChi2Cut;            ///< The selection cut on the matched chi2
+    unsigned int m_nMaxTensorToolRepeats; ///< The maximum number of repeat loops over tensor tools
+    unsigned int m_minClusterCaloHits;    ///< The selection cut on the number of cluster calo hits
+    float m_xOverlapWindow;               ///< The sampling pitch in the x coordinate
+    float m_pseudoChi2Cut;                ///< The selection cut on the matched chi2
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/ClearShowersTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/ClearShowersTool.cc
@@ -33,7 +33,8 @@ bool ClearShowersTool::HasLargeDirectConnections(IteratorList::const_iterator iI
         if (iIter == iIter2)
             continue;
 
-        if (((*iIter)->GetClusterU() == (*iIter2)->GetClusterU()) || ((*iIter)->GetClusterV() == (*iIter2)->GetClusterV()) || ((*iIter)->GetClusterW() == (*iIter2)->GetClusterW()) )
+        if (((*iIter)->GetClusterU() == (*iIter2)->GetClusterU()) || ((*iIter)->GetClusterV() == (*iIter2)->GetClusterV()) ||
+            ((*iIter)->GetClusterW() == (*iIter2)->GetClusterW()))
             return true;
     }
 
@@ -56,7 +57,8 @@ bool ClearShowersTool::IsLargerThanDirectConnections(IteratorList::const_iterato
         if (usedClusters.count(eIter->GetClusterU()) || usedClusters.count(eIter->GetClusterV()) || usedClusters.count(eIter->GetClusterW()))
             continue;
 
-        if (((*iIter)->GetClusterU() != eIter->GetClusterU()) && ((*iIter)->GetClusterV() != eIter->GetClusterV()) && ((*iIter)->GetClusterW() != eIter->GetClusterW()))
+        if (((*iIter)->GetClusterU() != eIter->GetClusterU()) && ((*iIter)->GetClusterV() != eIter->GetClusterV()) &&
+            ((*iIter)->GetClusterW() != eIter->GetClusterW()))
             continue;
 
         if (nMatchedSamplingPoints < minMatchedSamplingPointRatio * eIter->GetOverlapResult().GetNMatchedSamplingPoints())
@@ -74,7 +76,7 @@ bool ClearShowersTool::IsLargerThanDirectConnections(IteratorList::const_iterato
 bool ClearShowersTool::Run(ThreeViewShowersAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ProtoParticleVector protoParticleVector;
     this->FindClearShowers(overlapTensor, protoParticleVector);
@@ -127,8 +129,8 @@ void ClearShowersTool::FindClearShowers(const TensorType &overlapTensor, ProtoPa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClearShowersTool::SelectLargeShowerElements(const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters,
-    IteratorList &iteratorList) const
+void ClearShowersTool::SelectLargeShowerElements(
+    const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const
 {
     for (TensorType::ElementList::const_iterator eIter = elementList.begin(); eIter != elementList.end(); ++eIter)
     {
@@ -156,20 +158,20 @@ void ClearShowersTool::SelectLargeShowerElements(const TensorType::ElementList &
 
 StatusCode ClearShowersTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapSpanRatio", m_minXOverlapSpanRatio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapSpanRatio", m_minXOverlapSpanRatio));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/ClearShowersTool.h
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/ClearShowersTool.h
@@ -66,14 +66,13 @@ private:
      *  @param  usedClusters the list of clusters already marked as to be added to a pfo
      *  @param  iteratorList to receive a list of iterators to large shower-like elements
      */
-    void SelectLargeShowerElements(const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters,
-        IteratorList &iteratorList) const;
+    void SelectLargeShowerElements(const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const;
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for particle creation
-    float           m_minXOverlapFraction;              ///< The min x overlap fraction (in each view) for particle creation
-    unsigned int    m_minMatchedSamplingPointRatio;     ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
-    float           m_minXOverlapSpanRatio;             ///< The min ratio between 1st and 2nd highest x-overlap spans for simple ambiguity resolution
+    float m_minMatchedFraction;                  ///< The min matched sampling point fraction for particle creation
+    unsigned int m_minMatchedSamplingPoints;     ///< The min number of matched sampling points for particle creation
+    float m_minXOverlapFraction;                 ///< The min x overlap fraction (in each view) for particle creation
+    unsigned int m_minMatchedSamplingPointRatio; ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
+    float m_minXOverlapSpanRatio; ///< The min ratio between 1st and 2nd highest x-overlap spans for simple ambiguity resolution
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/SimpleShowersTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/SimpleShowersTool.cc
@@ -15,10 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleShowersTool::SimpleShowersTool() :
-    m_minMatchedFraction(0.2f),
-    m_minMatchedSamplingPoints(40),
-    m_minXOverlapFraction(0.5f)
+SimpleShowersTool::SimpleShowersTool() : m_minMatchedFraction(0.2f), m_minMatchedSamplingPoints(40), m_minXOverlapFraction(0.5f)
 {
 }
 
@@ -27,7 +24,7 @@ SimpleShowersTool::SimpleShowersTool() :
 bool SimpleShowersTool::Run(ThreeViewShowersAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ProtoParticleVector protoParticleVector;
     this->FindBestShower(overlapTensor, protoParticleVector);
@@ -99,14 +96,14 @@ bool SimpleShowersTool::PassesElementCuts(TensorType::ElementList::const_iterato
 
 StatusCode SimpleShowersTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/SimpleShowersTool.h
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/SimpleShowersTool.h
@@ -44,9 +44,9 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for particle creation
-    float           m_minXOverlapFraction;              ///< The min x overlap fraction (in each view) for particle creation
+    float m_minMatchedFraction;              ///< The min matched sampling point fraction for particle creation
+    unsigned int m_minMatchedSamplingPoints; ///< The min number of matched sampling points for particle creation
+    float m_minXOverlapFraction;             ///< The min x overlap fraction (in each view) for particle creation
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/SplitShowersTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/SplitShowersTool.cc
@@ -44,7 +44,7 @@ SplitShowersTool::SplitShowersTool() :
 bool SplitShowersTool::Run(ThreeViewShowersAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ClusterMergeMap clusterMergeMap;
     this->FindSplitShowers(pAlgorithm, overlapTensor, clusterMergeMap);
@@ -146,8 +146,8 @@ void SplitShowersTool::SelectTensorElements(TensorType::ElementList::const_itera
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void SplitShowersTool::FindShowerMerges(ThreeViewShowersAlgorithm *const pAlgorithm, const IteratorList &iteratorList, ClusterSet &usedClusters,
-    ClusterMergeMap &clusterMergeMap) const
+void SplitShowersTool::FindShowerMerges(ThreeViewShowersAlgorithm *const pAlgorithm, const IteratorList &iteratorList,
+    ClusterSet &usedClusters, ClusterMergeMap &clusterMergeMap) const
 {
     for (IteratorList::const_iterator iIter1 = iteratorList.begin(), iIter1End = iteratorList.end(); iIter1 != iIter1End; ++iIter1)
     {
@@ -182,16 +182,16 @@ void SplitShowersTool::FindShowerMerges(ThreeViewShowersAlgorithm *const pAlgori
                 if ((1 == m_nCommonClusters) && !((2 == nClustersU) || (2 == nClustersV) || (2 == nClustersW)))
                     throw StatusCodeException(STATUS_CODE_FAILURE);
 
-                if (m_checkClusterProximities && (!this->CheckClusterProximities(pAlgorithm, clusterListU) ||
-                    !this->CheckClusterProximities(pAlgorithm, clusterListV) ||
-                    !this->CheckClusterProximities(pAlgorithm, clusterListW)))
+                if (m_checkClusterProximities &&
+                    (!this->CheckClusterProximities(pAlgorithm, clusterListU) || !this->CheckClusterProximities(pAlgorithm, clusterListV) ||
+                        !this->CheckClusterProximities(pAlgorithm, clusterListW)))
                 {
                     continue;
                 }
 
                 if (m_checkClusterVertexRelations && (!this->CheckClusterVertexRelations(pAlgorithm, clusterListU) ||
-                    !this->CheckClusterVertexRelations(pAlgorithm, clusterListV) ||
-                    !this->CheckClusterVertexRelations(pAlgorithm, clusterListW)))
+                                                         !this->CheckClusterVertexRelations(pAlgorithm, clusterListV) ||
+                                                         !this->CheckClusterVertexRelations(pAlgorithm, clusterListW)))
                 {
                     continue;
                 }
@@ -218,7 +218,7 @@ void SplitShowersTool::FindShowerMerges(ThreeViewShowersAlgorithm *const pAlgori
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool SplitShowersTool::CheckClusterProximities(ThreeViewShowersAlgorithm */*const pAlgorithm*/, const ClusterList &clusterList) const
+bool SplitShowersTool::CheckClusterProximities(ThreeViewShowersAlgorithm * /*const pAlgorithm*/, const ClusterList &clusterList) const
 {
     if (1 == clusterList.size())
         return true;
@@ -246,7 +246,8 @@ bool SplitShowersTool::CheckClusterVertexRelations(ThreeViewShowersAlgorithm *co
 {
     const VertexList *pVertexList(NULL);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList));
-    const Vertex *const pVertex(((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : NULL);
+    const Vertex *const pVertex(
+        ((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : NULL);
 
     if (NULL == pVertex)
         return true;
@@ -263,13 +264,17 @@ bool SplitShowersTool::CheckClusterVertexRelations(ThreeViewShowersAlgorithm *co
 
             if (LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
                 LArPointingClusterHelper::IsNode(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-                LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-                LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance))
+                LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance,
+                    m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+                LArPointingClusterHelper::IsEmission(vertex2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance,
+                    m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance))
             {
                 ++nVertexAssociations;
             }
         }
-        catch (StatusCodeException &) {}
+        catch (StatusCodeException &)
+        {
+        }
     }
 
     if (nVertexAssociations > m_maxVertexAssociations)
@@ -309,8 +314,8 @@ bool SplitShowersTool::CheckClusterSplitPositions(ThreeViewShowersAlgorithm *con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void SplitShowersTool::GetSplitXDetails(ThreeViewShowersAlgorithm *const pAlgorithm, const Cluster *const pClusterA, const Cluster *const pClusterB,
-    float &splitXPosition, float &overlapX) const
+void SplitShowersTool::GetSplitXDetails(ThreeViewShowersAlgorithm *const pAlgorithm, const Cluster *const pClusterA,
+    const Cluster *const pClusterB, float &splitXPosition, float &overlapX) const
 {
     const TwoDSlidingFitResult &fitResultA(pAlgorithm->GetCachedSlidingFitResult(pClusterA).GetShowerFitResult());
     const TwoDSlidingFitResult &fitResultB(pAlgorithm->GetCachedSlidingFitResult(pClusterB).GetShowerFitResult());
@@ -363,7 +368,8 @@ bool SplitShowersTool::ApplyChanges(ThreeViewShowersAlgorithm *const pAlgorithm,
     ClusterMergeMap consolidatedMergeMap;
 
     ClusterList clusterList;
-    for (const auto &mapEntry : clusterMergeMap) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterMergeMap)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : clusterList)
@@ -387,8 +393,7 @@ bool SplitShowersTool::ApplyChanges(ThreeViewShowersAlgorithm *const pAlgorithm,
 
 StatusCode SplitShowersTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NCommonClusters", m_nCommonClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NCommonClusters", m_nCommonClusters));
 
     if ((1 != m_nCommonClusters) && (2 != m_nCommonClusters))
     {
@@ -396,44 +401,44 @@ StatusCode SplitShowersTool::ReadSettings(const TiXmlHandle xmlHandle)
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CheckClusterProximities", m_checkClusterProximities));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CheckClusterProximities", m_checkClusterProximities));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClusterSeparation", m_maxClusterSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClusterSeparation", m_maxClusterSeparation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CheckClusterVertexRelations", m_checkClusterVertexRelations));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CheckClusterVertexRelations", m_checkClusterVertexRelations));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexAngularAllowance", m_vertexAngularAllowance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexAngularAllowance", m_vertexAngularAllowance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexAssociations", m_maxVertexAssociations));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxVertexAssociations", m_maxVertexAssociations));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CheckClusterSplitPositions", m_checkClusterSplitPositions));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CheckClusterSplitPositions", m_checkClusterSplitPositions));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VetoMergeXDifference", m_vetoMergeXDifference));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VetoMergeXDifference", m_vetoMergeXDifference));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VetoMergeXOverlap", m_vetoMergeXOverlap));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VetoMergeXOverlap", m_vetoMergeXOverlap));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/SplitShowersTool.h
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/SplitShowersTool.h
@@ -102,8 +102,8 @@ private:
      *  @param  splitXPosition to receive the split position estimate
      *  @param  overlapX to receive the overlap estimate
      */
-    void GetSplitXDetails(ThreeViewShowersAlgorithm *const pAlgorithm, const pandora::Cluster *const pClusterA, const pandora::Cluster *const pClusterB,
-        float &splitXPosition, float &overlapX) const;
+    void GetSplitXDetails(ThreeViewShowersAlgorithm *const pAlgorithm, const pandora::Cluster *const pClusterA,
+        const pandora::Cluster *const pClusterB, float &splitXPosition, float &overlapX) const;
 
     /**
      *  @brief  Populate the cluster merge map, based on the information contained in the provided cluster list
@@ -126,23 +126,23 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_nCommonClusters;                  ///< The number of common clusters
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for use as a key tensor element
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for use as a key tensor element
+    unsigned int m_nCommonClusters;          ///< The number of common clusters
+    float m_minMatchedFraction;              ///< The min matched sampling point fraction for use as a key tensor element
+    unsigned int m_minMatchedSamplingPoints; ///< The min number of matched sampling points for use as a key tensor element
 
-    bool            m_checkClusterProximities;          ///< Whether to check the proximities of the candidate split shower clusters
-    float           m_maxClusterSeparation;             ///< The maximum separation for clusters to be merged
+    bool m_checkClusterProximities; ///< Whether to check the proximities of the candidate split shower clusters
+    float m_maxClusterSeparation;   ///< The maximum separation for clusters to be merged
 
-    bool            m_checkClusterVertexRelations;      ///< Whether to check the consistency of the clusters with the event vertex
-    float           m_minVertexLongitudinalDistance;    ///< Vertex association check: min longitudinal distance cut
-    float           m_maxVertexLongitudinalDistance;    ///< Vertex association check: max longitudinal distance cut
-    float           m_maxVertexTransverseDistance;      ///< Vertex association check: max transverse distance cut
-    float           m_vertexAngularAllowance;           ///< Vertex association check: pointing angular allowance in degrees
-    unsigned int    m_maxVertexAssociations;            ///< The maximum number of vertex associations for clusters to be merged
+    bool m_checkClusterVertexRelations;    ///< Whether to check the consistency of the clusters with the event vertex
+    float m_minVertexLongitudinalDistance; ///< Vertex association check: min longitudinal distance cut
+    float m_maxVertexLongitudinalDistance; ///< Vertex association check: max longitudinal distance cut
+    float m_maxVertexTransverseDistance;   ///< Vertex association check: max transverse distance cut
+    float m_vertexAngularAllowance;        ///< Vertex association check: pointing angular allowance in degrees
+    unsigned int m_maxVertexAssociations;  ///< The maximum number of vertex associations for clusters to be merged
 
-    bool            m_checkClusterSplitPositions;       ///< Whether to check the cluster split positions, if there are splits in multiple views
-    float           m_vetoMergeXDifference;             ///< The x distance between split positions in two views below which may refuse a merge
-    float           m_vetoMergeXOverlap;                ///< The x overlap between candidate cluster sliding fits below which may refuse a merge
+    bool m_checkClusterSplitPositions; ///< Whether to check the cluster split positions, if there are splits in multiple views
+    float m_vetoMergeXDifference;      ///< The x distance between split positions in two views below which may refuse a merge
+    float m_vetoMergeXOverlap;         ///< The x overlap between candidate cluster sliding fits below which may refuse a merge
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/ThreeViewShowersAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/ThreeViewShowersAlgorithm.cc
@@ -93,7 +93,7 @@ void ThreeViewShowersAlgorithm::SelectInputClusters(const ClusterList *const pIn
 
 void ThreeViewShowersAlgorithm::PrepareInputClusters(ClusterList &preparedClusterList)
 {
-    for (ClusterList::iterator iter = preparedClusterList.begin(), iterEnd = preparedClusterList.end(); iter != iterEnd; )
+    for (ClusterList::iterator iter = preparedClusterList.begin(), iterEnd = preparedClusterList.end(); iter != iterEnd;)
     {
         const Cluster *const pCluster(*iter);
 
@@ -146,7 +146,8 @@ void ThreeViewShowersAlgorithm::RemoveFromSlidingFitCache(const Cluster *const p
 void ThreeViewShowersAlgorithm::CalculateOverlapResult(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW)
 {
     ShowerOverlapResult overlapResult;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->CalculateOverlapResult(pClusterU, pClusterV, pClusterW, overlapResult));
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->CalculateOverlapResult(pClusterU, pClusterV, pClusterW, overlapResult));
 
     if (overlapResult.IsInitialized())
         this->GetMatchingControl().GetOverlapTensor().SetOverlapResult(pClusterU, pClusterV, pClusterW, overlapResult);
@@ -154,7 +155,8 @@ void ThreeViewShowersAlgorithm::CalculateOverlapResult(const Cluster *const pClu
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode ThreeViewShowersAlgorithm::CalculateOverlapResult(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW, ShowerOverlapResult &overlapResult)
+StatusCode ThreeViewShowersAlgorithm::CalculateOverlapResult(
+    const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW, ShowerOverlapResult &overlapResult)
 {
     const TwoDSlidingShowerFitResult &fitResultU(this->GetCachedSlidingFitResult(pClusterU));
     const TwoDSlidingShowerFitResult &fitResultV(this->GetCachedSlidingFitResult(pClusterV));
@@ -183,7 +185,8 @@ StatusCode ThreeViewShowersAlgorithm::CalculateOverlapResult(const Cluster *cons
     if (0 == nSampledHits)
         return STATUS_CODE_NOT_FOUND;
 
-    const XOverlap xOverlapObject(xSampling.m_uMinX, xSampling.m_uMaxX, xSampling.m_vMinX, xSampling.m_vMaxX, xSampling.m_wMinX, xSampling.m_wMaxX, xSampling.m_xOverlapSpan);
+    const XOverlap xOverlapObject(xSampling.m_uMinX, xSampling.m_uMaxX, xSampling.m_vMinX, xSampling.m_vMaxX, xSampling.m_wMinX,
+        xSampling.m_wMaxX, xSampling.m_xOverlapSpan);
     const ShowerOverlapResult showerOverlapResult(nMatchedHits, nSampledHits, xOverlapObject);
 
     if ((showerOverlapResult.GetMatchedFraction() < m_minShowerMatchedFraction) || (showerOverlapResult.GetNMatchedSamplingPoints() < m_minShowerMatchedPoints))
@@ -195,9 +198,9 @@ StatusCode ThreeViewShowersAlgorithm::CalculateOverlapResult(const Cluster *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeViewShowersAlgorithm::GetShowerPositionMaps(const TwoDSlidingShowerFitResult &fitResultU, const TwoDSlidingShowerFitResult &fitResultV,
-    const TwoDSlidingShowerFitResult &fitResultW, const XSampling &xSampling, ShowerPositionMapPair &positionMapsU, ShowerPositionMapPair &positionMapsV,
-    ShowerPositionMapPair &positionMapsW) const
+void ThreeViewShowersAlgorithm::GetShowerPositionMaps(const TwoDSlidingShowerFitResult &fitResultU,
+    const TwoDSlidingShowerFitResult &fitResultV, const TwoDSlidingShowerFitResult &fitResultW, const XSampling &xSampling,
+    ShowerPositionMapPair &positionMapsU, ShowerPositionMapPair &positionMapsV, ShowerPositionMapPair &positionMapsW) const
 {
     const unsigned int nPoints(static_cast<unsigned int>(xSampling.m_nPoints));
 
@@ -258,13 +261,14 @@ void ThreeViewShowersAlgorithm::GetShowerPositionMaps(const TwoDSlidingShowerFit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeViewShowersAlgorithm::GetBestHitOverlapFraction(const Cluster *const pCluster, const XSampling &xSampling, const ShowerPositionMapPair &positionMaps,
-    unsigned int &nSampledHits, unsigned int &nMatchedHits) const
+void ThreeViewShowersAlgorithm::GetBestHitOverlapFraction(const Cluster *const pCluster, const XSampling &xSampling,
+    const ShowerPositionMapPair &positionMaps, unsigned int &nSampledHits, unsigned int &nMatchedHits) const
 {
     if ((xSampling.m_maxX - xSampling.m_minX) < std::numeric_limits<float>::epsilon())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-    nSampledHits = 0; nMatchedHits = 0;
+    nSampledHits = 0;
+    nMatchedHits = 0;
     unsigned int nMatchedHits1(0), nMatchedHits2(0);
     const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
 
@@ -302,7 +306,7 @@ void ThreeViewShowersAlgorithm::ExamineOverlapContainer()
 {
     unsigned int repeatCounter(0);
 
-    for (TensorToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd; )
+    for (TensorToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd;)
     {
         if ((*iter)->Run(this, this->GetMatchingControl().GetOverlapTensor()))
         {
@@ -321,8 +325,8 @@ void ThreeViewShowersAlgorithm::ExamineOverlapContainer()
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeViewShowersAlgorithm::XSampling::XSampling(const TwoDSlidingFitResult &fitResultU, const TwoDSlidingFitResult &fitResultV,
-    const TwoDSlidingFitResult &fitResultW)
+ThreeViewShowersAlgorithm::XSampling::XSampling(
+    const TwoDSlidingFitResult &fitResultU, const TwoDSlidingFitResult &fitResultV, const TwoDSlidingFitResult &fitResultW)
 {
     fitResultU.GetMinAndMaxX(m_uMinX, m_uMaxX);
     fitResultV.GetMinAndMaxX(m_vMinX, m_vMaxX);
@@ -334,9 +338,12 @@ ThreeViewShowersAlgorithm::XSampling::XSampling(const TwoDSlidingFitResult &fitR
 
     if (m_xOverlapSpan > std::numeric_limits<float>::epsilon())
     {
-        const float nPointsU(std::fabs((m_xOverlapSpan / (m_uMaxX - m_uMinX)) * static_cast<float>(fitResultU.GetMaxLayer() - fitResultU.GetMinLayer())));
-        const float nPointsV(std::fabs((m_xOverlapSpan / (m_vMaxX - m_vMinX)) * static_cast<float>(fitResultV.GetMaxLayer() - fitResultV.GetMinLayer())));
-        const float nPointsW(std::fabs((m_xOverlapSpan / (m_wMaxX - m_wMinX)) * static_cast<float>(fitResultW.GetMaxLayer() - fitResultW.GetMinLayer())));
+        const float nPointsU(
+            std::fabs((m_xOverlapSpan / (m_uMaxX - m_uMinX)) * static_cast<float>(fitResultU.GetMaxLayer() - fitResultU.GetMinLayer())));
+        const float nPointsV(
+            std::fabs((m_xOverlapSpan / (m_vMaxX - m_vMinX)) * static_cast<float>(fitResultV.GetMaxLayer() - fitResultV.GetMinLayer())));
+        const float nPointsW(
+            std::fabs((m_xOverlapSpan / (m_wMaxX - m_wMinX)) * static_cast<float>(fitResultW.GetMaxLayer() - fitResultW.GetMinLayer())));
         m_nPoints = 1.f + ((nPointsU + nPointsV + nPointsW) / 3.f);
     }
 }
@@ -358,12 +365,11 @@ StatusCode ThreeViewShowersAlgorithm::XSampling::GetBin(const float x, int &xBin
 StatusCode ThreeViewShowersAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     AlgorithmToolVector algorithmToolVector;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle,
-        "ShowerTools", algorithmToolVector));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "ShowerTools", algorithmToolVector));
 
     for (AlgorithmToolVector::const_iterator iter = algorithmToolVector.begin(), iterEnd = algorithmToolVector.end(); iter != iterEnd; ++iter)
     {
-        ShowerTensorTool *const pShowerTensorTool(dynamic_cast<ShowerTensorTool*>(*iter));
+        ShowerTensorTool *const pShowerTensorTool(dynamic_cast<ShowerTensorTool *>(*iter));
 
         if (!pShowerTensorTool)
             return STATUS_CODE_INVALID_PARAMETER;
@@ -371,28 +377,27 @@ StatusCode ThreeViewShowersAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         m_algorithmToolVector.push_back(pShowerTensorTool);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NMaxTensorToolRepeats", m_nMaxTensorToolRepeats));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NMaxTensorToolRepeats", m_nMaxTensorToolRepeats));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IgnoreUnavailableClusters", m_ignoreUnavailableClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "IgnoreUnavailableClusters", m_ignoreUnavailableClusters));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterCaloHits", m_minClusterCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterCaloHits", m_minClusterCaloHits));
 
     float minClusterLength = std::sqrt(m_minClusterLengthSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", minClusterLength));
     m_minClusterLengthSquared = minClusterLength * minClusterLength;
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinShowerMatchedFraction", m_minShowerMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinShowerMatchedFraction", m_minShowerMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinShowerMatchedPoints", m_minShowerMatchedPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinShowerMatchedPoints", m_minShowerMatchedPoints));
 
     return BaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArShowerMatching/ThreeViewShowersAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArShowerMatching/ThreeViewShowersAlgorithm.h
@@ -26,10 +26,10 @@ class ShowerTensorTool;
 /**
  *  @brief  ThreeViewShowersAlgorithm class
  */
-class ThreeViewShowersAlgorithm : public NViewMatchingAlgorithm<ThreeViewMatchingControl<ShowerOverlapResult> >
+class ThreeViewShowersAlgorithm : public NViewMatchingAlgorithm<ThreeViewMatchingControl<ShowerOverlapResult>>
 {
 public:
-    typedef NViewMatchingAlgorithm<ThreeViewMatchingControl<ShowerOverlapResult> > BaseAlgorithm;
+    typedef NViewMatchingAlgorithm<ThreeViewMatchingControl<ShowerOverlapResult>> BaseAlgorithm;
 
     /**
      *  @brief  Default constructor
@@ -74,16 +74,16 @@ private:
          */
         pandora::StatusCode GetBin(const float x, int &xBin) const;
 
-        float       m_uMinX;         ///< The min x value in the u view
-        float       m_uMaxX;         ///< The max x value in the u view
-        float       m_vMinX;         ///< The min x value in the v view
-        float       m_vMaxX;         ///< The max x value in the v view
-        float       m_wMinX;         ///< The min x value in the w view
-        float       m_wMaxX;         ///< The max x value in the w view
-        float       m_minX;          ///< The min x value of the common x-overlap range
-        float       m_maxX;          ///< The max x value of the common x-overlap range
-        float       m_xOverlapSpan;  ///< The x-overlap span
-        float       m_nPoints;       ///< The number of sampling points to be used
+        float m_uMinX;        ///< The min x value in the u view
+        float m_uMaxX;        ///< The max x value in the u view
+        float m_vMinX;        ///< The min x value in the v view
+        float m_vMaxX;        ///< The max x value in the v view
+        float m_wMinX;        ///< The min x value in the w view
+        float m_wMaxX;        ///< The max x value in the w view
+        float m_minX;         ///< The min x value of the common x-overlap range
+        float m_maxX;         ///< The max x value of the common x-overlap range
+        float m_xOverlapSpan; ///< The x-overlap span
+        float m_nPoints;      ///< The number of sampling points to be used
     };
 
     void TidyUp();
@@ -112,8 +112,8 @@ private:
      *  @param  pClusterW the cluster from the W view
      *  @param  overlapResult to receive the overlap result
      */
-    pandora::StatusCode CalculateOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW,
-        ShowerOverlapResult &overlapResult);
+    pandora::StatusCode CalculateOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV,
+        const pandora::Cluster *const pClusterW, ShowerOverlapResult &overlapResult);
 
     typedef std::pair<ShowerPositionMap, ShowerPositionMap> ShowerPositionMapPair;
 
@@ -128,8 +128,9 @@ private:
      *  @param  positionMapsV to receive the shower position maps for the v view
      *  @param  positionMapsW to receive the shower position maps for the w view
      */
-    void GetShowerPositionMaps(const TwoDSlidingShowerFitResult &fitResultU, const TwoDSlidingShowerFitResult &fitResultV, const TwoDSlidingShowerFitResult &fitResultW,
-        const XSampling &xSampling, ShowerPositionMapPair &positionMapsU, ShowerPositionMapPair &positionMapsV, ShowerPositionMapPair &positionMapsW) const;
+    void GetShowerPositionMaps(const TwoDSlidingShowerFitResult &fitResultU, const TwoDSlidingShowerFitResult &fitResultV,
+        const TwoDSlidingShowerFitResult &fitResultW, const XSampling &xSampling, ShowerPositionMapPair &positionMapsU,
+        ShowerPositionMapPair &positionMapsV, ShowerPositionMapPair &positionMapsW) const;
 
     /**
      *  @brief  Get the best fraction of hits, in the common x-overlap range, contained within the provided pair of shower boundaries
@@ -140,25 +141,25 @@ private:
      *  @param  nSampledHits to receive the number of hits in the common x-overlap range
      *  @param  nMatchedHits to receive the number of sampled hits contained within the shower edges
      */
-    void GetBestHitOverlapFraction(const pandora::Cluster *const pCluster, const XSampling &xSampling, const ShowerPositionMapPair &positionMaps,
-        unsigned int &nSampledHits, unsigned int &nMatchedHits) const;
+    void GetBestHitOverlapFraction(const pandora::Cluster *const pCluster, const XSampling &xSampling,
+        const ShowerPositionMapPair &positionMaps, unsigned int &nSampledHits, unsigned int &nMatchedHits) const;
 
     void ExamineOverlapContainer();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::vector<ShowerTensorTool*> TensorToolVector;
-    TensorToolVector                m_algorithmToolVector;          ///< The algorithm tool vector
-    unsigned int                    m_nMaxTensorToolRepeats;        ///< The maximum number of repeat loops over tensor tools
+    typedef std::vector<ShowerTensorTool *> TensorToolVector;
+    TensorToolVector m_algorithmToolVector; ///< The algorithm tool vector
+    unsigned int m_nMaxTensorToolRepeats;   ///< The maximum number of repeat loops over tensor tools
 
-    unsigned int                    m_slidingFitWindow;             ///< The layer window for the sliding linear fits
-    TwoDSlidingShowerFitResultMap   m_slidingFitResultMap;          ///< The sliding shower fit result map
+    unsigned int m_slidingFitWindow;                     ///< The layer window for the sliding linear fits
+    TwoDSlidingShowerFitResultMap m_slidingFitResultMap; ///< The sliding shower fit result map
 
-    bool                            m_ignoreUnavailableClusters;    ///< Whether to ignore (skip-over) unavailable clusters
-    unsigned int                    m_minClusterCaloHits;           ///< The min number of hits in base cluster selection method
-    float                           m_minClusterLengthSquared;      ///< The min length (squared) in base cluster selection method
+    bool m_ignoreUnavailableClusters;  ///< Whether to ignore (skip-over) unavailable clusters
+    unsigned int m_minClusterCaloHits; ///< The min number of hits in base cluster selection method
+    float m_minClusterLengthSquared;   ///< The min length (squared) in base cluster selection method
 
-    float                           m_minShowerMatchedFraction;     ///< The minimum shower matched sampling fraction to allow shower grouping
-    unsigned int                    m_minShowerMatchedPoints;       ///< The minimum number of matched shower sampling points to allow shower grouping
+    float m_minShowerMatchedFraction;      ///< The minimum shower matched sampling fraction to allow shower grouping
+    unsigned int m_minShowerMatchedPoints; ///< The minimum number of matched shower sampling points to allow shower grouping
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/MatchingBaseAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/MatchingBaseAlgorithm.cc
@@ -39,7 +39,7 @@ void MatchingBaseAlgorithm::SelectInputClusters(const ClusterList *const pInputC
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MatchingBaseAlgorithm::PrepareInputClusters(ClusterList &/*preparedClusterList*/)
+void MatchingBaseAlgorithm::PrepareInputClusters(ClusterList & /*preparedClusterList*/)
 {
 }
 
@@ -50,7 +50,8 @@ bool MatchingBaseAlgorithm::MakeClusterMerges(const ClusterMergeMap &clusterMerg
     ClusterSet deletedClusters;
 
     ClusterList parentClusters;
-    for (const auto &mapEntry : clusterMergeMap) parentClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterMergeMap)
+        parentClusters.push_back(mapEntry.first);
     parentClusters.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : parentClusters)
@@ -71,7 +72,8 @@ bool MatchingBaseAlgorithm::MakeClusterMerges(const ClusterMergeMap &clusterMerg
 
             this->UpdateUponDeletion(pDaughterCluster);
             this->UpdateUponDeletion(pParentCluster);
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pDaughterCluster, clusterListName, clusterListName));
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pDaughterCluster, clusterListName, clusterListName));
 
             this->UpdateForNewCluster(pParentCluster);
             deletedClusters.insert(pDaughterCluster);
@@ -86,7 +88,8 @@ bool MatchingBaseAlgorithm::MakeClusterMerges(const ClusterMergeMap &clusterMerg
 bool MatchingBaseAlgorithm::CreateThreeDParticles(const ProtoParticleVector &protoParticleVector)
 {
     bool particlesMade(false);
-    const PfoList *pPfoList(nullptr); std::string pfoListName;
+    const PfoList *pPfoList(nullptr);
+    std::string pfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
     for (const ProtoParticle &protoParticle : protoParticleVector)

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/MatchingBaseAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/MatchingBaseAlgorithm.h
@@ -24,11 +24,11 @@ namespace lar_content
 class ProtoParticle
 {
 public:
-    pandora::ClusterList    m_clusterList;                  ///< List of 2D clusters in a 3D proto particle
+    pandora::ClusterList m_clusterList; ///< List of 2D clusters in a 3D proto particle
 };
 
 typedef std::vector<ProtoParticle> ProtoParticleVector;
-typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterMergeMap;
+typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterMergeMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -96,7 +96,8 @@ public:
      *  @param  pCluster2 address of cluster2
      *  @param  pCluster3 address of cluster3
      */
-    virtual void CalculateOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const pandora::Cluster *const pCluster3 = nullptr) = 0;
+    virtual void CalculateOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
+        const pandora::Cluster *const pCluster3 = nullptr) = 0;
 
     /**
      *  @brief  Select a subset of input clusters for processing in this algorithm
@@ -177,7 +178,7 @@ protected:
 private:
     pandora::StatusCode Run();
 
-    std::string                 m_outputPfoListName;            ///< The output pfo list name
+    std::string m_outputPfoListName; ///< The output pfo list name
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingAlgorithm.cc
@@ -15,8 +15,8 @@
 #include "larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.h"
 
 #include "larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingAlgorithm.h"
-#include "larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.h"
 #include "larpandoracontent/LArThreeDReco/LArThreeDBase/ThreeViewMatchingControl.h"
+#include "larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.h"
 
 using namespace pandora;
 
@@ -24,8 +24,7 @@ namespace lar_content
 {
 
 template <typename T>
-NViewMatchingAlgorithm<T>::NViewMatchingAlgorithm() :
-    m_matchingControl(this)
+NViewMatchingAlgorithm<T>::NViewMatchingAlgorithm() : m_matchingControl(this)
 {
 }
 
@@ -54,7 +53,7 @@ void NViewMatchingAlgorithm<T>::UpdateUponDeletion(const Cluster *const pDeleted
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const std::string &NViewMatchingAlgorithm<T>::GetClusterListName(const HitType hitType) const
 {
     return m_matchingControl.GetClusterListName(hitType);
@@ -62,7 +61,7 @@ const std::string &NViewMatchingAlgorithm<T>::GetClusterListName(const HitType h
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const pandora::ClusterList &NViewMatchingAlgorithm<T>::GetInputClusterList(const HitType hitType) const
 {
     return m_matchingControl.GetInputClusterList(hitType);
@@ -70,7 +69,7 @@ const pandora::ClusterList &NViewMatchingAlgorithm<T>::GetInputClusterList(const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const pandora::ClusterList &NViewMatchingAlgorithm<T>::GetSelectedClusterList(const HitType hitType) const
 {
     return m_matchingControl.GetSelectedClusterList(hitType);
@@ -120,12 +119,12 @@ StatusCode NViewMatchingAlgorithm<T>::ReadSettings(const TiXmlHandle xmlHandle)
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template class NViewMatchingAlgorithm<TwoViewMatchingControl<float> >;
-template class NViewMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult> >;
-template class NViewMatchingAlgorithm<ThreeViewMatchingControl<float> >;
-template class NViewMatchingAlgorithm<ThreeViewMatchingControl<ShowerOverlapResult> >;
-template class NViewMatchingAlgorithm<ThreeViewMatchingControl<TransverseOverlapResult> >;
-template class NViewMatchingAlgorithm<ThreeViewMatchingControl<LongitudinalOverlapResult> >;
-template class NViewMatchingAlgorithm<ThreeViewMatchingControl<FragmentOverlapResult> >;
+template class NViewMatchingAlgorithm<TwoViewMatchingControl<float>>;
+template class NViewMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult>>;
+template class NViewMatchingAlgorithm<ThreeViewMatchingControl<float>>;
+template class NViewMatchingAlgorithm<ThreeViewMatchingControl<ShowerOverlapResult>>;
+template class NViewMatchingAlgorithm<ThreeViewMatchingControl<TransverseOverlapResult>>;
+template class NViewMatchingAlgorithm<ThreeViewMatchingControl<LongitudinalOverlapResult>>;
+template class NViewMatchingAlgorithm<ThreeViewMatchingControl<FragmentOverlapResult>>;
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingAlgorithm.h
@@ -16,7 +16,7 @@ namespace lar_content
 /**
  *  @brief  NViewMatchingAlgorithm class
  */
-template<typename T>
+template <typename T>
 class NViewMatchingAlgorithm : public MatchingBaseAlgorithm
 {
 public:
@@ -50,12 +50,12 @@ protected:
     virtual void TidyUp();
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    MatchingType    m_matchingControl;     ///< The matching control
+    MatchingType m_matchingControl; ///< The matching control
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 inline T &NViewMatchingAlgorithm<T>::GetMatchingControl()
 {
     return m_matchingControl;

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingControl.h
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewMatchingControl.h
@@ -102,13 +102,12 @@ protected:
      */
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) = 0;
 
-    MatchingBaseAlgorithm  *m_pAlgorithm;   ///< The address of the matching base algorithm
+    MatchingBaseAlgorithm *m_pAlgorithm; ///< The address of the matching base algorithm
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline NViewMatchingControl::NViewMatchingControl(MatchingBaseAlgorithm *const pAlgorithm) :
-    m_pAlgorithm(pAlgorithm)
+inline NViewMatchingControl::NViewMatchingControl(MatchingBaseAlgorithm *const pAlgorithm) : m_pAlgorithm(pAlgorithm)
 {
 }
 

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewTrackMatchingAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewTrackMatchingAlgorithm.cc
@@ -16,15 +16,15 @@
 #include "larpandoracontent/LArObjects/LArTrackTwoViewOverlapResult.h"
 
 #include "larpandoracontent/LArThreeDReco/LArThreeDBase/NViewTrackMatchingAlgorithm.h"
-#include "larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.h"
 #include "larpandoracontent/LArThreeDReco/LArThreeDBase/ThreeViewMatchingControl.h"
+#include "larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.h"
 
 using namespace pandora;
 
 namespace lar_content
 {
 
-template<typename T>
+template <typename T>
 NViewTrackMatchingAlgorithm<T>::NViewTrackMatchingAlgorithm() :
     m_slidingFitWindow(20),
     m_minClusterCaloHits(5),
@@ -41,7 +41,7 @@ NViewTrackMatchingAlgorithm<T>::~NViewTrackMatchingAlgorithm()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const TwoDSlidingFitResult &NViewTrackMatchingAlgorithm<T>::GetCachedSlidingFitResult(const Cluster *const pCluster) const
 {
     TwoDSlidingFitResultMap::const_iterator iter = m_slidingFitResultMap.find(pCluster);
@@ -52,16 +52,16 @@ const TwoDSlidingFitResult &NViewTrackMatchingAlgorithm<T>::GetCachedSlidingFitR
     return iter->second;
 }
 
-
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 bool NViewTrackMatchingAlgorithm<T>::MakeClusterSplits(const SplitPositionMap &splitPositionMap)
 {
     bool changesMade(false);
 
     ClusterList splitClusters;
-    for (const auto &mapEntry : splitPositionMap) splitClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : splitPositionMap)
+        splitClusters.push_back(mapEntry.first);
     splitClusters.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *pCurrentCluster : splitClusters)
@@ -101,9 +101,9 @@ bool NViewTrackMatchingAlgorithm<T>::MakeClusterSplits(const SplitPositionMap &s
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
-bool NViewTrackMatchingAlgorithm<T>::MakeClusterSplit(const CartesianVector &splitPosition, const Cluster *&pCurrentCluster, const Cluster *&pLowXCluster,
-    const Cluster *&pHighXCluster) const
+template <typename T>
+bool NViewTrackMatchingAlgorithm<T>::MakeClusterSplit(
+    const CartesianVector &splitPosition, const Cluster *&pCurrentCluster, const Cluster *&pLowXCluster, const Cluster *&pHighXCluster) const
 {
     CartesianVector lowXEnd(0.f, 0.f, 0.f), highXEnd(0.f, 0.f, 0.f);
 
@@ -114,7 +114,10 @@ bool NViewTrackMatchingAlgorithm<T>::MakeClusterSplit(const CartesianVector &spl
         lowXEnd = (innerIsLowX ? pointingCluster.GetInnerVertex().GetPosition() : pointingCluster.GetOuterVertex().GetPosition());
         highXEnd = (innerIsLowX ? pointingCluster.GetOuterVertex().GetPosition() : pointingCluster.GetInnerVertex().GetPosition());
     }
-    catch (const StatusCodeException &) {return false;}
+    catch (const StatusCodeException &)
+    {
+        return false;
+    }
 
     const CartesianVector lowXUnitVector((lowXEnd - splitPosition).GetUnitVector());
     const CartesianVector highXUnitVector((highXEnd - splitPosition).GetUnitVector());
@@ -161,7 +164,7 @@ bool NViewTrackMatchingAlgorithm<T>::MakeClusterSplit(const CartesianVector &spl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 bool NViewTrackMatchingAlgorithm<T>::SortSplitPositions(const pandora::CartesianVector &lhs, const pandora::CartesianVector &rhs)
 {
     return (lhs.GetX() < rhs.GetX());
@@ -169,7 +172,7 @@ bool NViewTrackMatchingAlgorithm<T>::SortSplitPositions(const pandora::Cartesian
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 void NViewTrackMatchingAlgorithm<T>::UpdateForNewCluster(const Cluster *const pNewCluster)
 {
     try
@@ -189,7 +192,7 @@ void NViewTrackMatchingAlgorithm<T>::UpdateForNewCluster(const Cluster *const pN
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 void NViewTrackMatchingAlgorithm<T>::UpdateUponDeletion(const Cluster *const pDeletedCluster)
 {
     this->RemoveFromSlidingFitCache(pDeletedCluster);
@@ -218,10 +221,10 @@ void NViewTrackMatchingAlgorithm<T>::SelectInputClusters(const ClusterList *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 void NViewTrackMatchingAlgorithm<T>::PrepareInputClusters(ClusterList &preparedClusterList)
 {
-    for (ClusterList::iterator iter = preparedClusterList.begin(), iterEnd = preparedClusterList.end(); iter != iterEnd; )
+    for (ClusterList::iterator iter = preparedClusterList.begin(), iterEnd = preparedClusterList.end(); iter != iterEnd;)
     {
         try
         {
@@ -240,7 +243,7 @@ void NViewTrackMatchingAlgorithm<T>::PrepareInputClusters(ClusterList &preparedC
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 void NViewTrackMatchingAlgorithm<T>::SetPfoParticleId(PandoraContentApi::ParticleFlowObject::Parameters &pfoParameters) const
 {
     pfoParameters.m_particleId = MU_MINUS; // Track
@@ -248,7 +251,7 @@ void NViewTrackMatchingAlgorithm<T>::SetPfoParticleId(PandoraContentApi::Particl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 void NViewTrackMatchingAlgorithm<T>::AddToSlidingFitCache(const Cluster *const pCluster)
 {
     const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
@@ -260,7 +263,7 @@ void NViewTrackMatchingAlgorithm<T>::AddToSlidingFitCache(const Cluster *const p
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 void NViewTrackMatchingAlgorithm<T>::RemoveFromSlidingFitCache(const Cluster *const pCluster)
 {
     TwoDSlidingFitResultMap::iterator iter = m_slidingFitResultMap.find(pCluster);
@@ -271,7 +274,7 @@ void NViewTrackMatchingAlgorithm<T>::RemoveFromSlidingFitCache(const Cluster *co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 void NViewTrackMatchingAlgorithm<T>::TidyUp()
 {
     m_slidingFitResultMap.clear();
@@ -280,18 +283,17 @@ void NViewTrackMatchingAlgorithm<T>::TidyUp()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 StatusCode NViewTrackMatchingAlgorithm<T>::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterCaloHits", m_minClusterCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterCaloHits", m_minClusterCaloHits));
 
     float minClusterLength = std::sqrt(m_minClusterLengthSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", minClusterLength));
     m_minClusterLengthSquared = minClusterLength * minClusterLength;
 
     return NViewMatchingAlgorithm<T>::ReadSettings(xmlHandle);
@@ -299,11 +301,11 @@ StatusCode NViewTrackMatchingAlgorithm<T>::ReadSettings(const TiXmlHandle xmlHan
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template class NViewTrackMatchingAlgorithm<TwoViewMatchingControl<float> >;
-template class NViewTrackMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult> >;
-template class NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<float> >;
-template class NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<TransverseOverlapResult> >;
-template class NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<LongitudinalOverlapResult> >;
-template class NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<FragmentOverlapResult> >;
+template class NViewTrackMatchingAlgorithm<TwoViewMatchingControl<float>>;
+template class NViewTrackMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult>>;
+template class NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<float>>;
+template class NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<TransverseOverlapResult>>;
+template class NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<LongitudinalOverlapResult>>;
+template class NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<FragmentOverlapResult>>;
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewTrackMatchingAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/NViewTrackMatchingAlgorithm.h
@@ -15,14 +15,14 @@
 namespace lar_content
 {
 
-typedef std::unordered_map<const pandora::Cluster*, pandora::CartesianPointVector> SplitPositionMap;
+typedef std::unordered_map<const pandora::Cluster *, pandora::CartesianPointVector> SplitPositionMap;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
  *  @brief  NViewTrackMatchingAlgorithm class
  */
-template<typename T>
+template <typename T>
 class NViewTrackMatchingAlgorithm : public NViewMatchingAlgorithm<T>
 {
 public:
@@ -105,16 +105,16 @@ protected:
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
 private:
-    unsigned int                m_slidingFitWindow;             ///< The layer window for the sliding linear fits
-    TwoDSlidingFitResultMap     m_slidingFitResultMap;          ///< The sliding fit result map
+    unsigned int m_slidingFitWindow;               ///< The layer window for the sliding linear fits
+    TwoDSlidingFitResultMap m_slidingFitResultMap; ///< The sliding fit result map
 
-    unsigned int                m_minClusterCaloHits;           ///< The min number of hits in base cluster selection method
-    float                       m_minClusterLengthSquared;      ///< The min length (squared) in base cluster selection method
+    unsigned int m_minClusterCaloHits; ///< The min number of hits in base cluster selection method
+    float m_minClusterLengthSquared;   ///< The min length (squared) in base cluster selection method
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 inline unsigned int NViewTrackMatchingAlgorithm<T>::GetSlidingFitWindow() const
 {
     return m_slidingFitWindow;

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/ThreeViewMatchingControl.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/ThreeViewMatchingControl.cc
@@ -113,7 +113,7 @@ void ThreeViewMatchingControl<T>::UpdateUponDeletion(const Cluster *const pDelet
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const std::string &ThreeViewMatchingControl<T>::GetClusterListName(const HitType hitType) const
 {
     if (TPC_VIEW_U == hitType)
@@ -130,7 +130,7 @@ const std::string &ThreeViewMatchingControl<T>::GetClusterListName(const HitType
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const pandora::ClusterList &ThreeViewMatchingControl<T>::GetInputClusterList(const HitType hitType) const
 {
     if ((TPC_VIEW_U == hitType) && m_pInputClusterListU)
@@ -147,7 +147,7 @@ const pandora::ClusterList &ThreeViewMatchingControl<T>::GetInputClusterList(con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const pandora::ClusterList &ThreeViewMatchingControl<T>::GetSelectedClusterList(const HitType hitType) const
 {
     if (TPC_VIEW_U == hitType)
@@ -167,12 +167,12 @@ const pandora::ClusterList &ThreeViewMatchingControl<T>::GetSelectedClusterList(
 template <typename T>
 void ThreeViewMatchingControl<T>::SelectAllInputClusters()
 {
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*m_pAlgorithm,
-        m_inputClusterListNameU, m_pInputClusterListU));
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*m_pAlgorithm,
-        m_inputClusterListNameV, m_pInputClusterListV));
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*m_pAlgorithm,
-        m_inputClusterListNameW, m_pInputClusterListW));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+        PandoraContentApi::GetList(*m_pAlgorithm, m_inputClusterListNameU, m_pInputClusterListU));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+        PandoraContentApi::GetList(*m_pAlgorithm, m_inputClusterListNameV, m_pInputClusterListV));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+        PandoraContentApi::GetList(*m_pAlgorithm, m_inputClusterListNameW, m_pInputClusterListW));
 
     if (!m_pInputClusterListU || !m_pInputClusterListV || !m_pInputClusterListW)
     {

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/ThreeViewMatchingControl.h
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/ThreeViewMatchingControl.h
@@ -18,7 +18,7 @@ namespace lar_content
 /**
  *  @brief  ThreeViewMatchingControl class
  */
-template<typename T>
+template <typename T>
 class ThreeViewMatchingControl : public NViewMatchingControl
 {
 public:
@@ -55,21 +55,21 @@ private:
     void TidyUp();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    const pandora::ClusterList *m_pInputClusterListU;           ///< Address of the input cluster list U
-    const pandora::ClusterList *m_pInputClusterListV;           ///< Address of the input cluster list V
-    const pandora::ClusterList *m_pInputClusterListW;           ///< Address of the input cluster list W
+    const pandora::ClusterList *m_pInputClusterListU; ///< Address of the input cluster list U
+    const pandora::ClusterList *m_pInputClusterListV; ///< Address of the input cluster list V
+    const pandora::ClusterList *m_pInputClusterListW; ///< Address of the input cluster list W
 
-    pandora::ClusterList        m_clusterListU;                 ///< The selected modified cluster list U
-    pandora::ClusterList        m_clusterListV;                 ///< The selected modified cluster list V
-    pandora::ClusterList        m_clusterListW;                 ///< The selected modified cluster list W
+    pandora::ClusterList m_clusterListU; ///< The selected modified cluster list U
+    pandora::ClusterList m_clusterListV; ///< The selected modified cluster list V
+    pandora::ClusterList m_clusterListW; ///< The selected modified cluster list W
 
-    TensorType                  m_overlapTensor;                ///< The overlap tensor
+    TensorType m_overlapTensor; ///< The overlap tensor
 
-    std::string                 m_inputClusterListNameU;        ///< The name of the view U cluster list
-    std::string                 m_inputClusterListNameV;        ///< The name of the view V cluster list
-    std::string                 m_inputClusterListNameW;        ///< The name of the view W cluster list
+    std::string m_inputClusterListNameU; ///< The name of the view U cluster list
+    std::string m_inputClusterListNameV; ///< The name of the view V cluster list
+    std::string m_inputClusterListNameW; ///< The name of the view W cluster list
 
-    friend class ThreeViewTrackFragmentsAlgorithm;              ///< ATTN This is for legacy purposes only
+    friend class ThreeViewTrackFragmentsAlgorithm; ///< ATTN This is for legacy purposes only
 
     template <typename U>
     friend class NViewMatchingAlgorithm;

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.cc
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.cc
@@ -98,7 +98,7 @@ void TwoViewMatchingControl<T>::UpdateUponDeletion(const Cluster *const pDeleted
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const std::string &TwoViewMatchingControl<T>::GetClusterListName(const HitType hitType) const
 {
     HitTypeToIndexMap::const_iterator iter = m_hitTypeToIndexMap.find(hitType);
@@ -113,7 +113,7 @@ const std::string &TwoViewMatchingControl<T>::GetClusterListName(const HitType h
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const pandora::ClusterList &TwoViewMatchingControl<T>::GetInputClusterList(const HitType hitType) const
 {
     HitTypeToIndexMap::const_iterator iter = m_hitTypeToIndexMap.find(hitType);
@@ -131,7 +131,7 @@ const pandora::ClusterList &TwoViewMatchingControl<T>::GetInputClusterList(const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 const pandora::ClusterList &TwoViewMatchingControl<T>::GetSelectedClusterList(const HitType hitType) const
 {
     HitTypeToIndexMap::const_iterator iter = m_hitTypeToIndexMap.find(hitType);
@@ -149,10 +149,10 @@ const pandora::ClusterList &TwoViewMatchingControl<T>::GetSelectedClusterList(co
 template <typename T>
 void TwoViewMatchingControl<T>::SelectAllInputClusters()
 {
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*m_pAlgorithm,
-        m_inputClusterListName1, m_pInputClusterList1));
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*m_pAlgorithm,
-        m_inputClusterListName2, m_pInputClusterList2));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+        PandoraContentApi::GetList(*m_pAlgorithm, m_inputClusterListName1, m_pInputClusterList1));
+    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+        PandoraContentApi::GetList(*m_pAlgorithm, m_inputClusterListName2, m_pInputClusterList2));
 
     if (!m_pInputClusterList1 || !m_pInputClusterList2)
     {

--- a/larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.h
+++ b/larpandoracontent/LArThreeDReco/LArThreeDBase/TwoViewMatchingControl.h
@@ -20,7 +20,7 @@ namespace lar_content
 /**
  *  @brief  TwoViewMatchingControl class
  */
-template<typename T>
+template <typename T>
 class TwoViewMatchingControl : public NViewMatchingControl
 {
 public:
@@ -57,19 +57,19 @@ private:
     void TidyUp();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    const pandora::ClusterList *m_pInputClusterList1;           ///< Address of the input cluster list 1
-    const pandora::ClusterList *m_pInputClusterList2;           ///< Address of the input cluster list 2
+    const pandora::ClusterList *m_pInputClusterList1; ///< Address of the input cluster list 1
+    const pandora::ClusterList *m_pInputClusterList2; ///< Address of the input cluster list 2
 
-    pandora::ClusterList        m_clusterList1;                 ///< The selected modified cluster list 1
-    pandora::ClusterList        m_clusterList2;                 ///< The selected modified cluster list 2
+    pandora::ClusterList m_clusterList1; ///< The selected modified cluster list 1
+    pandora::ClusterList m_clusterList2; ///< The selected modified cluster list 2
 
-    MatrixType                  m_overlapMatrix;                ///< The overlap matrix
+    MatrixType m_overlapMatrix; ///< The overlap matrix
 
-    typedef std::unordered_map<pandora::HitType, unsigned int, std::hash<int> > HitTypeToIndexMap;
-    HitTypeToIndexMap           m_hitTypeToIndexMap;            ///< The hit type to index map
+    typedef std::unordered_map<pandora::HitType, unsigned int, std::hash<int>> HitTypeToIndexMap;
+    HitTypeToIndexMap m_hitTypeToIndexMap; ///< The hit type to index map
 
-    std::string                 m_inputClusterListName1;        ///< The name of the view 1 cluster list
-    std::string                 m_inputClusterListName2;        ///< The name of the view 2 cluster list
+    std::string m_inputClusterListName1; ///< The name of the view 1 cluster list
+    std::string m_inputClusterListName2; ///< The name of the view 2 cluster list
 
     template <typename U>
     friend class NViewMatchingAlgorithm;

--- a/larpandoracontent/LArThreeDReco/LArTrackFragments/ClearTrackFragmentsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTrackFragments/ClearTrackFragmentsTool.cc
@@ -17,9 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClearTrackFragmentsTool::ClearTrackFragmentsTool() :
-    m_minMatchedSamplingPointFraction(0.5f),
-    m_minMatchedHits(5)
+ClearTrackFragmentsTool::ClearTrackFragmentsTool() : m_minMatchedSamplingPointFraction(0.5f), m_minMatchedHits(5)
 {
 }
 
@@ -28,7 +26,7 @@ ClearTrackFragmentsTool::ClearTrackFragmentsTool() :
 bool ClearTrackFragmentsTool::Run(ThreeViewTrackFragmentsAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     return this->FindTrackFragments(pAlgorithm, overlapTensor);
 }
@@ -73,9 +71,12 @@ bool ClearTrackFragmentsTool::FindTrackFragments(ThreeViewTrackFragmentsAlgorith
         if (!pFragmentCluster)
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
-        if (TPC_VIEW_U == fragmentHitType) pClusterU = pFragmentCluster;
-        if (TPC_VIEW_V == fragmentHitType) pClusterV = pFragmentCluster;
-        if (TPC_VIEW_W == fragmentHitType) pClusterW = pFragmentCluster;
+        if (TPC_VIEW_U == fragmentHitType)
+            pClusterU = pFragmentCluster;
+        if (TPC_VIEW_V == fragmentHitType)
+            pClusterV = pFragmentCluster;
+        if (TPC_VIEW_W == fragmentHitType)
+            pClusterW = pFragmentCluster;
 
         if (!(pClusterU->IsAvailable() && pClusterV->IsAvailable() && pClusterW->IsAvailable()))
             throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -151,16 +152,16 @@ void ClearTrackFragmentsTool::SelectClearElements(const TensorType::ElementList 
     for (TensorType::ElementList::const_iterator eIter1 = elementList.begin(), eIterEnd1 = elementList.end(); eIter1 != eIterEnd1; ++eIter1)
     {
         const CaloHitList &fragmentHits1(eIter1->GetOverlapResult().GetFragmentCaloHitList());
-        const float nCaloHits1(static_cast<float>(eIter1->GetClusterU()->GetNCaloHits() + eIter1->GetClusterV()->GetNCaloHits() +
-            eIter1->GetClusterW()->GetNCaloHits()));
+        const float nCaloHits1(static_cast<float>(
+            eIter1->GetClusterU()->GetNCaloHits() + eIter1->GetClusterV()->GetNCaloHits() + eIter1->GetClusterW()->GetNCaloHits()));
 
         bool isClearElement(true);
 
         for (TensorType::ElementList::const_iterator eIter2 = elementList.begin(), eIterEnd2 = elementList.end(); eIter2 != eIterEnd2; ++eIter2)
         {
             const CaloHitList &fragmentHits2(eIter2->GetOverlapResult().GetFragmentCaloHitList());
-            const float nCaloHits2(static_cast<float>(eIter2->GetClusterU()->GetNCaloHits() + eIter2->GetClusterV()->GetNCaloHits() +
-                    eIter2->GetClusterW()->GetNCaloHits()));
+            const float nCaloHits2(static_cast<float>(
+                eIter2->GetClusterU()->GetNCaloHits() + eIter2->GetClusterV()->GetNCaloHits() + eIter2->GetClusterW()->GetNCaloHits()));
 
             const bool commonClusterU(eIter1->GetClusterU() == eIter2->GetClusterU());
             const bool commonClusterV(eIter1->GetClusterV() == eIter2->GetClusterV());
@@ -310,7 +311,7 @@ void ClearTrackFragmentsTool::Recluster(ThreeViewTrackFragmentsAlgorithm *const 
             if (!badClusters.insert(pCluster).second)
                 throw StatusCodeException(STATUS_CODE_FAILURE);
 
-            (void) deletedClusters.insert(pCluster);
+            (void)deletedClusters.insert(pCluster);
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*pAlgorithm, pFragmentCluster, pCluster));
         }
     }
@@ -324,7 +325,8 @@ void ClearTrackFragmentsTool::Recluster(ThreeViewTrackFragmentsAlgorithm *const 
             const ClusterList *pTemporaryList(nullptr);
             std::string temporaryListName, currentListName;
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentListName<Cluster>(*pAlgorithm, currentListName));
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent<ClusterList>(*pAlgorithm, pTemporaryList, temporaryListName));
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::CreateTemporaryListAndSetCurrent<ClusterList>(*pAlgorithm, pTemporaryList, temporaryListName));
 
             PandoraContentApi::Cluster::Parameters hitParameters;
             hitParameters.m_caloHitList = daughterHits;
@@ -332,7 +334,7 @@ void ClearTrackFragmentsTool::Recluster(ThreeViewTrackFragmentsAlgorithm *const 
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*pAlgorithm, temporaryListName, currentListName));
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Cluster>(*pAlgorithm, currentListName));
 
-            (void) badClusters.erase(pFragmentCluster);
+            (void)badClusters.erase(pFragmentCluster);
         }
         else
         {
@@ -343,7 +345,8 @@ void ClearTrackFragmentsTool::Recluster(ThreeViewTrackFragmentsAlgorithm *const 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClearTrackFragmentsTool::RebuildClusters(ThreeViewTrackFragmentsAlgorithm *const pAlgorithm, const ClusterList &modifiedClusters, ClusterList &newClusters) const
+void ClearTrackFragmentsTool::RebuildClusters(
+    ThreeViewTrackFragmentsAlgorithm *const pAlgorithm, const ClusterList &modifiedClusters, ClusterList &newClusters) const
 {
     ClusterList rebuildList;
 
@@ -359,8 +362,8 @@ void ClearTrackFragmentsTool::RebuildClusters(ThreeViewTrackFragmentsAlgorithm *
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClearTrackFragmentsTool::GetAffectedKeyClusters(const TensorType &overlapTensor, const ClusterList &clustersToRemoveFromTensor,
-    ClusterList &affectedKeyClusters) const
+void ClearTrackFragmentsTool::GetAffectedKeyClusters(
+    const TensorType &overlapTensor, const ClusterList &clustersToRemoveFromTensor, ClusterList &affectedKeyClusters) const
 {
     for (TensorType::const_iterator tIterU = overlapTensor.begin(), tIterUEnd = overlapTensor.end(); tIterU != tIterUEnd; ++tIterU)
     {
@@ -377,13 +380,16 @@ void ClearTrackFragmentsTool::GetAffectedKeyClusters(const TensorType &overlapTe
                     if (clustersToRemoveFromTensor.end() == std::find(clustersToRemoveFromTensor.begin(), clustersToRemoveFromTensor.end(), *fIter))
                         continue;
 
-                    if ((TPC_VIEW_U != fragmentHitType) && (affectedKeyClusters.end() == std::find(affectedKeyClusters.begin(), affectedKeyClusters.end(), tIterU->first)))
+                    if ((TPC_VIEW_U != fragmentHitType) &&
+                        (affectedKeyClusters.end() == std::find(affectedKeyClusters.begin(), affectedKeyClusters.end(), tIterU->first)))
                         affectedKeyClusters.push_back(tIterU->first);
 
-                    if ((TPC_VIEW_V != fragmentHitType) && (affectedKeyClusters.end() == std::find(affectedKeyClusters.begin(), affectedKeyClusters.end(), tIterV->first)))
+                    if ((TPC_VIEW_V != fragmentHitType) &&
+                        (affectedKeyClusters.end() == std::find(affectedKeyClusters.begin(), affectedKeyClusters.end(), tIterV->first)))
                         affectedKeyClusters.push_back(tIterV->first);
 
-                    if ((TPC_VIEW_W != fragmentHitType) && (affectedKeyClusters.end() == std::find(affectedKeyClusters.begin(), affectedKeyClusters.end(), tIterW->first)))
+                    if ((TPC_VIEW_W != fragmentHitType) &&
+                        (affectedKeyClusters.end() == std::find(affectedKeyClusters.begin(), affectedKeyClusters.end(), tIterW->first)))
                         affectedKeyClusters.push_back(tIterW->first);
 
                     break;
@@ -399,11 +405,10 @@ void ClearTrackFragmentsTool::GetAffectedKeyClusters(const TensorType &overlapTe
 
 StatusCode ClearTrackFragmentsTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPointFraction", m_minMatchedSamplingPointFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPointFraction", m_minMatchedSamplingPointFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedHits", m_minMatchedHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedHits", m_minMatchedHits));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTrackFragments/ClearTrackFragmentsTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTrackFragments/ClearTrackFragmentsTool.h
@@ -88,8 +88,9 @@ private:
      *  @param  badClusters the set of clusters that should not be dereferenced
      *  @param  pFragmentCluster to receive the address of the new fragment cluster
      */
-    void Recluster(ThreeViewTrackFragmentsAlgorithm *const pAlgorithm, const pandora::Cluster *const pCluster, const pandora::CaloHitList &daughterHits,
-        const pandora::CaloHitList &separateHits, pandora::ClusterSet &deletedClusters, pandora::ClusterSet &badClusters, const pandora::Cluster *&pFragmentCluster) const;
+    void Recluster(ThreeViewTrackFragmentsAlgorithm *const pAlgorithm, const pandora::Cluster *const pCluster,
+        const pandora::CaloHitList &daughterHits, const pandora::CaloHitList &separateHits, pandora::ClusterSet &deletedClusters,
+        pandora::ClusterSet &badClusters, const pandora::Cluster *&pFragmentCluster) const;
 
     /**
      *  @brief  Rebuild clusters after fragmentation
@@ -98,7 +99,8 @@ private:
      *  @param  modifiedClusters the list of clusters to rebuild
      *  @param  newClusters the list of new clusters
      */
-    void RebuildClusters(ThreeViewTrackFragmentsAlgorithm *const pAlgorithm, const pandora::ClusterList &modifiedClusters, pandora::ClusterList &newClusters) const;
+    void RebuildClusters(ThreeViewTrackFragmentsAlgorithm *const pAlgorithm, const pandora::ClusterList &modifiedClusters,
+        pandora::ClusterList &newClusters) const;
 
     /**
      *  @brief  Get a list of the tensor key clusters for which tensor elements have been impacted by fragmentation operations
@@ -112,8 +114,8 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float               m_minMatchedSamplingPointFraction;  ///< The minimum fraction of matched sampling points
-    unsigned int        m_minMatchedHits;                   ///< The minimum number of matched calo hits
+    float m_minMatchedSamplingPointFraction; ///< The minimum fraction of matched sampling points
+    unsigned int m_minMatchedHits;           ///< The minimum number of matched calo hits
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTrackFragments/ThreeViewTrackFragmentsAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArTrackFragments/ThreeViewTrackFragmentsAlgorithm.h
@@ -28,10 +28,10 @@ class FragmentTensorTool;
 /**
  *  @brief  ThreeViewTrackFragmentsAlgorithm class
  */
-class ThreeViewTrackFragmentsAlgorithm : public NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<FragmentOverlapResult> >
+class ThreeViewTrackFragmentsAlgorithm : public NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<FragmentOverlapResult>>
 {
 public:
-    typedef NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<FragmentOverlapResult> > BaseAlgorithm;
+    typedef NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<FragmentOverlapResult>> BaseAlgorithm;
 
     /**
      *  @brief  Default constructor
@@ -66,7 +66,7 @@ protected:
     pandora::StatusCode CalculateOverlapResult(const TwoDSlidingFitResult &fitResult1, const TwoDSlidingFitResult &fitResult2,
         const pandora::ClusterList &inputClusterList, const pandora::Cluster *&pBestMatchedCluster, FragmentOverlapResult &fragmentOverlapResult) const;
 
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::Cluster*> HitToClusterMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterMap;
 
     /**
      *  @brief  Get the list of projected positions, in the third view, corresponding to a pair of sliding fit results
@@ -139,20 +139,20 @@ protected:
     void ExamineOverlapContainer();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::Cluster*, unsigned int> ClusterToMatchedHitsMap;
+    typedef std::unordered_map<const pandora::Cluster *, unsigned int> ClusterToMatchedHitsMap;
 
-    std::string         m_reclusteringAlgorithmName;        ///< Name of daughter algorithm to use for cluster re-building
+    std::string m_reclusteringAlgorithmName; ///< Name of daughter algorithm to use for cluster re-building
 
-    typedef std::vector<FragmentTensorTool*> TensorToolVector;
-    TensorToolVector    m_algorithmToolVector;              ///< The algorithm tool list
+    typedef std::vector<FragmentTensorTool *> TensorToolVector;
+    TensorToolVector m_algorithmToolVector; ///< The algorithm tool list
 
-    unsigned int        m_nMaxTensorToolRepeats;            ///< The maximum number of repeat loops over tensor tools
+    unsigned int m_nMaxTensorToolRepeats; ///< The maximum number of repeat loops over tensor tools
 
-    float               m_minXOverlap;                      ///< requirement on minimum X overlap for associated clusters
-    float               m_minXOverlapFraction;              ///< requirement on minimum X overlap fraction for associated clusters
-    float               m_maxPointDisplacementSquared;      ///< maximum allowed distance (squared) between projected points and associated hits
-    float               m_minMatchedSamplingPointFraction;  ///< minimum fraction of matched sampling points
-    unsigned int        m_minMatchedHits;                   ///< minimum number of matched calo hits
+    float m_minXOverlap;                     ///< requirement on minimum X overlap for associated clusters
+    float m_minXOverlapFraction;             ///< requirement on minimum X overlap fraction for associated clusters
+    float m_maxPointDisplacementSquared;     ///< maximum allowed distance (squared) between projected points and associated hits
+    float m_minMatchedSamplingPointFraction; ///< minimum fraction of matched sampling points
+    unsigned int m_minMatchedHits;           ///< minimum number of matched calo hits
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ClearTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ClearTracksTool.cc
@@ -6,17 +6,15 @@
  *  $Log: $
  */
 
-#include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ClearTracksTool.h"
+#include "Pandora/AlgorithmHeaders.h"
 
 using namespace pandora;
 
 namespace lar_content
 {
 
-ClearTracksTool::ClearTracksTool() :
-    m_minMatchedFraction(0.9f),
-    m_minXOverlapFraction(0.9f)
+ClearTracksTool::ClearTracksTool() : m_minMatchedFraction(0.9f), m_minXOverlapFraction(0.9f)
 {
 }
 
@@ -25,7 +23,7 @@ ClearTracksTool::ClearTracksTool() :
 bool ClearTracksTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     bool particlesMade(false);
 
@@ -38,8 +36,8 @@ bool ClearTracksTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClearTracksTool::CreateThreeDParticles(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList,
-    bool &particlesMade) const
+void ClearTracksTool::CreateThreeDParticles(
+    ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList, bool &particlesMade) const
 {
     ProtoParticleVector protoParticleVector;
 
@@ -73,11 +71,11 @@ void ClearTracksTool::CreateThreeDParticles(ThreeViewTransverseTracksAlgorithm *
 
 StatusCode ClearTracksTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ClearTracksTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ClearTracksTool.h
@@ -38,8 +38,8 @@ private:
      */
     void CreateThreeDParticles(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList, bool &particlesMade) const;
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    float           m_minXOverlapFraction;              ///< The min x overlap fraction (in each view) for particle creation
+    float m_minMatchedFraction;  ///< The min matched sampling point fraction for particle creation
+    float m_minXOverlapFraction; ///< The min x overlap fraction (in each view) for particle creation
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/LongTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/LongTracksTool.cc
@@ -32,7 +32,8 @@ bool LongTracksTool::HasLongDirectConnections(IteratorList::const_iterator iIter
         if (iIter == iIter2)
             continue;
 
-        if (((*iIter)->GetClusterU() == (*iIter2)->GetClusterU()) || ((*iIter)->GetClusterV() == (*iIter2)->GetClusterV()) || ((*iIter)->GetClusterW() == (*iIter2)->GetClusterW()) )
+        if (((*iIter)->GetClusterU() == (*iIter2)->GetClusterU()) || ((*iIter)->GetClusterV() == (*iIter2)->GetClusterV()) ||
+            ((*iIter)->GetClusterW() == (*iIter2)->GetClusterW()))
             return true;
     }
 
@@ -54,7 +55,8 @@ bool LongTracksTool::IsLongerThanDirectConnections(IteratorList::const_iterator 
         if (usedClusters.count(eIter->GetClusterU()) || usedClusters.count(eIter->GetClusterV()) || usedClusters.count(eIter->GetClusterW()))
             continue;
 
-        if (((*iIter)->GetClusterU() != eIter->GetClusterU()) && ((*iIter)->GetClusterV() != eIter->GetClusterV()) && ((*iIter)->GetClusterW() != eIter->GetClusterW()))
+        if (((*iIter)->GetClusterU() != eIter->GetClusterU()) && ((*iIter)->GetClusterV() != eIter->GetClusterV()) &&
+            ((*iIter)->GetClusterW() != eIter->GetClusterW()))
             continue;
 
         if (nMatchedSamplingPoints < minMatchedSamplingPointRatio * eIter->GetOverlapResult().GetNMatchedSamplingPoints())
@@ -69,7 +71,7 @@ bool LongTracksTool::IsLongerThanDirectConnections(IteratorList::const_iterator 
 bool LongTracksTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ProtoParticleVector protoParticleVector;
     this->FindLongTracks(overlapTensor, protoParticleVector);
@@ -122,8 +124,7 @@ void LongTracksTool::FindLongTracks(const TensorType &overlapTensor, ProtoPartic
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LongTracksTool::SelectLongElements(const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters,
-    IteratorList &iteratorList) const
+void LongTracksTool::SelectLongElements(const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const
 {
     for (TensorType::ElementList::const_iterator eIter = elementList.begin(); eIter != elementList.end(); ++eIter)
     {
@@ -151,17 +152,17 @@ void LongTracksTool::SelectLongElements(const TensorType::ElementList &elementLi
 
 StatusCode LongTracksTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/LongTracksTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/LongTracksTool.h
@@ -65,13 +65,12 @@ private:
      *  @param  usedClusters the list of clusters already marked as to be added to a pfo
      *  @param  iteratorList to receive a list of iterators to long track-like elements
      */
-    void SelectLongElements(const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters,
-        IteratorList &iteratorList) const;
+    void SelectLongElements(const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const;
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for particle creation
-    float           m_minXOverlapFraction;              ///< The min x overlap fraction (in each view) for particle creation
-    unsigned int    m_minMatchedSamplingPointRatio;     ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
+    float m_minMatchedFraction;                  ///< The min matched sampling point fraction for particle creation
+    unsigned int m_minMatchedSamplingPoints;     ///< The min number of matched sampling points for particle creation
+    float m_minXOverlapFraction;                 ///< The min x overlap fraction (in each view) for particle creation
+    unsigned int m_minMatchedSamplingPointRatio; ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackSegmentTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackSegmentTool.cc
@@ -44,9 +44,10 @@ MissingTrackSegmentTool::MissingTrackSegmentTool() :
 bool MissingTrackSegmentTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    ProtoParticleVector protoParticleVector; ClusterMergeMap clusterMergeMap;
+    ProtoParticleVector protoParticleVector;
+    ClusterMergeMap clusterMergeMap;
     this->FindTracks(pAlgorithm, overlapTensor, protoParticleVector, clusterMergeMap);
 
     const bool particlesMade(pAlgorithm->CreateThreeDParticles(protoParticleVector));
@@ -102,7 +103,8 @@ void MissingTrackSegmentTool::FindTracks(ThreeViewTransverseTracksAlgorithm *con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MissingTrackSegmentTool::SelectElements(const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const
+void MissingTrackSegmentTool::SelectElements(
+    const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const
 {
     for (TensorType::ElementList::const_iterator eIter = elementList.begin(); eIter != elementList.end(); ++eIter)
     {
@@ -118,8 +120,10 @@ void MissingTrackSegmentTool::SelectElements(const TensorType::ElementList &elem
         const XOverlap &xOverlap(eIter->GetOverlapResult().GetXOverlap());
         const float shortSpan(std::min(xOverlap.GetXSpanU(), std::min(xOverlap.GetXSpanV(), xOverlap.GetXSpanW())));
         const float longSpan1(std::max(xOverlap.GetXSpanU(), std::max(xOverlap.GetXSpanV(), xOverlap.GetXSpanW())));
-        const float longSpan2(((xOverlap.GetXSpanU() > shortSpan) && (xOverlap.GetXSpanU() < longSpan1)) ? xOverlap.GetXSpanU() :
-            ((xOverlap.GetXSpanV() > shortSpan) && (xOverlap.GetXSpanV() < longSpan1)) ? xOverlap.GetXSpanV() : xOverlap.GetXSpanW());
+        const float longSpan2(
+            ((xOverlap.GetXSpanU() > shortSpan) && (xOverlap.GetXSpanU() < longSpan1))
+                ? xOverlap.GetXSpanU()
+                : ((xOverlap.GetXSpanV() > shortSpan) && (xOverlap.GetXSpanV() < longSpan1)) ? xOverlap.GetXSpanV() : xOverlap.GetXSpanW());
 
         if ((xOverlap.GetXOverlapSpan() < std::numeric_limits<float>::epsilon()) || (longSpan1 < std::numeric_limits<float>::epsilon()))
             continue;
@@ -168,8 +172,8 @@ bool MissingTrackSegmentTool::PassesParticleChecks(ThreeViewTransverseTracksAlgo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MissingTrackSegmentTool::GetCandidateClusters(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle,
-    ClusterList &candidateClusters) const
+void MissingTrackSegmentTool::GetCandidateClusters(
+    ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle, ClusterList &candidateClusters) const
 {
     const ClusterList &clusterList(pAlgorithm->GetInputClusterList(particle.m_shortHitType));
 
@@ -189,10 +193,10 @@ void MissingTrackSegmentTool::GetCandidateClusters(ThreeViewTransverseTracksAlgo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void MissingTrackSegmentTool::GetSlidingFitResultMap(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const ClusterList &candidateClusterList,
-    TwoDSlidingFitResultMap &slidingFitResultMap) const
+void MissingTrackSegmentTool::GetSlidingFitResultMap(ThreeViewTransverseTracksAlgorithm *const pAlgorithm,
+    const ClusterList &candidateClusterList, TwoDSlidingFitResultMap &slidingFitResultMap) const
 {
-  const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
+    const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
     for (ClusterList::const_iterator iter = candidateClusterList.begin(), iterEnd = candidateClusterList.end(); iter != iterEnd; ++iter)
     {
@@ -201,7 +205,7 @@ void MissingTrackSegmentTool::GetSlidingFitResultMap(ThreeViewTransverseTracksAl
         try
         {
             const TwoDSlidingFitResult &slidingFitResult(pAlgorithm->GetCachedSlidingFitResult(pCluster));
-            (void) slidingFitResultMap.insert(TwoDSlidingFitResultMap::value_type(pCluster, slidingFitResult));
+            (void)slidingFitResultMap.insert(TwoDSlidingFitResultMap::value_type(pCluster, slidingFitResult));
             continue;
         }
         catch (StatusCodeException &)
@@ -211,7 +215,7 @@ void MissingTrackSegmentTool::GetSlidingFitResultMap(ThreeViewTransverseTracksAl
         try
         {
             const TwoDSlidingFitResult slidingFitResult(pCluster, pAlgorithm->GetSlidingFitWindow(), slidingFitPitch);
-            (void) slidingFitResultMap.insert(TwoDSlidingFitResultMap::value_type(pCluster, slidingFitResult));
+            (void)slidingFitResultMap.insert(TwoDSlidingFitResultMap::value_type(pCluster, slidingFitResult));
             continue;
         }
         catch (StatusCodeException &)
@@ -234,7 +238,8 @@ void MissingTrackSegmentTool::GetSegmentOverlapMap(ThreeViewTransverseTracksAlgo
     const unsigned int nPoints(static_cast<unsigned int>(1.f + (nPoints1 + nPoints2) / 2.f));
 
     ClusterList clusterList;
-    for (const auto &mapEntry : slidingFitResultMap) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : slidingFitResultMap)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (unsigned n = 0; n <= nPoints; ++n)
@@ -252,7 +257,8 @@ void MissingTrackSegmentTool::GetSegmentOverlapMap(ThreeViewTransverseTracksAlgo
             continue;
         }
 
-        const float prediction(LArGeometryHelper::MergeTwoPositions(this->GetPandora(), particle.m_hitType1, particle.m_hitType2, fitVector1.GetZ(), fitVector2.GetZ()));
+        const float prediction(LArGeometryHelper::MergeTwoPositions(
+            this->GetPandora(), particle.m_hitType1, particle.m_hitType2, fitVector1.GetZ(), fitVector2.GetZ()));
 
         for (const Cluster *const pCluster : clusterList)
         {
@@ -292,7 +298,8 @@ bool MissingTrackSegmentTool::MakeDecisions(const Particle &particle, const TwoD
     bool matchesACluster(false);
 
     ClusterVector sortedClusters;
-    for (const auto &mapEntry : segmentOverlapMap) sortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : segmentOverlapMap)
+        sortedClusters.push_back(mapEntry.first);
     std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster : sortedClusters)
@@ -380,20 +387,27 @@ MissingTrackSegmentTool::Particle::Particle(const TensorType::Element &element)
 {
     const XOverlap &xOverlap(element.GetOverlapResult().GetXOverlap());
 
-    m_shortHitType = ((xOverlap.GetXSpanU() < xOverlap.GetXSpanV()) && (xOverlap.GetXSpanU() < xOverlap.GetXSpanW())) ? TPC_VIEW_U :
-        ((xOverlap.GetXSpanV() < xOverlap.GetXSpanU()) && (xOverlap.GetXSpanV() < xOverlap.GetXSpanW())) ? TPC_VIEW_V :
-        ((xOverlap.GetXSpanW() < xOverlap.GetXSpanU()) && (xOverlap.GetXSpanW() < xOverlap.GetXSpanV())) ? TPC_VIEW_W : HIT_CUSTOM;
+    m_shortHitType = ((xOverlap.GetXSpanU() < xOverlap.GetXSpanV()) && (xOverlap.GetXSpanU() < xOverlap.GetXSpanW()))
+                         ? TPC_VIEW_U
+                         : ((xOverlap.GetXSpanV() < xOverlap.GetXSpanU()) && (xOverlap.GetXSpanV() < xOverlap.GetXSpanW()))
+                               ? TPC_VIEW_V
+                               : ((xOverlap.GetXSpanW() < xOverlap.GetXSpanU()) && (xOverlap.GetXSpanW() < xOverlap.GetXSpanV())) ? TPC_VIEW_W : HIT_CUSTOM;
 
     if (HIT_CUSTOM == m_shortHitType)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    m_pShortCluster = (TPC_VIEW_U == m_shortHitType) ? element.GetClusterU() : (TPC_VIEW_V == m_shortHitType) ? element.GetClusterV() : element.GetClusterW();
+    m_pShortCluster = (TPC_VIEW_U == m_shortHitType) ? element.GetClusterU()
+                                                     : (TPC_VIEW_V == m_shortHitType) ? element.GetClusterV() : element.GetClusterW();
     m_pCluster1 = (TPC_VIEW_U == m_shortHitType) ? element.GetClusterV() : element.GetClusterU();
     m_pCluster2 = (TPC_VIEW_W == m_shortHitType) ? element.GetClusterV() : element.GetClusterW();
     m_shortMinX = (TPC_VIEW_U == m_shortHitType) ? xOverlap.GetUMinX() : (TPC_VIEW_V == m_shortHitType) ? xOverlap.GetVMinX() : xOverlap.GetWMinX();
     m_shortMaxX = (TPC_VIEW_U == m_shortHitType) ? xOverlap.GetUMaxX() : (TPC_VIEW_V == m_shortHitType) ? xOverlap.GetVMaxX() : xOverlap.GetWMaxX();
-    m_longMinX = (TPC_VIEW_U == m_shortHitType) ? std::min(xOverlap.GetVMinX(), xOverlap.GetWMinX()) : (TPC_VIEW_V == m_shortHitType) ? std::min(xOverlap.GetUMinX(), xOverlap.GetWMinX()) : std::min(xOverlap.GetUMinX(), xOverlap.GetVMinX());
-    m_longMaxX = (TPC_VIEW_U == m_shortHitType) ? std::max(xOverlap.GetVMaxX(), xOverlap.GetWMaxX()) : (TPC_VIEW_V == m_shortHitType) ? std::max(xOverlap.GetUMaxX(), xOverlap.GetWMaxX()) : std::max(xOverlap.GetUMaxX(), xOverlap.GetVMaxX());
+    m_longMinX = (TPC_VIEW_U == m_shortHitType) ? std::min(xOverlap.GetVMinX(), xOverlap.GetWMinX())
+                                                : (TPC_VIEW_V == m_shortHitType) ? std::min(xOverlap.GetUMinX(), xOverlap.GetWMinX())
+                                                                                 : std::min(xOverlap.GetUMinX(), xOverlap.GetVMinX());
+    m_longMaxX = (TPC_VIEW_U == m_shortHitType) ? std::max(xOverlap.GetVMaxX(), xOverlap.GetWMaxX())
+                                                : (TPC_VIEW_V == m_shortHitType) ? std::max(xOverlap.GetUMaxX(), xOverlap.GetWMaxX())
+                                                                                 : std::max(xOverlap.GetUMaxX(), xOverlap.GetVMaxX());
 
     m_hitType1 = LArClusterHelper::GetClusterHitType(m_pCluster1);
     m_hitType2 = LArClusterHelper::GetClusterHitType(m_pCluster2);
@@ -404,44 +418,43 @@ MissingTrackSegmentTool::Particle::Particle(const TensorType::Element &element)
 
 StatusCode MissingTrackSegmentTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinInitialXOverlapFraction", m_minInitialXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinInitialXOverlapFraction", m_minInitialXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinFinalXOverlapFraction", m_minFinalXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinFinalXOverlapFraction", m_minFinalXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsInCandidateCluster", m_minCaloHitsInCandidateCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinCaloHitsInCandidateCluster", m_minCaloHitsInCandidateCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PseudoChi2Cut", m_pseudoChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PseudoChi2Cut", m_pseudoChi2Cut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MakePfoMinSamplingPoints", m_makePfoMinSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MakePfoMinSamplingPoints", m_makePfoMinSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MakePfoMinMatchedSamplingPoints", m_makePfoMinMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MakePfoMinMatchedSamplingPoints", m_makePfoMinMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MakePfoMinMatchedFraction", m_makePfoMinMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MakePfoMinMatchedFraction", m_makePfoMinMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MakePfoMaxImpactParameter", m_makePfoMaxImpactParameter));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MakePfoMaxImpactParameter", m_makePfoMaxImpactParameter));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MergeMaxChi2PerSamplingPoint", m_mergeMaxChi2PerSamplingPoint));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MergeMaxChi2PerSamplingPoint", m_mergeMaxChi2PerSamplingPoint));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MergeXContainmentTolerance", m_mergeXContainmentTolerance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MergeXContainmentTolerance", m_mergeXContainmentTolerance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackSegmentTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackSegmentTool.h
@@ -42,16 +42,16 @@ private:
          */
         Particle(const TensorType::Element &element);
 
-        const pandora::Cluster *m_pShortCluster;            ///< Address of the short cluster
-        const pandora::Cluster *m_pCluster1;                ///< Address of long cluster in view 1
-        const pandora::Cluster *m_pCluster2;                ///< Address of long cluster in view 2
-        pandora::HitType        m_shortHitType;             ///< The hit type of the short cluster
-        pandora::HitType        m_hitType1;                 ///< The hit type of the long cluster in view 1
-        pandora::HitType        m_hitType2;                 ///< The hit type of the long cluster in view 2
-        float                   m_shortMinX;                ///< The min x coordinate of the short cluster
-        float                   m_shortMaxX;                ///< The max x coordinate of the short cluster
-        float                   m_longMinX;                 ///< The min x coordinate of the long clusters
-        float                   m_longMaxX;                 ///< The max x coordinate of the long clusters
+        const pandora::Cluster *m_pShortCluster; ///< Address of the short cluster
+        const pandora::Cluster *m_pCluster1;     ///< Address of long cluster in view 1
+        const pandora::Cluster *m_pCluster2;     ///< Address of long cluster in view 2
+        pandora::HitType m_shortHitType;         ///< The hit type of the short cluster
+        pandora::HitType m_hitType1;             ///< The hit type of the long cluster in view 1
+        pandora::HitType m_hitType2;             ///< The hit type of the long cluster in view 2
+        float m_shortMinX;                       ///< The min x coordinate of the short cluster
+        float m_shortMaxX;                       ///< The max x coordinate of the short cluster
+        float m_longMinX;                        ///< The min x coordinate of the long clusters
+        float m_longMaxX;                        ///< The max x coordinate of the long clusters
     };
 
     /**
@@ -65,17 +65,17 @@ private:
          */
         SegmentOverlap();
 
-        unsigned int            m_nSamplingPoints;          ///< The number of sampling points
-        unsigned int            m_nMatchedSamplingPoints;   ///< The number of matched sampling points
-        float                   m_pseudoChi2Sum;            ///< The pseudo chi2 sum
-        float                   m_matchedSamplingMinX;      ///< The min matched sampling point x coordinate
-        float                   m_matchedSamplingMaxX;      ///< The max matched sampling point x coordinate
+        unsigned int m_nSamplingPoints;        ///< The number of sampling points
+        unsigned int m_nMatchedSamplingPoints; ///< The number of matched sampling points
+        float m_pseudoChi2Sum;                 ///< The pseudo chi2 sum
+        float m_matchedSamplingMinX;           ///< The min matched sampling point x coordinate
+        float m_matchedSamplingMaxX;           ///< The max matched sampling point x coordinate
     };
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::Cluster*, SegmentOverlap> SegmentOverlapMap;
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterMergeMap;
+    typedef std::unordered_map<const pandora::Cluster *, SegmentOverlap> SegmentOverlapMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterMergeMap;
 
     /**
      *  @brief  Find remaining tracks, hidden by missing track segments (and maybe other ambiguities) in the tensor
@@ -85,8 +85,8 @@ private:
      *  @param  protoParticleVector to receive the list of proto particles
      *  @param  clusterMergeMap to receive the cluster merge map
      */
-    void FindTracks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType &overlapTensor, ProtoParticleVector &protoParticleVector,
-        ClusterMergeMap &clusterMergeMap) const;
+    void FindTracks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType &overlapTensor,
+        ProtoParticleVector &protoParticleVector, ClusterMergeMap &clusterMergeMap) const;
 
     /**
      *  @brief  Select a list of the relevant elements from a set of connected tensor elements
@@ -105,8 +105,8 @@ private:
      *  @param  usedClusters the list of used clusters
      *  @param  clusterMergeMap to receive the cluster merge map
      */
-    bool PassesParticleChecks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element, pandora::ClusterSet &usedClusters,
-        ClusterMergeMap &clusterMergeMap) const;
+    bool PassesParticleChecks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element,
+        pandora::ClusterSet &usedClusters, ClusterMergeMap &clusterMergeMap) const;
 
     /**
      *  @brief  Get a list of candidate clusters, which may represent missing track segments for a provided particle
@@ -149,8 +149,8 @@ private:
      *
      *  @return whether to make the particle
      */
-    bool MakeDecisions(const Particle &particle, const TwoDSlidingFitResultMap &slidingFitResultMap, const SegmentOverlapMap &segmentOverlapMap,
-        pandora::ClusterSet &usedClusters, ClusterMergeMap &clusterMergeMap) const;
+    bool MakeDecisions(const Particle &particle, const TwoDSlidingFitResultMap &slidingFitResultMap,
+        const SegmentOverlapMap &segmentOverlapMap, pandora::ClusterSet &usedClusters, ClusterMergeMap &clusterMergeMap) const;
 
     /**
      *  @brief  Whether the segment overlap object passes cuts on matched sampling points, etc.
@@ -174,23 +174,23 @@ private:
     bool IsPossibleMerge(const pandora::Cluster *const pCluster, const Particle &particle, const SegmentOverlap &segmentOverlap,
         const TwoDSlidingFitResultMap &slidingFitResultMap) const;
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for particle creation
-    unsigned int    m_minMatchedSamplingPointRatio;     ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
+    float m_minMatchedFraction;                  ///< The min matched sampling point fraction for particle creation
+    unsigned int m_minMatchedSamplingPoints;     ///< The min number of matched sampling points for particle creation
+    unsigned int m_minMatchedSamplingPointRatio; ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
 
-    float           m_minInitialXOverlapFraction;       ///< The min x overlap fraction (between long clusters and short cluster vs. shared overlap)
-    float           m_minFinalXOverlapFraction;         ///< The min x overlap fraction between extended short cluster and the long clusters
+    float m_minInitialXOverlapFraction; ///< The min x overlap fraction (between long clusters and short cluster vs. shared overlap)
+    float m_minFinalXOverlapFraction;   ///< The min x overlap fraction between extended short cluster and the long clusters
 
-    unsigned int    m_minCaloHitsInCandidateCluster;    ///< The min no. of calo hits in a candidate cluster, for matching with long clusters
-    float           m_pseudoChi2Cut;                    ///< The pseudo chi2 cut to determine whether a sampling point is matched
+    unsigned int m_minCaloHitsInCandidateCluster; ///< The min no. of calo hits in a candidate cluster, for matching with long clusters
+    float m_pseudoChi2Cut;                        ///< The pseudo chi2 cut to determine whether a sampling point is matched
 
-    unsigned int    m_makePfoMinSamplingPoints;         ///< The min number of sampling points in order to be able to make pfo
-    unsigned int    m_makePfoMinMatchedSamplingPoints;  ///< The min number of matched sampling points in order to be able to make pfo
-    float           m_makePfoMinMatchedFraction;        ///< The min matched sampling point fraction in order to be able to make pfo
-    float           m_makePfoMaxImpactParameter;        ///< The max transverse impact parameter in order to be able to make pfo
+    unsigned int m_makePfoMinSamplingPoints;        ///< The min number of sampling points in order to be able to make pfo
+    unsigned int m_makePfoMinMatchedSamplingPoints; ///< The min number of matched sampling points in order to be able to make pfo
+    float m_makePfoMinMatchedFraction;              ///< The min matched sampling point fraction in order to be able to make pfo
+    float m_makePfoMaxImpactParameter;              ///< The max transverse impact parameter in order to be able to make pfo
 
-    float           m_mergeMaxChi2PerSamplingPoint;     ///< The max value of chi2 per sampling point in order to merge cluster with parent
-    float           m_mergeXContainmentTolerance;       ///< The tolerance in determining whether candidate cluster is contained in x window
+    float m_mergeMaxChi2PerSamplingPoint; ///< The max value of chi2 per sampling point in order to merge cluster with parent
+    float m_mergeXContainmentTolerance;   ///< The tolerance in determining whether candidate cluster is contained in x window
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.cc
@@ -6,8 +6,8 @@
  *  $Log: $
  */
 
-#include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.h"
+#include "Pandora/AlgorithmHeaders.h"
 
 using namespace pandora;
 
@@ -27,7 +27,7 @@ MissingTrackTool::MissingTrackTool() :
 bool MissingTrackTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ProtoParticleVector protoParticleVector;
     this->FindMissingTracks(overlapTensor, protoParticleVector);
@@ -57,9 +57,12 @@ void MissingTrackTool::FindMissingTracks(const TensorType &overlapTensor, ProtoP
             const bool includeW(eIter->GetClusterW()->IsAvailable() && !usedClusters.count(eIter->GetClusterW()));
 
             unsigned int nAvailable(0);
-            if (includeU) ++nAvailable;
-            if (includeV) ++nAvailable;
-            if (includeW) ++nAvailable;
+            if (includeU)
+                ++nAvailable;
+            if (includeV)
+                ++nAvailable;
+            if (includeW)
+                ++nAvailable;
 
             if (2 != nAvailable)
                 continue;
@@ -94,9 +97,12 @@ void MissingTrackTool::FindMissingTracks(const TensorType &overlapTensor, ProtoP
                 continue;
 
             ProtoParticle protoParticle;
-            if (includeU) protoParticle.m_clusterList.push_back(eIter->GetClusterU());
-            if (includeV) protoParticle.m_clusterList.push_back(eIter->GetClusterV());
-            if (includeW) protoParticle.m_clusterList.push_back(eIter->GetClusterW());
+            if (includeU)
+                protoParticle.m_clusterList.push_back(eIter->GetClusterU());
+            if (includeV)
+                protoParticle.m_clusterList.push_back(eIter->GetClusterV());
+            if (includeW)
+                protoParticle.m_clusterList.push_back(eIter->GetClusterW());
 
             protoParticleVector.push_back(protoParticle);
             usedClusters.insert(eIter->GetClusterU());
@@ -110,17 +116,17 @@ void MissingTrackTool::FindMissingTracks(const TensorType &overlapTensor, ProtoP
 
 StatusCode MissingTrackTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxReducedChiSquared", m_maxReducedChiSquared));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxReducedChiSquared", m_maxReducedChiSquared));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/MissingTrackTool.h
@@ -37,10 +37,10 @@ private:
      */
     void FindMissingTracks(const TensorType &overlapTensor, ProtoParticleVector &protoParticleVector) const;
 
-    unsigned int    m_minMatchedSamplingPoints;     ///< The min number of matched sampling points for the unavailable tensor element
-    float           m_minMatchedFraction;           ///< The min matched sampling point fraction for the unavailable tensor element
-    float           m_maxReducedChiSquared;         ///< The max reduced chi squared value for the unavailable tensor element
-    float           m_minXOverlapFraction;          ///< The min x overlap fraction for the two available clusters in the tensor element
+    unsigned int m_minMatchedSamplingPoints; ///< The min number of matched sampling points for the unavailable tensor element
+    float m_minMatchedFraction;              ///< The min matched sampling point fraction for the unavailable tensor element
+    float m_maxReducedChiSquared;            ///< The max reduced chi squared value for the unavailable tensor element
+    float m_minXOverlapFraction;             ///< The min x overlap fraction for the two available clusters in the tensor element
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/OvershootTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/OvershootTracksTool.cc
@@ -29,8 +29,8 @@ OvershootTracksTool::OvershootTracksTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void OvershootTracksTool::GetIteratorListModifications(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const IteratorList &iteratorList,
-    ModificationList &modificationList) const
+void OvershootTracksTool::GetIteratorListModifications(
+    ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const IteratorList &iteratorList, ModificationList &modificationList) const
 {
     for (IteratorList::const_iterator iIter1 = iteratorList.begin(), iIter1End = iteratorList.end(); iIter1 != iIter1End; ++iIter1)
     {
@@ -155,15 +155,19 @@ void OvershootTracksTool::SetSplitPosition(const LArPointingCluster::Vertex &ver
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool OvershootTracksTool::IsThreeDKink(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle, const bool isA1LowestInX,
-    const bool isA2LowestInX) const
+bool OvershootTracksTool::IsThreeDKink(
+    ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle, const bool isA1LowestInX, const bool isA2LowestInX) const
 {
     try
     {
-        const TwoDSlidingFitResult &lowXFitResult1(isA1LowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA1) : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB1));
-        const TwoDSlidingFitResult &highXFitResult1(isA1LowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB1) : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA1));
-        const TwoDSlidingFitResult &lowXFitResult2(isA2LowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA2) : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB2));
-        const TwoDSlidingFitResult &highXFitResult2(isA2LowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB2) : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA2));
+        const TwoDSlidingFitResult &lowXFitResult1(isA1LowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA1)
+                                                                 : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB1));
+        const TwoDSlidingFitResult &highXFitResult1(isA1LowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB1)
+                                                                  : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA1));
+        const TwoDSlidingFitResult &lowXFitResult2(isA2LowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA2)
+                                                                 : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB2));
+        const TwoDSlidingFitResult &highXFitResult2(isA2LowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB2)
+                                                                  : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA2));
         const TwoDSlidingFitResult &fitResultCommon3(pAlgorithm->GetCachedSlidingFitResult(particle.m_pCommonCluster));
 
         const float minusX(this->GetXSamplingPoint(particle.m_splitPosition, false, fitResultCommon3, lowXFitResult1, lowXFitResult2));
@@ -189,7 +193,8 @@ bool OvershootTracksTool::IsThreeDKink(ThreeViewTransverseTracksAlgorithm *const
         const HitType hitType3(LArClusterHelper::GetClusterHitType(particle.m_pCommonCluster));
 
         CartesianVector minus(0.f, 0.f, 0.f), split(0.f, 0.f, 0.f), plus(0.f, 0.f, 0.f);
-        float chi2Minus(std::numeric_limits<float>::max()), chi2Split(std::numeric_limits<float>::max()), chi2Plus(std::numeric_limits<float>::max());
+        float chi2Minus(std::numeric_limits<float>::max()), chi2Split(std::numeric_limits<float>::max()),
+            chi2Plus(std::numeric_limits<float>::max());
         LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), hitType1, hitType2, hitType3, minus1, minus2, minus3, minus, chi2Minus);
         LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), hitType1, hitType2, hitType3, split1, split2, split3, split, chi2Split);
         LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), hitType1, hitType2, hitType3, plus1, plus2, plus3, plus, chi2Plus);
@@ -217,14 +222,17 @@ OvershootTracksTool::Particle::Particle(const TensorType::Element &elementA, con
     m_splitPosition1(0.f, 0.f, 0.f),
     m_splitPosition2(0.f, 0.f, 0.f)
 {
-    const HitType commonView((elementA.GetClusterU() == elementB.GetClusterU()) ? TPC_VIEW_U :
-        (elementA.GetClusterV() == elementB.GetClusterV()) ? TPC_VIEW_V :
-        (elementA.GetClusterW() == elementB.GetClusterW()) ? TPC_VIEW_W : HIT_CUSTOM);
+    const HitType commonView((elementA.GetClusterU() == elementB.GetClusterU())
+                                 ? TPC_VIEW_U
+                                 : (elementA.GetClusterV() == elementB.GetClusterV())
+                                       ? TPC_VIEW_V
+                                       : (elementA.GetClusterW() == elementB.GetClusterW()) ? TPC_VIEW_W : HIT_CUSTOM);
 
     if (HIT_CUSTOM == commonView)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    m_pCommonCluster = (TPC_VIEW_U == commonView) ? elementA.GetClusterU() : (TPC_VIEW_V == commonView) ? elementA.GetClusterV() : elementA.GetClusterW();
+    m_pCommonCluster =
+        (TPC_VIEW_U == commonView) ? elementA.GetClusterU() : (TPC_VIEW_V == commonView) ? elementA.GetClusterV() : elementA.GetClusterW();
     m_pClusterA1 = (TPC_VIEW_U == commonView) ? elementA.GetClusterV() : elementA.GetClusterU();
     m_pClusterA2 = (TPC_VIEW_U == commonView) ? elementA.GetClusterW() : (TPC_VIEW_V == commonView) ? elementA.GetClusterW() : elementA.GetClusterV();
     m_pClusterB1 = (TPC_VIEW_U == commonView) ? elementB.GetClusterV() : elementB.GetClusterU();
@@ -239,14 +247,13 @@ OvershootTracksTool::Particle::Particle(const TensorType::Element &elementA, con
 
 StatusCode OvershootTracksTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SplitMode", m_splitMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SplitMode", m_splitMode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexXSeparation", m_maxVertexXSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxVertexXSeparation", m_maxVertexXSeparation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CosThetaCutForKinkSearch", m_cosThetaCutForKinkSearch));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CosThetaCutForKinkSearch", m_cosThetaCutForKinkSearch));
 
     return ThreeDKinkBaseTool::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/OvershootTracksTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/OvershootTracksTool.h
@@ -39,17 +39,18 @@ private:
          */
         Particle(const TensorType::Element &elementA, const TensorType::Element &elementB);
 
-        const pandora::Cluster     *m_pCommonCluster;       ///< Address of the common cluster
-        const pandora::Cluster     *m_pClusterA1;           ///< Address of cluster in element A, view 1
-        const pandora::Cluster     *m_pClusterA2;           ///< Address of cluster in element A, view 2
-        const pandora::Cluster     *m_pClusterB1;           ///< Address of cluster in element B, view 1
-        const pandora::Cluster     *m_pClusterB2;           ///< Address of cluster in element B, view 2
-        pandora::CartesianVector    m_splitPosition;        ///< The candidate split position for the common cluster
-        pandora::CartesianVector    m_splitPosition1;       ///< The candidate split position in view 1
-        pandora::CartesianVector    m_splitPosition2;       ///< The candidate split position in view 2
+        const pandora::Cluster *m_pCommonCluster;  ///< Address of the common cluster
+        const pandora::Cluster *m_pClusterA1;      ///< Address of cluster in element A, view 1
+        const pandora::Cluster *m_pClusterA2;      ///< Address of cluster in element A, view 2
+        const pandora::Cluster *m_pClusterB1;      ///< Address of cluster in element B, view 1
+        const pandora::Cluster *m_pClusterB2;      ///< Address of cluster in element B, view 2
+        pandora::CartesianVector m_splitPosition;  ///< The candidate split position for the common cluster
+        pandora::CartesianVector m_splitPosition1; ///< The candidate split position in view 1
+        pandora::CartesianVector m_splitPosition2; ///< The candidate split position in view 2
     };
 
-    void GetIteratorListModifications(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const IteratorList &iteratorList, ModificationList &modificationList) const;
+    void GetIteratorListModifications(
+        ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const IteratorList &iteratorList, ModificationList &modificationList) const;
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     /**
@@ -85,9 +86,9 @@ private:
     bool IsThreeDKink(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle, const bool isA1LowestInX,
         const bool isA2LowestInX) const;
 
-    bool            m_splitMode;                        ///< Whether to run in cluster splitting mode, as opposed to cluster merging mode
-    float           m_maxVertexXSeparation;             ///< The max separation between accompanying clusters vertex x positions to make split
-    float           m_cosThetaCutForKinkSearch;         ///< The cos theta cut used for the kink search in three dimensions
+    bool m_splitMode;                 ///< Whether to run in cluster splitting mode, as opposed to cluster merging mode
+    float m_maxVertexXSeparation;     ///< The max separation between accompanying clusters vertex x positions to make split
+    float m_cosThetaCutForKinkSearch; ///< The cos theta cut used for the kink search in three dimensions
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeDKinkBaseTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeDKinkBaseTool.cc
@@ -56,8 +56,8 @@ bool ThreeDKinkBaseTool::PassesElementCuts(TensorType::ElementList::const_iterat
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ThreeDKinkBaseTool::GetXSamplingPoint(const CartesianVector &splitPosition1, const bool isForwardInX, const TwoDSlidingFitResult &fitResult1,
-    const TwoDSlidingFitResult &fitResult2, const TwoDSlidingFitResult &fitResult3) const
+float ThreeDKinkBaseTool::GetXSamplingPoint(const CartesianVector &splitPosition1, const bool isForwardInX,
+    const TwoDSlidingFitResult &fitResult1, const TwoDSlidingFitResult &fitResult2, const TwoDSlidingFitResult &fitResult3) const
 {
     // Nearest common x position
     float xMin1(std::numeric_limits<float>::max()), xMax1(-std::numeric_limits<float>::max());
@@ -107,13 +107,13 @@ float ThreeDKinkBaseTool::GetXSamplingPoint(const CartesianVector &splitPosition
 bool ThreeDKinkBaseTool::IsALowestInX(const LArPointingCluster &pointingClusterA, const LArPointingCluster &pointingClusterB)
 {
     if ((pointingClusterA.GetInnerVertex().GetPosition().GetX() < pointingClusterB.GetInnerVertex().GetPosition().GetX()) &&
-        (pointingClusterA.GetInnerVertex().GetPosition().GetX() < pointingClusterB.GetOuterVertex().GetPosition().GetX()) )
+        (pointingClusterA.GetInnerVertex().GetPosition().GetX() < pointingClusterB.GetOuterVertex().GetPosition().GetX()))
     {
         return true;
     }
 
     if ((pointingClusterA.GetOuterVertex().GetPosition().GetX() < pointingClusterB.GetInnerVertex().GetPosition().GetX()) &&
-        (pointingClusterA.GetOuterVertex().GetPosition().GetX() < pointingClusterB.GetOuterVertex().GetPosition().GetX()) )
+        (pointingClusterA.GetOuterVertex().GetPosition().GetX() < pointingClusterB.GetOuterVertex().GetPosition().GetX()))
     {
         return true;
     }
@@ -126,7 +126,7 @@ bool ThreeDKinkBaseTool::IsALowestInX(const LArPointingCluster &pointingClusterA
 bool ThreeDKinkBaseTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ModificationList modificationList;
     this->GetModifications(pAlgorithm, overlapTensor, modificationList);
@@ -137,7 +137,8 @@ bool ThreeDKinkBaseTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorith
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDKinkBaseTool::GetModifications(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType &overlapTensor, ModificationList &modificationList) const
+void ThreeDKinkBaseTool::GetModifications(
+    ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType &overlapTensor, ModificationList &modificationList) const
 {
     ClusterSet usedClusters;
     ClusterVector sortedKeyClusters;
@@ -192,7 +193,8 @@ bool ThreeDKinkBaseTool::ApplyChanges(ThreeViewTransverseTracksAlgorithm *const 
     for (const Modification &modification : modificationList)
     {
         ClusterList parentClusters;
-        for (const auto &mapEntry : modification.m_clusterMergeMap) parentClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : modification.m_clusterMergeMap)
+            parentClusters.push_back(mapEntry.first);
         parentClusters.sort(LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pParentCluster : parentClusters)
@@ -210,7 +212,8 @@ bool ThreeDKinkBaseTool::ApplyChanges(ThreeViewTransverseTracksAlgorithm *const 
         }
 
         ClusterList splitClusters;
-        for (const auto &mapEntry : modification.m_splitPositionMap) splitClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : modification.m_splitPositionMap)
+            splitClusters.push_back(mapEntry.first);
         splitClusters.sort(LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pSplitCluster : splitClusters)
@@ -273,23 +276,23 @@ void ThreeDKinkBaseTool::SelectTensorElements(TensorType::ElementList::const_ite
 
 StatusCode ThreeDKinkBaseTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MajorityRulesMode", m_majorityRulesMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MajorityRulesMode", m_majorityRulesMode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinLongitudinalImpactParameter", m_minLongitudinalImpactParameter));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinLongitudinalImpactParameter", m_minLongitudinalImpactParameter));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NLayersForKinkSearch", m_nLayersForKinkSearch));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NLayersForKinkSearch", m_nLayersForKinkSearch));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "AdditionalXStepForKinkSearch", m_additionalXStepForKinkSearch));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "AdditionalXStepForKinkSearch", m_additionalXStepForKinkSearch));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeDKinkBaseTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeDKinkBaseTool.h
@@ -42,9 +42,9 @@ protected:
     class Modification
     {
     public:
-        SplitPositionMap            m_splitPositionMap;     ///< The split position map
-        ClusterMergeMap             m_clusterMergeMap;      ///< The cluster merge map
-        pandora::ClusterList        m_affectedClusters;     ///< The list of affected clusters
+        SplitPositionMap m_splitPositionMap;     ///< The split position map
+        ClusterMergeMap m_clusterMergeMap;       ///< The cluster merge map
+        pandora::ClusterList m_affectedClusters; ///< The list of affected clusters
     };
 
     typedef std::vector<Modification> ModificationList;
@@ -91,13 +91,13 @@ protected:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_nCommonClusters;                  ///< The number of common clusters
-    bool            m_majorityRulesMode;                ///< Whether to run in majority rules mode (always split overshoots, always merge undershoots)
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for use as a key tensor element
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for use as a key tensor element
-    float           m_minLongitudinalImpactParameter;   ///< The min longitudinal impact parameter for connecting accompanying clusters
-    int             m_nLayersForKinkSearch;             ///< The number of sliding fit layers to step in the kink search
-    float           m_additionalXStepForKinkSearch;     ///< An additional (safety) step to tack-on when choosing x sampling points
+    unsigned int m_nCommonClusters;          ///< The number of common clusters
+    bool m_majorityRulesMode;                ///< Whether to run in majority rules mode (always split overshoots, always merge undershoots)
+    float m_minMatchedFraction;              ///< The min matched sampling point fraction for use as a key tensor element
+    unsigned int m_minMatchedSamplingPoints; ///< The min number of matched sampling points for use as a key tensor element
+    float m_minLongitudinalImpactParameter;  ///< The min longitudinal impact parameter for connecting accompanying clusters
+    int m_nLayersForKinkSearch;              ///< The number of sliding fit layers to step in the kink search
+    float m_additionalXStepForKinkSearch;    ///< An additional (safety) step to tack-on when choosing x sampling points
 
 private:
     /**

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.h"
 
@@ -35,7 +35,8 @@ ThreeViewTransverseTracksAlgorithm::ThreeViewTransverseTracksAlgorithm() :
 void ThreeViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW)
 {
     TransverseOverlapResult overlapResult;
-    PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->CalculateOverlapResult(pClusterU, pClusterV, pClusterW, overlapResult));
+    PANDORA_THROW_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->CalculateOverlapResult(pClusterU, pClusterV, pClusterW, overlapResult));
 
     if (overlapResult.IsInitialized())
         this->GetMatchingControl().GetOverlapTensor().SetOverlapResult(pClusterU, pClusterV, pClusterW, overlapResult);
@@ -43,8 +44,8 @@ void ThreeViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *c
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode ThreeViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW,
-    TransverseOverlapResult &overlapResult)
+StatusCode ThreeViewTransverseTracksAlgorithm::CalculateOverlapResult(
+    const Cluster *const pClusterU, const Cluster *const pClusterV, const Cluster *const pClusterW, TransverseOverlapResult &overlapResult)
 {
     const TwoDSlidingFitResult &slidingFitResultU(this->GetCachedSlidingFitResult(pClusterU));
     const TwoDSlidingFitResult &slidingFitResultV(this->GetCachedSlidingFitResult(pClusterV));
@@ -59,13 +60,15 @@ StatusCode ThreeViewTransverseTracksAlgorithm::CalculateOverlapResult(const Clus
     if (!transverseOverlapResult.IsInitialized())
         return STATUS_CODE_NOT_FOUND;
 
-    if ((transverseOverlapResult.GetMatchedFraction() < m_minOverallMatchedFraction) || (transverseOverlapResult.GetNMatchedSamplingPoints() < m_minOverallMatchedPoints))
+    if ((transverseOverlapResult.GetMatchedFraction() < m_minOverallMatchedFraction) ||
+        (transverseOverlapResult.GetNMatchedSamplingPoints() < m_minOverallMatchedPoints))
         return STATUS_CODE_NOT_FOUND;
 
     const int nLayersSpannedU(slidingFitResultU.GetMaxLayer() - slidingFitResultU.GetMinLayer());
     const int nLayersSpannedV(slidingFitResultV.GetMaxLayer() - slidingFitResultV.GetMinLayer());
     const int nLayersSpannedW(slidingFitResultW.GetMaxLayer() - slidingFitResultW.GetMinLayer());
-    const unsigned int meanLayersSpanned(static_cast<unsigned int>((1.f / 3.f) * static_cast<float>(nLayersSpannedU + nLayersSpannedV + nLayersSpannedW)));
+    const unsigned int meanLayersSpanned(
+        static_cast<unsigned int>((1.f / 3.f) * static_cast<float>(nLayersSpannedU + nLayersSpannedV + nLayersSpannedW)));
 
     if (0 == meanLayersSpanned)
         return STATUS_CODE_FAILURE;
@@ -81,8 +84,8 @@ StatusCode ThreeViewTransverseTracksAlgorithm::CalculateOverlapResult(const Clus
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeViewTransverseTracksAlgorithm::GetFitSegmentTensor(const TwoDSlidingFitResult &slidingFitResultU, const TwoDSlidingFitResult &slidingFitResultV,
-    const TwoDSlidingFitResult &slidingFitResultW, FitSegmentTensor &fitSegmentTensor) const
+void ThreeViewTransverseTracksAlgorithm::GetFitSegmentTensor(const TwoDSlidingFitResult &slidingFitResultU,
+    const TwoDSlidingFitResult &slidingFitResultV, const TwoDSlidingFitResult &slidingFitResultW, FitSegmentTensor &fitSegmentTensor) const
 {
     FitSegmentList fitSegmentListU(slidingFitResultU.GetFitSegmentList());
     FitSegmentList fitSegmentListV(slidingFitResultV.GetFitSegmentList());
@@ -101,10 +104,12 @@ void ThreeViewTransverseTracksAlgorithm::GetFitSegmentTensor(const TwoDSlidingFi
                 const FitSegment &fitSegmentW(fitSegmentListW.at(indexW));
 
                 TransverseOverlapResult segmentOverlap;
-                if (STATUS_CODE_SUCCESS != this->GetSegmentOverlap(fitSegmentU, fitSegmentV, fitSegmentW, slidingFitResultU, slidingFitResultV, slidingFitResultW, segmentOverlap))
+                if (STATUS_CODE_SUCCESS != this->GetSegmentOverlap(fitSegmentU, fitSegmentV, fitSegmentW, slidingFitResultU,
+                                               slidingFitResultV, slidingFitResultW, segmentOverlap))
                     continue;
 
-                if ((segmentOverlap.GetMatchedFraction() < m_minSegmentMatchedFraction) || (segmentOverlap.GetNMatchedSamplingPoints() < m_minSegmentMatchedPoints))
+                if ((segmentOverlap.GetMatchedFraction() < m_minSegmentMatchedFraction) ||
+                    (segmentOverlap.GetNMatchedSamplingPoints() < m_minSegmentMatchedPoints))
                     continue;
 
                 fitSegmentTensor[indexU][indexV][indexW] = segmentOverlap;
@@ -115,9 +120,9 @@ void ThreeViewTransverseTracksAlgorithm::GetFitSegmentTensor(const TwoDSlidingFi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode ThreeViewTransverseTracksAlgorithm::GetSegmentOverlap(const FitSegment &fitSegmentU, const FitSegment &fitSegmentV, const FitSegment &fitSegmentW,
-    const TwoDSlidingFitResult &slidingFitResultU, const TwoDSlidingFitResult &slidingFitResultV, const TwoDSlidingFitResult &slidingFitResultW,
-    TransverseOverlapResult &transverseOverlapResult) const
+StatusCode ThreeViewTransverseTracksAlgorithm::GetSegmentOverlap(const FitSegment &fitSegmentU, const FitSegment &fitSegmentV,
+    const FitSegment &fitSegmentW, const TwoDSlidingFitResult &slidingFitResultU, const TwoDSlidingFitResult &slidingFitResultV,
+    const TwoDSlidingFitResult &slidingFitResultW, TransverseOverlapResult &transverseOverlapResult) const
 {
     // Assess x-overlap
     const float xSpanU(fitSegmentU.GetMaxX() - fitSegmentU.GetMinX());
@@ -176,8 +181,8 @@ StatusCode ThreeViewTransverseTracksAlgorithm::GetSegmentOverlap(const FitSegmen
     if (0 == nSamplingPoints)
         return STATUS_CODE_NOT_FOUND;
 
-    const XOverlap xOverlapObject(fitSegmentU.GetMinX(), fitSegmentU.GetMaxX(), fitSegmentV.GetMinX(),
-        fitSegmentV.GetMaxX(), fitSegmentW.GetMinX(), fitSegmentW.GetMaxX(), xOverlap);
+    const XOverlap xOverlapObject(fitSegmentU.GetMinX(), fitSegmentU.GetMaxX(), fitSegmentV.GetMinX(), fitSegmentV.GetMaxX(),
+        fitSegmentW.GetMinX(), fitSegmentW.GetMaxX(), xOverlap);
 
     transverseOverlapResult = TransverseOverlapResult(nMatchedSamplingPoints, nSamplingPoints, pseudoChi2Sum, xOverlapObject);
     return STATUS_CODE_SUCCESS;
@@ -185,7 +190,8 @@ StatusCode ThreeViewTransverseTracksAlgorithm::GetSegmentOverlap(const FitSegmen
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeViewTransverseTracksAlgorithm::GetBestOverlapResult(const FitSegmentTensor &fitSegmentTensor, TransverseOverlapResult &bestTransverseOverlapResult) const
+void ThreeViewTransverseTracksAlgorithm::GetBestOverlapResult(
+    const FitSegmentTensor &fitSegmentTensor, TransverseOverlapResult &bestTransverseOverlapResult) const
 {
     if (fitSegmentTensor.empty())
     {
@@ -222,11 +228,14 @@ void ThreeViewTransverseTracksAlgorithm::GetBestOverlapResult(const FitSegmentTe
                 TransverseOverlapResultVector transverseOverlapResultVector;
                 this->GetPreviousOverlapResults(indexU, indexV, indexW, fitSegmentSumTensor, transverseOverlapResultVector);
 
-                TransverseOverlapResultVector::const_iterator maxElement = std::max_element(transverseOverlapResultVector.begin(), transverseOverlapResultVector.end());
-                TransverseOverlapResult maxTransverseOverlapResult((transverseOverlapResultVector.end() != maxElement) ? *maxElement : TransverseOverlapResult());
+                TransverseOverlapResultVector::const_iterator maxElement =
+                    std::max_element(transverseOverlapResultVector.begin(), transverseOverlapResultVector.end());
+                TransverseOverlapResult maxTransverseOverlapResult(
+                    (transverseOverlapResultVector.end() != maxElement) ? *maxElement : TransverseOverlapResult());
 
                 TransverseOverlapResult thisOverlapResult;
-                if (fitSegmentTensor.count(indexU) && (fitSegmentTensor.find(indexU))->second.count(indexV) && ((fitSegmentTensor.find(indexU))->second.find(indexV))->second.count(indexW))
+                if (fitSegmentTensor.count(indexU) && (fitSegmentTensor.find(indexU))->second.count(indexV) &&
+                    ((fitSegmentTensor.find(indexU))->second.find(indexV))->second.count(indexW))
                     thisOverlapResult = (((fitSegmentTensor.find(indexU))->second.find(indexV))->second.find(indexW))->second;
 
                 if (!thisOverlapResult.IsInitialized() && !maxTransverseOverlapResult.IsInitialized())
@@ -257,8 +266,8 @@ void ThreeViewTransverseTracksAlgorithm::GetBestOverlapResult(const FitSegmentTe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeViewTransverseTracksAlgorithm::GetPreviousOverlapResults(const unsigned int indexU, const unsigned int indexV, const unsigned int indexW,
-    FitSegmentTensor &fitSegmentSumTensor, TransverseOverlapResultVector &transverseOverlapResultVector) const
+void ThreeViewTransverseTracksAlgorithm::GetPreviousOverlapResults(const unsigned int indexU, const unsigned int indexV,
+    const unsigned int indexW, FitSegmentTensor &fitSegmentSumTensor, TransverseOverlapResultVector &transverseOverlapResultVector) const
 {
     for (unsigned int iPermutation = 1; iPermutation < 8; ++iPermutation)
     {
@@ -289,7 +298,7 @@ void ThreeViewTransverseTracksAlgorithm::ExamineOverlapContainer()
 {
     unsigned int repeatCounter(0);
 
-    for (TensorToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd; )
+    for (TensorToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd;)
     {
         if ((*iter)->Run(this, this->GetMatchingControl().GetOverlapTensor()))
         {
@@ -311,12 +320,11 @@ void ThreeViewTransverseTracksAlgorithm::ExamineOverlapContainer()
 StatusCode ThreeViewTransverseTracksAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     AlgorithmToolVector algorithmToolVector;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle,
-        "TrackTools", algorithmToolVector));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "TrackTools", algorithmToolVector));
 
     for (AlgorithmToolVector::const_iterator iter = algorithmToolVector.begin(), iterEnd = algorithmToolVector.end(); iter != iterEnd; ++iter)
     {
-        TransverseTensorTool *const pTransverseTensorTool(dynamic_cast<TransverseTensorTool*>(*iter));
+        TransverseTensorTool *const pTransverseTensorTool(dynamic_cast<TransverseTensorTool *>(*iter));
 
         if (!pTransverseTensorTool)
             return STATUS_CODE_INVALID_PARAMETER;
@@ -324,29 +332,28 @@ StatusCode ThreeViewTransverseTracksAlgorithm::ReadSettings(const TiXmlHandle xm
         m_algorithmToolVector.push_back(pTransverseTensorTool);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NMaxTensorToolRepeats", m_nMaxTensorToolRepeats));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NMaxTensorToolRepeats", m_nMaxTensorToolRepeats));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxFitSegmentIndex", m_maxFitSegmentIndex));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxFitSegmentIndex", m_maxFitSegmentIndex));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PseudoChi2Cut", m_pseudoChi2Cut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PseudoChi2Cut", m_pseudoChi2Cut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSegmentMatchedFraction", m_minSegmentMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinSegmentMatchedFraction", m_minSegmentMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSegmentMatchedPoints", m_minSegmentMatchedPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinSegmentMatchedPoints", m_minSegmentMatchedPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinOverallMatchedFraction", m_minOverallMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinOverallMatchedFraction", m_minOverallMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinOverallMatchedPoints", m_minOverallMatchedPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinOverallMatchedPoints", m_minOverallMatchedPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSamplingPointsPerLayer", m_minSamplingPointsPerLayer));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinSamplingPointsPerLayer", m_minSamplingPointsPerLayer));
 
     return BaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/ThreeViewTransverseTracksAlgorithm.h
@@ -26,10 +26,10 @@ class TransverseTensorTool;
 /**
  *  @brief  ThreeViewTransverseTracksAlgorithm class
  */
-class ThreeViewTransverseTracksAlgorithm : public NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<TransverseOverlapResult> >
+class ThreeViewTransverseTracksAlgorithm : public NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<TransverseOverlapResult>>
 {
 public:
-    typedef NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<TransverseOverlapResult> > BaseAlgorithm;
+    typedef NViewTrackMatchingAlgorithm<ThreeViewMatchingControl<TransverseOverlapResult>> BaseAlgorithm;
 
     /**
      *  @brief  Default constructor
@@ -53,8 +53,8 @@ private:
      *
      *  @return statusCode, faster than throwing in regular use-cases
      */
-    pandora::StatusCode CalculateOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV, const pandora::Cluster *const pClusterW,
-        TransverseOverlapResult &overlapResult);
+    pandora::StatusCode CalculateOverlapResult(const pandora::Cluster *const pClusterU, const pandora::Cluster *const pClusterV,
+        const pandora::Cluster *const pClusterW, TransverseOverlapResult &overlapResult);
 
     /**
      *  @brief  Get the number of matched points for three fit segments and accompanying sliding fit results
@@ -81,8 +81,8 @@ private:
      *  @return statusCode, faster than throwing in regular use-cases
      */
     pandora::StatusCode GetSegmentOverlap(const FitSegment &fitSegmentU, const FitSegment &fitSegmentV, const FitSegment &fitSegmentW,
-        const TwoDSlidingFitResult &slidingFitResultU, const TwoDSlidingFitResult &slidingFitResultV, const TwoDSlidingFitResult &slidingFitResultW,
-        TransverseOverlapResult &transverseOverlapResult) const;
+        const TwoDSlidingFitResult &slidingFitResultU, const TwoDSlidingFitResult &slidingFitResultV,
+        const TwoDSlidingFitResult &slidingFitResultW, TransverseOverlapResult &transverseOverlapResult) const;
 
     /**
      *  @brief  Get the best overlap result, by examining the fit segment tensor
@@ -106,17 +106,17 @@ private:
     void ExamineOverlapContainer();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::vector<TransverseTensorTool*> TensorToolVector;
-    TensorToolVector            m_algorithmToolVector;      ///< The algorithm tool vector
+    typedef std::vector<TransverseTensorTool *> TensorToolVector;
+    TensorToolVector m_algorithmToolVector; ///< The algorithm tool vector
 
-    unsigned int                m_nMaxTensorToolRepeats;    ///< The maximum number of repeat loops over tensor tools
-    unsigned int                m_maxFitSegmentIndex;       ///< The maximum number of fit segments used when identifying best overlap result
-    float                       m_pseudoChi2Cut;            ///< The pseudo chi2 cut to identify matched sampling points
-    float                       m_minSegmentMatchedFraction;///< The minimum segment matched sampling fraction to allow segment grouping
-    unsigned int                m_minSegmentMatchedPoints;  ///< The minimum number of matched segment sampling points to allow segment grouping
-    float                       m_minOverallMatchedFraction;///< The minimum matched sampling fraction to allow particle creation
-    unsigned int                m_minOverallMatchedPoints;  ///< The minimum number of matched segment sampling points to allow particle creation
-    float                       m_minSamplingPointsPerLayer;///< The minimum number of sampling points per layer to allow particle creation
+    unsigned int m_nMaxTensorToolRepeats;   ///< The maximum number of repeat loops over tensor tools
+    unsigned int m_maxFitSegmentIndex;      ///< The maximum number of fit segments used when identifying best overlap result
+    float m_pseudoChi2Cut;                  ///< The pseudo chi2 cut to identify matched sampling points
+    float m_minSegmentMatchedFraction;      ///< The minimum segment matched sampling fraction to allow segment grouping
+    unsigned int m_minSegmentMatchedPoints; ///< The minimum number of matched segment sampling points to allow segment grouping
+    float m_minOverallMatchedFraction;      ///< The minimum matched sampling fraction to allow particle creation
+    unsigned int m_minOverallMatchedPoints; ///< The minimum number of matched segment sampling points to allow particle creation
+    float m_minSamplingPointsPerLayer;      ///< The minimum number of sampling points per layer to allow particle creation
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TrackSplittingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TrackSplittingTool.cc
@@ -39,7 +39,7 @@ TrackSplittingTool::TrackSplittingTool() :
 bool TrackSplittingTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, TensorType &overlapTensor)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     SplitPositionMap splitPositionMap;
     this->FindTracks(pAlgorithm, overlapTensor, splitPositionMap);
@@ -50,7 +50,8 @@ bool TrackSplittingTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgorith
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackSplittingTool::FindTracks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType &overlapTensor, SplitPositionMap &splitPositionMap) const
+void TrackSplittingTool::FindTracks(
+    ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType &overlapTensor, SplitPositionMap &splitPositionMap) const
 {
     ClusterSet usedClusters;
     ClusterVector sortedKeyClusters;
@@ -107,8 +108,10 @@ void TrackSplittingTool::SelectElements(const TensorType::ElementList &elementLi
         const XOverlap &xOverlap(eIter->GetOverlapResult().GetXOverlap());
         const float longSpan(std::max(xOverlap.GetXSpanU(), std::max(xOverlap.GetXSpanV(), xOverlap.GetXSpanW())));
         const float shortSpan1(std::min(xOverlap.GetXSpanU(), std::min(xOverlap.GetXSpanV(), xOverlap.GetXSpanW())));
-        const float shortSpan2(((xOverlap.GetXSpanU() > shortSpan1) && (xOverlap.GetXSpanU() < longSpan)) ? xOverlap.GetXSpanU() :
-            ((xOverlap.GetXSpanV() > shortSpan1) && (xOverlap.GetXSpanV() < longSpan)) ? xOverlap.GetXSpanV() : xOverlap.GetXSpanW());
+        const float shortSpan2(
+            ((xOverlap.GetXSpanU() > shortSpan1) && (xOverlap.GetXSpanU() < longSpan))
+                ? xOverlap.GetXSpanU()
+                : ((xOverlap.GetXSpanV() > shortSpan1) && (xOverlap.GetXSpanV() < longSpan)) ? xOverlap.GetXSpanV() : xOverlap.GetXSpanW());
 
         if ((shortSpan1 < std::numeric_limits<float>::epsilon()) || (longSpan < std::numeric_limits<float>::epsilon()))
             continue;
@@ -128,8 +131,8 @@ void TrackSplittingTool::SelectElements(const TensorType::ElementList &elementLi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackSplittingTool::PassesChecks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element, const bool isMinX,
-    ClusterSet &usedClusters, SplitPositionMap &splitPositionMap) const
+bool TrackSplittingTool::PassesChecks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element,
+    const bool isMinX, ClusterSet &usedClusters, SplitPositionMap &splitPositionMap) const
 {
     try
     {
@@ -144,7 +147,8 @@ bool TrackSplittingTool::PassesChecks(ThreeViewTransverseTracksAlgorithm *const 
             return false;
 
         const float splitX(isMinX ? (0.5f * (particle.m_short1MinX + particle.m_short2MinX)) : (0.5f * (particle.m_short1MaxX + particle.m_short2MaxX)));
-        const float shortDeltaX(isMinX ? std::fabs(particle.m_short1MinX - particle.m_short2MinX) : std::fabs(particle.m_short1MaxX - particle.m_short2MaxX));
+        const float shortDeltaX(
+            isMinX ? std::fabs(particle.m_short1MinX - particle.m_short2MinX) : std::fabs(particle.m_short1MaxX - particle.m_short2MaxX));
         const float longDeltaX(isMinX ? (splitX - particle.m_longMinX) : (particle.m_longMaxX - splitX));
 
         if (((shortDeltaX / longXSpan) > m_maxShortDeltaXFraction) || (shortDeltaX > m_maxAbsoluteShortDeltaX) ||
@@ -157,8 +161,14 @@ bool TrackSplittingTool::PassesChecks(ThreeViewTransverseTracksAlgorithm *const 
         const LArPointingCluster pointingCluster2(pAlgorithm->GetCachedSlidingFitResult(particle.m_pCluster2));
         const LArPointingCluster longPointingCluster(pAlgorithm->GetCachedSlidingFitResult(particle.m_pLongCluster));
 
-        const CartesianVector &position1(pointingCluster1.GetInnerVertex().GetPosition().GetX() < pointingCluster1.GetOuterVertex().GetPosition().GetX() ? pointingCluster1.GetInnerVertex().GetPosition() : pointingCluster1.GetOuterVertex().GetPosition());
-        const CartesianVector &position2(pointingCluster2.GetInnerVertex().GetPosition().GetX() < pointingCluster2.GetOuterVertex().GetPosition().GetX() ? pointingCluster2.GetInnerVertex().GetPosition() : pointingCluster2.GetOuterVertex().GetPosition());
+        const CartesianVector &position1(
+            pointingCluster1.GetInnerVertex().GetPosition().GetX() < pointingCluster1.GetOuterVertex().GetPosition().GetX()
+                ? pointingCluster1.GetInnerVertex().GetPosition()
+                : pointingCluster1.GetOuterVertex().GetPosition());
+        const CartesianVector &position2(
+            pointingCluster2.GetInnerVertex().GetPosition().GetX() < pointingCluster2.GetOuterVertex().GetPosition().GetX()
+                ? pointingCluster2.GetInnerVertex().GetPosition()
+                : pointingCluster2.GetOuterVertex().GetPosition());
 
         CartesianVector splitPosition(0.f, 0.f, 0.f);
         float chiSquared(std::numeric_limits<float>::max());
@@ -170,7 +180,8 @@ bool TrackSplittingTool::PassesChecks(ThreeViewTransverseTracksAlgorithm *const 
 
         const CartesianVector splitToInnerVertex(splitPosition - longPointingCluster.GetInnerVertex().GetPosition());
         const CartesianVector outerVertexToSplit(longPointingCluster.GetOuterVertex().GetPosition() - splitPosition);
-        const CartesianVector outerToInnerUnitVector((longPointingCluster.GetOuterVertex().GetPosition() - longPointingCluster.GetInnerVertex().GetPosition()).GetUnitVector());
+        const CartesianVector outerToInnerUnitVector(
+            (longPointingCluster.GetOuterVertex().GetPosition() - longPointingCluster.GetInnerVertex().GetPosition()).GetUnitVector());
 
         if ((splitToInnerVertex.GetDotProduct(outerToInnerUnitVector) > m_minSplitToVertexProjection) &&
             (outerVertexToSplit.GetDotProduct(outerToInnerUnitVector) > m_minSplitToVertexProjection))
@@ -210,14 +221,18 @@ TrackSplittingTool::Particle::Particle(const TensorType::Element &element)
 {
     const XOverlap &xOverlap(element.GetOverlapResult().GetXOverlap());
 
-    const HitType longHitType = ((xOverlap.GetXSpanU() > xOverlap.GetXSpanV()) && (xOverlap.GetXSpanU() > xOverlap.GetXSpanW())) ? TPC_VIEW_U :
-        ((xOverlap.GetXSpanV() > xOverlap.GetXSpanU()) && (xOverlap.GetXSpanV() > xOverlap.GetXSpanW())) ? TPC_VIEW_V :
-        ((xOverlap.GetXSpanW() > xOverlap.GetXSpanU()) && (xOverlap.GetXSpanW() > xOverlap.GetXSpanV())) ? TPC_VIEW_W : HIT_CUSTOM;
+    const HitType longHitType =
+        ((xOverlap.GetXSpanU() > xOverlap.GetXSpanV()) && (xOverlap.GetXSpanU() > xOverlap.GetXSpanW()))
+            ? TPC_VIEW_U
+            : ((xOverlap.GetXSpanV() > xOverlap.GetXSpanU()) && (xOverlap.GetXSpanV() > xOverlap.GetXSpanW()))
+                  ? TPC_VIEW_V
+                  : ((xOverlap.GetXSpanW() > xOverlap.GetXSpanU()) && (xOverlap.GetXSpanW() > xOverlap.GetXSpanV())) ? TPC_VIEW_W : HIT_CUSTOM;
 
     if (HIT_CUSTOM == longHitType)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    m_pLongCluster = (TPC_VIEW_U == longHitType) ? element.GetClusterU() : (TPC_VIEW_V == longHitType) ? element.GetClusterV() : element.GetClusterW();
+    m_pLongCluster =
+        (TPC_VIEW_U == longHitType) ? element.GetClusterU() : (TPC_VIEW_V == longHitType) ? element.GetClusterV() : element.GetClusterW();
     m_pCluster1 = (TPC_VIEW_U == longHitType) ? element.GetClusterV() : element.GetClusterU();
     m_pCluster2 = (TPC_VIEW_W == longHitType) ? element.GetClusterV() : element.GetClusterW();
     m_longMinX = (TPC_VIEW_U == longHitType) ? xOverlap.GetUMinX() : (TPC_VIEW_V == longHitType) ? xOverlap.GetVMinX() : xOverlap.GetWMinX();
@@ -233,35 +248,35 @@ TrackSplittingTool::Particle::Particle(const TensorType::Element &element)
 
 StatusCode TrackSplittingTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxShortDeltaXFraction", m_maxShortDeltaXFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxShortDeltaXFraction", m_maxShortDeltaXFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAbsoluteShortDeltaX", m_maxAbsoluteShortDeltaX));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAbsoluteShortDeltaX", m_maxAbsoluteShortDeltaX));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinLongDeltaXFraction", m_minLongDeltaXFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinLongDeltaXFraction", m_minLongDeltaXFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinAbsoluteLongDeltaX", m_minAbsoluteLongDeltaX));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinAbsoluteLongDeltaX", m_minAbsoluteLongDeltaX));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSplitToVertexProjection", m_minSplitToVertexProjection));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinSplitToVertexProjection", m_minSplitToVertexProjection));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxSplitVsFitPositionDistance", m_maxSplitVsFitPositionDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxSplitVsFitPositionDistance", m_maxSplitVsFitPositionDistance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TrackSplittingTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TrackSplittingTool.h
@@ -40,15 +40,15 @@ private:
          */
         Particle(const TensorType::Element &element);
 
-        const pandora::Cluster *m_pLongCluster;             ///< Address of the long cluster
-        const pandora::Cluster *m_pCluster1;                ///< Address of short cluster in view 1
-        const pandora::Cluster *m_pCluster2;                ///< Address of short cluster in view 2
-        float                   m_longMinX;                 ///< The min x coordinate of the long cluster
-        float                   m_longMaxX;                 ///< The max x coordinate of the long cluster
-        float                   m_short1MinX;               ///< The min x coordinate of short cluster 1
-        float                   m_short1MaxX;               ///< The max x coordinate of short cluster 1
-        float                   m_short2MinX;               ///< The min x coordinate of short cluster 2
-        float                   m_short2MaxX;               ///< The max x coordinate of short cluster 2
+        const pandora::Cluster *m_pLongCluster; ///< Address of the long cluster
+        const pandora::Cluster *m_pCluster1;    ///< Address of short cluster in view 1
+        const pandora::Cluster *m_pCluster2;    ///< Address of short cluster in view 2
+        float m_longMinX;                       ///< The min x coordinate of the long cluster
+        float m_longMaxX;                       ///< The max x coordinate of the long cluster
+        float m_short1MinX;                     ///< The min x coordinate of short cluster 1
+        float m_short1MaxX;                     ///< The max x coordinate of short cluster 1
+        float m_short2MinX;                     ///< The min x coordinate of short cluster 2
+        float m_short2MaxX;                     ///< The max x coordinate of short cluster 2
     };
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -80,8 +80,8 @@ private:
      *  @param  usedClusters the list of used clusters
      *  @param  splitPositionMap to receive the split position map
      */
-    bool PassesChecks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element, const bool isMinX, pandora::ClusterSet &usedClusters,
-        SplitPositionMap &splitPositionMap) const;
+    bool PassesChecks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element, const bool isMinX,
+        pandora::ClusterSet &usedClusters, SplitPositionMap &splitPositionMap) const;
 
     /**
      *  @brief  Check a candidate split position for consistency with the associated track cluster sliding linear fit
@@ -92,17 +92,17 @@ private:
      */
     bool CheckSplitPosition(const pandora::CartesianVector &splitPosition, const float splitX, const TwoDSlidingFitResult &longFitResult) const;
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for particle creation
-    float           m_minXOverlapFraction;              ///< The min x overlap fraction (between long clusters and short cluster vs. shared overlap)
-    unsigned int    m_minMatchedSamplingPointRatio;     ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
+    float m_minMatchedFraction;              ///< The min matched sampling point fraction for particle creation
+    unsigned int m_minMatchedSamplingPoints; ///< The min number of matched sampling points for particle creation
+    float m_minXOverlapFraction;             ///< The min x overlap fraction (between long clusters and short cluster vs. shared overlap)
+    unsigned int m_minMatchedSamplingPointRatio; ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
 
-    float           m_maxShortDeltaXFraction;           ///< Max x distance between ends of two short clusters (measured as fraction of long cluster x length)
-    float           m_maxAbsoluteShortDeltaX;           ///< Max x distance between ends of two short clusters (measured as an absolute distance)
-    float           m_minLongDeltaXFraction;            ///< Min x distance between ends of short and long clusters (measured as fraction of long cluster x length)
-    float           m_minAbsoluteLongDeltaX;            ///< Min x distance between ends of short and long clusters (measured as an absolute distance)
-    float           m_minSplitToVertexProjection;       ///< Min projected distance between split position and either inner or outer vertex of long cluster
-    float           m_maxSplitVsFitPositionDistance;    ///< Max allowed distance between split position and sliding linear fit position at the split x coordinate
+    float m_maxShortDeltaXFraction; ///< Max x distance between ends of two short clusters (measured as fraction of long cluster x length)
+    float m_maxAbsoluteShortDeltaX; ///< Max x distance between ends of two short clusters (measured as an absolute distance)
+    float m_minLongDeltaXFraction; ///< Min x distance between ends of short and long clusters (measured as fraction of long cluster x length)
+    float m_minAbsoluteLongDeltaX;      ///< Min x distance between ends of short and long clusters (measured as an absolute distance)
+    float m_minSplitToVertexProjection; ///< Min projected distance between split position and either inner or outer vertex of long cluster
+    float m_maxSplitVsFitPositionDistance; ///< Max allowed distance between split position and sliding linear fit position at the split x coordinate
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.cc
@@ -14,7 +14,6 @@
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/LongTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.h"
 
-
 using namespace pandora;
 
 namespace lar_content
@@ -50,7 +49,8 @@ bool TracksCrossingGapsTool::Run(ThreeViewTransverseTracksAlgorithm *const pAlgo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TracksCrossingGapsTool::FindTracks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType &overlapTensor, ProtoParticleVector &protoParticleVector) const
+void TracksCrossingGapsTool::FindTracks(
+    ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType &overlapTensor, ProtoParticleVector &protoParticleVector) const
 {
     ClusterSet usedClusters;
     ClusterVector sortedKeyClusters;
@@ -92,8 +92,8 @@ void TracksCrossingGapsTool::FindTracks(ThreeViewTransverseTracksAlgorithm *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TracksCrossingGapsTool::SelectElements(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::ElementList &elementList,
-    const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const
+void TracksCrossingGapsTool::SelectElements(ThreeViewTransverseTracksAlgorithm *const pAlgorithm,
+    const TensorType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const
 {
     for (TensorType::ElementList::const_iterator eIter = elementList.begin(); eIter != elementList.end(); ++eIter)
     {
@@ -126,8 +126,8 @@ void TracksCrossingGapsTool::SelectElements(ThreeViewTransverseTracksAlgorithm *
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TracksCrossingGapsTool::CalculateEffectiveOverlapFractions(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element,
-    float &xOverlapFractionU, float &xOverlapFractionV, float &xOverlapFractionW) const
+void TracksCrossingGapsTool::CalculateEffectiveOverlapFractions(ThreeViewTransverseTracksAlgorithm *const pAlgorithm,
+    const TensorType::Element &element, float &xOverlapFractionU, float &xOverlapFractionV, float &xOverlapFractionW) const
 {
     float xMinEffU(element.GetOverlapResult().GetXOverlap().GetUMinX()), xMaxEffU(element.GetOverlapResult().GetXOverlap().GetUMaxX());
     float xMinEffV(element.GetOverlapResult().GetXOverlap().GetVMinX()), xMaxEffV(element.GetOverlapResult().GetXOverlap().GetVMaxX());
@@ -147,8 +147,8 @@ void TracksCrossingGapsTool::CalculateEffectiveOverlapFractions(ThreeViewTransve
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TracksCrossingGapsTool::CalculateEffectiveOverlapSpan(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element,
-    float &xMinEffU, float &xMaxEffU, float &xMinEffV, float &xMaxEffV, float &xMinEffW, float &xMaxEffW) const
+void TracksCrossingGapsTool::CalculateEffectiveOverlapSpan(ThreeViewTransverseTracksAlgorithm *const pAlgorithm,
+    const TensorType::Element &element, float &xMinEffU, float &xMaxEffU, float &xMinEffV, float &xMaxEffV, float &xMinEffW, float &xMaxEffW) const
 {
     const float xMinAll(std::min(xMinEffU, std::min(xMinEffV, xMinEffW)));
     const float xMaxAll(std::max(xMaxEffU, std::max(xMaxEffV, xMaxEffW)));
@@ -170,9 +170,12 @@ void TracksCrossingGapsTool::CalculateEffectiveOverlapSpan(ThreeViewTransverseTr
         if (!this->PassesGapChecks(pAlgorithm, element, xSample, gapInU, gapInV, gapInW))
             break;
 
-        if (gapInU) dxUmin = xMinEffU - xSample;
-        if (gapInV) dxVmin = xMinEffV - xSample;
-        if (gapInW) dxWmin = xMinEffW - xSample;
+        if (gapInU)
+            dxUmin = xMinEffU - xSample;
+        if (gapInV)
+            dxVmin = xMinEffV - xSample;
+        if (gapInW)
+            dxWmin = xMinEffW - xSample;
     }
 
     for (int iSample = 1; iSample <= nSamplingPointsRight; ++iSample)
@@ -183,9 +186,12 @@ void TracksCrossingGapsTool::CalculateEffectiveOverlapSpan(ThreeViewTransverseTr
         if (!this->PassesGapChecks(pAlgorithm, element, xSample, gapInU, gapInV, gapInW))
             break;
 
-        if (gapInU) dxUmax = xSample - xMaxEffU;
-        if (gapInV) dxVmax = xSample - xMaxEffV;
-        if (gapInW) dxWmax = xSample - xMaxEffW;
+        if (gapInU)
+            dxUmax = xSample - xMaxEffU;
+        if (gapInV)
+            dxVmax = xSample - xMaxEffV;
+        if (gapInW)
+            dxWmax = xSample - xMaxEffW;
     }
 
     xMinEffU -= dxUmin;
@@ -198,8 +204,8 @@ void TracksCrossingGapsTool::CalculateEffectiveOverlapSpan(ThreeViewTransverseTr
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TracksCrossingGapsTool::PassesGapChecks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element, const float xSample,
-    bool &gapInU, bool &gapInV, bool &gapInW) const
+bool TracksCrossingGapsTool::PassesGapChecks(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const TensorType::Element &element,
+    const float xSample, bool &gapInU, bool &gapInV, bool &gapInW) const
 {
     const TwoDSlidingFitResult &slidingFitResultU(pAlgorithm->GetCachedSlidingFitResult(element.GetClusterU()));
     const TwoDSlidingFitResult &slidingFitResultV(pAlgorithm->GetCachedSlidingFitResult(element.GetClusterV()));
@@ -226,15 +232,17 @@ bool TracksCrossingGapsTool::PassesGapChecks(ThreeViewTransverseTracksAlgorithm 
         if ((STATUS_CODE_SUCCESS != statusCodeW) && (!this->IsEndOfCluster(xSample, slidingFitResultW)))
             return this->CheckXPositionInGap(xSample, slidingFitResultW, slidingFitResultU, slidingFitResultV, gapInW, gapInU, gapInV);
     }
-    catch (const StatusCodeException &statusCodeException) {}
+    catch (const StatusCodeException &statusCodeException)
+    {
+    }
 
     return false;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TracksCrossingGapsTool::CheckXPositionInGap(const float xSample, const TwoDSlidingFitResult &slidingFitResult1, const TwoDSlidingFitResult &slidingFitResult2,
-    const TwoDSlidingFitResult &slidingFitResult3, bool &gapIn1, bool &gapIn2, bool &gapIn3) const
+bool TracksCrossingGapsTool::CheckXPositionInGap(const float xSample, const TwoDSlidingFitResult &slidingFitResult1,
+    const TwoDSlidingFitResult &slidingFitResult2, const TwoDSlidingFitResult &slidingFitResult3, bool &gapIn1, bool &gapIn2, bool &gapIn3) const
 {
     CartesianVector fitPosition2(0.f, 0.f, 0.f), fitPosition3(0.f, 0.f, 0.f);
 
@@ -291,30 +299,28 @@ bool TracksCrossingGapsTool::CheckXPositionInGap(const float xSample, const TwoD
 bool TracksCrossingGapsTool::IsEndOfCluster(const float xSample, const TwoDSlidingFitResult &slidingFitResult) const
 {
     return ((std::fabs(slidingFitResult.GetGlobalMinLayerPosition().GetX() - xSample) < slidingFitResult.GetLayerPitch()) ||
-        (std::fabs(slidingFitResult.GetGlobalMaxLayerPosition().GetX() - xSample) < slidingFitResult.GetLayerPitch()));
+            (std::fabs(slidingFitResult.GetGlobalMaxLayerPosition().GetX() - xSample) < slidingFitResult.GetLayerPitch()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode TracksCrossingGapsTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-         "MaxGapTolerance", m_maxGapTolerance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxGapTolerance", m_maxGapTolerance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SampleStepSize", m_sampleStepSize));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SampleStepSize", m_sampleStepSize));
 
     if (m_sampleStepSize < std::numeric_limits<float>::epsilon())
     {
@@ -322,8 +328,7 @@ StatusCode TracksCrossingGapsTool::ReadSettings(const TiXmlHandle xmlHandle)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAngleRatio", m_maxAngleRatio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAngleRatio", m_maxAngleRatio));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/TracksCrossingGapsTool.h
@@ -106,7 +106,7 @@ private:
      *  @return boolean
      */
     bool CheckXPositionInGap(const float xSample, const TwoDSlidingFitResult &slidingFitResult1, const TwoDSlidingFitResult &slidingFitResult2,
-        const TwoDSlidingFitResult &slidingFitResult3, bool &gapIn1, bool &gapIn2, bool &gapIn3)const;
+        const TwoDSlidingFitResult &slidingFitResult3, bool &gapIn1, bool &gapIn2, bool &gapIn3) const;
 
     /**
      *  @brief  Check whether a x position is at the end of the cluster
@@ -118,13 +118,13 @@ private:
      */
     bool IsEndOfCluster(const float xSample, const TwoDSlidingFitResult &slidingFitResult) const;
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for particle creation
-    float           m_minXOverlapFraction;              ///< The min x overlap fraction (in each view) for particle creation
-    unsigned int    m_minMatchedSamplingPointRatio;     ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
-    float           m_maxGapTolerance;                  ///< The max gap tolerance
-    float           m_sampleStepSize;                   ///< The sampling step size used in association checks, units cm
-    unsigned int    m_maxAngleRatio;                    ///< The max ratio allowed in the angle
+    float m_minMatchedFraction;                  ///< The min matched sampling point fraction for particle creation
+    unsigned int m_minMatchedSamplingPoints;     ///< The min number of matched sampling points for particle creation
+    float m_minXOverlapFraction;                 ///< The min x overlap fraction (in each view) for particle creation
+    unsigned int m_minMatchedSamplingPointRatio; ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
+    float m_maxGapTolerance;                     ///< The max gap tolerance
+    float m_sampleStepSize;                      ///< The sampling step size used in association checks, units cm
+    unsigned int m_maxAngleRatio;                ///< The max ratio allowed in the angle
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/UndershootTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/UndershootTracksTool.cc
@@ -32,8 +32,8 @@ UndershootTracksTool::UndershootTracksTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void UndershootTracksTool::GetIteratorListModifications(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const IteratorList &iteratorList,
-    ModificationList &modificationList) const
+void UndershootTracksTool::GetIteratorListModifications(
+    ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const IteratorList &iteratorList, ModificationList &modificationList) const
 {
     for (IteratorList::const_iterator iIter1 = iteratorList.begin(), iIter1End = iteratorList.end(); iIter1 != iIter1End; ++iIter1)
     {
@@ -126,15 +126,17 @@ void UndershootTracksTool::GetIteratorListModifications(ThreeViewTransverseTrack
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool UndershootTracksTool::IsThreeDKink(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle, const CartesianVector &splitPosition,
-    const bool isALowestInX) const
+bool UndershootTracksTool::IsThreeDKink(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle,
+    const CartesianVector &splitPosition, const bool isALowestInX) const
 {
     try
     {
         const TwoDSlidingFitResult &fitResultCommon1(pAlgorithm->GetCachedSlidingFitResult(particle.m_pCommonCluster1));
         const TwoDSlidingFitResult &fitResultCommon2(pAlgorithm->GetCachedSlidingFitResult(particle.m_pCommonCluster2));
-        const TwoDSlidingFitResult &lowXFitResult(isALowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA) : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB));
-        const TwoDSlidingFitResult &highXFitResult(isALowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB) : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA));
+        const TwoDSlidingFitResult &lowXFitResult(isALowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA)
+                                                               : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB));
+        const TwoDSlidingFitResult &highXFitResult(isALowestInX ? pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterB)
+                                                                : pAlgorithm->GetCachedSlidingFitResult(particle.m_pClusterA));
 
         const float minusX(this->GetXSamplingPoint(splitPosition, false, lowXFitResult, fitResultCommon1, fitResultCommon2));
         const float plusX(this->GetXSamplingPoint(splitPosition, true, highXFitResult, fitResultCommon1, fitResultCommon2));
@@ -162,7 +164,8 @@ bool UndershootTracksTool::IsThreeDKink(ThreeViewTransverseTracksAlgorithm *cons
         const HitType hitType3(LArClusterHelper::GetClusterHitType(particle.m_pClusterA));
 
         CartesianVector minus(0.f, 0.f, 0.f), split(0.f, 0.f, 0.f), plus(0.f, 0.f, 0.f);
-        float chi2Minus(std::numeric_limits<float>::max()), chi2Split(std::numeric_limits<float>::max()), chi2Plus(std::numeric_limits<float>::max());
+        float chi2Minus(std::numeric_limits<float>::max()), chi2Split(std::numeric_limits<float>::max()),
+            chi2Plus(std::numeric_limits<float>::max());
         LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), hitType1, hitType2, hitType3, minus1, minus2, minus3, minus, chi2Minus);
         LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), hitType1, hitType2, hitType3, split1, split2, split3, split, chi2Split);
         LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), hitType1, hitType2, hitType3, plus1, plus2, plus3, plus, chi2Plus);
@@ -187,14 +190,20 @@ bool UndershootTracksTool::IsThreeDKink(ThreeViewTransverseTracksAlgorithm *cons
 
 UndershootTracksTool::Particle::Particle(const TensorType::Element &elementA, const TensorType::Element &elementB)
 {
-    m_pClusterA = (elementA.GetClusterU() != elementB.GetClusterU()) ? elementA.GetClusterU() :
-        (elementA.GetClusterV() != elementB.GetClusterV()) ? elementA.GetClusterV() : elementA.GetClusterW();
-    m_pClusterB = (elementA.GetClusterU() != elementB.GetClusterU()) ? elementB.GetClusterU() :
-        (elementA.GetClusterV() != elementB.GetClusterV()) ? elementB.GetClusterV() : elementB.GetClusterW();
-    m_pCommonCluster1 = (elementA.GetClusterU() == elementB.GetClusterU()) ? elementA.GetClusterU() :
-        (elementA.GetClusterV() == elementB.GetClusterV()) ? elementA.GetClusterV() : elementA.GetClusterW();
-    m_pCommonCluster2 = ((m_pClusterA != elementA.GetClusterU()) && (m_pCommonCluster1 != elementA.GetClusterU())) ? elementA.GetClusterU() :
-        ((m_pClusterA != elementA.GetClusterV()) && (m_pCommonCluster1 != elementA.GetClusterV())) ? elementA.GetClusterV() : elementA.GetClusterW();
+    m_pClusterA = (elementA.GetClusterU() != elementB.GetClusterU())
+                      ? elementA.GetClusterU()
+                      : (elementA.GetClusterV() != elementB.GetClusterV()) ? elementA.GetClusterV() : elementA.GetClusterW();
+    m_pClusterB = (elementA.GetClusterU() != elementB.GetClusterU())
+                      ? elementB.GetClusterU()
+                      : (elementA.GetClusterV() != elementB.GetClusterV()) ? elementB.GetClusterV() : elementB.GetClusterW();
+    m_pCommonCluster1 = (elementA.GetClusterU() == elementB.GetClusterU())
+                            ? elementA.GetClusterU()
+                            : (elementA.GetClusterV() == elementB.GetClusterV()) ? elementA.GetClusterV() : elementA.GetClusterW();
+    m_pCommonCluster2 = ((m_pClusterA != elementA.GetClusterU()) && (m_pCommonCluster1 != elementA.GetClusterU()))
+                            ? elementA.GetClusterU()
+                            : ((m_pClusterA != elementA.GetClusterV()) && (m_pCommonCluster1 != elementA.GetClusterV()))
+                                  ? elementA.GetClusterV()
+                                  : elementA.GetClusterW();
 
     if ((m_pClusterA == m_pClusterB) || (m_pCommonCluster1 == m_pCommonCluster2))
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -205,17 +214,16 @@ UndershootTracksTool::Particle::Particle(const TensorType::Element &elementA, co
 
 StatusCode UndershootTracksTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SplitMode", m_splitMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SplitMode", m_splitMode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseImpactParameter", m_maxTransverseImpactParameter));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseImpactParameter", m_maxTransverseImpactParameter));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinImpactParameterCosTheta", m_minImpactParameterCosTheta));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinImpactParameterCosTheta", m_minImpactParameterCosTheta));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CosThetaCutForKinkSearch", m_cosThetaCutForKinkSearch));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CosThetaCutForKinkSearch", m_cosThetaCutForKinkSearch));
 
     return ThreeDKinkBaseTool::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/UndershootTracksTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTransverseTrackMatching/UndershootTracksTool.h
@@ -39,13 +39,14 @@ private:
          */
         Particle(const TensorType::Element &elementA, const TensorType::Element &elementB);
 
-        const pandora::Cluster      *m_pClusterA;            ///< Address of non-shared cluster in element A
-        const pandora::Cluster      *m_pClusterB;            ///< Address of non-shared cluster in element B
-        const pandora::Cluster      *m_pCommonCluster1;      ///< Address of the common cluster in view 1
-        const pandora::Cluster      *m_pCommonCluster2;      ///< Address of the common cluster in view 2
+        const pandora::Cluster *m_pClusterA;       ///< Address of non-shared cluster in element A
+        const pandora::Cluster *m_pClusterB;       ///< Address of non-shared cluster in element B
+        const pandora::Cluster *m_pCommonCluster1; ///< Address of the common cluster in view 1
+        const pandora::Cluster *m_pCommonCluster2; ///< Address of the common cluster in view 2
     };
 
-    void GetIteratorListModifications(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const IteratorList &iteratorList, ModificationList &modificationList) const;
+    void GetIteratorListModifications(
+        ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const IteratorList &iteratorList, ModificationList &modificationList) const;
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     /**
@@ -58,13 +59,13 @@ private:
      *
      *  @return boolean
      */
-    bool IsThreeDKink(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle, const pandora::CartesianVector &splitPosition,
-        const bool isALowestInX) const;
+    bool IsThreeDKink(ThreeViewTransverseTracksAlgorithm *const pAlgorithm, const Particle &particle,
+        const pandora::CartesianVector &splitPosition, const bool isALowestInX) const;
 
-    bool            m_splitMode;                        ///< Whether to run in cluster splitting mode, as opposed to cluster merging mode
-    float           m_maxTransverseImpactParameter;     ///< The maximum transverse impact parameter for connecting broken clusters
-    float           m_minImpactParameterCosTheta;       ///< The minimum cos theta (angle between vertex directions) for connecting broken clusters
-    float           m_cosThetaCutForKinkSearch;         ///< The cos theta cut used for the kink search in three dimensions
+    bool m_splitMode;                     ///< Whether to run in cluster splitting mode, as opposed to cluster merging mode
+    float m_maxTransverseImpactParameter; ///< The maximum transverse impact parameter for connecting broken clusters
+    float m_minImpactParameterCosTheta;   ///< The minimum cos theta (angle between vertex directions) for connecting broken clusters
+    float m_cosThetaCutForKinkSearch;     ///< The cos theta cut used for the kink search in three dimensions
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewClearTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewClearTracksTool.cc
@@ -17,10 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoViewClearTracksTool::TwoViewClearTracksTool() :
-    m_minXOverlapFraction(0.1f),
-    m_minMatchingScore(0.95f),
-    m_minLocallyMatchedFraction(0.3f)
+TwoViewClearTracksTool::TwoViewClearTracksTool() : m_minXOverlapFraction(0.1f), m_minMatchingScore(0.95f), m_minLocallyMatchedFraction(0.3f)
 {
 }
 
@@ -29,7 +26,7 @@ TwoViewClearTracksTool::TwoViewClearTracksTool() :
 bool TwoViewClearTracksTool::Run(TwoViewTransverseTracksAlgorithm *const pAlgorithm, MatrixType &overlapMatrix)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     bool particlesMade(false);
 
@@ -42,7 +39,8 @@ bool TwoViewClearTracksTool::Run(TwoViewTransverseTracksAlgorithm *const pAlgori
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoViewClearTracksTool::CreateThreeDParticles(TwoViewTransverseTracksAlgorithm *const pAlgorithm, const MatrixType::ElementList &elementList, bool &particlesMade) const
+void TwoViewClearTracksTool::CreateThreeDParticles(
+    TwoViewTransverseTracksAlgorithm *const pAlgorithm, const MatrixType::ElementList &elementList, bool &particlesMade) const
 {
     ProtoParticleVector protoParticleVector;
 
@@ -72,14 +70,14 @@ void TwoViewClearTracksTool::CreateThreeDParticles(TwoViewTransverseTracksAlgori
 
 StatusCode TwoViewClearTracksTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchingScore", m_minMatchingScore));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchingScore", m_minMatchingScore));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinLocallyMatchedFraction", m_minLocallyMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinLocallyMatchedFraction", m_minLocallyMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewClearTracksTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewClearTracksTool.h
@@ -36,12 +36,11 @@ private:
      *  @param  elementList the tensor element list
      *  @param  particlesMade receive boolean indicating whether particles have been made
      */
-    void CreateThreeDParticles(TwoViewTransverseTracksAlgorithm *const pAlgorithm,
-        const MatrixType::ElementList &elementList, bool &particlesMade) const;
+    void CreateThreeDParticles(TwoViewTransverseTracksAlgorithm *const pAlgorithm, const MatrixType::ElementList &elementList, bool &particlesMade) const;
 
-    float           m_minXOverlapFraction;           ///< The min x overlap fraction value for particle creation
-    float           m_minMatchingScore;              ///< The min global matching score for particle creation
-    float           m_minLocallyMatchedFraction;     ///< The min locally matched fraction for particle creation
+    float m_minXOverlapFraction;       ///< The min x overlap fraction value for particle creation
+    float m_minMatchingScore;          ///< The min global matching score for particle creation
+    float m_minLocallyMatchedFraction; ///< The min locally matched fraction for particle creation
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewLongTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewLongTracksTool.cc
@@ -69,8 +69,8 @@ bool TwoViewLongTracksTool::IsLongerThanDirectConnections(IteratorList::const_it
 
 bool TwoViewLongTracksTool::Run(TwoViewTransverseTracksAlgorithm *const pAlgorithm, MatrixType &overlapMatrix)
 {
-   if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ProtoParticleVector protoParticleVector;
     this->FindLongTracks(overlapMatrix, protoParticleVector);
@@ -121,8 +121,8 @@ void TwoViewLongTracksTool::FindLongTracks(const MatrixType &overlapMatrix, Prot
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoViewLongTracksTool::SelectLongElements(const MatrixType::ElementList &elementList, const pandora::ClusterSet &usedClusters,
-    IteratorList &iteratorList) const
+void TwoViewLongTracksTool::SelectLongElements(
+    const MatrixType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const
 {
     for (MatrixType::ElementList::const_iterator eIter = elementList.begin(); eIter != elementList.end(); ++eIter)
     {
@@ -140,8 +140,7 @@ void TwoViewLongTracksTool::SelectLongElements(const MatrixType::ElementList &el
 
         const TwoViewXOverlap &xOverlap(eIter->GetOverlapResult().GetTwoViewXOverlap());
 
-        if ((xOverlap.GetXOverlapFraction0() > m_minXOverlapFraction) &&
-            (xOverlap.GetXOverlapFraction1() > m_minXOverlapFraction))
+        if ((xOverlap.GetXOverlapFraction0() > m_minXOverlapFraction) && (xOverlap.GetXOverlapFraction1() > m_minXOverlapFraction))
         {
             iteratorList.push_back(eIter);
         }
@@ -152,20 +151,20 @@ void TwoViewLongTracksTool::SelectLongElements(const MatrixType::ElementList &el
 
 StatusCode TwoViewLongTracksTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchingScore", m_minMatchingScore));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchingScore", m_minMatchingScore));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPointRatio", m_minMatchedSamplingPointRatio));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewLongTracksTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewLongTracksTool.h
@@ -65,14 +65,13 @@ private:
      *  @param  usedClusters the list of clusters already marked as to be added to a pfo
      *  @param  iteratorList to receive a list of iterators to long track-like elements
      */
-    void SelectLongElements(const MatrixType::ElementList &elementList, const pandora::ClusterSet &usedClusters,
-        IteratorList &iteratorList) const;
+    void SelectLongElements(const MatrixType::ElementList &elementList, const pandora::ClusterSet &usedClusters, IteratorList &iteratorList) const;
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    float           m_minMatchingScore;                 ///< The min global matching score for particle creation
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for particle creation
-    float           m_minXOverlapFraction;              ///< The min x overlap fraction (in each view) for particle creation
-    unsigned int    m_minMatchedSamplingPointRatio;     ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
+    float m_minMatchedFraction;                  ///< The min matched sampling point fraction for particle creation
+    float m_minMatchingScore;                    ///< The min global matching score for particle creation
+    unsigned int m_minMatchedSamplingPoints;     ///< The min number of matched sampling points for particle creation
+    float m_minXOverlapFraction;                 ///< The min x overlap fraction (in each view) for particle creation
+    unsigned int m_minMatchedSamplingPointRatio; ///< The min ratio between 1st and 2nd highest msps for simple ambiguity resolution
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.cc
@@ -28,7 +28,7 @@ TwoViewSimpleTracksTool::TwoViewSimpleTracksTool() :
 bool TwoViewSimpleTracksTool::Run(TwoViewTransverseTracksAlgorithm *const pAlgorithm, MatrixType &overlapMatrix)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     ProtoParticleVector protoParticleVector;
     this->FindBestTrack(overlapMatrix, protoParticleVector);
@@ -55,9 +55,9 @@ void TwoViewSimpleTracksTool::FindBestTrack(const MatrixType &overlapMatrix, Pro
         if (elementList.empty())
             continue;
 
-	for (MatrixType::ElementList::const_reverse_iterator iIter = elementList.rbegin(); iIter != elementList.rend(); ++iIter)
+        for (MatrixType::ElementList::const_reverse_iterator iIter = elementList.rbegin(); iIter != elementList.rend(); ++iIter)
         {
-            if(this->PassesElementCuts(iIter))
+            if (this->PassesElementCuts(iIter))
             {
                 if ((nullptr == iIter->GetCluster1()) || (nullptr == iIter->GetCluster2()))
                     continue;
@@ -91,8 +91,7 @@ bool TwoViewSimpleTracksTool::PassesElementCuts(MatrixType::ElementList::const_r
 
     const TwoViewXOverlap &xOverlap(eIter->GetOverlapResult().GetTwoViewXOverlap());
 
-    if (!((xOverlap.GetXOverlapFraction0() > m_minXOverlapFraction) &&
-         (xOverlap.GetXOverlapFraction1() > m_minXOverlapFraction)))
+    if (!((xOverlap.GetXOverlapFraction0() > m_minXOverlapFraction) && (xOverlap.GetXOverlapFraction1() > m_minXOverlapFraction)))
     {
         return false;
     }
@@ -104,17 +103,17 @@ bool TwoViewSimpleTracksTool::PassesElementCuts(MatrixType::ElementList::const_r
 
 StatusCode TwoViewSimpleTracksTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedFraction", m_minMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchedFraction", m_minMatchedFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchingScore", m_minMatchingScore));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinMatchingScore", m_minMatchingScore));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinXOverlapFraction", m_minXOverlapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinXOverlapFraction", m_minXOverlapFraction));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.h
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.h
@@ -44,10 +44,10 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float           m_minMatchedFraction;               ///< The min matched sampling point fraction for particle creation
-    float           m_minMatchingScore;                 ///< The min global matching score for particle creation
-    unsigned int    m_minMatchedSamplingPoints;         ///< The min number of matched sampling points for particle creation
-    float           m_minXOverlapFraction;              ///< The min x overlap fraction (in each view) for particle creation
+    float m_minMatchedFraction;              ///< The min matched sampling point fraction for particle creation
+    float m_minMatchingScore;                ///< The min global matching score for particle creation
+    unsigned int m_minMatchedSamplingPoints; ///< The min number of matched sampling points for particle creation
+    float m_minXOverlapFraction;             ///< The min x overlap fraction (in each view) for particle creation
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.cc
@@ -35,10 +35,10 @@ TwoViewTransverseTracksAlgorithm::TwoViewTransverseTracksAlgorithm() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *const pCluster1, const Cluster *const pCluster2,
-    const Cluster *const)
+void TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *const pCluster1, const Cluster *const pCluster2, const Cluster *const)
 {
-    m_randomNumberGenerator.seed(static_cast<std::mt19937::result_type>(pCluster1->GetOrderedCaloHitList().size() + pCluster2->GetOrderedCaloHitList().size()));
+    m_randomNumberGenerator.seed(
+        static_cast<std::mt19937::result_type>(pCluster1->GetOrderedCaloHitList().size() + pCluster2->GetOrderedCaloHitList().size()));
 
     TwoViewTransverseOverlapResult overlapResult;
     PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, this->CalculateOverlapResult(pCluster1, pCluster2, overlapResult));
@@ -49,15 +49,15 @@ void TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-pandora::StatusCode TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(const Cluster *const pCluster1,
-    const Cluster *const pCluster2, TwoViewTransverseOverlapResult &overlapResult)
+pandora::StatusCode TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(
+    const Cluster *const pCluster1, const Cluster *const pCluster2, TwoViewTransverseOverlapResult &overlapResult)
 {
     UIntSet daughterVolumeIntersection;
     LArGeometryHelper::GetCommonDaughterVolumes(pCluster1, pCluster2, daughterVolumeIntersection);
 
     if (daughterVolumeIntersection.empty())
         return STATUS_CODE_NOT_FOUND;
-    
+
     if (this->GetPrimaryAxisDotDriftAxis(pCluster1) > m_maxDotProduct || this->GetPrimaryAxisDotDriftAxis(pCluster2) > m_maxDotProduct)
         return STATUS_CODE_NOT_FOUND;
 
@@ -90,15 +90,15 @@ pandora::StatusCode TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(con
 
     if (1 > m_downsampleFactor)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
-    const unsigned int nSamples(std::max(m_minSamples, static_cast<unsigned int>(std::min(overlapHits1.size(), overlapHits2.size())) /
-        m_downsampleFactor));
+    const unsigned int nSamples(
+        std::max(m_minSamples, static_cast<unsigned int>(std::min(overlapHits1.size(), overlapHits2.size())) / m_downsampleFactor));
 
     DiscreteProbabilityVector::AllFloatInputData inputData1;
-    for (const pandora::CaloHit *const pCaloHit: overlapHits1)
+    for (const pandora::CaloHit *const pCaloHit : overlapHits1)
         inputData1.emplace_back(pCaloHit->GetPositionVector().GetX(), pCaloHit->GetInputEnergy());
 
     DiscreteProbabilityVector::AllFloatInputData inputData2;
-    for (const pandora::CaloHit *const pCaloHit: overlapHits2)
+    for (const pandora::CaloHit *const pCaloHit : overlapHits2)
         inputData2.emplace_back(pCaloHit->GetPositionVector().GetX(), pCaloHit->GetInputEnergy());
 
     const DiscreteProbabilityVector discreteProbabilityVector1(inputData1, xOverlapMax, false);
@@ -107,15 +107,15 @@ pandora::StatusCode TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(con
     DiscreteProbabilityVector::ResamplingPoints resamplingPointsX;
     for (unsigned int iSample = 0; iSample < nSamples; ++iSample)
     {
-        resamplingPointsX.emplace_back((xOverlapMin + (xOverlapMax - xOverlapMin) *
-            static_cast<float>(iSample + 1) / static_cast<float>(nSamples + 1)));
+        resamplingPointsX.emplace_back(
+            (xOverlapMin + (xOverlapMax - xOverlapMin) * static_cast<float>(iSample + 1) / static_cast<float>(nSamples + 1)));
     }
 
     const DiscreteProbabilityVector resampledDiscreteProbabilityVector1(discreteProbabilityVector1, resamplingPointsX);
     const DiscreteProbabilityVector resampledDiscreteProbabilityVector2(discreteProbabilityVector2, resamplingPointsX);
 
-    const float correlation(LArDiscreteProbabilityHelper::CalculateCorrelationCoefficient(
-        resampledDiscreteProbabilityVector1, resampledDiscreteProbabilityVector2));
+    const float correlation(
+        LArDiscreteProbabilityHelper::CalculateCorrelationCoefficient(resampledDiscreteProbabilityVector1, resampledDiscreteProbabilityVector2));
 
     const float pvalue(LArDiscreteProbabilityHelper::CalculateCorrelationCoefficientPValueFromPermutationTest(
         resampledDiscreteProbabilityVector1, resampledDiscreteProbabilityVector2, m_randomNumberGenerator, m_nPermutations));
@@ -124,8 +124,8 @@ pandora::StatusCode TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(con
     if (matchingScore < m_minOverallMatchingScore)
         return STATUS_CODE_NOT_FOUND;
 
-    const unsigned int nLocallyMatchedSamplingPoints(this->CalculateNumberOfLocallyMatchingSamplingPoints(resampledDiscreteProbabilityVector1,
-        resampledDiscreteProbabilityVector2, m_randomNumberGenerator));
+    const unsigned int nLocallyMatchedSamplingPoints(this->CalculateNumberOfLocallyMatchingSamplingPoints(
+        resampledDiscreteProbabilityVector1, resampledDiscreteProbabilityVector2, m_randomNumberGenerator));
     const int nComparisons(static_cast<int>(resampledDiscreteProbabilityVector1.GetSize()) - (static_cast<int>(m_minSamples) - 1));
     if (1 > nComparisons)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -134,20 +134,19 @@ pandora::StatusCode TwoViewTransverseTracksAlgorithm::CalculateOverlapResult(con
     if (locallyMatchedFraction < m_minOverallLocallyMatchedFraction)
         return STATUS_CODE_NOT_FOUND;
 
-    overlapResult = TwoViewTransverseOverlapResult(matchingScore, m_downsampleFactor, nComparisons, nLocallyMatchedSamplingPoints,
-        correlation, twoViewXOverlap);
+    overlapResult = TwoViewTransverseOverlapResult(
+        matchingScore, m_downsampleFactor, nComparisons, nLocallyMatchedSamplingPoints, correlation, twoViewXOverlap);
 
     return STATUS_CODE_SUCCESS;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-unsigned int TwoViewTransverseTracksAlgorithm::CalculateNumberOfLocallyMatchingSamplingPoints(
-    const DiscreteProbabilityVector &discreteProbabilityVector1, const DiscreteProbabilityVector &discreteProbabilityVector2,
-    std::mt19937 &randomNumberGenerator)
+unsigned int TwoViewTransverseTracksAlgorithm::CalculateNumberOfLocallyMatchingSamplingPoints(const DiscreteProbabilityVector &discreteProbabilityVector1,
+    const DiscreteProbabilityVector &discreteProbabilityVector2, std::mt19937 &randomNumberGenerator)
 {
     if (discreteProbabilityVector1.GetSize() != discreteProbabilityVector2.GetSize() ||
-        0 == discreteProbabilityVector1.GetSize()*discreteProbabilityVector2.GetSize())
+        0 == discreteProbabilityVector1.GetSize() * discreteProbabilityVector2.GetSize())
         throw STATUS_CODE_INVALID_PARAMETER;
 
     if (m_minSamples > discreteProbabilityVector1.GetSize())
@@ -170,14 +169,15 @@ unsigned int TwoViewTransverseTracksAlgorithm::CalculateNumberOfLocallyMatchingS
             }
             catch (const StatusCodeException &)
             {
-                std::cout << "TwoViewTransverseTracksAlgorithm: failed to calculate correlation coefficient p-value for these numbers" << std::endl;;
+                std::cout << "TwoViewTransverseTracksAlgorithm: failed to calculate correlation coefficient p-value for these numbers" << std::endl;
+                ;
                 std::cout << "----view 0: ";
                 for (unsigned int iElement = 0; iElement < localValues1.size(); ++iElement)
-                    std::cout<<localValues1.at(iElement) << " ";
+                    std::cout << localValues1.at(iElement) << " ";
                 std::cout << std::endl;
                 std::cout << "----view 1: ";
                 for (unsigned int iElement = 0; iElement < localValues2.size(); ++iElement)
-                    std::cout<<localValues2.at(iElement) << " ";
+                    std::cout << localValues2.at(iElement) << " ";
                 std::cout << std::endl;
             }
 
@@ -213,7 +213,7 @@ float TwoViewTransverseTracksAlgorithm::GetPrimaryAxisDotDriftAxis(const pandora
 void TwoViewTransverseTracksAlgorithm::ExamineOverlapContainer()
 {
     unsigned int repeatCounter(0);
-    for (MatrixToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd; )
+    for (MatrixToolVector::const_iterator iter = m_algorithmToolVector.begin(), iterEnd = m_algorithmToolVector.end(); iter != iterEnd;)
     {
         if ((*iter)->Run(this, this->GetMatchingControl().GetOverlapMatrix()))
         {
@@ -234,12 +234,11 @@ void TwoViewTransverseTracksAlgorithm::ExamineOverlapContainer()
 StatusCode TwoViewTransverseTracksAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     AlgorithmToolVector algorithmToolVector;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle,
-        "TrackTools", algorithmToolVector));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "TrackTools", algorithmToolVector));
 
     for (AlgorithmToolVector::const_iterator iter = algorithmToolVector.begin(), iterEnd = algorithmToolVector.end(); iter != iterEnd; ++iter)
     {
-        TransverseMatrixTool *const pTransverseMatrixTool(dynamic_cast<TransverseMatrixTool*>(*iter));
+        TransverseMatrixTool *const pTransverseMatrixTool(dynamic_cast<TransverseMatrixTool *>(*iter));
 
         if (!pTransverseMatrixTool)
             return STATUS_CODE_INVALID_PARAMETER;
@@ -247,29 +246,26 @@ StatusCode TwoViewTransverseTracksAlgorithm::ReadSettings(const TiXmlHandle xmlH
         m_algorithmToolVector.push_back(pTransverseMatrixTool);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NMaxMatrixToolRepeats", m_nMaxMatrixToolRepeats));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NMaxMatrixToolRepeats", m_nMaxMatrixToolRepeats));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DownsampleFactor", m_downsampleFactor));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DownsampleFactor", m_downsampleFactor));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSamples", m_minSamples));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinSamples", m_minSamples));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NPermutations", m_nPermutations));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NPermutations", m_nPermutations));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LocalMatchingScoreThreshold", m_localMatchingScoreThreshold));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "LocalMatchingScoreThreshold", m_localMatchingScoreThreshold));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxDotProduct", m_maxDotProduct));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxDotProduct", m_maxDotProduct));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinOverallMatchingScore", m_minOverallMatchingScore));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinOverallMatchingScore", m_minOverallMatchingScore));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinOverallLocallyMatchedFraction", m_minOverallLocallyMatchedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinOverallLocallyMatchedFraction", m_minOverallLocallyMatchedFraction));
 
     return BaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h
@@ -29,10 +29,10 @@ class TransverseMatrixTool;
 /**
  *  @brief  TwoViewTransverseTracksAlgorithm class
  */
-class TwoViewTransverseTracksAlgorithm : public NViewTrackMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult> >
+class TwoViewTransverseTracksAlgorithm : public NViewTrackMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult>>
 {
 public:
-    typedef NViewTrackMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult> > BaseAlgorithm;
+    typedef NViewTrackMatchingAlgorithm<TwoViewMatchingControl<TwoViewTransverseOverlapResult>> BaseAlgorithm;
     typedef std::set<unsigned int> UIntSet;
 
     /**
@@ -41,8 +41,7 @@ public:
     TwoViewTransverseTracksAlgorithm();
 
 private:
-    void CalculateOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-        const pandora::Cluster *const);
+    void CalculateOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const pandora::Cluster *const);
 
     /**
      *  @brief  Calculates the two view overlap result
@@ -51,8 +50,8 @@ private:
      *  @param  pCluster2 the view 1 cluster
      *  @param  overlapResult the two view overlap result
      */
-    pandora::StatusCode CalculateOverlapResult(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-        TwoViewTransverseOverlapResult &overlapResult);
+    pandora::StatusCode CalculateOverlapResult(
+        const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, TwoViewTransverseOverlapResult &overlapResult);
 
     /**
      *  @brief  Calculates the number of the sliding windows that contains charge bins that locally match
@@ -78,18 +77,18 @@ private:
     void ExamineOverlapContainer();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::vector<TransverseMatrixTool*> MatrixToolVector;
-    MatrixToolVector            m_algorithmToolVector;                   ///< The algorithm tool vector
+    typedef std::vector<TransverseMatrixTool *> MatrixToolVector;
+    MatrixToolVector m_algorithmToolVector; ///< The algorithm tool vector
 
-    unsigned int                m_nMaxMatrixToolRepeats;                 ///< The maximum number of repeat loops over matrix tools
-    unsigned int                m_downsampleFactor;                      ///< The downsampling (hit merging) applied to hits in the overlap region
-    unsigned int                m_minSamples;                            ///< The minimum number of samples needed for comparing charges
-    unsigned int                m_nPermutations;                         ///< The number of permutations for calculating p-values
-    float                       m_localMatchingScoreThreshold;           ///< The minimum score to classify a local region as matching
-    float                       m_maxDotProduct;                         ///M The maximum allowed cluster primary qxis Dot drift axis to fill the overlap result
-    float                       m_minOverallMatchingScore;               ///< The minimum required global matching score to fill the overlap result
-    float                       m_minOverallLocallyMatchedFraction;      ///< The minimum required lcoally matched fraction to fill the overlap result
-    std::mt19937                m_randomNumberGenerator;                 ///< The random number generator
+    unsigned int m_nMaxMatrixToolRepeats;     ///< The maximum number of repeat loops over matrix tools
+    unsigned int m_downsampleFactor;          ///< The downsampling (hit merging) applied to hits in the overlap region
+    unsigned int m_minSamples;                ///< The minimum number of samples needed for comparing charges
+    unsigned int m_nPermutations;             ///< The number of permutations for calculating p-values
+    float m_localMatchingScoreThreshold;      ///< The minimum score to classify a local region as matching
+    float m_maxDotProduct;                    ///M The maximum allowed cluster primary qxis Dot drift axis to fill the overlap result
+    float m_minOverallMatchingScore;          ///< The minimum required global matching score to fill the overlap result
+    float m_minOverallLocallyMatchedFraction; ///< The minimum required lcoally matched fraction to fill the overlap result
+    std::mt19937 m_randomNumberGenerator;     ///< The random number generator
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTrackShowerId/BranchGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/BranchGrowingAlgorithm.cc
@@ -70,11 +70,12 @@ void BranchGrowingAlgorithm::FindAssociatedClusters(const Cluster *const pPartic
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BranchGrowingAlgorithm::IdentifyClusterMerges(const ClusterVector &particleSeedVector, const ClusterUsageMap &backwardUsageMap,
-    SeedAssociationList &seedAssociationList) const
+void BranchGrowingAlgorithm::IdentifyClusterMerges(
+    const ClusterVector &particleSeedVector, const ClusterUsageMap &backwardUsageMap, SeedAssociationList &seedAssociationList) const
 {
     ClusterVector sortedCandidates;
-    for (const auto &mapEntry : backwardUsageMap) sortedCandidates.push_back(mapEntry.first);
+    for (const auto &mapEntry : backwardUsageMap)
+        sortedCandidates.push_back(mapEntry.first);
     std::sort(sortedCandidates.begin(), sortedCandidates.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster : sortedCandidates)
@@ -85,7 +86,8 @@ void BranchGrowingAlgorithm::IdentifyClusterMerges(const ClusterVector &particle
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
         ClusterVector sortedSeeds;
-        for (const auto &mapEntry : particleSeedUsageMap) sortedSeeds.push_back(mapEntry.first);
+        for (const auto &mapEntry : particleSeedUsageMap)
+            sortedSeeds.push_back(mapEntry.first);
         std::sort(sortedSeeds.begin(), sortedSeeds.end(), LArClusterHelper::SortByNHits);
 
         const Cluster *pBestParticleSeed = NULL;

--- a/larpandoracontent/LArTrackShowerId/BranchGrowingAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/BranchGrowingAlgorithm.h
@@ -80,12 +80,12 @@ protected:
         AssociationType GetType() const;
 
     private:
-        unsigned int    m_order;
+        unsigned int m_order;
         AssociationType m_type;
     };
 
-    typedef std::unordered_map<const pandora::Cluster*, Association> ClusterAssociationMap;
-    typedef std::unordered_map<const pandora::Cluster*, ClusterAssociationMap> ClusterUsageMap;
+    typedef std::unordered_map<const pandora::Cluster *, Association> ClusterAssociationMap;
+    typedef std::unordered_map<const pandora::Cluster *, ClusterAssociationMap> ClusterUsageMap;
 
     /**
      *  @brief  Determine whether two clusters are associated
@@ -108,7 +108,7 @@ protected:
     void FindAssociatedClusters(const pandora::Cluster *const pParticleSeed, pandora::ClusterVector &candidateClusters,
         ClusterUsageMap &forwardUsageMap, ClusterUsageMap &backwardUsageMap) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterVector> SeedAssociationList;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterVector> SeedAssociationList;
 
     /**
      *  @brief  Identify cluster merges
@@ -126,17 +126,13 @@ protected:
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline BranchGrowingAlgorithm::Association::Association() :
-    m_order(std::numeric_limits<unsigned int>::max()),
-    m_type(NONE)
+inline BranchGrowingAlgorithm::Association::Association() : m_order(std::numeric_limits<unsigned int>::max()), m_type(NONE)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline BranchGrowingAlgorithm::Association::Association(const unsigned int order, const AssociationType type) :
-    m_order(order),
-    m_type(type)
+inline BranchGrowingAlgorithm::Association::Association(const unsigned int order, const AssociationType type) : m_order(order), m_type(type)
 {
 }
 

--- a/larpandoracontent/LArTrackShowerId/ClusterCharacterisationBaseAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/ClusterCharacterisationBaseAlgorithm.cc
@@ -38,7 +38,8 @@ StatusCode ClusterCharacterisationBaseAlgorithm::Run()
     for (const std::string &clusterListName : m_inputClusterListNames)
     {
         const ClusterList *pClusterList = NULL;
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
 
         if (!pClusterList || pClusterList->empty())
         {
@@ -91,17 +92,15 @@ StatusCode ClusterCharacterisationBaseAlgorithm::Run()
 
 StatusCode ClusterCharacterisationBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputClusterListNames", m_inputClusterListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
 
-   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-         "ZeroMode", m_zeroMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ZeroMode", m_zeroMode));
 
-   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "OverwriteExistingId", m_overwriteExistingId));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "OverwriteExistingId", m_overwriteExistingId));
 
-   PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseUnavailableClusters", m_useUnavailableClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseUnavailableClusters", m_useUnavailableClusters));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTrackShowerId/ClusterCharacterisationBaseAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/ClusterCharacterisationBaseAlgorithm.h
@@ -42,12 +42,12 @@ protected:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector   m_inputClusterListNames;        ///< The names of the input cluster lists
+    pandora::StringVector m_inputClusterListNames; ///< The names of the input cluster lists
 
-    bool                    m_zeroMode;                     ///< Whether to zero all existing cluster particle id, overrides all other parameters
+    bool m_zeroMode; ///< Whether to zero all existing cluster particle id, overrides all other parameters
 
-    bool                    m_overwriteExistingId;          ///< Whether to consider any clusters that already have an assigned particle id
-    bool                    m_useUnavailableClusters;       ///< Whether to consider clusters that are already constituents of a pfo
+    bool m_overwriteExistingId;    ///< Whether to consider any clusters that already have an assigned particle id
+    bool m_useUnavailableClusters; ///< Whether to consider clusters that are already constituents of a pfo
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTrackShowerId/CutClusterCharacterisationAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/CutClusterCharacterisationAlgorithm.cc
@@ -38,7 +38,7 @@ CutClusterCharacterisationAlgorithm::CutClusterCharacterisationAlgorithm() :
 float CutClusterCharacterisationAlgorithm::GetVertexDistance(const Algorithm *const pAlgorithm, const Cluster *const pCluster)
 {
     const VertexList *pVertexList = nullptr;
-    (void) PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList);
+    (void)PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList);
 
     if (!pVertexList || (pVertexList->size() != 1) || (VERTEX_3D != pVertexList->front()->GetVertexType()))
         return -1.f;
@@ -52,8 +52,7 @@ float CutClusterCharacterisationAlgorithm::GetVertexDistance(const Algorithm *co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float CutClusterCharacterisationAlgorithm::GetShowerFitWidth(const Algorithm *const pAlgorithm, const Cluster *const pCluster,
-    const unsigned int showerFitWindow)
+float CutClusterCharacterisationAlgorithm::GetShowerFitWidth(const Algorithm *const pAlgorithm, const Cluster *const pCluster, const unsigned int showerFitWindow)
 {
     try
     {
@@ -148,29 +147,27 @@ bool CutClusterCharacterisationAlgorithm::IsClearTrack(const Cluster *const pClu
 
 StatusCode CutClusterCharacterisationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingShowerFitWindow", m_slidingShowerFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingShowerFitWindow", m_slidingShowerFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsCut", m_minCaloHitsCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitsCut", m_minCaloHitsCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxShowerLengthCut", m_maxShowerLengthCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxShowerLengthCut", m_maxShowerLengthCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PathLengthRatioCut", m_pathLengthRatioCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PathLengthRatioCut", m_pathLengthRatioCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "RTWidthRatioCut", m_rTWidthRatioCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "RTWidthRatioCut", m_rTWidthRatioCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexDistanceRatioCut", m_vertexDistanceRatioCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexDistanceRatioCut", m_vertexDistanceRatioCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerWidthRatioCut", m_showerWidthRatioCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowerWidthRatioCut", m_showerWidthRatioCut));
 
     return ClusterCharacterisationBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTrackShowerId/CutClusterCharacterisationAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/CutClusterCharacterisationAlgorithm.h
@@ -49,14 +49,14 @@ private:
     virtual bool IsClearTrack(const pandora::Cluster *const pCluster) const;
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int            m_slidingFitWindow;             ///< The layer window for the sliding linear fits
-    unsigned int            m_slidingShowerFitWindow;       ///< The layer window for the sliding shower fits
-    unsigned int            m_minCaloHitsCut;               ///< The minimum number of calo hits to qualify as a track
-    float                   m_maxShowerLengthCut;           ///< The maximum cluster length to qualify as a shower
-    float                   m_pathLengthRatioCut;           ///< The maximum ratio of path length to straight line length to qualify as a track
-    float                   m_rTWidthRatioCut;              ///< The maximum ratio of transverse fit position width to straight line length to qualify as a track
-    float                   m_vertexDistanceRatioCut;       ///< The maximum ratio of vertex separation to straight line length to qualify as a track
-    float                   m_showerWidthRatioCut;          ///< The maximum ratio of shower fit width to straight line length to qualify as a track
+    unsigned int m_slidingFitWindow;       ///< The layer window for the sliding linear fits
+    unsigned int m_slidingShowerFitWindow; ///< The layer window for the sliding shower fits
+    unsigned int m_minCaloHitsCut;         ///< The minimum number of calo hits to qualify as a track
+    float m_maxShowerLengthCut;            ///< The maximum cluster length to qualify as a shower
+    float m_pathLengthRatioCut;            ///< The maximum ratio of path length to straight line length to qualify as a track
+    float m_rTWidthRatioCut;        ///< The maximum ratio of transverse fit position width to straight line length to qualify as a track
+    float m_vertexDistanceRatioCut; ///< The maximum ratio of vertex separation to straight line length to qualify as a track
+    float m_showerWidthRatioCut;    ///< The maximum ratio of shower fit width to straight line length to qualify as a track
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTrackShowerId/CutPfoCharacterisationAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/CutPfoCharacterisationAlgorithm.cc
@@ -80,15 +80,15 @@ bool CutPfoCharacterisationAlgorithm::IsClearTrack(const Cluster *const pCluster
 
 bool CutPfoCharacterisationAlgorithm::IsClearTrack(const pandora::ParticleFlowObject *const /*pPfo*/) const
 {
-	throw StatusCodeException(STATUS_CODE_NOT_ALLOWED);
+    throw StatusCodeException(STATUS_CODE_NOT_ALLOWED);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode CutPfoCharacterisationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "PostBranchAddition", m_postBranchAddition));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PostBranchAddition", m_postBranchAddition));
 
     // Allow change in default values via a single xml tag, can subsequently override all individual values below, if required
     if (m_postBranchAddition)
@@ -99,23 +99,23 @@ StatusCode CutPfoCharacterisationAlgorithm::ReadSettings(const TiXmlHandle xmlHa
         m_showerWidthRatioCut = 0.3f;
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingShowerFitWindow", m_slidingShowerFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingShowerFitWindow", m_slidingShowerFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxShowerLengthCut", m_maxShowerLengthCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxShowerLengthCut", m_maxShowerLengthCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DTDLWidthRatioCut", m_dTdLWidthRatioCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DTDLWidthRatioCut", m_dTdLWidthRatioCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexDistanceRatioCut", m_vertexDistanceRatioCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexDistanceRatioCut", m_vertexDistanceRatioCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerWidthRatioCut", m_showerWidthRatioCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowerWidthRatioCut", m_showerWidthRatioCut));
 
     return PfoCharacterisationBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTrackShowerId/CutPfoCharacterisationAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/CutPfoCharacterisationAlgorithm.h
@@ -29,13 +29,13 @@ private:
     bool IsClearTrack(const pandora::ParticleFlowObject *const pPfo) const;
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    bool                    m_postBranchAddition;           ///< Whether to use configuration for shower clusters post branch addition
-    unsigned int            m_slidingFitWindow;             ///< The layer window for the sliding linear fits
-    unsigned int            m_slidingShowerFitWindow;       ///< The layer window for the sliding shower fits
-    float                   m_maxShowerLengthCut;           ///< The maximum cluster length to qualify as a shower
-    float                   m_dTdLWidthRatioCut;            ///< The maximum ratio of transverse fit gradient width to straight line length to qualify as a track
-    float                   m_vertexDistanceRatioCut;       ///< The maximum ratio of vertex separation to straight line length to qualify as a track
-    float                   m_showerWidthRatioCut;          ///< The maximum ratio of shower fit width to straight line length to qualify as a track
+    bool m_postBranchAddition;             ///< Whether to use configuration for shower clusters post branch addition
+    unsigned int m_slidingFitWindow;       ///< The layer window for the sliding linear fits
+    unsigned int m_slidingShowerFitWindow; ///< The layer window for the sliding shower fits
+    float m_maxShowerLengthCut;            ///< The maximum cluster length to qualify as a shower
+    float m_dTdLWidthRatioCut;      ///< The maximum ratio of transverse fit gradient width to straight line length to qualify as a track
+    float m_vertexDistanceRatioCut; ///< The maximum ratio of vertex separation to straight line length to qualify as a track
+    float m_showerWidthRatioCut;    ///< The maximum ratio of shower fit width to straight line length to qualify as a track
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc
@@ -20,7 +20,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-template<typename T>
+template <typename T>
 MvaPfoCharacterisationAlgorithm<T>::MvaPfoCharacterisationAlgorithm() :
     m_trainingSetMode(false),
     m_testBeamMode(false),
@@ -42,7 +42,7 @@ MvaPfoCharacterisationAlgorithm<T>::MvaPfoCharacterisationAlgorithm() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const Cluster *const pCluster) const
 {
     if (pCluster->GetNCaloHits() < m_minCaloHitsCut)
@@ -59,7 +59,9 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const Cluster *const pClus
             const MCParticle *const pMCParticle(MCParticleHelper::GetMainMCParticle(pCluster));
             isTrueTrack = ((PHOTON != pMCParticle->GetParticleId()) && (E_MINUS != std::abs(pMCParticle->GetParticleId())));
         }
-        catch (const StatusCodeException &) {}
+        catch (const StatusCodeException &)
+        {
+        }
 
         LArMvaHelper::ProduceTrainingExample(m_trainingOutputFile, isTrueTrack, featureVector);
         return isTrueTrack;
@@ -77,7 +79,7 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const Cluster *const pClus
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlowObject *const pPfo) const
 {
     if (!LArPfoHelper::IsThreeD(pPfo))
@@ -95,7 +97,8 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
     ClusterList wClusterList;
     LArPfoHelper::GetClusters(pPfo, TPC_VIEW_W, wClusterList);
 
-    const PfoCharacterisationFeatureTool::FeatureToolVector &chosenFeatureToolVector(wClusterList.empty() ? m_featureToolVectorNoChargeInfo : m_featureToolVectorThreeD);
+    const PfoCharacterisationFeatureTool::FeatureToolVector &chosenFeatureToolVector(
+        wClusterList.empty() ? m_featureToolVectorNoChargeInfo : m_featureToolVectorThreeD);
     const LArMvaHelper::MvaFeatureVector featureVector(LArMvaHelper::CalculateFeatures(chosenFeatureToolVector, this, pPfo));
 
     if (m_trainingSetMode && m_applyReconstructabilityChecks)
@@ -109,20 +112,24 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
         // Mapping target MCParticles -> truth associated Hits
         LArMCParticleHelper::MCContributionMap targetMCParticleToHitsMap;
         if (!m_testBeamMode)
-            LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, targetMCParticleToHitsMap);
+            LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters,
+                LArMCParticleHelper::IsBeamNeutrinoFinalState, targetMCParticleToHitsMap);
         else
-            LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsBeamParticle, targetMCParticleToHitsMap);
+            LArMCParticleHelper::SelectReconstructableMCParticles(
+                pMCParticleList, pCaloHitList, m_primaryParameters, LArMCParticleHelper::IsBeamParticle, targetMCParticleToHitsMap);
 
         LArMCParticleHelper::MCContributionMapVector mcParticlesToGoodHitsMaps({targetMCParticleToHitsMap});
 
         LArMCParticleHelper::PfoContributionMap pfoToReconstructable2DHitsMap;
-        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(PfoList(1, pPfo), mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap, m_primaryParameters.m_foldBackHierarchy);
+        LArMCParticleHelper::GetPfoToReconstructable2DHitsMap(
+            PfoList(1, pPfo), mcParticlesToGoodHitsMaps, pfoToReconstructable2DHitsMap, m_primaryParameters.m_foldBackHierarchy);
         if (pfoToReconstructable2DHitsMap.empty())
             return false;
 
         LArMCParticleHelper::PfoToMCParticleHitSharingMap pfoToMCParticleHitSharingMap;
         LArMCParticleHelper::MCParticleToPfoHitSharingMap mcParticleToPfoHitSharingMap;
-        LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(pfoToReconstructable2DHitsMap, mcParticlesToGoodHitsMaps, pfoToMCParticleHitSharingMap, mcParticleToPfoHitSharingMap);
+        LArMCParticleHelper::GetPfoMCParticleHitSharingMaps(
+            pfoToReconstructable2DHitsMap, mcParticlesToGoodHitsMaps, pfoToMCParticleHitSharingMap, mcParticleToPfoHitSharingMap);
         if (pfoToMCParticleHitSharingMap.empty())
             return false;
 
@@ -158,7 +165,8 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
 
         const int nHitsInPfoTotal(pfoToReconstructable2DHitsMap.at(pPfo).size());
         const float purity((nHitsInPfoTotal > 0) ? nHitsSharedWithBestMCParticleTotal / static_cast<float>(nHitsInPfoTotal) : 0.f);
-        const float completeness((nHitsInBestMCParticleTotal > 0) ? nHitsSharedWithBestMCParticleTotal / static_cast<float>(nHitsInBestMCParticleTotal) : 0.f);
+        const float completeness(
+            (nHitsInBestMCParticleTotal > 0) ? nHitsSharedWithBestMCParticleTotal / static_cast<float>(nHitsInBestMCParticleTotal) : 0.f);
 
         CaloHitList checkHitListW;
         LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, checkHitListW);
@@ -198,11 +206,10 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
 
         if (isMainMCParticleSet)
         {
-            if (completeness >= 0.f && purity >= 0.f && !mischaracterisedPfo &&
-                (!m_applyFiducialCut || this->PassesFiducialCut(threeDVertexPosition)))
+            if (completeness >= 0.f && purity >= 0.f && !mischaracterisedPfo && (!m_applyFiducialCut || this->PassesFiducialCut(threeDVertexPosition)))
             {
                 std::string outputFile(m_trainingOutputFile);
-                const std::string end=((wClusterList.empty()) ? "noChargeInfo.txt" : ".txt");
+                const std::string end = ((wClusterList.empty()) ? "noChargeInfo.txt" : ".txt");
                 outputFile.append(end);
                 LArMvaHelper::ProduceTrainingExample(outputFile, isTrueTrack, featureVector);
             }
@@ -221,7 +228,9 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
             isTrueTrack = ((PHOTON != pMCParticle->GetParticleId()) && (E_MINUS != std::abs(pMCParticle->GetParticleId())));
             isMainMCParticleSet = (pMCParticle->GetParticleId() != 0);
         }
-        catch (const StatusCodeException &) {}
+        catch (const StatusCodeException &)
+        {
+        }
 
         if (isMainMCParticleSet)
         {
@@ -264,41 +273,39 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 StatusCode MvaPfoCharacterisationAlgorithm<T>::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPrimaryGoodHits", m_primaryParameters.m_minPrimaryGoodHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinPrimaryGoodHits", m_primaryParameters.m_minPrimaryGoodHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsForGoodView", m_primaryParameters.m_minHitsForGoodView));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitsForGoodView", m_primaryParameters.m_minHitsForGoodView));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinPrimaryGoodViews", m_primaryParameters.m_minPrimaryGoodViews));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinPrimaryGoodViews", m_primaryParameters.m_minPrimaryGoodViews));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectInputHits", m_primaryParameters.m_selectInputHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "SelectInputHits", m_primaryParameters.m_selectInputHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitSharingFraction", m_primaryParameters.m_minHitSharingFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitSharingFraction", m_primaryParameters.m_minHitSharingFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxPhotonPropagation", m_primaryParameters.m_maxPhotonPropagation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxPhotonPropagation", m_primaryParameters.m_maxPhotonPropagation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FoldToPrimaries", m_primaryParameters.m_foldBackHierarchy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "FoldToPrimaries", m_primaryParameters.m_foldBackHierarchy));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrainingSetMode", m_trainingSetMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TrainingSetMode", m_trainingSetMode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsCut", m_minCaloHitsCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitsCut", m_minCaloHitsCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseThreeDInformation", m_useThreeDInformation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseThreeDInformation", m_useThreeDInformation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));
 
     // ATTN Support legacy XML configurations (note an order of precedence of XML keys exists)
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BdtFileName", m_mvaFileName));
@@ -311,20 +318,26 @@ StatusCode MvaPfoCharacterisationAlgorithm<T>::ReadSettings(const TiXmlHandle xm
 
     if (m_useThreeDInformation)
     {
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BdtFileNameNoChargeInfo", m_mvaFileNameNoChargeInfo));
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SvmFileNameNoChargeInfo", m_mvaFileNameNoChargeInfo));
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MvaFileNameNoChargeInfo", m_mvaFileNameNoChargeInfo));
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+            XmlHelper::ReadValue(xmlHandle, "BdtFileNameNoChargeInfo", m_mvaFileNameNoChargeInfo));
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+            XmlHelper::ReadValue(xmlHandle, "SvmFileNameNoChargeInfo", m_mvaFileNameNoChargeInfo));
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+            XmlHelper::ReadValue(xmlHandle, "MvaFileNameNoChargeInfo", m_mvaFileNameNoChargeInfo));
 
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BdtNameNoChargeInfo", m_mvaNameNoChargeInfo));
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SvmNameNoChargeInfo", m_mvaNameNoChargeInfo));
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MvaNameNoChargeInfo", m_mvaNameNoChargeInfo));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BdtNameNoChargeInfo", m_mvaNameNoChargeInfo));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SvmNameNoChargeInfo", m_mvaNameNoChargeInfo));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MvaNameNoChargeInfo", m_mvaNameNoChargeInfo));
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EnableProbability",  m_enableProbability));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EnableProbability", m_enableProbability));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinProbabilityCut", m_minProbabilityCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinProbabilityCut", m_minProbabilityCut));
 
     if (m_trainingSetMode)
     {
@@ -332,7 +345,8 @@ StatusCode MvaPfoCharacterisationAlgorithm<T>::ReadSettings(const TiXmlHandle xm
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "TrainingOutputFileName", m_trainingOutputFile));
         PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TestBeamMode", m_testBeamMode));
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ApplyFiducialCut", m_applyFiducialCut));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ApplyFiducialCut", m_applyFiducialCut));
         if (m_applyFiducialCut)
         {
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "FiducialCutMinX", m_fiducialMinX));
@@ -342,7 +356,8 @@ StatusCode MvaPfoCharacterisationAlgorithm<T>::ReadSettings(const TiXmlHandle xm
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "FiducialCutMinZ", m_fiducialMinZ));
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "FiducialCutMaxZ", m_fiducialMaxZ));
         }
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ApplyReconstructabilityChecks", m_applyReconstructabilityChecks));
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+            XmlHelper::ReadValue(xmlHandle, "ApplyReconstructabilityChecks", m_applyReconstructabilityChecks));
     }
     else
     {
@@ -359,7 +374,8 @@ StatusCode MvaPfoCharacterisationAlgorithm<T>::ReadSettings(const TiXmlHandle xm
         {
             if (m_mvaFileNameNoChargeInfo.empty() || m_mvaNameNoChargeInfo.empty())
             {
-                std::cout << "MvaPfoCharacterisationAlgorithm: MvaFileNameNoChargeInfo and MvaNameNoChargeInfo must be set if in classification mode for no charge info in 3D mode " << std::endl;
+                std::cout << "MvaPfoCharacterisationAlgorithm: MvaFileNameNoChargeInfo and MvaNameNoChargeInfo must be set if in classification mode for no charge info in 3D mode "
+                          << std::endl;
                 return STATUS_CODE_INVALID_PARAMETER;
             }
             const std::string fullMvaFileNameNoChargeInfo(LArFileHelper::FindFileInPath(m_mvaFileNameNoChargeInfo, m_filePathEnvironmentVariable));
@@ -373,7 +389,8 @@ StatusCode MvaPfoCharacterisationAlgorithm<T>::ReadSettings(const TiXmlHandle xm
     if (m_useThreeDInformation)
     {
         AlgorithmToolVector algorithmToolVectorNoChargeInfo;
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "FeatureToolsNoChargeInfo", algorithmToolVectorNoChargeInfo));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+            XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "FeatureToolsNoChargeInfo", algorithmToolVectorNoChargeInfo));
 
         for (AlgorithmTool *const pAlgorithmTool : algorithmToolVector)
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, LArMvaHelper::AddFeatureToolToVector(pAlgorithmTool, m_featureToolVectorThreeD));

--- a/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.h
@@ -22,7 +22,7 @@ namespace lar_content
 /**
  *  @brief  MvaPfoCharacterisationAlgorithm class
  */
-template<typename T>
+template <typename T>
 class MvaPfoCharacterisationAlgorithm : public PfoCharacterisationBaseAlgorithm
 {
 public:
@@ -36,39 +36,39 @@ protected:
     virtual bool IsClearTrack(const pandora::Cluster *const pCluster) const;
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    ClusterCharacterisationFeatureTool::FeatureToolVector   m_featureToolVector;                ///< The feature tool map
-    PfoCharacterisationFeatureTool::FeatureToolVector       m_featureToolVectorThreeD;          ///< The feature tool map for 3D info
-    PfoCharacterisationFeatureTool::FeatureToolVector       m_featureToolVectorNoChargeInfo;    ///< The feature tool map for missing W view
+    ClusterCharacterisationFeatureTool::FeatureToolVector m_featureToolVector;         ///< The feature tool map
+    PfoCharacterisationFeatureTool::FeatureToolVector m_featureToolVectorThreeD;       ///< The feature tool map for 3D info
+    PfoCharacterisationFeatureTool::FeatureToolVector m_featureToolVectorNoChargeInfo; ///< The feature tool map for missing W view
 
-    T                       m_mva;                          ///< The mva
-    T                       m_mvaNoChargeInfo;              ///< The mva for missing W view
+    T m_mva;             ///< The mva
+    T m_mvaNoChargeInfo; ///< The mva for missing W view
 
-    bool                    m_trainingSetMode;              ///< Whether to train
-    bool                    m_testBeamMode;                 ///< Whether the training set is from a test beam experiment
-    bool                    m_enableProbability;            ///< Whether to use probabilities instead of binary classification
-    bool                    m_useThreeDInformation;         ///< Whether to use 3D information
-    float                   m_minProbabilityCut;            ///< The minimum probability to label a cluster as track-like
-    unsigned int            m_minCaloHitsCut;               ///< The minimum number of calo hits to qualify as a track
-    bool                    m_applyFiducialCut;             ///< Whether to apply a fiducial volume cut during training
-    float                   m_fiducialMinX;                 ///< Fiducial volume minimum x
-    float                   m_fiducialMaxX;                 ///< Fiducial volume maximum x
-    float                   m_fiducialMinY;                 ///< Fiducial volume minimum y
-    float                   m_fiducialMaxY;                 ///< Fiducial volume maximum y
-    float                   m_fiducialMinZ;                 ///< Fiducial volume minimum z
-    float                   m_fiducialMaxZ;                 ///< Fiducial volume maximum z
-    bool                    m_applyReconstructabilityChecks;///< Whether to apply reconstructability checks during training
+    bool m_trainingSetMode;               ///< Whether to train
+    bool m_testBeamMode;                  ///< Whether the training set is from a test beam experiment
+    bool m_enableProbability;             ///< Whether to use probabilities instead of binary classification
+    bool m_useThreeDInformation;          ///< Whether to use 3D information
+    float m_minProbabilityCut;            ///< The minimum probability to label a cluster as track-like
+    unsigned int m_minCaloHitsCut;        ///< The minimum number of calo hits to qualify as a track
+    bool m_applyFiducialCut;              ///< Whether to apply a fiducial volume cut during training
+    float m_fiducialMinX;                 ///< Fiducial volume minimum x
+    float m_fiducialMaxX;                 ///< Fiducial volume maximum x
+    float m_fiducialMinY;                 ///< Fiducial volume minimum y
+    float m_fiducialMaxY;                 ///< Fiducial volume maximum y
+    float m_fiducialMinZ;                 ///< Fiducial volume minimum z
+    float m_fiducialMaxZ;                 ///< Fiducial volume maximum z
+    bool m_applyReconstructabilityChecks; ///< Whether to apply reconstructability checks during training
 
-    std::string             m_caloHitListName;              ///< Name of input calo hit list
-    std::string             m_mcParticleListName;           ///< Name of input MC particle list
+    std::string m_caloHitListName;    ///< Name of input calo hit list
+    std::string m_mcParticleListName; ///< Name of input MC particle list
 
-    std::string             m_trainingOutputFile;           ///< The training output file
-    std::string             m_filePathEnvironmentVariable;  ///< The environment variable providing a list of paths to mva files
-    std::string             m_mvaFileName;                  ///< The mva input file
-    std::string             m_mvaName;                      ///< The name of the mva to find
-    std::string             m_mvaFileNameNoChargeInfo;      ///< The mva input file for PFOs missing the W view, and thus charge info
-    std::string             m_mvaNameNoChargeInfo;          ///< The name of the mva to find for PFOs missing the W view, and thus charge info
+    std::string m_trainingOutputFile;          ///< The training output file
+    std::string m_filePathEnvironmentVariable; ///< The environment variable providing a list of paths to mva files
+    std::string m_mvaFileName;                 ///< The mva input file
+    std::string m_mvaName;                     ///< The name of the mva to find
+    std::string m_mvaFileNameNoChargeInfo;     ///< The mva input file for PFOs missing the W view, and thus charge info
+    std::string m_mvaNameNoChargeInfo;         ///< The name of the mva to find for PFOs missing the W view, and thus charge info
 
-    LArMCParticleHelper::PrimaryParameters  m_primaryParameters;    ///< The mc particle primary selection parameters
+    LArMCParticleHelper::PrimaryParameters m_primaryParameters; ///< The mc particle primary selection parameters
 
 private:
     /**

--- a/larpandoracontent/LArTrackShowerId/PfoCharacterisationBaseAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/PfoCharacterisationBaseAlgorithm.cc
@@ -140,14 +140,14 @@ StatusCode PfoCharacterisationBaseAlgorithm::ReadSettings(const TiXmlHandle xmlH
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ShowerPfoListName", m_showerPfoListName));
     m_inputPfoListNames.push_back(m_showerPfoListName);
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UpdateClusterIds", m_updateClusterIds));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UpdateClusterIds", m_updateClusterIds));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinTrackLikeViews", m_minTrackLikeViews));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinTrackLikeViews", m_minTrackLikeViews));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseThreeDInformation", m_useThreeDInformation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseThreeDInformation", m_useThreeDInformation));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTrackShowerId/PfoCharacterisationBaseAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/PfoCharacterisationBaseAlgorithm.h
@@ -61,14 +61,14 @@ protected:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string             m_trackPfoListName;             ///< The track pfo list name
-    std::string             m_showerPfoListName;            ///< The shower pfo list name
-    pandora::StringVector   m_inputPfoListNames;            ///< The names of the input pfo lists
+    std::string m_trackPfoListName;            ///< The track pfo list name
+    std::string m_showerPfoListName;           ///< The shower pfo list name
+    pandora::StringVector m_inputPfoListNames; ///< The names of the input pfo lists
 
-    bool                    m_updateClusterIds;             ///< Whether to update daughter cluster particle id labels to match pfo id
-    bool                    m_postBranchAddition;           ///< Whether to use configuration for shower clusters post branch addition
-    bool                    m_useThreeDInformation;         ///< Whether to use PFO and 3D information or clusters for characterisation
-    unsigned int            m_minTrackLikeViews;            ///< The minimum number of track-like views to declare a pfo as track-like
+    bool m_updateClusterIds;          ///< Whether to update daughter cluster particle id labels to match pfo id
+    bool m_postBranchAddition;        ///< Whether to use configuration for shower clusters post branch addition
+    bool m_useThreeDInformation;      ///< Whether to use PFO and 3D information or clusters for characterisation
+    unsigned int m_minTrackLikeViews; ///< The minimum number of track-like views to declare a pfo as track-like
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.cc
@@ -40,9 +40,11 @@ ShowerGrowingAlgorithm::ShowerGrowingAlgorithm() :
 bool ShowerGrowingAlgorithm::IsVertexAssociated(const LArPointingCluster &pointingCluster, const CartesianVector &vertexPosition2D) const
 {
     return (LArPointingClusterHelper::IsNode(vertexPosition2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsNode(vertexPosition2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-        LArPointingClusterHelper::IsEmission(vertexPosition2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-        LArPointingClusterHelper::IsEmission(vertexPosition2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
+            LArPointingClusterHelper::IsNode(vertexPosition2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+            LArPointingClusterHelper::IsEmission(vertexPosition2D, pointingCluster.GetInnerVertex(), m_minVertexLongitudinalDistance,
+                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+            LArPointingClusterHelper::IsEmission(vertexPosition2D, pointingCluster.GetOuterVertex(), m_minVertexLongitudinalDistance,
+                m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -69,7 +71,8 @@ StatusCode ShowerGrowingAlgorithm::Run()
         try
         {
             const ClusterList *pClusterList = nullptr;
-            PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
+            PANDORA_RETURN_RESULT_IF_AND_IF(
+                STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
 
             if (!pClusterList || pClusterList->empty())
             {
@@ -98,7 +101,8 @@ void ShowerGrowingAlgorithm::SimpleModeShowerGrowing(const ClusterList *const pC
 {
     const VertexList *pVertexList(nullptr);
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pVertexList));
-    const Vertex *const pVertex(((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
+    const Vertex *const pVertex(
+        ((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
 
     ClusterSet usedClusters;
 
@@ -126,8 +130,7 @@ void ShowerGrowingAlgorithm::SimpleModeShowerGrowing(const ClusterList *const pC
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool ShowerGrowingAlgorithm::GetNextSeedCandidate(const ClusterList *const pClusterList, const ClusterSet &usedClusters,
-    const Cluster *&pSeedCluster) const
+bool ShowerGrowingAlgorithm::GetNextSeedCandidate(const ClusterList *const pClusterList, const ClusterSet &usedClusters, const Cluster *&pSeedCluster) const
 {
     pSeedCluster = nullptr;
 
@@ -158,8 +161,7 @@ bool ShowerGrowingAlgorithm::GetNextSeedCandidate(const ClusterList *const pClus
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ShowerGrowingAlgorithm::GetAllVertexSeedCandidates(const ClusterList *const pClusterList, const Vertex *const pVertex,
-    ClusterVector &seedClusters) const
+void ShowerGrowingAlgorithm::GetAllVertexSeedCandidates(const ClusterList *const pClusterList, const Vertex *const pVertex, ClusterVector &seedClusters) const
 {
     ClusterVector clusterVector;
     clusterVector.insert(clusterVector.end(), pClusterList->begin(), pClusterList->end());
@@ -196,8 +198,8 @@ void ShowerGrowingAlgorithm::GetAllVertexSeedCandidates(const ClusterList *const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ShowerGrowingAlgorithm::GetSeedAssociationList(const ClusterVector &particleSeedVector, const ClusterList *const pClusterList,
-    SeedAssociationList &seedAssociationList) const
+void ShowerGrowingAlgorithm::GetSeedAssociationList(
+    const ClusterVector &particleSeedVector, const ClusterList *const pClusterList, SeedAssociationList &seedAssociationList) const
 {
     if (particleSeedVector.empty())
         return;
@@ -233,11 +235,12 @@ void ShowerGrowingAlgorithm::GetSeedAssociationList(const ClusterVector &particl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ShowerGrowingAlgorithm::ProcessSeedAssociationDetails(const SeedAssociationList &seedAssociationList, const std::string &clusterListName,
-    ClusterSet &usedClusters) const
+void ShowerGrowingAlgorithm::ProcessSeedAssociationDetails(
+    const SeedAssociationList &seedAssociationList, const std::string &clusterListName, ClusterSet &usedClusters) const
 {
     ClusterList clusterList;
-    for (const auto &mapEntry : seedAssociationList) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : seedAssociationList)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : clusterList)
@@ -260,7 +263,8 @@ void ShowerGrowingAlgorithm::ProcessBranchClusters(const Cluster *const pParentC
     {
         if (pBranchCluster->IsAvailable())
         {
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pBranchCluster, listName, listName));
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pBranchCluster, listName, listName));
         }
 
         m_clusterDirectionMap.erase(pBranchCluster);
@@ -273,15 +277,17 @@ ShowerGrowingAlgorithm::AssociationType ShowerGrowingAlgorithm::AreClustersAssoc
 {
     const VertexList *pVertexList(nullptr);
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pVertexList));
-    const Vertex *const pVertex(((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
+    const Vertex *const pVertex(
+        ((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
 
     // Direction of seed cluster (cache for efficiency)
     ClusterDirectionMap::const_iterator seedIter = m_clusterDirectionMap.find(pClusterSeed);
 
     if (m_clusterDirectionMap.end() == seedIter)
     {
-        const LArVertexHelper::ClusterDirection direction((nullptr == pVertex) ? LArVertexHelper::DIRECTION_UNKNOWN :
-            LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex, pClusterSeed, m_directionTanAngle, m_directionApexShift));
+        const LArVertexHelper::ClusterDirection direction((nullptr == pVertex) ? LArVertexHelper::DIRECTION_UNKNOWN
+                                                                               : LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex,
+                                                                                     pClusterSeed, m_directionTanAngle, m_directionApexShift));
         seedIter = m_clusterDirectionMap.insert(ClusterDirectionMap::value_type(pClusterSeed, direction)).first;
     }
 
@@ -294,8 +300,9 @@ ShowerGrowingAlgorithm::AssociationType ShowerGrowingAlgorithm::AreClustersAssoc
 
     if (m_clusterDirectionMap.end() == candIter)
     {
-        const LArVertexHelper::ClusterDirection direction((nullptr == pVertex) ? LArVertexHelper::DIRECTION_UNKNOWN :
-            LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex, pCluster, m_directionTanAngle, m_directionApexShift));
+        const LArVertexHelper::ClusterDirection direction((nullptr == pVertex) ? LArVertexHelper::DIRECTION_UNKNOWN
+                                                                               : LArVertexHelper::GetClusterDirectionInZ(this->GetPandora(), pVertex,
+                                                                                     pCluster, m_directionTanAngle, m_directionApexShift));
         candIter = m_clusterDirectionMap.insert(ClusterDirectionMap::value_type(pCluster, direction)).first;
     }
 
@@ -311,8 +318,7 @@ ShowerGrowingAlgorithm::AssociationType ShowerGrowingAlgorithm::AreClustersAssoc
 
     // Association check 1(a), look for enclosed clusters
     if ((cOuter < m_nearbyClusterDistance && cInner < m_nearbyClusterDistance) &&
-        (!checkSeedForward || (sInner > m_nearbyClusterDistance)) &&
-        (!checkSeedBackward || (sOuter > m_nearbyClusterDistance)))
+        (!checkSeedForward || (sInner > m_nearbyClusterDistance)) && (!checkSeedBackward || (sOuter > m_nearbyClusterDistance)))
     {
         return STRONG;
     }
@@ -321,23 +327,20 @@ ShowerGrowingAlgorithm::AssociationType ShowerGrowingAlgorithm::AreClustersAssoc
     if ((checkSeedForward == checkCandidateForward) && (checkSeedBackward == checkCandidateBackward))
     {
         if ((cInner < m_nearbyClusterDistance && sOuter < m_nearbyClusterDistance) &&
-            (!checkSeedForward || (sInner > m_nearbyClusterDistance)) &&
-            (!checkSeedBackward || (cOuter > m_nearbyClusterDistance)))
+            (!checkSeedForward || (sInner > m_nearbyClusterDistance)) && (!checkSeedBackward || (cOuter > m_nearbyClusterDistance)))
         {
             return STRONG;
         }
 
         if ((cOuter < m_nearbyClusterDistance && sInner < m_nearbyClusterDistance) &&
-            (!checkSeedBackward || (sOuter > m_nearbyClusterDistance)) &&
-            (!checkSeedForward || (cInner > m_nearbyClusterDistance)))
+            (!checkSeedBackward || (sOuter > m_nearbyClusterDistance)) && (!checkSeedForward || (cInner > m_nearbyClusterDistance)))
         {
             return STRONG;
         }
     }
 
     // Association check 2, look for branching clusters
-    if ((!checkSeedForward || (sInner > m_remoteClusterDistance)) &&
-        (!checkSeedBackward || (sOuter > m_remoteClusterDistance)) &&
+    if ((!checkSeedForward || (sInner > m_remoteClusterDistance)) && (!checkSeedBackward || (sOuter > m_remoteClusterDistance)) &&
         ((checkCandidateForward && (cInner < m_nearbyClusterDistance)) || (checkCandidateBackward && (cOuter < m_nearbyClusterDistance))))
     {
         return STANDARD;
@@ -356,7 +359,8 @@ float ShowerGrowingAlgorithm::GetFigureOfMerit(const SeedAssociationList &seedAs
 {
     const VertexList *pVertexList(nullptr);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pVertexList));
-    const Vertex *const pVertex(((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
+    const Vertex *const pVertex(
+        ((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
 
     // ATTN Consistently returning same value will accept all candidate cluster merges
     if (!pVertex)
@@ -365,7 +369,8 @@ float ShowerGrowingAlgorithm::GetFigureOfMerit(const SeedAssociationList &seedAs
     unsigned int nVertexAssociatedSeeds(0), nVertexAssociatedNonSeeds(0);
 
     ClusterList clusterList;
-    for (const auto &mapEntry : seedAssociationList) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : seedAssociationList)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pSeedCluster : clusterList)
@@ -375,12 +380,24 @@ float ShowerGrowingAlgorithm::GetFigureOfMerit(const SeedAssociationList &seedAs
         const CartesianVector vertex2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
 
         LArPointingClusterList pointingClusterSeedList;
-        try {pointingClusterSeedList.push_back(LArPointingCluster(pSeedCluster));} catch (StatusCodeException &) {}
+        try
+        {
+            pointingClusterSeedList.push_back(LArPointingCluster(pSeedCluster));
+        }
+        catch (StatusCodeException &)
+        {
+        }
 
         LArPointingClusterList pointingClusterNonSeedList;
         for (const Cluster *const pAssociatedCluster : associatedClusters)
         {
-            try {pointingClusterNonSeedList.push_back(LArPointingCluster(pAssociatedCluster));} catch (StatusCodeException &) {}
+            try
+            {
+                pointingClusterNonSeedList.push_back(LArPointingCluster(pAssociatedCluster));
+            }
+            catch (StatusCodeException &)
+            {
+            }
         }
 
         nVertexAssociatedSeeds += this->GetNVertexConnections(vertex2D, pointingClusterSeedList);
@@ -412,32 +429,32 @@ StatusCode ShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NearbyClusterDistance", m_nearbyClusterDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NearbyClusterDistance", m_nearbyClusterDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "RemoteClusterDistance", m_remoteClusterDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "RemoteClusterDistance", m_remoteClusterDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DirectionTanAngle", m_directionTanAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DirectionTanAngle", m_directionTanAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DirectionApexShift", m_directionApexShift));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DirectionApexShift", m_directionApexShift));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexLongitudinalDistance", m_minVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexLongitudinalDistance", m_maxVertexLongitudinalDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxVertexTransverseDistance", m_maxVertexTransverseDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexAngularAllowance", m_vertexAngularAllowance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexAngularAllowance", m_vertexAngularAllowance));
 
     return BranchGrowingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.h
@@ -51,8 +51,8 @@ protected:
      */
     static bool SortClusters(const pandora::Cluster *const pLhs, const pandora::Cluster *const pRhs);
 
-    typedef std::unordered_map<const pandora::Cluster*, LArVertexHelper::ClusterDirection> ClusterDirectionMap;
-    mutable ClusterDirectionMap m_clusterDirectionMap;          ///< The cluster direction map
+    typedef std::unordered_map<const pandora::Cluster *, LArVertexHelper::ClusterDirection> ClusterDirectionMap;
+    mutable ClusterDirectionMap m_clusterDirectionMap; ///< The cluster direction map
 
 private:
     pandora::StatusCode Run();
@@ -84,8 +84,8 @@ private:
      *  @param  pVertex the address of the vertex
      *  @param  seedClusters to receive the list of vertex seed candidates
      */
-    void GetAllVertexSeedCandidates(const pandora::ClusterList *const pClusterList, const pandora::Vertex *const pVertex,
-        pandora::ClusterVector &seedClusters) const;
+    void GetAllVertexSeedCandidates(
+        const pandora::ClusterList *const pClusterList, const pandora::Vertex *const pVertex, pandora::ClusterVector &seedClusters) const;
 
     /**
      *  @brief  Get the seed association list for a given vector of particle seed candidates
@@ -105,8 +105,8 @@ private:
      *  @param  pfoList the pfo list
      *  @param  usedClusters the list of candidates already considered
      */
-    void ProcessSeedAssociationDetails(const SeedAssociationList &seedAssociationList, const std::string &clusterListName,
-        pandora::ClusterSet &usedClusters) const;
+    void ProcessSeedAssociationDetails(
+        const SeedAssociationList &seedAssociationList, const std::string &clusterListName, pandora::ClusterSet &usedClusters) const;
 
     /**
      *  @brief  Process the list of branch clusters, merging with specified parent cluster, dealing with any existing pfos as required
@@ -116,8 +116,8 @@ private:
      *  @param  listName the cluster list name
      *  @param  pfoList the input pfo list
      */
-    void ProcessBranchClusters(const pandora::Cluster *const pParentCluster, const pandora::ClusterVector &branchClusters,
-        const std::string &listName) const;
+    void ProcessBranchClusters(
+        const pandora::Cluster *const pParentCluster, const pandora::ClusterVector &branchClusters, const std::string &listName) const;
 
     AssociationType AreClustersAssociated(const pandora::Cluster *const pClusterSeed, const pandora::Cluster *const pCluster) const;
 
@@ -142,19 +142,19 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector       m_inputClusterListNames;        ///< The names of the input cluster lists
+    pandora::StringVector m_inputClusterListNames; ///< The names of the input cluster lists
 
-    unsigned int                m_minCaloHitsPerCluster;        ///< The minimum number of calo hits per (seed or branch) cluster
-    float                       m_nearbyClusterDistance;        ///< The nearby cluster distance, used for determining cluster associations
-    float                       m_remoteClusterDistance;        ///< The remote cluster distance, used for determining cluster associations
+    unsigned int m_minCaloHitsPerCluster; ///< The minimum number of calo hits per (seed or branch) cluster
+    float m_nearbyClusterDistance;        ///< The nearby cluster distance, used for determining cluster associations
+    float m_remoteClusterDistance;        ///< The remote cluster distance, used for determining cluster associations
 
-    float                       m_directionTanAngle;            ///< Direction determination, look for vertex inside triangle with apex shifted along the cluster length
-    float                       m_directionApexShift;           ///< Direction determination, look for vertex inside triangle with apex shifted along the cluster length
+    float m_directionTanAngle;  ///< Direction determination, look for vertex inside triangle with apex shifted along the cluster length
+    float m_directionApexShift; ///< Direction determination, look for vertex inside triangle with apex shifted along the cluster length
 
-    float                       m_minVertexLongitudinalDistance;///< Vertex association check: min longitudinal distance cut
-    float                       m_maxVertexLongitudinalDistance;///< Vertex association check: max longitudinal distance cut
-    float                       m_maxVertexTransverseDistance;  ///< Vertex association check: max transverse distance cut
-    float                       m_vertexAngularAllowance;       ///< Vertex association check: pointing angular allowance in degrees
+    float m_minVertexLongitudinalDistance; ///< Vertex association check: min longitudinal distance cut
+    float m_maxVertexLongitudinalDistance; ///< Vertex association check: max longitudinal distance cut
+    float m_maxVertexTransverseDistance;   ///< Vertex association check: max transverse distance cut
+    float m_vertexAngularAllowance;        ///< Vertex association check: pointing angular allowance in degrees
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
@@ -23,16 +23,13 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoDShowerFitFeatureTool::TwoDShowerFitFeatureTool() :
-    m_slidingShowerFitWindow(3),
-    m_slidingLinearFitWindow(10000)
+TwoDShowerFitFeatureTool::TwoDShowerFitFeatureTool() : m_slidingShowerFitWindow(3), m_slidingLinearFitWindow(10000)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDShowerFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm,
-    const pandora::Cluster *const pCluster)
+void TwoDShowerFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -41,9 +38,10 @@ void TwoDShowerFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector
     try
     {
         const TwoDSlidingFitResult slidingFitResultLarge(pCluster, m_slidingLinearFitWindow, LArGeometryHelper::GetWireZPitch(this->GetPandora()));
-        const float straightLineLength = (slidingFitResultLarge.GetGlobalMaxLayerPosition() - slidingFitResultLarge.GetGlobalMinLayerPosition()).GetMagnitude();
+        const float straightLineLength =
+            (slidingFitResultLarge.GetGlobalMaxLayerPosition() - slidingFitResultLarge.GetGlobalMinLayerPosition()).GetMagnitude();
         if (straightLineLength > std::numeric_limits<float>::epsilon())
-            ratio = (CutClusterCharacterisationAlgorithm::GetShowerFitWidth(pAlgorithm, pCluster, m_slidingShowerFitWindow))/straightLineLength;
+            ratio = (CutClusterCharacterisationAlgorithm::GetShowerFitWidth(pAlgorithm, pCluster, m_slidingShowerFitWindow)) / straightLineLength;
     }
     catch (const StatusCodeException &)
     {
@@ -56,11 +54,11 @@ void TwoDShowerFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector
 
 StatusCode TwoDShowerFitFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingShowerFitWindow", m_slidingShowerFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingShowerFitWindow", m_slidingShowerFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingLinearFitWindow", m_slidingLinearFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingLinearFitWindow", m_slidingLinearFitWindow));
 
     return STATUS_CODE_SUCCESS;
 }
@@ -68,30 +66,29 @@ StatusCode TwoDShowerFitFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TwoDLinearFitFeatureTool::TwoDLinearFitFeatureTool() :
-    m_slidingLinearFitWindow(3),
-    m_slidingLinearFitWindowLarge(10000)
+TwoDLinearFitFeatureTool::TwoDLinearFitFeatureTool() : m_slidingLinearFitWindow(3), m_slidingLinearFitWindowLarge(10000)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDLinearFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm,
-const pandora::Cluster * const pCluster)
+void TwoDLinearFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    float dTdLWidth(-1.f), straightLineLengthLarge(-1.f), diffWithStraightLineMean(-1.f), diffWithStraightLineSigma(-1.f), maxFitGapLength(-1.f), rmsSlidingLinearFit(-1.f);
-    this->CalculateVariablesSlidingLinearFit(pCluster, straightLineLengthLarge, diffWithStraightLineMean, diffWithStraightLineSigma, dTdLWidth, maxFitGapLength, rmsSlidingLinearFit);
+    float dTdLWidth(-1.f), straightLineLengthLarge(-1.f), diffWithStraightLineMean(-1.f), diffWithStraightLineSigma(-1.f),
+        maxFitGapLength(-1.f), rmsSlidingLinearFit(-1.f);
+    this->CalculateVariablesSlidingLinearFit(pCluster, straightLineLengthLarge, diffWithStraightLineMean, diffWithStraightLineSigma,
+        dTdLWidth, maxFitGapLength, rmsSlidingLinearFit);
 
     if (straightLineLengthLarge > std::numeric_limits<float>::epsilon())
     {
-        diffWithStraightLineMean  /= straightLineLengthLarge;
+        diffWithStraightLineMean /= straightLineLengthLarge;
         diffWithStraightLineSigma /= straightLineLengthLarge;
-        dTdLWidth                 /= straightLineLengthLarge;
-        maxFitGapLength           /= straightLineLengthLarge;
-        rmsSlidingLinearFit       /= straightLineLengthLarge;
+        dTdLWidth /= straightLineLengthLarge;
+        maxFitGapLength /= straightLineLengthLarge;
+        rmsSlidingLinearFit /= straightLineLengthLarge;
     }
 
     featureVector.push_back(straightLineLengthLarge);
@@ -110,12 +107,14 @@ void TwoDLinearFitFeatureTool::CalculateVariablesSlidingLinearFit(const pandora:
     try
     {
         const TwoDSlidingFitResult slidingFitResult(pCluster, m_slidingLinearFitWindow, LArGeometryHelper::GetWireZPitch(this->GetPandora()));
-        const TwoDSlidingFitResult slidingFitResultLarge(pCluster, m_slidingLinearFitWindowLarge, LArGeometryHelper::GetWireZPitch(this->GetPandora()));
+        const TwoDSlidingFitResult slidingFitResultLarge(
+            pCluster, m_slidingLinearFitWindowLarge, LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
         if (slidingFitResult.GetLayerFitResultMap().empty())
             throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
 
-        straightLineLengthLarge = (slidingFitResultLarge.GetGlobalMaxLayerPosition() - slidingFitResultLarge.GetGlobalMinLayerPosition()).GetMagnitude();
+        straightLineLengthLarge =
+            (slidingFitResultLarge.GetGlobalMaxLayerPosition() - slidingFitResultLarge.GetGlobalMinLayerPosition()).GetMagnitude();
         rmsSlidingLinearFit = 0.f;
 
         FloatVector diffWithStraightLineVector;
@@ -131,7 +130,8 @@ void TwoDLinearFitFeatureTool::CalculateVariablesSlidingLinearFit(const pandora:
             CartesianVector thisFitPosition(0.f, 0.f, 0.f);
             slidingFitResult.GetGlobalPosition(layerFitResult.GetL(), layerFitResult.GetFitT(), thisFitPosition);
 
-            LayerFitResultMap::const_iterator iterLarge = slidingFitResultLarge.GetLayerFitResultMap().find(slidingFitResultLarge.GetLayer(layerFitResult.GetL()));
+            LayerFitResultMap::const_iterator iterLarge =
+                slidingFitResultLarge.GetLayerFitResultMap().find(slidingFitResultLarge.GetLayer(layerFitResult.GetL()));
 
             if (slidingFitResultLarge.GetLayerFitResultMap().end() == iterLarge)
                 throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -191,11 +191,11 @@ void TwoDLinearFitFeatureTool::CalculateVariablesSlidingLinearFit(const pandora:
 
 StatusCode TwoDLinearFitFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingLinearFitWindow", m_slidingLinearFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingLinearFitWindow", m_slidingLinearFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingLinearFitWindowLarge", m_slidingLinearFitWindowLarge));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "SlidingLinearFitWindowLarge", m_slidingLinearFitWindowLarge));
 
     return STATUS_CODE_SUCCESS;
 }
@@ -203,15 +203,14 @@ StatusCode TwoDLinearFitFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-TwoDVertexDistanceFeatureTool::TwoDVertexDistanceFeatureTool() :
-    m_slidingLinearFitWindow(10000)
+TwoDVertexDistanceFeatureTool::TwoDVertexDistanceFeatureTool() : m_slidingLinearFitWindow(10000)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDVertexDistanceFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm,
-    const pandora::Cluster *const pCluster)
+void TwoDVertexDistanceFeatureTool::Run(
+    LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -222,7 +221,7 @@ void TwoDVertexDistanceFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureV
         const TwoDSlidingFitResult slidingFitResultLarge(pCluster, m_slidingLinearFitWindow, LArGeometryHelper::GetWireZPitch(this->GetPandora()));
         straightLineLength = (slidingFitResultLarge.GetGlobalMaxLayerPosition() - slidingFitResultLarge.GetGlobalMinLayerPosition()).GetMagnitude();
         if (straightLineLength > std::numeric_limits<float>::epsilon())
-            ratio = (CutClusterCharacterisationAlgorithm::GetVertexDistance(pAlgorithm, pCluster))/straightLineLength;
+            ratio = (CutClusterCharacterisationAlgorithm::GetVertexDistance(pAlgorithm, pCluster)) / straightLineLength;
     }
     catch (const StatusCodeException &)
     {
@@ -235,8 +234,8 @@ void TwoDVertexDistanceFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureV
 
 StatusCode TwoDVertexDistanceFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingLinearFitWindow", m_slidingLinearFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingLinearFitWindow", m_slidingLinearFitWindow));
 
     return STATUS_CODE_SUCCESS;
 }
@@ -250,7 +249,8 @@ PfoHierarchyFeatureTool::PfoHierarchyFeatureTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void PfoHierarchyFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo)
+void PfoHierarchyFeatureTool::Run(
+    LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -270,7 +270,7 @@ void PfoHierarchyFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector,
         // ATTN This relies on knowing that the first pfo in allDaughtersPfoList is the input pfo
         allDaughtersPfoList.pop_front();
 
-        for(const ParticleFlowObject *const pDaughterPfo : allDaughtersPfoList)
+        for (const ParticleFlowObject *const pDaughterPfo : allDaughtersPfoList)
         {
             CaloHitList daughter3DHitList;
             LArPfoHelper::GetCaloHits(pDaughterPfo, TPC_3D, daughter3DHitList);
@@ -280,7 +280,8 @@ void PfoHierarchyFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector,
 
     const LArMvaHelper::MvaFeature nDaughters(static_cast<double>(nDaughterPfos));
     const LArMvaHelper::MvaFeature nDaughterHits3D(static_cast<double>(nDaughterHits3DTotal));
-    const LArMvaHelper::MvaFeature daughterParentNHitsRatio((nParentHits3D > 0) ? static_cast<double>(nDaughterHits3DTotal) / static_cast<double>(nParentHits3D) : 0.);
+    const LArMvaHelper::MvaFeature daughterParentNHitsRatio(
+        (nParentHits3D > 0) ? static_cast<double>(nDaughterHits3DTotal) / static_cast<double>(nParentHits3D) : 0.);
 
     featureVector.push_back(nDaughters);
     featureVector.push_back(nDaughterHits3D);
@@ -297,16 +298,14 @@ StatusCode PfoHierarchyFeatureTool::ReadSettings(const TiXmlHandle /*xmlHandle*/
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDLinearFitFeatureTool::ThreeDLinearFitFeatureTool() :
-    m_slidingLinearFitWindow(3),
-    m_slidingLinearFitWindowLarge(10000)
+ThreeDLinearFitFeatureTool::ThreeDLinearFitFeatureTool() : m_slidingLinearFitWindow(3), m_slidingLinearFitWindowLarge(10000)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDLinearFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm,
-    const pandora::ParticleFlowObject *const pInputPfo)
+void ThreeDLinearFitFeatureTool::Run(
+    LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -319,19 +318,21 @@ void ThreeDLinearFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVect
 
     for (const Cluster *const pCluster : clusterList)
     {
-        float straightLineLengthLargeCluster(-1.f), diffWithStraightLineMeanCluster(-1.f), maxFitGapLengthCluster(-1.f), rmsSlidingLinearFitCluster(-1.f);
+        float straightLineLengthLargeCluster(-1.f), diffWithStraightLineMeanCluster(-1.f), maxFitGapLengthCluster(-1.f),
+            rmsSlidingLinearFitCluster(-1.f);
 
-        this->CalculateVariablesSlidingLinearFit(pCluster, straightLineLengthLargeCluster, diffWithStraightLineMeanCluster, maxFitGapLengthCluster, rmsSlidingLinearFitCluster);
+        this->CalculateVariablesSlidingLinearFit(
+            pCluster, straightLineLengthLargeCluster, diffWithStraightLineMeanCluster, maxFitGapLengthCluster, rmsSlidingLinearFitCluster);
 
         if (straightLineLengthLargeCluster > std::numeric_limits<float>::epsilon())
         {
-            diffWithStraightLineMeanCluster  /= straightLineLengthLargeCluster;
-            maxFitGapLengthCluster           /= straightLineLengthLargeCluster;
-            rmsSlidingLinearFitCluster       /= straightLineLengthLargeCluster;
+            diffWithStraightLineMeanCluster /= straightLineLengthLargeCluster;
+            maxFitGapLengthCluster /= straightLineLengthLargeCluster;
+            rmsSlidingLinearFitCluster /= straightLineLengthLargeCluster;
 
-            diffWithStraightLineMean   += diffWithStraightLineMeanCluster;
-            maxFitGapLength            += maxFitGapLengthCluster;
-            rmsSlidingLinearFit        += rmsSlidingLinearFitCluster;
+            diffWithStraightLineMean += diffWithStraightLineMeanCluster;
+            maxFitGapLength += maxFitGapLengthCluster;
+            rmsSlidingLinearFit += rmsSlidingLinearFitCluster;
 
             ++nClustersUsed;
         }
@@ -341,9 +342,9 @@ void ThreeDLinearFitFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVect
     {
         const float nClusters(static_cast<float>(nClustersUsed));
         length = std::sqrt(LArPfoHelper::GetThreeDLengthSquared(pInputPfo));
-        diff   = diffWithStraightLineMean / nClusters;
-        gap    = maxFitGapLength          / nClusters;
-        rms    = rmsSlidingLinearFit      / nClusters;
+        diff = diffWithStraightLineMean / nClusters;
+        gap = maxFitGapLength / nClusters;
+        rms = rmsSlidingLinearFit / nClusters;
     }
 
     featureVector.push_back(length);
@@ -360,12 +361,14 @@ void ThreeDLinearFitFeatureTool::CalculateVariablesSlidingLinearFit(const pandor
     try
     {
         const TwoDSlidingFitResult slidingFitResult(pCluster, m_slidingLinearFitWindow, LArGeometryHelper::GetWireZPitch(this->GetPandora()));
-        const TwoDSlidingFitResult slidingFitResultLarge(pCluster, m_slidingLinearFitWindowLarge, LArGeometryHelper::GetWireZPitch(this->GetPandora()));
+        const TwoDSlidingFitResult slidingFitResultLarge(
+            pCluster, m_slidingLinearFitWindowLarge, LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
         if (slidingFitResult.GetLayerFitResultMap().empty())
             throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
 
-        straightLineLengthLarge = (slidingFitResultLarge.GetGlobalMaxLayerPosition() - slidingFitResultLarge.GetGlobalMinLayerPosition()).GetMagnitude();
+        straightLineLengthLarge =
+            (slidingFitResultLarge.GetGlobalMaxLayerPosition() - slidingFitResultLarge.GetGlobalMinLayerPosition()).GetMagnitude();
         rmsSlidingLinearFit = 0.f;
 
         FloatVector diffWithStraightLineVector;
@@ -381,7 +384,8 @@ void ThreeDLinearFitFeatureTool::CalculateVariablesSlidingLinearFit(const pandor
             CartesianVector thisFitPosition(0.f, 0.f, 0.f);
             slidingFitResult.GetGlobalPosition(layerFitResult.GetL(), layerFitResult.GetFitT(), thisFitPosition);
 
-            LayerFitResultMap::const_iterator iterLarge = slidingFitResultLarge.GetLayerFitResultMap().find(slidingFitResultLarge.GetLayer(layerFitResult.GetL()));
+            LayerFitResultMap::const_iterator iterLarge =
+                slidingFitResultLarge.GetLayerFitResultMap().find(slidingFitResultLarge.GetLayer(layerFitResult.GetL()));
 
             if (slidingFitResultLarge.GetLayerFitResultMap().end() == iterLarge)
                 throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -419,7 +423,6 @@ void ThreeDLinearFitFeatureTool::CalculateVariablesSlidingLinearFit(const pandor
             diffWithStraightLineMean += diffWithStraightLine;
 
         diffWithStraightLineMean /= static_cast<float>(diffWithStraightLineVector.size());
-
     }
     catch (const StatusCodeException &)
     {
@@ -434,11 +437,11 @@ void ThreeDLinearFitFeatureTool::CalculateVariablesSlidingLinearFit(const pandor
 
 StatusCode ThreeDLinearFitFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingLinearFitWindow", m_slidingLinearFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingLinearFitWindow", m_slidingLinearFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingLinearFitWindowLarge", m_slidingLinearFitWindowLarge));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "SlidingLinearFitWindowLarge", m_slidingLinearFitWindowLarge));
 
     return STATUS_CODE_SUCCESS;
 }
@@ -452,8 +455,8 @@ ThreeDVertexDistanceFeatureTool::ThreeDVertexDistanceFeatureTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDVertexDistanceFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm,
-    const pandora::ParticleFlowObject *const pInputPfo)
+void ThreeDVertexDistanceFeatureTool::Run(
+    LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -461,7 +464,7 @@ void ThreeDVertexDistanceFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featur
     LArMvaHelper::MvaFeature vertexDistance;
 
     const VertexList *pVertexList(nullptr);
-    (void) PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList);
+    (void)PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList);
 
     if (!pVertexList || pVertexList->empty())
     {
@@ -510,16 +513,14 @@ StatusCode ThreeDVertexDistanceFeatureTool::ReadSettings(const TiXmlHandle /*xml
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDOpeningAngleFeatureTool::ThreeDOpeningAngleFeatureTool() :
-    m_hitFraction(0.5f),
-    m_defaultValue(0.1f)
+ThreeDOpeningAngleFeatureTool::ThreeDOpeningAngleFeatureTool() : m_hitFraction(0.5f), m_defaultValue(0.1f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDOpeningAngleFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm,
-    const pandora::ParticleFlowObject *const pInputPfo)
+void ThreeDOpeningAngleFeatureTool::Run(
+    LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -549,9 +550,11 @@ void ThreeDOpeningAngleFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureV
 
                 const float openingAngle(this->OpeningAngle(eigenVecsStart.at(0), eigenVecsStart.at(1), eigenValuesStart));
                 const float closingAngle(this->OpeningAngle(eigenVecsEnd.at(0), eigenVecsEnd.at(1), eigenValuesEnd));
-                diffAngle = std::fabs(openingAngle-closingAngle);
+                diffAngle = std::fabs(openingAngle - closingAngle);
             }
-            catch (const StatusCodeException &){}
+            catch (const StatusCodeException &)
+            {
+            }
         }
         else
         {
@@ -568,7 +571,7 @@ void ThreeDOpeningAngleFeatureTool::Divide3DCaloHitList(const Algorithm *const p
     CartesianPointVector &pointVectorStart, CartesianPointVector &pointVectorEnd)
 {
     const VertexList *pVertexList(nullptr);
-    (void) PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList);
+    (void)PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList);
 
     if (threeDCaloHitList.empty() || !pVertexList || pVertexList->empty())
         return;
@@ -589,7 +592,8 @@ void ThreeDOpeningAngleFeatureTool::Divide3DCaloHitList(const Algorithm *const p
     {
         // Order by distance to vertex, so first ones are closer to nuvertex
         CaloHitVector threeDCaloHitVector(threeDCaloHitList.begin(), threeDCaloHitList.end());
-        std::sort(threeDCaloHitVector.begin(), threeDCaloHitVector.end(), ThreeDChargeFeatureTool::VertexComparator(pInteractionVertex->GetPosition()));
+        std::sort(threeDCaloHitVector.begin(), threeDCaloHitVector.end(),
+            ThreeDChargeFeatureTool::VertexComparator(pInteractionVertex->GetPosition()));
 
         unsigned int iHit(1);
         const unsigned int nHits(threeDCaloHitVector.size());
@@ -609,8 +613,7 @@ void ThreeDOpeningAngleFeatureTool::Divide3DCaloHitList(const Algorithm *const p
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ThreeDOpeningAngleFeatureTool::OpeningAngle(const CartesianVector &principal, const CartesianVector &secondary,
-    const CartesianVector &eigenValues) const
+float ThreeDOpeningAngleFeatureTool::OpeningAngle(const CartesianVector &principal, const CartesianVector &secondary, const CartesianVector &eigenValues) const
 {
     const float principalMagnitude(principal.GetMagnitude());
     const float secondaryMagnitude(secondary.GetMagnitude());
@@ -638,7 +641,7 @@ float ThreeDOpeningAngleFeatureTool::OpeningAngle(const CartesianVector &princip
     if (eigenValues.GetX() < std::numeric_limits<float>::epsilon())
     {
         std::cout << "PcaShowerParticleBuildingAlgorithm::OpeningAngle - principal eigenvalue less than or equal to 0." << std::endl;
-        throw StatusCodeException( STATUS_CODE_INVALID_PARAMETER );
+        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
     }
     else if (eigenValues.GetY() < std::numeric_limits<float>::epsilon())
     {
@@ -652,11 +655,9 @@ float ThreeDOpeningAngleFeatureTool::OpeningAngle(const CartesianVector &princip
 
 StatusCode ThreeDOpeningAngleFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HitFraction", m_hitFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitFraction", m_hitFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DefaultValue", m_defaultValue));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DefaultValue", m_defaultValue));
 
     return STATUS_CODE_SUCCESS;
 }
@@ -670,8 +671,8 @@ ThreeDPCAFeatureTool::ThreeDPCAFeatureTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDPCAFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm,
-    const pandora::ParticleFlowObject *const pInputPfo)
+void ThreeDPCAFeatureTool::Run(
+    LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -695,8 +696,8 @@ void ThreeDPCAFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, co
 
             if (principalEigenvalue > std::numeric_limits<float>::epsilon())
             {
-                pca1 = secondaryEigenvalue/principalEigenvalue;
-                pca2 = tertiaryEigenvalue/principalEigenvalue;
+                pca1 = secondaryEigenvalue / principalEigenvalue;
+                pca2 = tertiaryEigenvalue / principalEigenvalue;
             }
             else
             {
@@ -705,7 +706,9 @@ void ThreeDPCAFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, co
                 pca2 = 0.;
             }
         }
-        catch (const StatusCodeException &){}
+        catch (const StatusCodeException &)
+        {
+        }
     }
 
     featureVector.push_back(pca1);
@@ -722,15 +725,14 @@ StatusCode ThreeDPCAFeatureTool::ReadSettings(const TiXmlHandle /*xmlHandle*/)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDChargeFeatureTool::ThreeDChargeFeatureTool() :
-    m_endChargeFraction(0.1f)
+ThreeDChargeFeatureTool::ThreeDChargeFeatureTool() : m_endChargeFraction(0.1f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDChargeFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm,
-    const pandora::ParticleFlowObject *const pInputPfo)
+void ThreeDChargeFeatureTool::Run(
+    LArMvaHelper::MvaFeatureVector &featureVector, const Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
@@ -756,8 +758,8 @@ void ThreeDChargeFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector,
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDChargeFeatureTool::CalculateChargeVariables(const Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, float &totalCharge,
-    float &chargeSigma, float &chargeMean, float &endCharge)
+void ThreeDChargeFeatureTool::CalculateChargeVariables(const Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster,
+    float &totalCharge, float &chargeSigma, float &chargeMean, float &endCharge)
 {
     totalCharge = 0.f;
     chargeSigma = 0.f;
@@ -799,10 +801,11 @@ void ThreeDChargeFeatureTool::CalculateChargeVariables(const Algorithm *const pA
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ThreeDChargeFeatureTool::OrderCaloHitsByDistanceToVertex(const Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, CaloHitList &caloHitList)
+void ThreeDChargeFeatureTool::OrderCaloHitsByDistanceToVertex(
+    const Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, CaloHitList &caloHitList)
 {
     const VertexList *pVertexList(nullptr);
-    (void) PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList);
+    (void)PandoraContentApi::GetCurrentList(*pAlgorithm, pVertexList);
 
     if (!pVertexList || pVertexList->empty())
         return;
@@ -836,8 +839,8 @@ void ThreeDChargeFeatureTool::OrderCaloHitsByDistanceToVertex(const Algorithm *c
 
 StatusCode ThreeDChargeFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EndChargeFraction", m_endChargeFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EndChargeFraction", m_endChargeFraction));
 
     return STATUS_CODE_SUCCESS;
 }
@@ -845,8 +848,7 @@ StatusCode ThreeDChargeFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDChargeFeatureTool::VertexComparator::VertexComparator(const CartesianVector vertexPosition2D) :
-    m_neutrinoVertex(vertexPosition2D)
+ThreeDChargeFeatureTool::VertexComparator::VertexComparator(const CartesianVector vertexPosition2D) : m_neutrinoVertex(vertexPosition2D)
 {
 }
 
@@ -854,8 +856,8 @@ ThreeDChargeFeatureTool::VertexComparator::VertexComparator(const CartesianVecto
 
 bool ThreeDChargeFeatureTool::VertexComparator::operator()(const CaloHit *const left, const CaloHit *const right) const
 {
-    const float distanceL((left->GetPositionVector()-m_neutrinoVertex).GetMagnitudeSquared());
-    const float distanceR((right->GetPositionVector()-m_neutrinoVertex).GetMagnitudeSquared());
+    const float distanceL((left->GetPositionVector() - m_neutrinoVertex).GetMagnitudeSquared());
+    const float distanceR((right->GetPositionVector() - m_neutrinoVertex).GetMagnitudeSquared());
     return distanceL < distanceR;
 }
 

--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h
@@ -13,8 +13,8 @@
 namespace lar_content
 {
 
-typedef MvaFeatureTool<const pandora::Algorithm *const, const pandora::Cluster *const>  ClusterCharacterisationFeatureTool;
-typedef MvaFeatureTool<const pandora::Algorithm *const, const pandora::ParticleFlowObject *const>  PfoCharacterisationFeatureTool;
+typedef MvaFeatureTool<const pandora::Algorithm *const, const pandora::Cluster *const> ClusterCharacterisationFeatureTool;
+typedef MvaFeatureTool<const pandora::Algorithm *const, const pandora::ParticleFlowObject *const> PfoCharacterisationFeatureTool;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -34,7 +34,7 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-   /**
+    /**
     *  @brief  Calculation of the shower fit width variable
     *
     *  @param  pAlgorithm address of the calling algorithm
@@ -44,8 +44,8 @@ private:
     */
     float CalculateShowerFitWidth(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster) const;
 
-    unsigned int    m_slidingShowerFitWindow;        ///< The sliding shower fit window
-    unsigned int    m_slidingLinearFitWindow;        ///< The sliding linear fit window
+    unsigned int m_slidingShowerFitWindow; ///< The sliding shower fit window
+    unsigned int m_slidingLinearFitWindow; ///< The sliding linear fit window
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -80,8 +80,8 @@ private:
     void CalculateVariablesSlidingLinearFit(const pandora::Cluster *const pCluster, float &straightLineLengthLarge, float &diffWithStraigthLineMean,
         float &diffWithStraightLineSigma, float &dTdLWidth, float &maxFitGapLength, float &rmsSlidingLinearFit) const;
 
-    unsigned int    m_slidingLinearFitWindow;       ///< The sliding linear fit window
-    unsigned int    m_slidingLinearFitWindowLarge;  ///< The sliding linear fit window - should be large, providing a simple linear fit
+    unsigned int m_slidingLinearFitWindow;      ///< The sliding linear fit window
+    unsigned int m_slidingLinearFitWindowLarge; ///< The sliding linear fit window - should be large, providing a simple linear fit
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -111,7 +111,7 @@ private:
      */
     float CalculateVertexDistance(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster) const;
 
-    unsigned int    m_slidingLinearFitWindow;       ///< The sliding linear fit window
+    unsigned int m_slidingLinearFitWindow; ///< The sliding linear fit window
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -162,11 +162,11 @@ private:
      *  @param  maxFitGapLength to receive the max fit gap length variable
      *  @param  rmsSlidingLinearFit to receive the RMS from the linear fit
      */
-    void CalculateVariablesSlidingLinearFit(const pandora::Cluster *const pCluster, float &straightLineLengthLarge, float &diffWithStraigthLineMean,
-        float &maxFitGapLength, float &rmsSlidingLinearFit) const;
+    void CalculateVariablesSlidingLinearFit(const pandora::Cluster *const pCluster, float &straightLineLengthLarge,
+        float &diffWithStraigthLineMean, float &maxFitGapLength, float &rmsSlidingLinearFit) const;
 
-    unsigned int    m_slidingLinearFitWindow;       ///< The sliding linear fit window
-    unsigned int    m_slidingLinearFitWindowLarge;  ///< The sliding linear fit window - should be large, providing a simple linear fit
+    unsigned int m_slidingLinearFitWindow;      ///< The sliding linear fit window
+    unsigned int m_slidingLinearFitWindowLarge; ///< The sliding linear fit window - should be large, providing a simple linear fit
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -225,10 +225,11 @@ private:
      *
      *  @return the opening angle
      */
-    float OpeningAngle(const pandora::CartesianVector &principal, const pandora::CartesianVector &secondary, const pandora::CartesianVector &eigenValues) const;
+    float OpeningAngle(const pandora::CartesianVector &principal, const pandora::CartesianVector &secondary,
+        const pandora::CartesianVector &eigenValues) const;
 
-    float   m_hitFraction;          ///< Fraction of hits in start and end of pfo
-    float   m_defaultValue;         ///< Default value to return, in case calculation not feasible
+    float m_hitFraction;  ///< Fraction of hits in start and end of pfo
+    float m_defaultValue; ///< Default value to return, in case calculation not feasible
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -283,8 +284,7 @@ public:
          */
         bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
 
-        pandora::CartesianVector   m_neutrinoVertex;    //The neutrino vertex used to sort
-
+        pandora::CartesianVector m_neutrinoVertex; //The neutrino vertex used to sort
     };
 
     void Run(LArMvaHelper::MvaFeatureVector &featureVector, const pandora::Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo);
@@ -301,8 +301,8 @@ private:
      *  @param  startCharge, to receive the charge in the initial 10% hits
      *  @param  endCharge, to receive the charge in the last 10% hits
      */
-    void CalculateChargeVariables(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, float &totalCharge, float &chargeSigma,
-        float &chargeMean, float &endCharge);
+    void CalculateChargeVariables(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, float &totalCharge,
+        float &chargeSigma, float &chargeMean, float &endCharge);
 
     /**
      *  @brief  Function to order the calo hit list by distance to neutrino vertex
@@ -312,11 +312,12 @@ private:
      *  @param  caloHitList to receive the ordered calo hit list
      *
      */
-    void OrderCaloHitsByDistanceToVertex(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, pandora::CaloHitList &caloHitList);
+    void OrderCaloHitsByDistanceToVertex(
+        const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, pandora::CaloHitList &caloHitList);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float           m_endChargeFraction;           ///< Fraction of hits that will be considered to calculate end charge (default 10%)
+    float m_endChargeFraction; ///< Fraction of hits that will be considered to calculate end charge (default 10%)
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.cc
@@ -17,9 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClusterAssociationAlgorithm::ClusterAssociationAlgorithm() :
-    m_mergeMade(false),
-    m_resolveAmbiguousAssociations(true)
+ClusterAssociationAlgorithm::ClusterAssociationAlgorithm() : m_mergeMade(false), m_resolveAmbiguousAssociations(true)
 {
 }
 
@@ -51,7 +49,7 @@ StatusCode ClusterAssociationAlgorithm::Run()
                 if (pClusterList->end() == std::find(pClusterList->begin(), pClusterList->end(), pCluster))
                     continue;
 
-                this->UnambiguousPropagation(pCluster, true,  clusterAssociationMap);
+                this->UnambiguousPropagation(pCluster, true, clusterAssociationMap);
                 this->UnambiguousPropagation(pCluster, false, clusterAssociationMap);
             }
         }
@@ -156,8 +154,8 @@ void ClusterAssociationAlgorithm::AmbiguousPropagation(const Cluster *const pClu
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClusterAssociationAlgorithm::UpdateForUnambiguousMerge(const Cluster *const pClusterToEnlarge, const Cluster *const pClusterToDelete, const bool isForwardMerge,
-    ClusterAssociationMap &clusterAssociationMap) const
+void ClusterAssociationAlgorithm::UpdateForUnambiguousMerge(const Cluster *const pClusterToEnlarge, const Cluster *const pClusterToDelete,
+    const bool isForwardMerge, ClusterAssociationMap &clusterAssociationMap) const
 {
     ClusterAssociationMap::iterator iterEnlarge = clusterAssociationMap.find(pClusterToEnlarge);
     ClusterAssociationMap::iterator iterDelete = clusterAssociationMap.find(pClusterToDelete);
@@ -194,8 +192,8 @@ void ClusterAssociationAlgorithm::UpdateForUnambiguousMerge(const Cluster *const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClusterAssociationAlgorithm::UpdateForAmbiguousMerge(const Cluster *const pClusterToEnlarge, const Cluster *const pClusterToDelete, const bool isForwardMerge,
-    ClusterAssociationMap &clusterAssociationMap) const
+void ClusterAssociationAlgorithm::UpdateForAmbiguousMerge(const Cluster *const pClusterToEnlarge, const Cluster *const pClusterToDelete,
+    const bool isForwardMerge, ClusterAssociationMap &clusterAssociationMap) const
 {
     ClusterAssociationMap::iterator iterEnlarge = clusterAssociationMap.find(pClusterToEnlarge);
     ClusterAssociationMap::iterator iterDelete = clusterAssociationMap.find(pClusterToDelete);
@@ -261,18 +259,18 @@ void ClusterAssociationAlgorithm::UpdateForAmbiguousMerge(const Cluster *const p
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClusterAssociationAlgorithm::NavigateAlongAssociations(const ClusterAssociationMap &clusterAssociationMap, const Cluster *const pCluster,
-    const bool isForward, const Cluster *&pExtremalCluster, ClusterSet &clusterSet) const
+void ClusterAssociationAlgorithm::NavigateAlongAssociations(const ClusterAssociationMap &clusterAssociationMap,
+    const Cluster *const pCluster, const bool isForward, const Cluster *&pExtremalCluster, ClusterSet &clusterSet) const
 {
     ClusterAssociationMap::const_iterator iterAssociation = clusterAssociationMap.find(pCluster);
 
     if (clusterAssociationMap.end() == iterAssociation)
         throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
 
-    (void) clusterSet.insert(pCluster);
+    (void)clusterSet.insert(pCluster);
 
     if ((pCluster != pExtremalCluster) && this->IsExtremalCluster(isForward, pExtremalCluster, pCluster))
-          pExtremalCluster = pCluster;
+        pExtremalCluster = pCluster;
 
     const ClusterSet &associatedClusterSet(isForward ? iterAssociation->second.m_forwardAssociations : iterAssociation->second.m_backwardAssociations);
 
@@ -286,8 +284,8 @@ void ClusterAssociationAlgorithm::NavigateAlongAssociations(const ClusterAssocia
 
 StatusCode ClusterAssociationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ResolveAmbiguousAssociations", m_resolveAmbiguousAssociations));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ResolveAmbiguousAssociations", m_resolveAmbiguousAssociations));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.h
@@ -36,11 +36,11 @@ protected:
     class ClusterAssociation
     {
     public:
-        pandora::ClusterSet     m_forwardAssociations;      ///< The list of forward associations
-        pandora::ClusterSet     m_backwardAssociations;     ///< The list of backward associations
+        pandora::ClusterSet m_forwardAssociations;  ///< The list of forward associations
+        pandora::ClusterSet m_backwardAssociations; ///< The list of backward associations
     };
 
-    typedef std::unordered_map<const pandora::Cluster*, ClusterAssociation> ClusterAssociationMap;
+    typedef std::unordered_map<const pandora::Cluster *, ClusterAssociation> ClusterAssociationMap;
 
     /**
      *  @brief  Populate cluster vector with subset of cluster list, containing clusters judged to be clean
@@ -67,7 +67,8 @@ protected:
      *
      *  @return boolean
      */
-    virtual bool IsExtremalCluster(const bool isForward, const pandora::Cluster *const pCurrentCluster, const pandora::Cluster *const pTestCluster) const = 0;
+    virtual bool IsExtremalCluster(
+        const bool isForward, const pandora::Cluster *const pCurrentCluster, const pandora::Cluster *const pTestCluster) const = 0;
 
 private:
     /**
@@ -96,8 +97,8 @@ private:
      *  @param  isForwardMerge whether merge is forward (pClusterToEnlarge is forward-associated with pClusterToDelete)
      *  @param  clusterAssociationMap the cluster association map
      */
-    void UpdateForUnambiguousMerge(const pandora::Cluster *const pClusterToEnlarge, const pandora::Cluster *const pClusterToDelete, const bool isForwardMerge,
-        ClusterAssociationMap &clusterAssociationMap) const;
+    void UpdateForUnambiguousMerge(const pandora::Cluster *const pClusterToEnlarge, const pandora::Cluster *const pClusterToDelete,
+        const bool isForwardMerge, ClusterAssociationMap &clusterAssociationMap) const;
 
     /**
      *  @brief  Update cluster association map to reflect an ambiguous cluster merge
@@ -107,8 +108,8 @@ private:
      *  @param  isForwardMerge whether merge is forward (pClusterToEnlarge is forward-associated with pClusterToDelete)
      *  @param  clusterAssociationMap the cluster association map
      */
-    void UpdateForAmbiguousMerge(const pandora::Cluster *const pClusterToEnlarge, const pandora::Cluster *const pClusterToDelete, const bool isForwardMerge,
-        ClusterAssociationMap &clusterAssociationMap) const;
+    void UpdateForAmbiguousMerge(const pandora::Cluster *const pClusterToEnlarge, const pandora::Cluster *const pClusterToDelete,
+        const bool isForwardMerge, ClusterAssociationMap &clusterAssociationMap) const;
 
     /**
      *  @brief  Navigate along cluster associations, from specified cluster, in specified direction
@@ -119,12 +120,12 @@ private:
      *  @param  pExtremalCluster to receive the extremal cluster
      *  @param  clusterSet to receive set of clusters traversed
      */
-    void NavigateAlongAssociations(const ClusterAssociationMap &clusterAssociationMap, const pandora::Cluster *const pCluster, const bool isForward,
-        const pandora::Cluster *&pExtremalCluster, pandora::ClusterSet &clusterSet) const;
+    void NavigateAlongAssociations(const ClusterAssociationMap &clusterAssociationMap, const pandora::Cluster *const pCluster,
+        const bool isForward, const pandora::Cluster *&pExtremalCluster, pandora::ClusterSet &clusterSet) const;
 
     mutable bool m_mergeMade;
 
-    bool         m_resolveAmbiguousAssociations;        ///< Whether to resolve ambiguous associations
+    bool m_resolveAmbiguousAssociations; ///< Whether to resolve ambiguous associations
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterExtensionAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterExtensionAlgorithm.h
@@ -35,8 +35,8 @@ protected:
         enum VertexType
         {
             UNDEFINED = 0,
-            INNER     = 1,
-            OUTER     = 2
+            INNER = 1,
+            OUTER = 2
         };
 
         /**
@@ -44,8 +44,8 @@ protected:
          */
         enum AssociationType
         {
-            NONE   = 0,
-            WEAK   = 1,
+            NONE = 0,
+            WEAK = 1,
             STRONG = 2
         };
 
@@ -88,14 +88,14 @@ protected:
         float GetFigureOfMerit() const;
 
     private:
-        VertexType      m_parent;           ///<
-        VertexType      m_daughter;         ///<
-        AssociationType m_association;      ///<
-        float           m_fom;              ///<
+        VertexType m_parent;           ///<
+        VertexType m_daughter;         ///<
+        AssociationType m_association; ///<
+        float m_fom;                   ///<
     };
 
-    typedef std::unordered_map<const pandora::Cluster*, ClusterAssociation> ClusterAssociationMap;
-    typedef std::unordered_map<const pandora::Cluster*, ClusterAssociationMap> ClusterAssociationMatrix;
+    typedef std::unordered_map<const pandora::Cluster *, ClusterAssociation> ClusterAssociationMap;
+    typedef std::unordered_map<const pandora::Cluster *, ClusterAssociationMap> ClusterAssociationMatrix;
 
     /**
      *  @brief  Fill the cluster association matrix
@@ -105,7 +105,7 @@ protected:
      */
     virtual void FillClusterAssociationMatrix(const pandora::ClusterVector &clusterVector, ClusterAssociationMatrix &clusterAssociationMatrix) const = 0;
 
-     /**
+    /**
      *  @brief  Fill the cluster merge map
      *
      *  @param  clusterAssociationMatrix the matrix of cluster associations
@@ -117,8 +117,8 @@ protected:
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline ClusterExtensionAlgorithm::ClusterAssociation::ClusterAssociation(const VertexType parent, const VertexType daughter,
-        const AssociationType association, const float fom) :
+inline ClusterExtensionAlgorithm::ClusterAssociation::ClusterAssociation(
+    const VertexType parent, const VertexType daughter, const AssociationType association, const float fom) :
     m_parent(parent),
     m_daughter(daughter),
     m_association(association),

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterGrowingAlgorithm.cc
@@ -17,8 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClusterGrowingAlgorithm::ClusterGrowingAlgorithm() :
-    m_maxClusterSeparation(2.5f)
+ClusterGrowingAlgorithm::ClusterGrowingAlgorithm() : m_maxClusterSeparation(2.5f)
 {
 }
 
@@ -34,7 +33,8 @@ StatusCode ClusterGrowingAlgorithm::Run()
     }
     else
     {
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputClusterListName, pClusterList));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputClusterListName, pClusterList));
     }
 
     if (!pClusterList || pClusterList->empty())
@@ -69,8 +69,8 @@ StatusCode ClusterGrowingAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClusterGrowingAlgorithm::GetListOfNonSeedClusters(const ClusterVector &inputClusters, const ClusterVector &seedClusters,
-    ClusterVector &nonSeedClusters) const
+void ClusterGrowingAlgorithm::GetListOfNonSeedClusters(
+    const ClusterVector &inputClusters, const ClusterVector &seedClusters, ClusterVector &nonSeedClusters) const
 {
     for (ClusterVector::const_iterator iter = inputClusters.begin(), iterEnd = inputClusters.end(); iter != iterEnd; ++iter)
     {
@@ -87,8 +87,8 @@ void ClusterGrowingAlgorithm::GetListOfNonSeedClusters(const ClusterVector &inpu
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClusterGrowingAlgorithm::PopulateClusterMergeMap(const ClusterVector &seedClusters, const ClusterVector &nonSeedClusters,
-    ClusterMergeMap &clusterMergeMap) const
+void ClusterGrowingAlgorithm::PopulateClusterMergeMap(
+    const ClusterVector &seedClusters, const ClusterVector &nonSeedClusters, ClusterMergeMap &clusterMergeMap) const
 {
     for (ClusterVector::const_iterator nIter = nonSeedClusters.begin(), nIterEnd = nonSeedClusters.end(); nIter != nIterEnd; ++nIter)
     {
@@ -119,7 +119,8 @@ void ClusterGrowingAlgorithm::PopulateClusterMergeMap(const ClusterVector &seedC
 void ClusterGrowingAlgorithm::MergeClusters(const ClusterMergeMap &clusterMergeMap) const
 {
     ClusterList parentClusterList;
-    for (const auto &mapEntry : clusterMergeMap) parentClusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterMergeMap)
+        parentClusterList.push_back(mapEntry.first);
     parentClusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : parentClusterList)
@@ -137,8 +138,8 @@ void ClusterGrowingAlgorithm::MergeClusters(const ClusterMergeMap &clusterMergeM
             }
             else
             {
-                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pAssociatedCluster,
-                    m_inputClusterListName, m_inputClusterListName));
+                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                    PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pAssociatedCluster, m_inputClusterListName, m_inputClusterListName));
             }
         }
     }
@@ -148,11 +149,11 @@ void ClusterGrowingAlgorithm::MergeClusters(const ClusterMergeMap &clusterMergeM
 
 StatusCode ClusterGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputClusterListName", m_inputClusterListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InputClusterListName", m_inputClusterListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClusterSeparation", m_maxClusterSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClusterSeparation", m_maxClusterSeparation));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterGrowingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterGrowingAlgorithm.h
@@ -30,7 +30,7 @@ protected:
     virtual pandora::StatusCode Run();
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterMergeMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterMergeMap;
 
     /**
      *  @brief  Populate cluster vector with the subset of clusters judged to be clean
@@ -49,7 +49,6 @@ protected:
     virtual void GetListOfSeedClusters(const pandora::ClusterVector &cleanClusters, pandora::ClusterVector &seedClusters) const = 0;
 
 private:
-
     /**
      *  @brief Get List of non-seed clusters
      *
@@ -67,8 +66,8 @@ private:
      *  @param nonSeedClusters the input vector of non-seed clusters
      *  @param clusterMergeMap the output map of cluster merges
      */
-    void PopulateClusterMergeMap(const pandora::ClusterVector &seedClusters, const pandora::ClusterVector &nonSeedClusters,
-        ClusterMergeMap &clusterMergeMap) const;
+    void PopulateClusterMergeMap(
+        const pandora::ClusterVector &seedClusters, const pandora::ClusterVector &nonSeedClusters, ClusterMergeMap &clusterMergeMap) const;
 
     /**
      *  @brief Merge clusters
@@ -77,9 +76,9 @@ private:
      */
     void MergeClusters(const ClusterMergeMap &clusterMergeMap) const;
 
-    std::string     m_inputClusterListName;  ///< The name of the input cluster list. If not specified, will access current list.
+    std::string m_inputClusterListName; ///< The name of the input cluster list. If not specified, will access current list.
 
-    float           m_maxClusterSeparation;  ///< Maximum distance at which clusters can be joined
+    float m_maxClusterSeparation; ///< Maximum distance at which clusters can be joined
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterMergingAlgorithm.cc
@@ -27,7 +27,8 @@ StatusCode ClusterMergingAlgorithm::Run()
     }
     else
     {
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputClusterListName, pClusterList));
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputClusterListName, pClusterList));
     }
 
     if (!pClusterList || pClusterList->empty())
@@ -76,7 +77,7 @@ void ClusterMergingAlgorithm::MergeClusters(ClusterVector &clusterVector, Cluste
             if (!pAssociatedCluster->IsAvailable())
                 throw StatusCodeException(STATUS_CODE_FAILURE);
 
-            (void) clusterVetoList.insert(pAssociatedCluster);
+            (void)clusterVetoList.insert(pAssociatedCluster);
 
             if (m_inputClusterListName.empty())
             {
@@ -84,8 +85,8 @@ void ClusterMergingAlgorithm::MergeClusters(ClusterVector &clusterVector, Cluste
             }
             else
             {
-                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pSeedCluster, pAssociatedCluster,
-                    m_inputClusterListName, m_inputClusterListName));
+                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                    PandoraContentApi::MergeAndDeleteClusters(*this, pSeedCluster, pAssociatedCluster, m_inputClusterListName, m_inputClusterListName));
             }
         }
     }
@@ -93,7 +94,8 @@ void ClusterMergingAlgorithm::MergeClusters(ClusterVector &clusterVector, Cluste
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClusterMergingAlgorithm::CollectAssociatedClusters(const Cluster *const pSeedCluster, const ClusterMergeMap &clusterMergeMap, ClusterList& associatedClusterList) const
+void ClusterMergingAlgorithm::CollectAssociatedClusters(
+    const Cluster *const pSeedCluster, const ClusterMergeMap &clusterMergeMap, ClusterList &associatedClusterList) const
 {
     ClusterSet clusterVetoList;
     this->CollectAssociatedClusters(pSeedCluster, pSeedCluster, clusterMergeMap, clusterVetoList, associatedClusterList);
@@ -101,8 +103,8 @@ void ClusterMergingAlgorithm::CollectAssociatedClusters(const Cluster *const pSe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ClusterMergingAlgorithm::CollectAssociatedClusters(const Cluster *const pSeedCluster, const Cluster *const pCurrentCluster, const ClusterMergeMap &clusterMergeMap,
-    const ClusterSet &clusterVetoList, ClusterList &associatedClusterList) const
+void ClusterMergingAlgorithm::CollectAssociatedClusters(const Cluster *const pSeedCluster, const Cluster *const pCurrentCluster,
+    const ClusterMergeMap &clusterMergeMap, const ClusterSet &clusterVetoList, ClusterList &associatedClusterList) const
 {
     if (clusterVetoList.count(pCurrentCluster))
         return;
@@ -159,8 +161,8 @@ void ClusterMergingAlgorithm::GetSortedListOfCleanClusters(const ClusterVector &
 
 StatusCode ClusterMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputClusterListName", m_inputClusterListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InputClusterListName", m_inputClusterListName));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterMergingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterMergingAlgorithm.h
@@ -24,7 +24,7 @@ protected:
     virtual pandora::StatusCode Run();
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterList> ClusterMergeMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterMergeMap;
 
     /**
      *  @brief  Populate cluster vector with subset of cluster list, containing clusters judged to be clean
@@ -57,9 +57,10 @@ protected:
      *  @param  clusterMergeMap the map of cluster associations
      *  @param  associatedClusterList the output list of associated clusters
      */
-    void CollectAssociatedClusters(const pandora::Cluster *const pSeedCluster, const ClusterMergeMap &clusterMergeMap, pandora::ClusterList& associatedClusterList) const;
+    void CollectAssociatedClusters(const pandora::Cluster *const pSeedCluster, const ClusterMergeMap &clusterMergeMap,
+        pandora::ClusterList &associatedClusterList) const;
 
-   /**
+    /**
      *  @brief  Collect up all clusters associations related to a given seed cluster
      *
      *  @param  pSeedCluster pointer to the initial cluster
@@ -68,8 +69,8 @@ protected:
      *  @param  clusterVetoList the list of clusters that have already been merged
      *  @param  associatedClusterList the output list of associated clusters
      */
-    void CollectAssociatedClusters(const pandora::Cluster *const pSeedCluster, const pandora::Cluster *const pCurrentCluster, const ClusterMergeMap &clusterMergeMap,
-        const pandora::ClusterSet &clusterVetoList, pandora::ClusterList& associatedClusterList) const;
+    void CollectAssociatedClusters(const pandora::Cluster *const pSeedCluster, const pandora::Cluster *const pCurrentCluster,
+        const ClusterMergeMap &clusterMergeMap, const pandora::ClusterSet &clusterVetoList, pandora::ClusterList &associatedClusterList) const;
 
     /**
      *  @brief  Sort the selected clusters, so that they have a well-defined ordering
@@ -79,7 +80,7 @@ protected:
      */
     void GetSortedListOfCleanClusters(const pandora::ClusterVector &inputClusters, pandora::ClusterVector &outputClusters) const;
 
-    std::string     m_inputClusterListName;     ///< The name of the input cluster list. If not specified, will access current list.
+    std::string m_inputClusterListName; ///< The name of the input cluster list. If not specified, will access current list.
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.cc
@@ -63,8 +63,14 @@ void CrossGapsAssociationAlgorithm::PopulateClusterAssociationMap(const ClusterV
 
     for (const Cluster *const pCluster : clusterVector)
     {
-        try {(void) slidingFitResultMap.insert(TwoDSlidingFitResultMap::value_type(pCluster, TwoDSlidingFitResult(pCluster, m_slidingFitWindow, slidingFitPitch)));}
-        catch (StatusCodeException &) {}
+        try
+        {
+            (void)slidingFitResultMap.insert(
+                TwoDSlidingFitResultMap::value_type(pCluster, TwoDSlidingFitResult(pCluster, m_slidingFitWindow, slidingFitPitch)));
+        }
+        catch (StatusCodeException &)
+        {
+        }
     }
 
     // ATTN This method assumes that clusters have been sorted by layer
@@ -99,7 +105,7 @@ void CrossGapsAssociationAlgorithm::PopulateClusterAssociationMap(const ClusterV
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool CrossGapsAssociationAlgorithm::IsExtremalCluster(const bool isForward, const Cluster *const pCurrentCluster,  const Cluster *const pTestCluster) const
+bool CrossGapsAssociationAlgorithm::IsExtremalCluster(const bool isForward, const Cluster *const pCurrentCluster, const Cluster *const pTestCluster) const
 {
     const unsigned int currentLayer(isForward ? pCurrentCluster->GetOuterPseudoLayer() : pCurrentCluster->GetInnerPseudoLayer());
     const unsigned int testLayer(isForward ? pTestCluster->GetOuterPseudoLayer() : pTestCluster->GetInnerPseudoLayer());
@@ -124,13 +130,13 @@ bool CrossGapsAssociationAlgorithm::AreClustersAssociated(const TwoDSlidingFitRe
         return false;
 
     return (this->IsAssociated(innerFitResult.GetGlobalMaxLayerPosition(), innerFitResult.GetGlobalMaxLayerDirection(), outerFitResult) &&
-        this->IsAssociated(outerFitResult.GetGlobalMinLayerPosition(), outerFitResult.GetGlobalMinLayerDirection() * -1.f, innerFitResult));
+            this->IsAssociated(outerFitResult.GetGlobalMinLayerPosition(), outerFitResult.GetGlobalMinLayerDirection() * -1.f, innerFitResult));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool CrossGapsAssociationAlgorithm::IsAssociated(const CartesianVector &startPosition, const CartesianVector &startDirection,
-    const TwoDSlidingFitResult &targetFitResult) const
+bool CrossGapsAssociationAlgorithm::IsAssociated(
+    const CartesianVector &startPosition, const CartesianVector &startDirection, const TwoDSlidingFitResult &targetFitResult) const
 {
     const HitType hitType(LArClusterHelper::GetClusterHitType(targetFitResult.GetCluster()));
     unsigned int nSamplingPoints(0), nGapSamplingPoints(0), nMatchedSamplingPoints(0), nUnmatchedSampleRun(0);
@@ -197,20 +203,18 @@ bool CrossGapsAssociationAlgorithm::IsNearCluster(const CartesianVector &samplin
 
 StatusCode CrossGapsAssociationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterHits", m_minClusterHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterHits", m_minClusterHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLayers", m_minClusterLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLayers", m_minClusterLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxSamplingPoints", m_maxSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxSamplingPoints", m_maxSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SampleStepSize", m_sampleStepSize));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SampleStepSize", m_sampleStepSize));
 
     if (m_sampleStepSize < std::numeric_limits<float>::epsilon())
     {
@@ -218,20 +222,19 @@ StatusCode CrossGapsAssociationAlgorithm::ReadSettings(const TiXmlHandle xmlHand
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxUnmatchedSampleRun", m_maxUnmatchedSampleRun));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxUnmatchedSampleRun", m_maxUnmatchedSampleRun));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxOnClusterDistance", m_maxOnClusterDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxOnClusterDistance", m_maxOnClusterDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingPoints", m_minMatchedSamplingPoints));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMatchedSamplingFraction", m_minMatchedSamplingFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMatchedSamplingFraction", m_minMatchedSamplingFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "GapTolerance", m_gapTolerance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "GapTolerance", m_gapTolerance));
 
     return ClusterAssociationAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.h
@@ -67,16 +67,16 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_minClusterHits;               ///< The minimum allowed number of hits in a clean cluster
-    unsigned int    m_minClusterLayers;             ///< The minimum allowed number of layers for a clean cluster
-    unsigned int    m_slidingFitWindow;             ///< The layer window for the sliding linear fits
-    unsigned int    m_maxSamplingPoints;            ///< The maximum number of extension sampling points considered per association check
-    float           m_sampleStepSize;               ///< The sampling step size used in association checks, units cm
-    unsigned int    m_maxUnmatchedSampleRun;        ///< The maximum run of unmatched (and non-gap) samples to consider before stopping
-    float           m_maxOnClusterDistance;         ///< The maximum distance between a sampling point and sliding fit to target cluster
-    unsigned int    m_minMatchedSamplingPoints;     ///< Minimum number of matched sampling points to declare association
-    float           m_minMatchedSamplingFraction;   ///< Minimum ratio between matched sampling points and expectation to declare association
-    float           m_gapTolerance;                 ///< The tolerance to use when querying whether a sampling point is in a gap, units cm
+    unsigned int m_minClusterHits;           ///< The minimum allowed number of hits in a clean cluster
+    unsigned int m_minClusterLayers;         ///< The minimum allowed number of layers for a clean cluster
+    unsigned int m_slidingFitWindow;         ///< The layer window for the sliding linear fits
+    unsigned int m_maxSamplingPoints;        ///< The maximum number of extension sampling points considered per association check
+    float m_sampleStepSize;                  ///< The sampling step size used in association checks, units cm
+    unsigned int m_maxUnmatchedSampleRun;    ///< The maximum run of unmatched (and non-gap) samples to consider before stopping
+    float m_maxOnClusterDistance;            ///< The maximum distance between a sampling point and sliding fit to target cluster
+    unsigned int m_minMatchedSamplingPoints; ///< Minimum number of matched sampling points to declare association
+    float m_minMatchedSamplingFraction;      ///< Minimum ratio between matched sampling points and expectation to declare association
+    float m_gapTolerance;                    ///< The tolerance to use when querying whether a sampling point is in a gap, units cm
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsExtensionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsExtensionAlgorithm.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
 
 #include "larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsExtensionAlgorithm.h"
@@ -78,9 +78,9 @@ void CrossGapsExtensionAlgorithm::FillClusterAssociationMatrix(const ClusterVect
             const float lengthSquaredInner(LArClusterHelper::GetLengthSquared(pClusterInner));
             const float lengthSquaredOuter(LArClusterHelper::GetLengthSquared(pClusterOuter));
 
-            (void) clusterAssociationMatrix[pClusterInner].insert(ClusterAssociationMap::value_type(pClusterOuter,
+            (void)clusterAssociationMatrix[pClusterInner].insert(ClusterAssociationMap::value_type(pClusterOuter,
                 ClusterAssociation(ClusterAssociation::INNER, ClusterAssociation::OUTER, ClusterAssociation::STRONG, lengthSquaredOuter)));
-            (void) clusterAssociationMatrix[pClusterOuter].insert(ClusterAssociationMap::value_type(pClusterInner,
+            (void)clusterAssociationMatrix[pClusterOuter].insert(ClusterAssociationMap::value_type(pClusterInner,
                 ClusterAssociation(ClusterAssociation::OUTER, ClusterAssociation::INNER, ClusterAssociation::STRONG, lengthSquaredInner)));
         }
     }
@@ -88,16 +88,21 @@ void CrossGapsExtensionAlgorithm::FillClusterAssociationMatrix(const ClusterVect
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CrossGapsExtensionAlgorithm::BuildPointingClusterList(const ClusterVector &clusterVector, LArPointingClusterList &innerPointingClusterList,
-    LArPointingClusterList &outerPointingClusterList) const
+void CrossGapsExtensionAlgorithm::BuildPointingClusterList(const ClusterVector &clusterVector,
+    LArPointingClusterList &innerPointingClusterList, LArPointingClusterList &outerPointingClusterList) const
 {
     // Convert each input cluster into a pointing cluster
     LArPointingClusterList pointingClusterList;
 
     for (const Cluster *const pCluster : clusterVector)
     {
-        try {pointingClusterList.push_back(LArPointingCluster(pCluster));}
-        catch (StatusCodeException &) {}
+        try
+        {
+            pointingClusterList.push_back(LArPointingCluster(pCluster));
+        }
+        catch (StatusCodeException &)
+        {
+        }
     }
 
     // Identify clusters adjacent to detector gaps
@@ -107,8 +112,8 @@ void CrossGapsExtensionAlgorithm::BuildPointingClusterList(const ClusterVector &
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CrossGapsExtensionAlgorithm::BuildPointingClusterList(const bool useInner, const LArPointingClusterList &inputPointingClusterList,
-    LArPointingClusterList &outputPointingClusterList) const
+void CrossGapsExtensionAlgorithm::BuildPointingClusterList(
+    const bool useInner, const LArPointingClusterList &inputPointingClusterList, LArPointingClusterList &outputPointingClusterList) const
 {
     for (const LArPointingCluster &pointingCluster : inputPointingClusterList)
     {
@@ -162,7 +167,8 @@ void CrossGapsExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
     ClusterAssociationMatrix clusterAssociationMatrix;
 
     ClusterVector sortedInputClusters;
-    for (const auto &mapEntry : inputAssociationMatrix) sortedInputClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : inputAssociationMatrix)
+        sortedInputClusters.push_back(mapEntry.first);
     std::sort(sortedInputClusters.begin(), sortedInputClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster1 : sortedInputClusters)
@@ -190,7 +196,8 @@ void CrossGapsExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
             bool isAssociated(true);
 
             ClusterVector sortedAssociationClusters;
-            for (const auto &mapEntry : associationMap1) sortedAssociationClusters.push_back(mapEntry.first);
+            for (const auto &mapEntry : associationMap1)
+                sortedAssociationClusters.push_back(mapEntry.first);
             std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
             for (const Cluster *const pCluster3 : sortedAssociationClusters)
@@ -203,8 +210,7 @@ void CrossGapsExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
 
                 const ClusterAssociation &association23(iter23->second);
 
-                if (association12.GetParent() == association13.GetParent() &&
-                    association23.GetParent() == association21.GetParent() &&
+                if (association12.GetParent() == association13.GetParent() && association23.GetParent() == association21.GetParent() &&
                     association13.GetDaughter() != association23.GetDaughter())
                 {
                     isAssociated = false;
@@ -214,18 +220,18 @@ void CrossGapsExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
 
             if (isAssociated)
             {
-                (void) clusterAssociationMatrix[pCluster1].insert(ClusterAssociationMap::value_type(pCluster2, association12));
-                (void) clusterAssociationMatrix[pCluster2].insert(ClusterAssociationMap::value_type(pCluster1, association21));
+                (void)clusterAssociationMatrix[pCluster1].insert(ClusterAssociationMap::value_type(pCluster2, association12));
+                (void)clusterAssociationMatrix[pCluster2].insert(ClusterAssociationMap::value_type(pCluster1, association21));
             }
         }
     }
-
 
     // Second step: find the best associations A -> X and B -> Y
     ClusterAssociationMatrix intermediateAssociationMatrix;
 
     ClusterVector sortedClusters;
-    for (const auto &mapEntry : clusterAssociationMatrix) sortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterAssociationMatrix)
+        sortedClusters.push_back(mapEntry.first);
     std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : sortedClusters)
@@ -239,7 +245,8 @@ void CrossGapsExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
         ClusterAssociation bestAssociationOuter(ClusterAssociation::UNDEFINED, ClusterAssociation::UNDEFINED, ClusterAssociation::NONE, 0.f);
 
         ClusterVector sortedAssociationClusters;
-        for (const auto &mapEntry : clusterAssociationMap) sortedAssociationClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : clusterAssociationMap)
+            sortedAssociationClusters.push_back(mapEntry.first);
         std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedAssociationClusters)
@@ -268,16 +275,16 @@ void CrossGapsExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
         }
 
         if (pBestClusterInner)
-            (void) intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterInner, bestAssociationInner));
+            (void)intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterInner, bestAssociationInner));
 
         if (pBestClusterOuter)
-            (void) intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterOuter, bestAssociationOuter));
+            (void)intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterOuter, bestAssociationOuter));
     }
-
 
     // Third step: make the merge if A -> X and B -> Y is in fact A -> B and B -> A
     ClusterVector intermediateSortedClusters;
-    for (const auto &mapEntry : intermediateAssociationMatrix) intermediateSortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : intermediateAssociationMatrix)
+        intermediateSortedClusters.push_back(mapEntry.first);
     std::sort(intermediateSortedClusters.begin(), intermediateSortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : intermediateSortedClusters)
@@ -285,7 +292,8 @@ void CrossGapsExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
         const ClusterAssociationMap &parentAssociationMap(intermediateAssociationMatrix.at(pParentCluster));
 
         ClusterVector sortedAssociationClusters;
-        for (const auto &mapEntry : parentAssociationMap) sortedAssociationClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : parentAssociationMap)
+            sortedAssociationClusters.push_back(mapEntry.first);
         std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedAssociationClusters)
@@ -322,21 +330,19 @@ void CrossGapsExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
 
 StatusCode CrossGapsExtensionAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinGapFraction", m_minGapFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinGapFraction", m_minGapFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxGapTolerance", m_maxGapTolerance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxGapTolerance", m_maxGapTolerance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
     float maxCosRelativeAngle(std::cos(m_maxRelativeAngle * M_PI / 180.0));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCosRelativeAngle", maxCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCosRelativeAngle", maxCosRelativeAngle));
     m_maxRelativeAngle = (180.0 / M_PI) * std::acos(maxCosRelativeAngle);
 
     return ClusterExtensionAlgorithm::ReadSettings(xmlHandle);

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsExtensionAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsExtensionAlgorithm.h
@@ -70,11 +70,11 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float   m_minClusterLength;               ///<
-    float   m_minGapFraction;                 ///<
-    float   m_maxGapTolerance;                ///<
-    float   m_maxTransverseDisplacement;      ///<
-    float   m_maxRelativeAngle;               ///<
+    float m_minClusterLength;          ///<
+    float m_minGapFraction;            ///<
+    float m_maxGapTolerance;           ///<
+    float m_maxTransverseDisplacement; ///<
+    float m_maxRelativeAngle;          ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/HitWidthClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/HitWidthClusterMergingAlgorithm.cc
@@ -19,15 +19,15 @@ namespace lar_content
 {
 
 HitWidthClusterMergingAlgorithm::HitWidthClusterMergingAlgorithm() :
-  m_maxConstituentHitWidth(0.5f),
-  m_hitWidthScalingFactor(1.f),
-  m_fittingWeight(20.f),
-  m_minClusterWeight(0.5f),
-  m_maxXMergeDistance(5.f),
-  m_maxZMergeDistance(2.f),
-  m_minMergeCosOpeningAngle(0.97f),
-  m_minDirectionDeviationCosAngle(0.9f),
-  m_minClusterSparseness(0.3f)
+    m_maxConstituentHitWidth(0.5f),
+    m_hitWidthScalingFactor(1.f),
+    m_fittingWeight(20.f),
+    m_minClusterWeight(0.5f),
+    m_maxXMergeDistance(5.f),
+    m_maxZMergeDistance(2.f),
+    m_minMergeCosOpeningAngle(0.97f),
+    m_minDirectionDeviationCosAngle(0.9f),
+    m_minClusterSparseness(0.3f)
 {
 }
 
@@ -45,7 +45,8 @@ void HitWidthClusterMergingAlgorithm::GetListOfCleanClusters(const ClusterList *
         if (LArHitWidthHelper::GetOriginalTotalClusterWeight(pCluster) < m_minClusterWeight)
             continue;
 
-        const unsigned int numberOfProposedConstituentHits(LArHitWidthHelper::GetNProposedConstituentHits(pCluster, m_maxConstituentHitWidth, m_hitWidthScalingFactor));
+        const unsigned int numberOfProposedConstituentHits(
+            LArHitWidthHelper::GetNProposedConstituentHits(pCluster, m_maxConstituentHitWidth, m_hitWidthScalingFactor));
 
         if (numberOfProposedConstituentHits == 0)
             continue;
@@ -56,8 +57,8 @@ void HitWidthClusterMergingAlgorithm::GetListOfCleanClusters(const ClusterList *
         if (clusterSparseness < m_minClusterSparseness)
             continue;
 
-        m_clusterToParametersMap.insert(std::pair<const Cluster*, LArHitWidthHelper::ClusterParameters>(pCluster,
-            LArHitWidthHelper::ClusterParameters(pCluster, m_maxConstituentHitWidth, false, m_hitWidthScalingFactor)));
+        m_clusterToParametersMap.insert(std::pair<const Cluster *, LArHitWidthHelper::ClusterParameters>(
+            pCluster, LArHitWidthHelper::ClusterParameters(pCluster, m_maxConstituentHitWidth, false, m_hitWidthScalingFactor)));
 
         clusterVector.push_back(pCluster);
     }
@@ -73,7 +74,8 @@ void HitWidthClusterMergingAlgorithm::PopulateClusterAssociationMap(const Cluste
     for (ClusterVector::const_iterator iterCurrentCluster = clusterVector.begin(); iterCurrentCluster != clusterVector.end(); ++iterCurrentCluster)
     {
         const Cluster *const pCurrentCluster = *iterCurrentCluster;
-        const LArHitWidthHelper::ClusterParameters &currentClusterParameters(LArHitWidthHelper::GetClusterParameters(pCurrentCluster, m_clusterToParametersMap));
+        const LArHitWidthHelper::ClusterParameters &currentClusterParameters(
+            LArHitWidthHelper::GetClusterParameters(pCurrentCluster, m_clusterToParametersMap));
 
         for (ClusterVector::const_iterator iterTestCluster = iterCurrentCluster; iterTestCluster != clusterVector.end(); ++iterTestCluster)
         {
@@ -81,7 +83,8 @@ void HitWidthClusterMergingAlgorithm::PopulateClusterAssociationMap(const Cluste
                 continue;
 
             const Cluster *const pTestCluster = *iterTestCluster;
-            const LArHitWidthHelper::ClusterParameters &testClusterParameters(LArHitWidthHelper::GetClusterParameters(pTestCluster, m_clusterToParametersMap));
+            const LArHitWidthHelper::ClusterParameters &testClusterParameters(
+                LArHitWidthHelper::GetClusterParameters(pTestCluster, m_clusterToParametersMap));
 
             if (!this->AreClustersAssociated(currentClusterParameters, testClusterParameters))
                 continue;
@@ -96,11 +99,13 @@ void HitWidthClusterMergingAlgorithm::PopulateClusterAssociationMap(const Cluste
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool HitWidthClusterMergingAlgorithm::IsExtremalCluster(const bool isForward, const Cluster *const pCurrentCluster,  const Cluster *const pTestCluster) const
+bool HitWidthClusterMergingAlgorithm::IsExtremalCluster(const bool isForward, const Cluster *const pCurrentCluster, const Cluster *const pTestCluster) const
 {
     //ATTN - cannot use map since higherXExtrema may have changed during merging
-    const LArHitWidthHelper::ConstituentHitVector currentConstituentHitVector(LArHitWidthHelper::GetConstituentHits(pCurrentCluster, m_maxConstituentHitWidth, m_hitWidthScalingFactor, false));
-    const LArHitWidthHelper::ConstituentHitVector testConstituentHitVector(LArHitWidthHelper::GetConstituentHits(pTestCluster, m_maxConstituentHitWidth, m_hitWidthScalingFactor, false));
+    const LArHitWidthHelper::ConstituentHitVector currentConstituentHitVector(
+        LArHitWidthHelper::GetConstituentHits(pCurrentCluster, m_maxConstituentHitWidth, m_hitWidthScalingFactor, false));
+    const LArHitWidthHelper::ConstituentHitVector testConstituentHitVector(
+        LArHitWidthHelper::GetConstituentHits(pTestCluster, m_maxConstituentHitWidth, m_hitWidthScalingFactor, false));
     const CartesianVector currentHigherXExtrema(LArHitWidthHelper::GetExtremalCoordinatesHigherX(currentConstituentHitVector));
     const CartesianVector testHigherXExtrema(LArHitWidthHelper::GetExtremalCoordinatesHigherX(testConstituentHitVector));
     float currentMaxX(currentHigherXExtrema.GetX()), testMaxX(testHigherXExtrema.GetX());
@@ -121,8 +126,8 @@ bool HitWidthClusterMergingAlgorithm::IsExtremalCluster(const bool isForward, co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool HitWidthClusterMergingAlgorithm::AreClustersAssociated(const LArHitWidthHelper::ClusterParameters &currentFitParameters,
-    const LArHitWidthHelper::ClusterParameters &testFitParameters) const
+bool HitWidthClusterMergingAlgorithm::AreClustersAssociated(
+    const LArHitWidthHelper::ClusterParameters &currentFitParameters, const LArHitWidthHelper::ClusterParameters &testFitParameters) const
 {
     // check cluster extrema are not too far away in x
     if (testFitParameters.GetLowerXExtrema().GetX() > (currentFitParameters.GetHigherXExtrema().GetX() + m_maxXMergeDistance))
@@ -157,7 +162,8 @@ bool HitWidthClusterMergingAlgorithm::AreClustersAssociated(const LArHitWidthHel
 
     try
     {
-        this->GetClusterDirection(currentFitParameters.GetConstituentHitVector(), currentClusterDirection, currentFitParameters.GetHigherXExtrema(), m_fittingWeight);
+        this->GetClusterDirection(currentFitParameters.GetConstituentHitVector(), currentClusterDirection,
+            currentFitParameters.GetHigherXExtrema(), m_fittingWeight);
         this->GetClusterDirection(testFitParameters.GetConstituentHitVector(), testClusterDirection, testMergePoint, m_fittingWeight);
     }
     catch (const StatusCodeException &)
@@ -171,7 +177,8 @@ bool HitWidthClusterMergingAlgorithm::AreClustersAssociated(const LArHitWidthHel
 
     // check that the new direction is consistent with the old clusters
     LArHitWidthHelper::ConstituentHitVector newConstituentHitVector(currentFitParameters.GetConstituentHitVector());
-    newConstituentHitVector.insert(newConstituentHitVector.end(), testFitParameters.GetConstituentHitVector().begin(), testFitParameters.GetConstituentHitVector().end());
+    newConstituentHitVector.insert(newConstituentHitVector.end(), testFitParameters.GetConstituentHitVector().begin(),
+        testFitParameters.GetConstituentHitVector().end());
 
     const CartesianVector midpoint((currentFitParameters.GetHigherXExtrema() + testMergePoint) * 0.5);
     CartesianVector newClusterDirection(0.f, 0.f, 0.f);
@@ -196,8 +203,8 @@ bool HitWidthClusterMergingAlgorithm::AreClustersAssociated(const LArHitWidthHel
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void HitWidthClusterMergingAlgorithm::FindClosestPointToPosition(const CartesianVector &position, const LArHitWidthHelper::ConstituentHitVector &constituentHitVector,
-    CartesianVector &closestPoint) const
+void HitWidthClusterMergingAlgorithm::FindClosestPointToPosition(const CartesianVector &position,
+    const LArHitWidthHelper::ConstituentHitVector &constituentHitVector, CartesianVector &closestPoint) const
 {
     float minDistanceSquared(std::numeric_limits<float>::max());
     for (const LArHitWidthHelper::ConstituentHit &constituentHit : constituentHitVector)
@@ -215,8 +222,8 @@ void HitWidthClusterMergingAlgorithm::FindClosestPointToPosition(const Cartesian
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void HitWidthClusterMergingAlgorithm::GetClusterDirection(const LArHitWidthHelper::ConstituentHitVector &constituentHitVector, CartesianVector &direction,
-    const CartesianVector &fitReferencePoint, const float fittingWeight) const
+void HitWidthClusterMergingAlgorithm::GetClusterDirection(const LArHitWidthHelper::ConstituentHitVector &constituentHitVector,
+    CartesianVector &direction, const CartesianVector &fitReferencePoint, const float fittingWeight) const
 {
     float weightSum(0.f), weightedLSum(0.f), weightedTSum(0.f);
     bool isLConstant(true), isTConstant(true);
@@ -272,7 +279,7 @@ void HitWidthClusterMergingAlgorithm::GetClusterDirection(const LArHitWidthHelpe
         return;
     }
 
-    const float weightedLMean(weightedLSum/weightSum), weightedTMean(weightedTSum/weightSum);
+    const float weightedLMean(weightedLSum / weightSum), weightedTMean(weightedTSum / weightSum);
     float numerator(0.f), denominator(0.f);
 
     for (const LArHitWidthHelper::ConstituentHit &constituentHit : constituentHitSubsetVector)
@@ -285,7 +292,7 @@ void HitWidthClusterMergingAlgorithm::GetClusterDirection(const LArHitWidthHelpe
         denominator += hitWeight * pow(rL - weightedLMean, 2);
     }
 
-    const float gradient(numerator/denominator);
+    const float gradient(numerator / denominator);
 
     // change coordinates to z=mx+c fit and normalise
     this->GetGlobalDirection(axisDirection, gradient, direction);
@@ -297,13 +304,14 @@ void HitWidthClusterMergingAlgorithm::GetClusterDirection(const LArHitWidthHelpe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void HitWidthClusterMergingAlgorithm::GetConstituentHitSubsetVector(const LArHitWidthHelper::ConstituentHitVector &constituentHitVector, const CartesianVector &fitReferencePoint,
-    const float fittingWeight, LArHitWidthHelper::ConstituentHitVector &constituentHitSubsetVector) const
+void HitWidthClusterMergingAlgorithm::GetConstituentHitSubsetVector(const LArHitWidthHelper::ConstituentHitVector &constituentHitVector,
+    const CartesianVector &fitReferencePoint, const float fittingWeight, LArHitWidthHelper::ConstituentHitVector &constituentHitSubsetVector) const
 {
     LArHitWidthHelper::ConstituentHitVector sortedConstituentHitVector(constituentHitVector);
 
     // sort hits with respect to their distance to the fitReferencePoint (closest -> furthest)
-    std::sort(sortedConstituentHitVector.begin(), sortedConstituentHitVector.end(), LArHitWidthHelper::ConstituentHit::SortByDistanceToPoint(fitReferencePoint));
+    std::sort(sortedConstituentHitVector.begin(), sortedConstituentHitVector.end(),
+        LArHitWidthHelper::ConstituentHit::SortByDistanceToPoint(fitReferencePoint));
 
     float weightCount(0.f);
     for (const LArHitWidthHelper::ConstituentHit &constituentHit : sortedConstituentHitVector)
@@ -319,8 +327,8 @@ void HitWidthClusterMergingAlgorithm::GetConstituentHitSubsetVector(const LArHit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void HitWidthClusterMergingAlgorithm::GetFittingAxes(const LArHitWidthHelper::ConstituentHitVector &constituentHitSubsetVector, CartesianVector &axisDirection,
-    CartesianVector &orthoDirection) const
+void HitWidthClusterMergingAlgorithm::GetFittingAxes(const LArHitWidthHelper::ConstituentHitVector &constituentHitSubsetVector,
+    CartesianVector &axisDirection, CartesianVector &orthoDirection) const
 {
     CartesianPointVector constituentHitSubsetPositionVector(LArHitWidthHelper::GetConstituentHitPositionVector(constituentHitSubsetVector));
 
@@ -345,7 +353,8 @@ void HitWidthClusterMergingAlgorithm::GetFittingAxes(const LArHitWidthHelper::Co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void HitWidthClusterMergingAlgorithm::GetFittingCoordinates(const CartesianVector &axisDirection, const CartesianVector &constituentHitPosition, float &rL, float &rT) const
+void HitWidthClusterMergingAlgorithm::GetFittingCoordinates(
+    const CartesianVector &axisDirection, const CartesianVector &constituentHitPosition, float &rL, float &rT) const
 {
     // axisDirection is in positive z by convention so use opening angle to obtain coordinates in rotated frame
     const CartesianVector xAxis(1.f, 0.f, 0.f);
@@ -385,7 +394,8 @@ void HitWidthClusterMergingAlgorithm::RemoveShortcutAssociations(const ClusterVe
             continue;
 
         // put ClusterSet into ClusterVector
-        ClusterVector primaryForwardAssociations(primaryMapIter->second.m_forwardAssociations.begin(), primaryMapIter->second.m_forwardAssociations.end());
+        ClusterVector primaryForwardAssociations(
+            primaryMapIter->second.m_forwardAssociations.begin(), primaryMapIter->second.m_forwardAssociations.end());
         std::sort(primaryForwardAssociations.begin(), primaryForwardAssociations.end(), LArClusterHelper::SortByNHits);
 
         // remove primary clusters that are present in secondary associations of other primary clusters
@@ -410,7 +420,7 @@ void HitWidthClusterMergingAlgorithm::RemoveShortcutAssociations(const ClusterVe
                     const ClusterSet::const_iterator forwardAssociationToRemove(tempPrimaryForwardAssociations.find(pConsideredCluster));
 
                     // if association has already been removed
-                    if(forwardAssociationToRemove == tempPrimaryForwardAssociations.end())
+                    if (forwardAssociationToRemove == tempPrimaryForwardAssociations.end())
                         continue;
 
                     ClusterSet &tempPrimaryBackwardAssociations(tempMap.find(pConsideredCluster)->second.m_backwardAssociations);
@@ -434,32 +444,31 @@ void HitWidthClusterMergingAlgorithm::RemoveShortcutAssociations(const ClusterVe
 
 StatusCode HitWidthClusterMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FittingWeight", m_fittingWeight));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FittingWeight", m_fittingWeight));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterWeight", m_minClusterWeight));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterWeight", m_minClusterWeight));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxXMergeDistance", m_maxXMergeDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxXMergeDistance", m_maxXMergeDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxZMergeDistance", m_maxZMergeDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxZMergeDistance", m_maxZMergeDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinMergeCosOpeningAngle", m_minMergeCosOpeningAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMergeCosOpeningAngle", m_minMergeCosOpeningAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinDirectionDeviationCosAngle", m_minDirectionDeviationCosAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinDirectionDeviationCosAngle", m_minDirectionDeviationCosAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxConstituentHitWidth", m_maxConstituentHitWidth));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxConstituentHitWidth", m_maxConstituentHitWidth));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HitWidthScalingFactor", m_hitWidthScalingFactor));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitWidthScalingFactor", m_hitWidthScalingFactor));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterSparseness", m_minClusterSparseness));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterSparseness", m_minClusterSparseness));
 
     return ClusterAssociationAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/HitWidthClusterMergingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/HitWidthClusterMergingAlgorithm.h
@@ -31,7 +31,7 @@ public:
 private:
     void GetListOfCleanClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const;
     void PopulateClusterAssociationMap(const pandora::ClusterVector &clusterVector, ClusterAssociationMap &clusterAssociationMap) const;
-    bool IsExtremalCluster(const bool isForward, const pandora::Cluster *const pCurrentCluster,  const pandora::Cluster *const pTestCluster) const;
+    bool IsExtremalCluster(const bool isForward, const pandora::Cluster *const pCurrentCluster, const pandora::Cluster *const pTestCluster) const;
 
     /**
      *  @brief  Determine whether two clusters are associated
@@ -41,7 +41,8 @@ private:
      *
      *  @return boolean whether the clusters are associated
      */
-    bool AreClustersAssociated(const LArHitWidthHelper::ClusterParameters &currentClusterParameters, const LArHitWidthHelper::ClusterParameters &testClusterParameters) const;
+    bool AreClustersAssociated(const LArHitWidthHelper::ClusterParameters &currentClusterParameters,
+        const LArHitWidthHelper::ClusterParameters &testClusterParameters) const;
 
     /**
      *  @brief  Determine the position of the constituent hit that lies closest to a specified position
@@ -51,8 +52,8 @@ private:
      *  @param  closestPoint the position of the closest constituent hit
      *
      */
-    void FindClosestPointToPosition(const pandora::CartesianVector &position, const LArHitWidthHelper::ConstituentHitVector &constituentHitVector,
-        pandora::CartesianVector &closestPoint) const;
+    void FindClosestPointToPosition(const pandora::CartesianVector &position,
+        const LArHitWidthHelper::ConstituentHitVector &constituentHitVector, pandora::CartesianVector &closestPoint) const;
 
     /**
      *  @brief  Determine the cluster direction at a reference point by performing a weighted least squared fit to the input consitutent hit positions
@@ -103,7 +104,8 @@ private:
      *  @param  rT the fitting 'z' coordinate
      *
      */
-    void GetFittingCoordinates(const pandora::CartesianVector &axisDirection, const pandora::CartesianVector &constituentHitPosition, float &rL, float &rT) const;
+    void GetFittingCoordinates(
+        const pandora::CartesianVector &axisDirection, const pandora::CartesianVector &constituentHitPosition, float &rL, float &rT) const;
 
     /**
      *  @brief  Translate a gradient in the fitting coordinate frame to a direction vector in the detector frame
@@ -126,18 +128,18 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float m_maxConstituentHitWidth;           ///< The maximum hit width of a constituent hit of broken up hit, units cm
-    float m_hitWidthScalingFactor;            ///< The scaling factor of the hit widths
-    float m_fittingWeight;                    ///< The maximum hit weight considered in the least squared fit
-    float m_minClusterWeight;                 ///< The threshold hit weight of the original, unscaled cluster to be considered in the merging process
-    float m_maxXMergeDistance;                ///< The maximum x distance between merging points of associated clusters, units cm
-    float m_maxZMergeDistance;                ///< The maximum z distance between merging points of associated clusters, units cm
-    float m_minMergeCosOpeningAngle;          ///< The minimum cosine opening angle of the directions of associated clusters
-    float m_minDirectionDeviationCosAngle;    ///< The minimum cosine opening angle of the direction of and associated cluster before and after merge
-    float m_minClusterSparseness;             ///< The threshold sparseness of a cluster to be considered in the merging process
+    float m_maxConstituentHitWidth;  ///< The maximum hit width of a constituent hit of broken up hit, units cm
+    float m_hitWidthScalingFactor;   ///< The scaling factor of the hit widths
+    float m_fittingWeight;           ///< The maximum hit weight considered in the least squared fit
+    float m_minClusterWeight;        ///< The threshold hit weight of the original, unscaled cluster to be considered in the merging process
+    float m_maxXMergeDistance;       ///< The maximum x distance between merging points of associated clusters, units cm
+    float m_maxZMergeDistance;       ///< The maximum z distance between merging points of associated clusters, units cm
+    float m_minMergeCosOpeningAngle; ///< The minimum cosine opening angle of the directions of associated clusters
+    float m_minDirectionDeviationCosAngle; ///< The minimum cosine opening angle of the direction of and associated cluster before and after merge
+    float m_minClusterSparseness;          ///< The threshold sparseness of a cluster to be considered in the merging process
 
     // ATTN Dangling pointers emerge during cluster merging, here explicitly not dereferenced
-    mutable LArHitWidthHelper::ClusterToParametersMap m_clusterToParametersMap;   ///< The map [cluster -> cluster parameters]
+    mutable LArHitWidthHelper::ClusterToParametersMap m_clusterToParametersMap; ///< The map [cluster -> cluster parameters]
 };
 
 } //namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalAssociationAlgorithm.cc
@@ -74,7 +74,7 @@ void LongitudinalAssociationAlgorithm::PopulateClusterAssociationMap(const Clust
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool LongitudinalAssociationAlgorithm::IsExtremalCluster(const bool isForward, const Cluster *const pCurrentCluster,  const Cluster *const pTestCluster) const
+bool LongitudinalAssociationAlgorithm::IsExtremalCluster(const bool isForward, const Cluster *const pCurrentCluster, const Cluster *const pTestCluster) const
 {
     const unsigned int currentLayer(isForward ? pCurrentCluster->GetOuterPseudoLayer() : pCurrentCluster->GetInnerPseudoLayer());
     const unsigned int testLayer(isForward ? pTestCluster->GetOuterPseudoLayer() : pTestCluster->GetInnerPseudoLayer());
@@ -132,8 +132,8 @@ bool LongitudinalAssociationAlgorithm::AreClustersAssociated(const Cluster *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool LongitudinalAssociationAlgorithm::AreClustersAssociated(const CartesianVector &innerClusterEnd, const CartesianVector &outerClusterStart,
-    const ClusterFitResult &innerFit, const ClusterFitResult &outerFit) const
+bool LongitudinalAssociationAlgorithm::AreClustersAssociated(const CartesianVector &innerClusterEnd,
+    const CartesianVector &outerClusterStart, const ClusterFitResult &innerFit, const ClusterFitResult &outerFit) const
 {
     if (!innerFit.IsFitSuccessful() || !outerFit.IsFitSuccessful())
         return false;
@@ -141,11 +141,15 @@ bool LongitudinalAssociationAlgorithm::AreClustersAssociated(const CartesianVect
     if (innerFit.GetDirection().GetCosOpeningAngle(outerFit.GetDirection()) < m_minCosRelativeAngle)
         return false;
 
-    const CartesianVector innerEndFit1(innerFit.GetIntercept() + innerFit.GetDirection() * (innerFit.GetDirection().GetDotProduct(innerClusterEnd - innerFit.GetIntercept())));
-    const CartesianVector innerEndFit2(outerFit.GetIntercept() + outerFit.GetDirection() * (outerFit.GetDirection().GetDotProduct(innerClusterEnd - outerFit.GetIntercept())));
+    const CartesianVector innerEndFit1(
+        innerFit.GetIntercept() + innerFit.GetDirection() * (innerFit.GetDirection().GetDotProduct(innerClusterEnd - innerFit.GetIntercept())));
+    const CartesianVector innerEndFit2(
+        outerFit.GetIntercept() + outerFit.GetDirection() * (outerFit.GetDirection().GetDotProduct(innerClusterEnd - outerFit.GetIntercept())));
 
-    const CartesianVector outerStartFit1(outerFit.GetIntercept() + outerFit.GetDirection() * (outerFit.GetDirection().GetDotProduct(outerClusterStart - outerFit.GetIntercept())));
-    const CartesianVector outerStartFit2(innerFit.GetIntercept() + innerFit.GetDirection() * (innerFit.GetDirection().GetDotProduct(outerClusterStart - innerFit.GetIntercept())));
+    const CartesianVector outerStartFit1(
+        outerFit.GetIntercept() + outerFit.GetDirection() * (outerFit.GetDirection().GetDotProduct(outerClusterStart - outerFit.GetIntercept())));
+    const CartesianVector outerStartFit2(
+        innerFit.GetIntercept() + innerFit.GetDirection() * (innerFit.GetDirection().GetDotProduct(outerClusterStart - innerFit.GetIntercept())));
 
     const CartesianVector clusterSeparation(outerClusterStart - innerClusterEnd);
 
@@ -178,34 +182,29 @@ bool LongitudinalAssociationAlgorithm::AreClustersAssociated(const CartesianVect
 
 StatusCode LongitudinalAssociationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLayers", m_minClusterLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLayers", m_minClusterLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxGapLayers", m_maxGapLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxGapLayers", m_maxGapLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FitLayers", m_fitLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FitLayers", m_fitLayers));
 
     float maxGapDistance = std::sqrt(m_maxGapDistanceSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxGapDistance", maxGapDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxGapDistance", maxGapDistance));
     m_maxGapDistanceSquared = maxGapDistance * maxGapDistance;
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCosRelativeAngle", m_minCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosRelativeAngle", m_minCosRelativeAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HitSizeZ", m_hitSizeZ));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitSizeZ", m_hitSizeZ));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HitSizeX", m_hitSizeX));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitSizeX", m_hitSizeX));
 
     return ClusterAssociationAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalAssociationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalAssociationAlgorithm.h
@@ -57,15 +57,15 @@ private:
     bool AreClustersAssociated(const pandora::CartesianVector &innerClusterEnd, const pandora::CartesianVector &outerClusterStart,
         const pandora::ClusterFitResult &innerFit, const pandora::ClusterFitResult &outerFit) const;
 
-    unsigned int m_minClusterLayers;            ///< minimum allowed number of layers for a clean cluster
-    unsigned int m_maxGapLayers;                ///< maximum allowed number of layers between associated clusters
-    unsigned int m_fitLayers;                   ///< number of layers to fit at start and end of cluster
-    float        m_maxGapDistanceSquared;       ///< maximum allowed distance (squared) between associated clusters
-    float        m_minCosRelativeAngle;         ///< maximum allowed relative angle between associated clusters
-    float        m_maxTransverseDisplacement;   ///< maximum allowed transverse displacement after extrapolation (normalised to cell size)
-    float        m_maxLongitudinalDisplacement; ///< maximum allowed longitudinal displacement after extrapolation (normalised to cell size)
-    float        m_hitSizeZ;                    ///< estimated hit size in z (wire number) dimension, units cm
-    float        m_hitSizeX;                    ///< estimated hit size in x (drift time) dimension, units cm
+    unsigned int m_minClusterLayers;     ///< minimum allowed number of layers for a clean cluster
+    unsigned int m_maxGapLayers;         ///< maximum allowed number of layers between associated clusters
+    unsigned int m_fitLayers;            ///< number of layers to fit at start and end of cluster
+    float m_maxGapDistanceSquared;       ///< maximum allowed distance (squared) between associated clusters
+    float m_minCosRelativeAngle;         ///< maximum allowed relative angle between associated clusters
+    float m_maxTransverseDisplacement;   ///< maximum allowed transverse displacement after extrapolation (normalised to cell size)
+    float m_maxLongitudinalDisplacement; ///< maximum allowed longitudinal displacement after extrapolation (normalised to cell size)
+    float m_hitSizeZ;                    ///< estimated hit size in z (wire number) dimension, units cm
+    float m_hitSizeX;                    ///< estimated hit size in x (drift time) dimension, units cm
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalExtensionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalExtensionAlgorithm.cc
@@ -86,8 +86,8 @@ void LongitudinalExtensionAlgorithm::FillClusterAssociationMatrix(const ClusterV
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LongitudinalExtensionAlgorithm::FillClusterAssociationMatrix(const LArPointingCluster &clusterI, const LArPointingCluster &clusterJ,
-    ClusterAssociationMatrix &clusterAssociationMatrix) const
+void LongitudinalExtensionAlgorithm::FillClusterAssociationMatrix(
+    const LArPointingCluster &clusterI, const LArPointingCluster &clusterJ, ClusterAssociationMatrix &clusterAssociationMatrix) const
 {
     const Cluster *const pClusterI(clusterI.GetCluster());
     const Cluster *const pClusterJ(clusterJ.GetCluster());
@@ -164,9 +164,8 @@ void LongitudinalExtensionAlgorithm::FillClusterAssociationMatrix(const LArPoint
         LArPointingClusterHelper::GetImpactParameters(vertexPositionJ, vertexDirectionJ, vertexPositionI, rL2, rT2);
 
         if ((rL1 > -2.5f && rL1 < std::min(0.66f * clusterLengthJ, m_emissionMaxLongitudinalDisplacement)) &&
-            (rL2 > -2.5f && rL2 < std::min(0.66f * clusterLengthI, m_emissionMaxLongitudinalDisplacement)) &&
-            (rT1 < m_emissionMaxTransverseDisplacement) && (rT2 < m_emissionMaxTransverseDisplacement) &&
-            (targetVertexI.GetRms() < 0.5f && targetVertexJ.GetRms() < 0.5f) &&
+            (rL2 > -2.5f && rL2 < std::min(0.66f * clusterLengthI, m_emissionMaxLongitudinalDisplacement)) && (rT1 < m_emissionMaxTransverseDisplacement) &&
+            (rT2 < m_emissionMaxTransverseDisplacement) && (targetVertexI.GetRms() < 0.5f && targetVertexJ.GetRms() < 0.5f) &&
             (cosTheta > m_emissionMaxCosRelativeAngle) && (std::fabs(cosThetaI) > 0.25f) && (std::fabs(cosThetaJ) > 0.25f))
         {
             associationType = ClusterAssociation::STRONG;
@@ -178,8 +177,10 @@ void LongitudinalExtensionAlgorithm::FillClusterAssociationMatrix(const LArPoint
     {
         const ClusterAssociation::VertexType vertexTypeI(targetVertexI.IsInnerVertex() ? ClusterAssociation::INNER : ClusterAssociation::OUTER);
         const ClusterAssociation::VertexType vertexTypeJ(targetVertexJ.IsInnerVertex() ? ClusterAssociation::INNER : ClusterAssociation::OUTER);
-        (void) clusterAssociationMatrix[pClusterI].insert(ClusterAssociationMap::value_type(pClusterJ, ClusterAssociation(vertexTypeI, vertexTypeJ, associationType, clusterLengthJ)));
-        (void) clusterAssociationMatrix[pClusterJ].insert(ClusterAssociationMap::value_type(pClusterI, ClusterAssociation(vertexTypeJ, vertexTypeI, associationType, clusterLengthI)));
+        (void)clusterAssociationMatrix[pClusterI].insert(
+            ClusterAssociationMap::value_type(pClusterJ, ClusterAssociation(vertexTypeI, vertexTypeJ, associationType, clusterLengthJ)));
+        (void)clusterAssociationMatrix[pClusterJ].insert(
+            ClusterAssociationMap::value_type(pClusterI, ClusterAssociation(vertexTypeJ, vertexTypeI, associationType, clusterLengthI)));
         return;
     }
 }
@@ -197,7 +198,8 @@ void LongitudinalExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociatio
     ClusterAssociationMatrix clusterAssociationMatrix;
 
     ClusterVector sortedInputClusters;
-    for (const auto &mapEntry : inputAssociationMatrix) sortedInputClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : inputAssociationMatrix)
+        sortedInputClusters.push_back(mapEntry.first);
     std::sort(sortedInputClusters.begin(), sortedInputClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster1 : sortedInputClusters)
@@ -225,7 +227,8 @@ void LongitudinalExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociatio
             bool isAssociated(true);
 
             ClusterVector sortedAssociationClusters;
-            for (const auto &mapEntry : associationMap1) sortedAssociationClusters.push_back(mapEntry.first);
+            for (const auto &mapEntry : associationMap1)
+                sortedAssociationClusters.push_back(mapEntry.first);
             std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
             for (const Cluster *const pCluster3 : sortedAssociationClusters)
@@ -238,8 +241,7 @@ void LongitudinalExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociatio
 
                 const ClusterAssociation &association23(iter23->second);
 
-                if (association12.GetParent() == association13.GetParent() &&
-                    association23.GetParent() == association21.GetParent() &&
+                if (association12.GetParent() == association13.GetParent() && association23.GetParent() == association21.GetParent() &&
                     association13.GetDaughter() != association23.GetDaughter())
                 {
                     isAssociated = false;
@@ -249,18 +251,18 @@ void LongitudinalExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociatio
 
             if (isAssociated)
             {
-                (void) clusterAssociationMatrix[pCluster1].insert(ClusterAssociationMap::value_type(pCluster2, association12));
-                (void) clusterAssociationMatrix[pCluster2].insert(ClusterAssociationMap::value_type(pCluster1, association21));
+                (void)clusterAssociationMatrix[pCluster1].insert(ClusterAssociationMap::value_type(pCluster2, association12));
+                (void)clusterAssociationMatrix[pCluster2].insert(ClusterAssociationMap::value_type(pCluster1, association21));
             }
         }
     }
-
 
     // Second step: find the best associations A -> X and B -> Y
     ClusterAssociationMatrix intermediateAssociationMatrix;
 
     ClusterVector sortedClusters;
-    for (const auto &mapEntry : clusterAssociationMatrix) sortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterAssociationMatrix)
+        sortedClusters.push_back(mapEntry.first);
     std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : sortedClusters)
@@ -274,7 +276,8 @@ void LongitudinalExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociatio
         ClusterAssociation bestAssociationOuter(ClusterAssociation::UNDEFINED, ClusterAssociation::UNDEFINED, ClusterAssociation::NONE, 0.f);
 
         ClusterVector sortedAssociationClusters;
-        for (const auto &mapEntry : clusterAssociationMap) sortedAssociationClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : clusterAssociationMap)
+            sortedAssociationClusters.push_back(mapEntry.first);
         std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedAssociationClusters)
@@ -311,16 +314,16 @@ void LongitudinalExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociatio
         }
 
         if (pBestClusterInner)
-            (void) intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterInner, bestAssociationInner));
+            (void)intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterInner, bestAssociationInner));
 
         if (pBestClusterOuter)
-            (void) intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterOuter, bestAssociationOuter));
+            (void)intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterOuter, bestAssociationOuter));
     }
-
 
     // Third step: make the merge if A -> X and B -> Y is in fact A -> B and B -> A
     ClusterVector intermediateSortedClusters;
-    for (const auto &mapEntry : intermediateAssociationMatrix) intermediateSortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : intermediateAssociationMatrix)
+        intermediateSortedClusters.push_back(mapEntry.first);
     std::sort(intermediateSortedClusters.begin(), intermediateSortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : intermediateSortedClusters)
@@ -328,7 +331,8 @@ void LongitudinalExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociatio
         const ClusterAssociationMap &parentAssociationMap(intermediateAssociationMatrix.at(pParentCluster));
 
         ClusterVector sortedAssociationClusters;
-        for (const auto &mapEntry : parentAssociationMap) sortedAssociationClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : parentAssociationMap)
+            sortedAssociationClusters.push_back(mapEntry.first);
         std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedAssociationClusters)
@@ -365,26 +369,26 @@ void LongitudinalExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociatio
 
 StatusCode LongitudinalExtensionAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMinLength", m_clusterMinLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterMinLength", m_clusterMinLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMinLayerOccupancy", m_clusterMinLayerOccupancy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ClusterMinLayerOccupancy", m_clusterMinLayerOccupancy));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NodeMaxDisplacement", m_nodeMaxDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NodeMaxDisplacement", m_nodeMaxDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NodeMaxCosRelativeAngle", m_nodeMaxCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "NodeMaxCosRelativeAngle", m_nodeMaxCosRelativeAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EmissionMaxLongitudinalDisplacement", m_emissionMaxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "EmissionMaxLongitudinalDisplacement", m_emissionMaxLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EmissionMaxTransverseDisplacement", m_emissionMaxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "EmissionMaxTransverseDisplacement", m_emissionMaxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EmissionMaxCosRelativeAngle", m_emissionMaxCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "EmissionMaxCosRelativeAngle", m_emissionMaxCosRelativeAngle));
 
     return ClusterExtensionAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalExtensionAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/LongitudinalExtensionAlgorithm.h
@@ -38,17 +38,18 @@ private:
      *  @param  clusterJ the second pointing cluster
      *  @param  clusterAssociationMatrix the matrix of cluster associations
      */
-    void FillClusterAssociationMatrix(const LArPointingCluster &clusterI, const LArPointingCluster &clusterJ, ClusterAssociationMatrix &clusterAssociationMatrix) const;
+    void FillClusterAssociationMatrix(
+        const LArPointingCluster &clusterI, const LArPointingCluster &clusterJ, ClusterAssociationMatrix &clusterAssociationMatrix) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float   m_clusterMinLength;                     ///<
-    float   m_clusterMinLayerOccupancy;             ///<
-    float   m_nodeMaxDisplacement;                  ///<
-    float   m_nodeMaxCosRelativeAngle;              ///<
-    float   m_emissionMaxLongitudinalDisplacement;  ///<
-    float   m_emissionMaxTransverseDisplacement;    ///<
-    float   m_emissionMaxCosRelativeAngle;          ///<
+    float m_clusterMinLength;                    ///<
+    float m_clusterMinLayerOccupancy;            ///<
+    float m_nodeMaxDisplacement;                 ///<
+    float m_nodeMaxCosRelativeAngle;             ///<
+    float m_emissionMaxLongitudinalDisplacement; ///<
+    float m_emissionMaxTransverseDisplacement;   ///<
+    float m_emissionMaxCosRelativeAngle;         ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterGrowingAlgorithm.cc
@@ -17,8 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleClusterGrowingAlgorithm::SimpleClusterGrowingAlgorithm() :
-    m_minCaloHitsPerCluster(5)
+SimpleClusterGrowingAlgorithm::SimpleClusterGrowingAlgorithm() : m_minCaloHitsPerCluster(5)
 {
 }
 
@@ -60,8 +59,8 @@ void SimpleClusterGrowingAlgorithm::GetListOfSeedClusters(const ClusterVector &i
 
 StatusCode SimpleClusterGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
 
     return ClusterGrowingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterGrowingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterGrowingAlgorithm.h
@@ -32,7 +32,7 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int m_minCaloHitsPerCluster;    ///< The minimum number of calo hits per seed cluster
+    unsigned int m_minCaloHitsPerCluster; ///< The minimum number of calo hits per seed cluster
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterMergingAlgorithm.cc
@@ -17,9 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleClusterMergingAlgorithm::SimpleClusterMergingAlgorithm() :
-    m_minCaloHitsPerCluster(5),
-    m_maxClusterSeparation(2.5f)
+SimpleClusterMergingAlgorithm::SimpleClusterMergingAlgorithm() : m_minCaloHitsPerCluster(5), m_maxClusterSeparation(2.5f)
 {
 }
 
@@ -69,9 +67,9 @@ void SimpleClusterMergingAlgorithm::PopulateClusterMergeMap(const ClusterVector 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool SimpleClusterMergingAlgorithm::IsAssociated(const Cluster* const pClusterI, const Cluster* const pClusterJ) const
+bool SimpleClusterMergingAlgorithm::IsAssociated(const Cluster *const pClusterI, const Cluster *const pClusterJ) const
 {
-    if (LArClusterHelper::GetClosestDistance(pClusterI,pClusterJ) > m_maxClusterSeparation)
+    if (LArClusterHelper::GetClosestDistance(pClusterI, pClusterJ) > m_maxClusterSeparation)
         return false;
 
     return true;
@@ -81,11 +79,11 @@ bool SimpleClusterMergingAlgorithm::IsAssociated(const Cluster* const pClusterI,
 
 StatusCode SimpleClusterMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClusterSeparation", m_maxClusterSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClusterSeparation", m_maxClusterSeparation));
 
     return ClusterMergingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterMergingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/SimpleClusterMergingAlgorithm.h
@@ -38,12 +38,12 @@ private:
      *
      *  @return boolean
      */
-    bool IsAssociated(const pandora::Cluster* const pClusterI, const pandora::Cluster* const pClusterJ) const;
+    bool IsAssociated(const pandora::Cluster *const pClusterI, const pandora::Cluster *const pClusterJ) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int m_minCaloHitsPerCluster;    ///< The min number of calo hits per candidate cluster
-    float        m_maxClusterSeparation;     ///< Maximum distance at which clusters can be joined
+    unsigned int m_minCaloHitsPerCluster; ///< The min number of calo hits per candidate cluster
+    float m_maxClusterSeparation;         ///< Maximum distance at which clusters can be joined
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseAssociationAlgorithm.cc
@@ -127,7 +127,7 @@ void TransverseAssociationAlgorithm::GetNearbyClusterMap(const ClusterVector &al
         allCaloHits.insert(allCaloHits.end(), daughterHits.begin(), daughterHits.end());
 
         for (const CaloHit *const pCaloHit : daughterHits)
-            (void) hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHit, pCluster));
+            (void)hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHit, pCluster));
     }
 
     HitKDTree2D kdTree;
@@ -149,14 +149,15 @@ void TransverseAssociationAlgorithm::GetNearbyClusterMap(const ClusterVector &al
             kdTree.search(searchRegionHits, found);
 
             for (const auto &hit : found)
-                (void) nearbyClusters[pCluster].insert(hitToClusterMap.at(hit.data));
+                (void)nearbyClusters[pCluster].insert(hitToClusterMap.at(hit.data));
         }
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TransverseAssociationAlgorithm::SortInputClusters(const ClusterVector &inputVector, ClusterVector &shortVector, ClusterVector &transverseMediumVector, ClusterVector &longitudinalMediumVector, ClusterVector &longVector) const
+void TransverseAssociationAlgorithm::SortInputClusters(const ClusterVector &inputVector, ClusterVector &shortVector,
+    ClusterVector &transverseMediumVector, ClusterVector &longitudinalMediumVector, ClusterVector &longVector) const
 {
     for (ClusterVector::const_iterator iter = inputVector.begin(), iterEnd = inputVector.end(); iter != iterEnd; ++iter)
     {
@@ -258,8 +259,9 @@ void TransverseAssociationAlgorithm::FillTransverseClusterList(const ClusterToCl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TransverseAssociationAlgorithm::FillTransverseAssociationMap(const ClusterToClustersMap &nearbyClusters, const TransverseClusterList &transverseClusterList,
-    const ClusterAssociationMap &transverseAssociationMap, ClusterAssociationMap &clusterAssociationMap) const
+void TransverseAssociationAlgorithm::FillTransverseAssociationMap(const ClusterToClustersMap &nearbyClusters,
+    const TransverseClusterList &transverseClusterList, const ClusterAssociationMap &transverseAssociationMap,
+    ClusterAssociationMap &clusterAssociationMap) const
 {
     for (TransverseClusterList::const_iterator iter1 = transverseClusterList.begin(), iterEnd1 = transverseClusterList.end(); iter1 != iterEnd1; ++iter1)
     {
@@ -270,24 +272,23 @@ void TransverseAssociationAlgorithm::FillTransverseAssociationMap(const ClusterT
         if (transverseAssociationMap.end() == iterInner)
             continue;
 
-        for (TransverseClusterList::const_iterator iter2 = transverseClusterList.begin(), iterEnd2 = transverseClusterList.end(); iter2 != iterEnd2; ++iter2)
+        for (TransverseClusterList::const_iterator iter2 = transverseClusterList.begin(), iterEnd2 = transverseClusterList.end();
+             iter2 != iterEnd2; ++iter2)
         {
             LArTransverseCluster *const pOuterTransverseCluster = *iter2;
             const Cluster *const pOuterCluster(pOuterTransverseCluster->GetSeedCluster());
 
             ClusterAssociationMap::const_iterator iterOuter = transverseAssociationMap.find(pOuterCluster);
-            if(transverseAssociationMap.end() == iterOuter)
+            if (transverseAssociationMap.end() == iterOuter)
                 continue;
 
             if (pInnerCluster == pOuterCluster)
                 continue;
 
-            if (iterInner->second.m_forwardAssociations.count(pOuterCluster) == 0 ||
-                iterOuter->second.m_backwardAssociations.count(pInnerCluster) == 0)
+            if (iterInner->second.m_forwardAssociations.count(pOuterCluster) == 0 || iterOuter->second.m_backwardAssociations.count(pInnerCluster) == 0)
                 continue;
 
-            if (!this->IsExtremalCluster(true, pInnerCluster, pOuterCluster) ||
-                !this->IsExtremalCluster(false, pOuterCluster, pInnerCluster))
+            if (!this->IsExtremalCluster(true, pInnerCluster, pOuterCluster) || !this->IsExtremalCluster(false, pOuterCluster, pInnerCluster))
                 continue;
 
             if (!this->IsTransverseAssociated(pInnerTransverseCluster, pOuterTransverseCluster, nearbyClusters))
@@ -308,7 +309,8 @@ void TransverseAssociationAlgorithm::GetAssociatedClusters(const ClusterToCluste
     if (associationMap.end() == iterI)
         return;
 
-    for (ClusterSet::const_iterator iterJ = iterI->second.m_forwardAssociations.begin(), iterEndJ = iterI->second.m_forwardAssociations.end(); iterJ != iterEndJ; ++iterJ)
+    for (ClusterSet::const_iterator iterJ = iterI->second.m_forwardAssociations.begin(), iterEndJ = iterI->second.m_forwardAssociations.end();
+         iterJ != iterEndJ; ++iterJ)
     {
         const Cluster *const pClusterJ = *iterJ;
 
@@ -316,7 +318,8 @@ void TransverseAssociationAlgorithm::GetAssociatedClusters(const ClusterToCluste
             associatedVector.push_back(pClusterJ);
     }
 
-    for (ClusterSet::const_iterator iterJ = iterI->second.m_backwardAssociations.begin(), iterEndJ = iterI->second.m_backwardAssociations.end(); iterJ != iterEndJ; ++iterJ)
+    for (ClusterSet::const_iterator iterJ = iterI->second.m_backwardAssociations.begin(), iterEndJ = iterI->second.m_backwardAssociations.end();
+         iterJ != iterEndJ; ++iterJ)
     {
         const Cluster *const pClusterJ = *iterJ;
 
@@ -329,35 +332,34 @@ void TransverseAssociationAlgorithm::GetAssociatedClusters(const ClusterToCluste
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TransverseAssociationAlgorithm::IsAssociated(const bool isForward, const Cluster *const pFirstCluster, const Cluster *const pSecondCluster,
-    const ClusterToClustersMap &nearbyClusters) const
+bool TransverseAssociationAlgorithm::IsAssociated(const bool isForward, const Cluster *const pFirstCluster,
+    const Cluster *const pSecondCluster, const ClusterToClustersMap &nearbyClusters) const
 {
     if ((0 == nearbyClusters.at(pFirstCluster).count(pSecondCluster)) || (0 == nearbyClusters.at(pSecondCluster).count(pFirstCluster)))
         return false;
 
-    CartesianVector firstInner(0.f,0.f,0.f), firstOuter(0.f,0.f,0.f);
-    CartesianVector secondInner(0.f,0.f,0.f), secondOuter(0.f,0.f,0.f);
+    CartesianVector firstInner(0.f, 0.f, 0.f), firstOuter(0.f, 0.f, 0.f);
+    CartesianVector secondInner(0.f, 0.f, 0.f), secondOuter(0.f, 0.f, 0.f);
     this->GetExtremalCoordinatesX(pFirstCluster, firstInner, firstOuter);
     this->GetExtremalCoordinatesX(pSecondCluster, secondInner, secondOuter);
 
     const CartesianVector firstCoordinate(isForward ? firstOuter : firstInner);
     const CartesianVector secondCoordinate(isForward ? secondOuter : secondInner);
 
-    if ((firstCoordinate.GetZ() > std::max(secondInner.GetZ(),secondOuter.GetZ()) + m_maxLongitudinalOverlap) ||
-        (firstCoordinate.GetZ() < std::min(secondInner.GetZ(),secondOuter.GetZ()) - m_maxLongitudinalOverlap))
+    if ((firstCoordinate.GetZ() > std::max(secondInner.GetZ(), secondOuter.GetZ()) + m_maxLongitudinalOverlap) ||
+        (firstCoordinate.GetZ() < std::min(secondInner.GetZ(), secondOuter.GetZ()) - m_maxLongitudinalOverlap))
         return false;
 
-    if ((isForward && secondCoordinate.GetX() < firstCoordinate.GetX()) ||
-        (!isForward && secondCoordinate.GetX() > firstCoordinate.GetX()))
+    if ((isForward && secondCoordinate.GetX() < firstCoordinate.GetX()) || (!isForward && secondCoordinate.GetX() > firstCoordinate.GetX()))
         return false;
 
     const CartesianVector firstProjection(LArClusterHelper::GetClosestPosition(firstCoordinate, pSecondCluster));
 
-    if((isForward && firstProjection.GetX() < firstCoordinate.GetX() - m_maxTransverseOverlap) ||
+    if ((isForward && firstProjection.GetX() < firstCoordinate.GetX() - m_maxTransverseOverlap) ||
         (!isForward && firstProjection.GetX() > firstCoordinate.GetX() + m_maxTransverseOverlap))
         return false;
 
-    if((isForward && firstProjection.GetX() > firstCoordinate.GetX() + m_clusterWindow) ||
+    if ((isForward && firstProjection.GetX() > firstCoordinate.GetX() + m_clusterWindow) ||
         (!isForward && firstProjection.GetX() < firstCoordinate.GetX() - m_clusterWindow))
         return false;
 
@@ -366,14 +368,14 @@ bool TransverseAssociationAlgorithm::IsAssociated(const bool isForward, const Cl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TransverseAssociationAlgorithm::IsTransverseAssociated(const Cluster *const pInnerCluster, const Cluster *const pOuterCluster,
-    const ClusterToClustersMap &nearbyClusters) const
+bool TransverseAssociationAlgorithm::IsTransverseAssociated(
+    const Cluster *const pInnerCluster, const Cluster *const pOuterCluster, const ClusterToClustersMap &nearbyClusters) const
 {
     if ((0 == nearbyClusters.at(pInnerCluster).count(pOuterCluster)) || (0 == nearbyClusters.at(pOuterCluster).count(pInnerCluster)))
         return false;
 
-    CartesianVector innerInner(0.f,0.f,0.f), innerOuter(0.f,0.f,0.f);
-    CartesianVector outerInner(0.f,0.f,0.f), outerOuter(0.f,0.f,0.f);
+    CartesianVector innerInner(0.f, 0.f, 0.f), innerOuter(0.f, 0.f, 0.f);
+    CartesianVector outerInner(0.f, 0.f, 0.f), outerOuter(0.f, 0.f, 0.f);
     this->GetExtremalCoordinatesX(pInnerCluster, innerInner, innerOuter);
     this->GetExtremalCoordinatesX(pOuterCluster, outerInner, outerOuter);
 
@@ -391,8 +393,7 @@ bool TransverseAssociationAlgorithm::IsTransverseAssociated(const Cluster *const
     const CartesianVector innerProjection(LArClusterHelper::GetClosestPosition(outerInner, pInnerCluster));
     const CartesianVector outerProjection(LArClusterHelper::GetClosestPosition(innerOuter, pOuterCluster));
 
-    if (innerOuter.GetX() > innerProjection.GetX() + m_maxTransverseOverlap ||
-        outerInner.GetX() < outerProjection.GetX() - m_maxTransverseOverlap)
+    if (innerOuter.GetX() > innerProjection.GetX() + m_maxTransverseOverlap || outerInner.GetX() < outerProjection.GetX() - m_maxTransverseOverlap)
         return false;
 
     return true;
@@ -432,7 +433,8 @@ bool TransverseAssociationAlgorithm::IsTransverseAssociated(const LArTransverseC
     if (direction.GetCrossProduct(testVertex - innerVertex).GetMagnitudeSquared() > m_transverseClusterMaxDisplacement * m_transverseClusterMaxDisplacement)
         return false;
 
-    if ((direction.GetDotProduct(testVertex - innerVertex) < -1.f * m_clusterWindow) || (direction.GetDotProduct(testVertex - outerVertex) > +1.f * m_clusterWindow))
+    if ((direction.GetDotProduct(testVertex - innerVertex) < -1.f * m_clusterWindow) ||
+        (direction.GetDotProduct(testVertex - outerVertex) > +1.f * m_clusterWindow))
         return false;
 
     return true;
@@ -442,8 +444,8 @@ bool TransverseAssociationAlgorithm::IsTransverseAssociated(const LArTransverseC
 
 bool TransverseAssociationAlgorithm::IsOverlapping(const Cluster *const pInnerCluster, const Cluster *const pOuterCluster) const
 {
-    CartesianVector innerInner(0.f,0.f,0.f), innerOuter(0.f,0.f,0.f);
-    CartesianVector outerInner(0.f,0.f,0.f), outerOuter(0.f,0.f,0.f);
+    CartesianVector innerInner(0.f, 0.f, 0.f), innerOuter(0.f, 0.f, 0.f);
+    CartesianVector outerInner(0.f, 0.f, 0.f), outerOuter(0.f, 0.f, 0.f);
     this->GetExtremalCoordinatesX(pInnerCluster, innerInner, innerOuter);
     this->GetExtremalCoordinatesX(pOuterCluster, outerInner, outerOuter);
 
@@ -575,9 +577,10 @@ void TransverseAssociationAlgorithm::GetExtremalCoordinatesXZ(const Cluster *con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TransverseAssociationAlgorithm::GetExtremalCoordinatesX(const Cluster *const pCluster, CartesianVector &innerCoordinate, CartesianVector &outerCoordinate) const
+void TransverseAssociationAlgorithm::GetExtremalCoordinatesX(
+    const Cluster *const pCluster, CartesianVector &innerCoordinate, CartesianVector &outerCoordinate) const
 {
-    CartesianVector firstCoordinate(0.f,0.f,0.f), secondCoordinate(0.f,0.f,0.f);
+    CartesianVector firstCoordinate(0.f, 0.f, 0.f), secondCoordinate(0.f, 0.f, 0.f);
     LArClusterHelper::GetExtremalCoordinates(pCluster, firstCoordinate, secondCoordinate);
 
     innerCoordinate = (firstCoordinate.GetX() < secondCoordinate.GetX() ? firstCoordinate : secondCoordinate);
@@ -586,15 +589,17 @@ void TransverseAssociationAlgorithm::GetExtremalCoordinatesX(const Cluster *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TransverseAssociationAlgorithm::FillReducedAssociationMap(const ClusterAssociationMap &inputAssociationMap, ClusterAssociationMap &outputAssociationMap) const
+void TransverseAssociationAlgorithm::FillReducedAssociationMap(
+    const ClusterAssociationMap &inputAssociationMap, ClusterAssociationMap &outputAssociationMap) const
 {
     return this->FillReducedAssociationMap(inputAssociationMap, inputAssociationMap, inputAssociationMap, outputAssociationMap);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TransverseAssociationAlgorithm::FillReducedAssociationMap(const ClusterAssociationMap &firstAssociationMap, const ClusterAssociationMap &secondAssociationMap,
-    const ClusterAssociationMap &secondAssociationMapSwapped, ClusterAssociationMap &clusterAssociationMap) const
+void TransverseAssociationAlgorithm::FillReducedAssociationMap(const ClusterAssociationMap &firstAssociationMap,
+    const ClusterAssociationMap &secondAssociationMap, const ClusterAssociationMap &secondAssociationMapSwapped,
+    ClusterAssociationMap &clusterAssociationMap) const
 {
     // Remove associations A->B from the first association map
     // if A->C exists in the second map and C->B exists in the reversed second map
@@ -604,7 +609,8 @@ void TransverseAssociationAlgorithm::FillReducedAssociationMap(const ClusterAsso
     // already exists in the map.
 
     ClusterVector sortedClusters;
-    for (const auto &mapEntry : firstAssociationMap) sortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : firstAssociationMap)
+        sortedClusters.push_back(mapEntry.first);
     std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster : sortedClusters)
@@ -622,8 +628,10 @@ void TransverseAssociationAlgorithm::FillReducedAssociationMap(const ClusterAsso
 
         if (secondAssociationMap.end() != iterSecond)
         {
-            sortedMiddleClustersF.insert(sortedMiddleClustersF.end(), iterSecond->second.m_forwardAssociations.begin(), iterSecond->second.m_forwardAssociations.end());
-            sortedMiddleClustersB.insert(sortedMiddleClustersB.end(), iterSecond->second.m_backwardAssociations.begin(), iterSecond->second.m_backwardAssociations.end());
+            sortedMiddleClustersF.insert(sortedMiddleClustersF.end(), iterSecond->second.m_forwardAssociations.begin(),
+                iterSecond->second.m_forwardAssociations.end());
+            sortedMiddleClustersB.insert(sortedMiddleClustersB.end(), iterSecond->second.m_backwardAssociations.begin(),
+                iterSecond->second.m_backwardAssociations.end());
             std::sort(sortedMiddleClustersF.begin(), sortedMiddleClustersF.end(), LArClusterHelper::SortByNHits);
             std::sort(sortedMiddleClustersB.begin(), sortedMiddleClustersB.end(), LArClusterHelper::SortByNHits);
         }
@@ -674,14 +682,16 @@ void TransverseAssociationAlgorithm::FillReducedAssociationMap(const ClusterAsso
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TransverseAssociationAlgorithm::FillSymmetricAssociationMap(const ClusterAssociationMap &inputAssociationMap, ClusterAssociationMap &outputAssociationMap) const
+void TransverseAssociationAlgorithm::FillSymmetricAssociationMap(
+    const ClusterAssociationMap &inputAssociationMap, ClusterAssociationMap &outputAssociationMap) const
 {
     // Generate a symmetrised association map, so that both A--Fwd-->B and B--Bwd-->A both exist.
     // If A is associated to B through both a backward and forward association (very bad!),
     // try to rationalise this through majority voting, otherwise remove the association.
 
     ClusterVector sortedClusters;
-    for (const auto &mapEntry : inputAssociationMap) sortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : inputAssociationMap)
+        sortedClusters.push_back(mapEntry.first);
     std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster : sortedClusters)
@@ -714,8 +724,8 @@ void TransverseAssociationAlgorithm::FillSymmetricAssociationMap(const ClusterAs
 
             if (nCounter > 0)
             {
-                if(!(outputAssociationMap[pCluster].m_backwardAssociations.count(pForwardCluster) == 0 &&
-                     outputAssociationMap[pForwardCluster].m_forwardAssociations.count(pCluster) == 0))
+                if (!(outputAssociationMap[pCluster].m_backwardAssociations.count(pForwardCluster) == 0 &&
+                        outputAssociationMap[pForwardCluster].m_forwardAssociations.count(pCluster) == 0))
                     throw StatusCodeException(STATUS_CODE_FAILURE);
 
                 outputAssociationMap[pCluster].m_forwardAssociations.insert(pForwardCluster);
@@ -743,8 +753,8 @@ void TransverseAssociationAlgorithm::FillSymmetricAssociationMap(const ClusterAs
 
             if (nCounter < 0)
             {
-                if(!(outputAssociationMap[pCluster].m_forwardAssociations.count(pBackwardCluster) == 0 &&
-                     outputAssociationMap[pBackwardCluster].m_backwardAssociations.count(pCluster) == 0))
+                if (!(outputAssociationMap[pCluster].m_forwardAssociations.count(pBackwardCluster) == 0 &&
+                        outputAssociationMap[pBackwardCluster].m_backwardAssociations.count(pCluster) == 0))
                     throw StatusCodeException(STATUS_CODE_FAILURE);
 
                 outputAssociationMap[pCluster].m_backwardAssociations.insert(pBackwardCluster);
@@ -756,7 +766,8 @@ void TransverseAssociationAlgorithm::FillSymmetricAssociationMap(const ClusterAs
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TransverseAssociationAlgorithm::FinalizeClusterAssociationMap(const ClusterAssociationMap &inputAssociationMap, ClusterAssociationMap &outputAssociationMap) const
+void TransverseAssociationAlgorithm::FinalizeClusterAssociationMap(
+    const ClusterAssociationMap &inputAssociationMap, ClusterAssociationMap &outputAssociationMap) const
 {
     ClusterAssociationMap intermediateAssociationMap;
     this->FillSymmetricAssociationMap(inputAssociationMap, intermediateAssociationMap);
@@ -782,7 +793,9 @@ TransverseAssociationAlgorithm::LArTransverseCluster::LArTransverseCluster(const
 
     for (ClusterList::const_iterator iterI = clusterList.begin(), iterEndI = clusterList.end(); iterI != iterEndI; ++iterI)
     {
-        for (OrderedCaloHitList::const_iterator iterJ = (*iterI)->GetOrderedCaloHitList().begin(), iterEndJ = (*iterI)->GetOrderedCaloHitList().end(); iterJ != iterEndJ; ++iterJ)
+        for (OrderedCaloHitList::const_iterator iterJ = (*iterI)->GetOrderedCaloHitList().begin(),
+                                                iterEndJ = (*iterI)->GetOrderedCaloHitList().end();
+             iterJ != iterEndJ; ++iterJ)
         {
             for (CaloHitList::const_iterator iterK = iterJ->second->begin(), iterEndK = iterJ->second->end(); iterK != iterEndK; ++iterK)
             {
@@ -797,9 +810,9 @@ TransverseAssociationAlgorithm::LArTransverseCluster::LArTransverseCluster(const
                 Swzz += pCaloHit->GetPositionVector().GetZ() * pCaloHit->GetPositionVector().GetZ();
                 Swxx += pCaloHit->GetPositionVector().GetX() * pCaloHit->GetPositionVector().GetX();
                 Swzx += pCaloHit->GetPositionVector().GetZ() * pCaloHit->GetPositionVector().GetX();
-                Swz  += pCaloHit->GetPositionVector().GetZ();
-                Swx  += pCaloHit->GetPositionVector().GetX();
-                Sw   += 1.;
+                Swz += pCaloHit->GetPositionVector().GetZ();
+                Swx += pCaloHit->GetPositionVector().GetX();
+                Sw += 1.;
             }
         }
     }
@@ -837,14 +850,11 @@ TransverseAssociationAlgorithm::LArTransverseCluster::LArTransverseCluster(const
 
 StatusCode TransverseAssociationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FirstLengthCut", m_firstLengthCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FirstLengthCut", m_firstLengthCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SecondLengthCut", m_secondLengthCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SecondLengthCut", m_secondLengthCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterWindow", m_clusterWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterWindow", m_clusterWindow));
 
     const StatusCode angleStatusCode(XmlHelper::ReadValue(xmlHandle, "clusterAngle", m_clusterAngle));
 
@@ -858,23 +868,23 @@ StatusCode TransverseAssociationAlgorithm::ReadSettings(const TiXmlHandle xmlHan
         return angleStatusCode;
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseOverlap", m_maxTransverseOverlap));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxTransverseOverlap", m_maxTransverseOverlap));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxProjectedOverlap", m_maxProjectedOverlap));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxProjectedOverlap", m_maxProjectedOverlap));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalOverlap", m_maxLongitudinalOverlap));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalOverlap", m_maxLongitudinalOverlap));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TransverseClusterMinCosTheta", m_transverseClusterMinCosTheta));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "TransverseClusterMinCosTheta", m_transverseClusterMinCosTheta));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TransverseClusterMinLength", m_transverseClusterMinLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "TransverseClusterMinLength", m_transverseClusterMinLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TransverseClusterMaxDisplacement", m_transverseClusterMaxDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "TransverseClusterMaxDisplacement", m_transverseClusterMaxDisplacement));
 
     return ClusterAssociationAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseAssociationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseAssociationAlgorithm.h
@@ -15,8 +15,10 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -82,21 +84,21 @@ private:
         const pandora::CartesianVector &GetDirection() const;
 
     private:
-        const pandora::Cluster     *m_pSeedCluster;
-        pandora::ClusterVector      m_associatedClusters;
-        pandora::CartesianVector    m_innerVertex;
-        pandora::CartesianVector    m_outerVertex;
-        pandora::CartesianVector    m_direction;
+        const pandora::Cluster *m_pSeedCluster;
+        pandora::ClusterVector m_associatedClusters;
+        pandora::CartesianVector m_innerVertex;
+        pandora::CartesianVector m_outerVertex;
+        pandora::CartesianVector m_direction;
     };
 
-    typedef std::vector<LArTransverseCluster*> TransverseClusterList;
+    typedef std::vector<LArTransverseCluster *> TransverseClusterList;
 
-    typedef KDTreeLinkerAlgo<const pandora::CaloHit*, 2> HitKDTree2D;
-    typedef KDTreeNodeInfoT<const pandora::CaloHit*, 2> HitKDNode2D;
+    typedef KDTreeLinkerAlgo<const pandora::CaloHit *, 2> HitKDTree2D;
+    typedef KDTreeNodeInfoT<const pandora::CaloHit *, 2> HitKDNode2D;
     typedef std::vector<HitKDNode2D> HitKDNode2DList;
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterSet> ClusterToClustersMap;
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::Cluster*> HitToClusterMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterSet> ClusterToClustersMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterMap;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
     void GetListOfCleanClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const;
@@ -120,9 +122,8 @@ private:
      *  @param  longitudinalMediumClusters the output vector of longitudinal medium clusters
      *  @param  longClusters the output vector of all long clusters
      */
-    void SortInputClusters(const pandora::ClusterVector &inputClusters, pandora::ClusterVector &shortClusters,
-        pandora::ClusterVector &transverseMediumClusters, pandora::ClusterVector &longitudinalMediumClusters,
-        pandora::ClusterVector &longClusters) const;
+    void SortInputClusters(const pandora::ClusterVector &inputClusters, pandora::ClusterVector &shortClusters, pandora::ClusterVector &transverseMediumClusters,
+        pandora::ClusterVector &longitudinalMediumClusters, pandora::ClusterVector &longClusters) const;
 
     /**
      *  @brief  Form a reduced set of associations between two input lists of clusters
@@ -145,8 +146,7 @@ private:
      *  @param  secondAssociationMap the reversed map of associations between first and cluster vectors
      */
     void FillAssociationMap(const ClusterToClustersMap &nearbyClusters, const pandora::ClusterVector &firstVector,
-        const pandora::ClusterVector &secondVector, ClusterAssociationMap &firstAssociationMap,
-        ClusterAssociationMap &secondAssociationMap) const;
+        const pandora::ClusterVector &secondVector, ClusterAssociationMap &firstAssociationMap, ClusterAssociationMap &secondAssociationMap) const;
 
     /**
      *  @brief  Create transverse cluster objects, these are protoclusters with a direction and inner/outer vertices
@@ -156,7 +156,7 @@ private:
      *  @param  inputAssociationMap the map of associations between input clusters
      *  @param  transverseClusterList the output vector of transverse cluster objects
      */
-    void FillTransverseClusterList(const ClusterToClustersMap &nearbyClusters, const  pandora::ClusterVector &inputClusters,
+    void FillTransverseClusterList(const ClusterToClustersMap &nearbyClusters, const pandora::ClusterVector &inputClusters,
         const ClusterAssociationMap &inputAssociationMap, TransverseClusterList &transverseClusterList) const;
 
     /**
@@ -203,8 +203,8 @@ private:
      *
      *  @return boolean
      */
-    bool IsTransverseAssociated(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
-        const ClusterToClustersMap &nearbyClusters) const;
+    bool IsTransverseAssociated(
+        const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const ClusterToClustersMap &nearbyClusters) const;
 
     /**
      *  @brief  Determine whether two transverse clusters are associated
@@ -215,8 +215,8 @@ private:
      *
      *  @return boolean
      */
-    bool IsTransverseAssociated(const LArTransverseCluster *const pTransverseCluster1, const LArTransverseCluster *const pTransverseCluster2,
-        const ClusterToClustersMap &nearbyClusters) const;
+    bool IsTransverseAssociated(const LArTransverseCluster *const pTransverseCluster1,
+        const LArTransverseCluster *const pTransverseCluster2, const ClusterToClustersMap &nearbyClusters) const;
 
     /**
      *  @brief  Determine whether one transverse cluster is associated with the vertex from a second transverse cluster
@@ -295,8 +295,8 @@ private:
      *  @param  innerCoordinate the inner coordinate
      *  @param  outerCoordinate the outer coordinate
      */
-    void GetExtremalCoordinatesX(const pandora::Cluster *const pCluster, pandora::CartesianVector &innerCoordinate,
-        pandora::CartesianVector &outerCoordinate) const;
+    void GetExtremalCoordinatesX(
+        const pandora::Cluster *const pCluster, pandora::CartesianVector &innerCoordinate, pandora::CartesianVector &outerCoordinate) const;
 
     /**
      *  @brief Remove double-counting from association map
@@ -333,24 +333,24 @@ private:
      */
     void FinalizeClusterAssociationMap(const ClusterAssociationMap &inputAssociationMap, ClusterAssociationMap &outputAssociationMap) const;
 
-    float        m_firstLengthCut;                   ///<
-    float        m_secondLengthCut;                  ///<
+    float m_firstLengthCut;  ///<
+    float m_secondLengthCut; ///<
 
-    float        m_clusterWindow;                    ///<
-    float        m_clusterAngle;                     ///<
-    float        m_clusterCosAngle;                  ///<
-    float        m_clusterTanAngle;                  ///<
+    float m_clusterWindow;   ///<
+    float m_clusterAngle;    ///<
+    float m_clusterCosAngle; ///<
+    float m_clusterTanAngle; ///<
 
-    float        m_maxTransverseOverlap;             ///<
-    float        m_maxProjectedOverlap;              ///<
-    float        m_maxLongitudinalOverlap;           ///<
+    float m_maxTransverseOverlap;   ///<
+    float m_maxProjectedOverlap;    ///<
+    float m_maxLongitudinalOverlap; ///<
 
-    float        m_transverseClusterMinCosTheta;     ///<
-    float        m_transverseClusterMinLength;       ///<
-    float        m_transverseClusterMaxDisplacement; ///<
+    float m_transverseClusterMinCosTheta;     ///<
+    float m_transverseClusterMinLength;       ///<
+    float m_transverseClusterMaxDisplacement; ///<
 
-    float        m_searchRegionX;                    ///< Search region, applied to x dimension, for look-up from kd-trees
-    float        m_searchRegionZ;                    ///< Search region, applied to u/v/w dimension, for look-up from kd-trees
+    float m_searchRegionX; ///< Search region, applied to x dimension, for look-up from kd-trees
+    float m_searchRegionZ; ///< Search region, applied to u/v/w dimension, for look-up from kd-trees
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseExtensionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseExtensionAlgorithm.cc
@@ -46,7 +46,7 @@ void TransverseExtensionAlgorithm::FillClusterAssociationMatrix(const ClusterVec
     {
         const Cluster *const pCluster(*iter);
 
-        if (LArClusterHelper::GetLengthSquared(pCluster) < m_minClusterLength * m_minClusterLength )
+        if (LArClusterHelper::GetLengthSquared(pCluster) < m_minClusterLength * m_minClusterLength)
             continue;
 
         try
@@ -77,7 +77,8 @@ void TransverseExtensionAlgorithm::FillClusterAssociationMatrix(const ClusterVec
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TransverseExtensionAlgorithm::FillClusterAssociationMatrix(const LArPointingCluster &pointingCluster, const Cluster* const pDaughterCluster, ClusterAssociationMatrix &clusterAssociationMatrix) const
+void TransverseExtensionAlgorithm::FillClusterAssociationMatrix(const LArPointingCluster &pointingCluster,
+    const Cluster *const pDaughterCluster, ClusterAssociationMatrix &clusterAssociationMatrix) const
 {
     const Cluster *const pParentCluster(pointingCluster.GetCluster());
 
@@ -86,8 +87,8 @@ void TransverseExtensionAlgorithm::FillClusterAssociationMatrix(const LArPointin
 
     for (unsigned int useInner = 0; useInner < 2; ++useInner)
     {
-        const LArPointingCluster::Vertex &pointingVertex(useInner==1 ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
-        const ClusterAssociation::VertexType vertexType(useInner==1 ? ClusterAssociation::INNER : ClusterAssociation::OUTER);
+        const LArPointingCluster::Vertex &pointingVertex(useInner == 1 ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
+        const ClusterAssociation::VertexType vertexType(useInner == 1 ? ClusterAssociation::INNER : ClusterAssociation::OUTER);
 
         if (pointingVertex.GetRms() > 0.5f)
             continue;
@@ -113,15 +114,15 @@ void TransverseExtensionAlgorithm::FillClusterAssociationMatrix(const LArPointin
         const float outerL(firstL > secondL ? firstL : secondL);
         const float outerT(firstL > secondL ? firstT : secondT);
 
-        if (innerL > 0.f && innerL < 2.5f && outerL < m_maxLongitudinalDisplacement &&
-            innerT < m_maxTransverseDisplacement && outerT < 1.5f * m_maxTransverseDisplacement)
+        if (innerL > 0.f && innerL < 2.5f && outerL < m_maxLongitudinalDisplacement && innerT < m_maxTransverseDisplacement &&
+            outerT < 1.5f * m_maxTransverseDisplacement)
         {
             associationType = ClusterAssociation::STRONG;
             figureOfMerit = outerL;
         }
 
-        (void) clusterAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pDaughterCluster,
-               ClusterAssociation(vertexType, vertexType, associationType, figureOfMerit)));
+        (void)clusterAssociationMatrix[pParentCluster].insert(
+            ClusterAssociationMap::value_type(pDaughterCluster, ClusterAssociation(vertexType, vertexType, associationType, figureOfMerit)));
     }
 }
 
@@ -133,7 +134,8 @@ void TransverseExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationM
 
     // Loop over parent clusters and select nearby daughter clusters that are closer than another parent cluster
     ClusterVector sortedParentClusters;
-    for (const auto &mapEntry : parentToDaughterMatrix) sortedParentClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : parentToDaughterMatrix)
+        sortedParentClusters.push_back(mapEntry.first);
     std::sort(sortedParentClusters.begin(), sortedParentClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : sortedParentClusters)
@@ -145,7 +147,8 @@ void TransverseExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationM
 
         // Find the nearest parent cluster
         ClusterVector sortedLocalDaughterClusters;
-        for (const auto &mapEntry : daughterToAssociationMap) sortedLocalDaughterClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : daughterToAssociationMap)
+            sortedLocalDaughterClusters.push_back(mapEntry.first);
         std::sort(sortedLocalDaughterClusters.begin(), sortedLocalDaughterClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedLocalDaughterClusters)
@@ -170,17 +173,18 @@ void TransverseExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationM
             if (clusterAssociation.GetAssociation() == ClusterAssociation::STRONG)
             {
                 if (clusterAssociation.GetParent() == ClusterAssociation::INNER && clusterAssociation.GetFigureOfMerit() < maxDisplacementInner)
-                    (void) daughterToParentMatrix[pDaughterCluster].insert(ClusterAssociationMap::value_type(pParentCluster, clusterAssociation));
+                    (void)daughterToParentMatrix[pDaughterCluster].insert(ClusterAssociationMap::value_type(pParentCluster, clusterAssociation));
 
                 if (clusterAssociation.GetParent() == ClusterAssociation::OUTER && clusterAssociation.GetFigureOfMerit() < maxDisplacementOuter)
-                    (void) daughterToParentMatrix[pDaughterCluster].insert(ClusterAssociationMap::value_type(pParentCluster, clusterAssociation));
+                    (void)daughterToParentMatrix[pDaughterCluster].insert(ClusterAssociationMap::value_type(pParentCluster, clusterAssociation));
             }
         }
     }
 
     // Loop over daughter clusters and select the nearest parent clusters
     ClusterVector sortedDaughterClusters;
-    for (const auto &mapEntry : daughterToParentMatrix) sortedDaughterClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : daughterToParentMatrix)
+        sortedDaughterClusters.push_back(mapEntry.first);
     std::sort(sortedDaughterClusters.begin(), sortedDaughterClusters.end(), LArClusterHelper::SortByNHits);
 
     // Loop over parent clusters and select nearby daughter clusters that are closer than another parent cluster
@@ -192,7 +196,8 @@ void TransverseExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationM
         float minDisplacement(std::numeric_limits<float>::max());
 
         ClusterVector sortedLocalParentClusters;
-        for (const auto &mapEntry : parentToAssociationMap) sortedLocalParentClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : parentToAssociationMap)
+            sortedLocalParentClusters.push_back(mapEntry.first);
         std::sort(sortedLocalParentClusters.begin(), sortedLocalParentClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pCandidateParentCluster : sortedLocalParentClusters)
@@ -225,14 +230,14 @@ void TransverseExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationM
 
 StatusCode TransverseExtensionAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-    "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-    "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-    "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
     return ClusterExtensionAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseExtensionAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/TransverseExtensionAlgorithm.h
@@ -40,13 +40,14 @@ private:
      *  @param  pDaughterCluster the address of the daughter cluster
      *  @param  clusterAssociationMatrix the matrix of cluster associations
      */
-    void FillClusterAssociationMatrix(const LArPointingCluster &parentCluster, const pandora::Cluster* const pDaughterCluster, ClusterAssociationMatrix &clusterAssociationMatrix) const;
+    void FillClusterAssociationMatrix(const LArPointingCluster &parentCluster, const pandora::Cluster *const pDaughterCluster,
+        ClusterAssociationMatrix &clusterAssociationMatrix) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float m_minClusterLength;              ///<
-    float m_maxLongitudinalDisplacement;   ///<
-    float m_maxTransverseDisplacement;     ///<
+    float m_minClusterLength;            ///<
+    float m_maxLongitudinalDisplacement; ///<
+    float m_maxTransverseDisplacement;   ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterCreation/ClusteringParentAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterCreation/ClusteringParentAlgorithm.cc
@@ -15,9 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClusteringParentAlgorithm::ClusteringParentAlgorithm() :
-    m_replaceCurrentCaloHitList(false),
-    m_replaceCurrentClusterList(true)
+ClusteringParentAlgorithm::ClusteringParentAlgorithm() : m_replaceCurrentCaloHitList(false), m_replaceCurrentClusterList(true)
 {
 }
 
@@ -48,8 +46,8 @@ StatusCode ClusteringParentAlgorithm::Run()
     // Run the initial cluster formation algorithm
     const ClusterList *pClusterList = NULL;
     std::string newClusterListName;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RunClusteringAlgorithm(*this, m_clusteringAlgorithmName,
-        pClusterList, newClusterListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::RunClusteringAlgorithm(*this, m_clusteringAlgorithmName, pClusterList, newClusterListName));
 
     // Run the topological association algorithms to modify clusters
     if (!pClusterList->empty() && !m_associationAlgorithmName.empty())
@@ -78,25 +76,21 @@ StatusCode ClusteringParentAlgorithm::Run()
 StatusCode ClusteringParentAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     // Daughter algorithm parameters
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithm(*this, xmlHandle,
-        "ClusterFormation", m_clusteringAlgorithmName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithm(*this, xmlHandle, "ClusterFormation", m_clusteringAlgorithmName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ProcessAlgorithm(*this, xmlHandle,
-        "ClusterAssociation", m_associationAlgorithmName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ProcessAlgorithm(*this, xmlHandle, "ClusterAssociation", m_associationAlgorithmName));
 
     // Input parameters: name of input calo hit list and whether it should persist as the current list after algorithm has finished
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputCaloHitListName", m_inputCaloHitListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InputCaloHitListName", m_inputCaloHitListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "ReplaceCurrentCaloHitList", m_replaceCurrentCaloHitList));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ReplaceCurrentCaloHitList", m_replaceCurrentCaloHitList));
 
     // Output parameters: name of output cluster list and whether it should subsequently be used as the current list
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterListName", m_clusterListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListName", m_clusterListName));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "ReplaceCurrentClusterList", m_replaceCurrentClusterList));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ReplaceCurrentClusterList", m_replaceCurrentClusterList));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterCreation/ClusteringParentAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterCreation/ClusteringParentAlgorithm.h
@@ -28,14 +28,14 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string     m_clusteringAlgorithmName;      ///< The name of the clustering algorithm to run
-    std::string     m_associationAlgorithmName;     ///< The name of the topological association algorithm to run
+    std::string m_clusteringAlgorithmName;  ///< The name of the clustering algorithm to run
+    std::string m_associationAlgorithmName; ///< The name of the topological association algorithm to run
 
-    std::string     m_inputCaloHitListName;         ///< The name of the input calo hit list, containing the hits to be clustered
-    bool            m_replaceCurrentCaloHitList;    ///< Whether to permanently replace the original calo hit list as the "current" list upon completion
+    std::string m_inputCaloHitListName; ///< The name of the input calo hit list, containing the hits to be clustered
+    bool m_replaceCurrentCaloHitList;   ///< Whether to permanently replace the original calo hit list as the "current" list upon completion
 
-    std::string     m_clusterListName;              ///< The name under which to save the new cluster list
-    bool            m_replaceCurrentClusterList;    ///< Whether to subsequently use the new cluster list as the "current" list
+    std::string m_clusterListName;    ///< The name under which to save the new cluster list
+    bool m_replaceCurrentClusterList; ///< Whether to subsequently use the new cluster list as the "current" list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterCreation/SimpleClusterCreationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterCreation/SimpleClusterCreationAlgorithm.cc
@@ -17,8 +17,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-SimpleClusterCreationAlgorithm::SimpleClusterCreationAlgorithm() :
-    m_clusteringWindowSquared(1.f)
+SimpleClusterCreationAlgorithm::SimpleClusterCreationAlgorithm() : m_clusteringWindowSquared(1.f)
 {
 }
 
@@ -147,8 +146,7 @@ void SimpleClusterCreationAlgorithm::CollectAssociatedHits(const CaloHit *const 
 StatusCode SimpleClusterCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     float clusteringWindow = std::sqrt(m_clusteringWindowSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusteringWindow", clusteringWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusteringWindow", clusteringWindow));
     m_clusteringWindowSquared = clusteringWindow * clusteringWindow;
 
     return STATUS_CODE_SUCCESS;

--- a/larpandoracontent/LArTwoDReco/LArClusterCreation/SimpleClusterCreationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterCreation/SimpleClusterCreationAlgorithm.h
@@ -29,7 +29,7 @@ public:
 private:
     pandora::StatusCode Run();
 
-    typedef std::unordered_map<const pandora::CaloHit*, pandora::CaloHitList> HitAssociationMap;
+    typedef std::unordered_map<const pandora::CaloHit *, pandora::CaloHitList> HitAssociationMap;
 
     /**
      *  @brief Select calo hits for clustering
@@ -69,7 +69,7 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float   m_clusteringWindowSquared;      ///< Maximum distance (squared) for two hits to be joined
+    float m_clusteringWindowSquared; ///< Maximum distance (squared) for two hits to be joined
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterCreation/TrackClusterCreationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterCreation/TrackClusterCreationAlgorithm.cc
@@ -21,7 +21,7 @@ TrackClusterCreationAlgorithm::TrackClusterCreationAlgorithm() :
     m_mergeBackFilteredHits(true),
     m_maxGapLayers(2),
     m_maxCaloHitSeparationSquared(1.3f * 1.3f),
-    m_minCaloHitSeparationSquared(0.4f *  0.4f),
+    m_minCaloHitSeparationSquared(0.4f * 0.4f),
     m_closeSeparationSquared(0.9f * 0.9f)
 {
 }
@@ -45,7 +45,7 @@ StatusCode TrackClusterCreationAlgorithm::Run()
     this->IdentifyJoins(selectedCaloHitList, forwardHitAssociationMap, backwardHitAssociationMap, hitJoinMap);
     this->CreateClusters(selectedCaloHitList, hitJoinMap, hitToClusterMap);
 
-    if( !m_mergeBackFilteredHits )
+    if (!m_mergeBackFilteredHits)
         this->CreateClusters(rejectedCaloHitList, hitJoinMap, hitToClusterMap);
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->AddFilteredCaloHits(selectedCaloHitList, rejectedCaloHitList, hitToClusterMap));
@@ -55,7 +55,8 @@ StatusCode TrackClusterCreationAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TrackClusterCreationAlgorithm::FilterCaloHits(const CaloHitList *const pCaloHitList, OrderedCaloHitList &selectedCaloHitList, OrderedCaloHitList& rejectedCaloHitList) const
+StatusCode TrackClusterCreationAlgorithm::FilterCaloHits(
+    const CaloHitList *const pCaloHitList, OrderedCaloHitList &selectedCaloHitList, OrderedCaloHitList &rejectedCaloHitList) const
 {
     CaloHitList availableHitList;
 
@@ -103,8 +104,8 @@ StatusCode TrackClusterCreationAlgorithm::FilterCaloHits(const CaloHitList *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TrackClusterCreationAlgorithm::AddFilteredCaloHits(const OrderedCaloHitList &selectedCaloHitList, const OrderedCaloHitList& rejectedCaloHitList,
-    HitToClusterMap &hitToClusterMap) const
+StatusCode TrackClusterCreationAlgorithm::AddFilteredCaloHits(
+    const OrderedCaloHitList &selectedCaloHitList, const OrderedCaloHitList &rejectedCaloHitList, HitToClusterMap &hitToClusterMap) const
 {
     for (OrderedCaloHitList::const_iterator iter = rejectedCaloHitList.begin(), iterEnd = rejectedCaloHitList.end(); iter != iterEnd; ++iter)
     {
@@ -161,7 +162,7 @@ StatusCode TrackClusterCreationAlgorithm::AddFilteredCaloHits(const OrderedCaloH
 
                 const Cluster *const pCluster = mapIter->second;
                 PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToCluster(*this, pCluster, pCaloHitI));
-                (void) hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHitI, pCluster));
+                (void)hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHitI, pCluster));
 
                 newClusteredHits.push_back(pCaloHitI);
                 carryOn = true;
@@ -180,8 +181,8 @@ StatusCode TrackClusterCreationAlgorithm::AddFilteredCaloHits(const OrderedCaloH
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackClusterCreationAlgorithm::MakePrimaryAssociations(const OrderedCaloHitList &orderedCaloHitList, HitAssociationMap &forwardHitAssociationMap,
-    HitAssociationMap &backwardHitAssociationMap) const
+void TrackClusterCreationAlgorithm::MakePrimaryAssociations(const OrderedCaloHitList &orderedCaloHitList,
+    HitAssociationMap &forwardHitAssociationMap, HitAssociationMap &backwardHitAssociationMap) const
 {
     for (OrderedCaloHitList::const_iterator iterI = orderedCaloHitList.begin(), iterIEnd = orderedCaloHitList.end(); iterI != iterIEnd; ++iterI)
     {
@@ -190,7 +191,8 @@ void TrackClusterCreationAlgorithm::MakePrimaryAssociations(const OrderedCaloHit
         CaloHitVector caloHitsI(iterI->second->begin(), iterI->second->end());
         std::sort(caloHitsI.begin(), caloHitsI.end(), LArClusterHelper::SortHitsByPosition);
 
-        for (OrderedCaloHitList::const_iterator iterJ = iterI, iterJEnd = orderedCaloHitList.end(); (nLayersConsidered++ <= m_maxGapLayers + 1) && (iterJ != iterJEnd); ++iterJ)
+        for (OrderedCaloHitList::const_iterator iterJ = iterI, iterJEnd = orderedCaloHitList.end();
+             (nLayersConsidered++ <= m_maxGapLayers + 1) && (iterJ != iterJEnd); ++iterJ)
         {
             if (iterJ->first == iterI->first || iterJ->first > iterI->first + m_maxGapLayers + 1)
                 continue;
@@ -209,8 +211,8 @@ void TrackClusterCreationAlgorithm::MakePrimaryAssociations(const OrderedCaloHit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackClusterCreationAlgorithm::MakeSecondaryAssociations(const OrderedCaloHitList &orderedCaloHitList, HitAssociationMap &forwardHitAssociationMap,
-    HitAssociationMap &backwardHitAssociationMap) const
+void TrackClusterCreationAlgorithm::MakeSecondaryAssociations(const OrderedCaloHitList &orderedCaloHitList,
+    HitAssociationMap &forwardHitAssociationMap, HitAssociationMap &backwardHitAssociationMap) const
 {
     for (OrderedCaloHitList::const_iterator iter = orderedCaloHitList.begin(), iterEnd = orderedCaloHitList.end(); iter != iterEnd; ++iter)
     {
@@ -242,8 +244,8 @@ void TrackClusterCreationAlgorithm::MakeSecondaryAssociations(const OrderedCaloH
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackClusterCreationAlgorithm::IdentifyJoins(const OrderedCaloHitList &orderedCaloHitList, const HitAssociationMap &forwardHitAssociationMap,
-    const HitAssociationMap &backwardHitAssociationMap, HitJoinMap &hitJoinMap) const
+void TrackClusterCreationAlgorithm::IdentifyJoins(const OrderedCaloHitList &orderedCaloHitList,
+    const HitAssociationMap &forwardHitAssociationMap, const HitAssociationMap &backwardHitAssociationMap, HitJoinMap &hitJoinMap) const
 {
     for (OrderedCaloHitList::const_iterator iter = orderedCaloHitList.begin(), iterEnd = orderedCaloHitList.end(); iter != iterEnd; ++iter)
     {
@@ -271,7 +273,8 @@ void TrackClusterCreationAlgorithm::IdentifyJoins(const OrderedCaloHitList &orde
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackClusterCreationAlgorithm::CreateClusters(const OrderedCaloHitList &orderedCaloHitList, const HitJoinMap &hitJoinMap, HitToClusterMap& hitToClusterMap) const
+void TrackClusterCreationAlgorithm::CreateClusters(
+    const OrderedCaloHitList &orderedCaloHitList, const HitJoinMap &hitJoinMap, HitToClusterMap &hitToClusterMap) const
 {
     for (OrderedCaloHitList::const_iterator iter = orderedCaloHitList.begin(), iterEnd = orderedCaloHitList.end(); iter != iterEnd; ++iter)
     {
@@ -312,8 +315,8 @@ void TrackClusterCreationAlgorithm::CreateClusters(const OrderedCaloHitList &ord
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackClusterCreationAlgorithm::CreatePrimaryAssociation(const CaloHit *const pCaloHitI, const CaloHit *const pCaloHitJ, HitAssociationMap &forwardHitAssociationMap,
-    HitAssociationMap &backwardHitAssociationMap) const
+void TrackClusterCreationAlgorithm::CreatePrimaryAssociation(const CaloHit *const pCaloHitI, const CaloHit *const pCaloHitJ,
+    HitAssociationMap &forwardHitAssociationMap, HitAssociationMap &backwardHitAssociationMap) const
 {
     const float distanceSquared((pCaloHitJ->GetPositionVector() - pCaloHitI->GetPositionVector()).GetMagnitudeSquared());
 
@@ -345,8 +348,8 @@ void TrackClusterCreationAlgorithm::CreatePrimaryAssociation(const CaloHit *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackClusterCreationAlgorithm::CreateSecondaryAssociation(const CaloHit *const pCaloHitI, const CaloHit *const pCaloHitJ, HitAssociationMap &forwardHitAssociationMap,
-    HitAssociationMap &backwardHitAssociationMap) const
+void TrackClusterCreationAlgorithm::CreateSecondaryAssociation(const CaloHit *const pCaloHitI, const CaloHit *const pCaloHitJ,
+    HitAssociationMap &forwardHitAssociationMap, HitAssociationMap &backwardHitAssociationMap) const
 {
     HitAssociationMap::iterator forwardIter = forwardHitAssociationMap.find(pCaloHitI);
     HitAssociationMap::iterator backwardIter = backwardHitAssociationMap.find(pCaloHitJ);
@@ -378,8 +381,8 @@ void TrackClusterCreationAlgorithm::CreateSecondaryAssociation(const CaloHit *co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const CaloHit *TrackClusterCreationAlgorithm::GetJoinHit(const CaloHit *const pCaloHit, const HitAssociationMap &hitAssociationMapI,
-    const HitAssociationMap &hitAssociationMapJ) const
+const CaloHit *TrackClusterCreationAlgorithm::GetJoinHit(
+    const CaloHit *const pCaloHit, const HitAssociationMap &hitAssociationMapI, const HitAssociationMap &hitAssociationMapJ) const
 {
     HitAssociationMap::const_iterator iterI = hitAssociationMapI.find(pCaloHit);
 
@@ -404,8 +407,8 @@ const CaloHit *TrackClusterCreationAlgorithm::GetJoinHit(const CaloHit *const pC
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const CaloHit *TrackClusterCreationAlgorithm::TraceHitAssociation(const CaloHit *const pCaloHit, const HitAssociationMap &hitAssociationMapI,
-    const HitAssociationMap &hitAssociationMapJ, unsigned int &nSteps) const
+const CaloHit *TrackClusterCreationAlgorithm::TraceHitAssociation(const CaloHit *const pCaloHit,
+    const HitAssociationMap &hitAssociationMapI, const HitAssociationMap &hitAssociationMapJ, unsigned int &nSteps) const
 {
     nSteps = 0;
     const CaloHit *pThisHit = pCaloHit;
@@ -437,25 +440,23 @@ const CaloHit *TrackClusterCreationAlgorithm::TraceHitAssociation(const CaloHit 
 
 StatusCode TrackClusterCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MergeBackFilteredHits", m_mergeBackFilteredHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MergeBackFilteredHits", m_mergeBackFilteredHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxGapLayers", m_maxGapLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxGapLayers", m_maxGapLayers));
 
     float maxCaloHitSeparation = std::sqrt(m_maxCaloHitSeparationSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCaloHitSeparation", maxCaloHitSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCaloHitSeparation", maxCaloHitSeparation));
     m_maxCaloHitSeparationSquared = maxCaloHitSeparation * maxCaloHitSeparation;
 
     float minCaloHitSeparation = std::sqrt(m_minCaloHitSeparationSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitSeparation", minCaloHitSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitSeparation", minCaloHitSeparation));
     m_minCaloHitSeparationSquared = minCaloHitSeparation * minCaloHitSeparation;
 
     float closeSeparation = std::sqrt(m_closeSeparationSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CloseSeparation", closeSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CloseSeparation", closeSeparation));
     m_closeSeparationSquared = closeSeparation * closeSeparation;
 
     return STATUS_CODE_SUCCESS;

--- a/larpandoracontent/LArTwoDReco/LArClusterCreation/TrackClusterCreationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterCreation/TrackClusterCreationAlgorithm.h
@@ -78,15 +78,15 @@ private:
         float GetSecondaryDistanceSquared() const;
 
     private:
-        const pandora::CaloHit *m_pPrimaryTarget;               ///< the primary target
-        const pandora::CaloHit *m_pSecondaryTarget;             ///< the secondary target
-        float                   m_primaryDistanceSquared;       ///< the primary distance squared
-        float                   m_secondaryDistanceSquared;     ///< the secondary distance squared
+        const pandora::CaloHit *m_pPrimaryTarget;   ///< the primary target
+        const pandora::CaloHit *m_pSecondaryTarget; ///< the secondary target
+        float m_primaryDistanceSquared;             ///< the primary distance squared
+        float m_secondaryDistanceSquared;           ///< the secondary distance squared
     };
 
-    typedef std::unordered_map<const pandora::CaloHit*, HitAssociation> HitAssociationMap;
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::CaloHit*> HitJoinMap;
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::Cluster*> HitToClusterMap;
+    typedef std::unordered_map<const pandora::CaloHit *, HitAssociation> HitAssociationMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::CaloHit *> HitJoinMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterMap;
 
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -98,7 +98,8 @@ private:
      *  @param  selectedCaloHitList the output selected list of selected hits
      *  @param  rejectedCaloHitList the output rejected list of rejected hits
      */
-    pandora::StatusCode FilterCaloHits(const pandora::CaloHitList *const pCaloHitList, pandora::OrderedCaloHitList &selectedCaloHitList, pandora::OrderedCaloHitList& rejectedCaloHitList) const;
+    pandora::StatusCode FilterCaloHits(const pandora::CaloHitList *const pCaloHitList, pandora::OrderedCaloHitList &selectedCaloHitList,
+        pandora::OrderedCaloHitList &rejectedCaloHitList) const;
 
     /**
      *  @brief  Merge previously filtered hits back into their associated clusters
@@ -107,7 +108,8 @@ private:
      *  @param  rejectedCaloHitList the ordered list of rejected hits
      *  @param  hitToClusterMap the mapping between hits and their clusters
      */
-    pandora::StatusCode AddFilteredCaloHits(const pandora::OrderedCaloHitList &selectedCaloHitList, const pandora::OrderedCaloHitList& rejectedCaloHitList, HitToClusterMap& hitToClusterMap) const;
+    pandora::StatusCode AddFilteredCaloHits(const pandora::OrderedCaloHitList &selectedCaloHitList,
+        const pandora::OrderedCaloHitList &rejectedCaloHitList, HitToClusterMap &hitToClusterMap) const;
 
     /**
      *  @brief  Control primary association formation
@@ -147,7 +149,7 @@ private:
      *  @param  hitJoinMap the hit join map
      *  @param  hitToClusterMap the mapping between hits and their clusters
      */
-    void CreateClusters(const pandora::OrderedCaloHitList &orderedCaloHitList, const HitJoinMap &hitJoinMap, HitToClusterMap& hitToClusterMap) const;
+    void CreateClusters(const pandora::OrderedCaloHitList &orderedCaloHitList, const HitJoinMap &hitJoinMap, HitToClusterMap &hitToClusterMap) const;
 
     /**
      *  @brief  Create primary association if appropriate, hitI<->hitJ
@@ -157,8 +159,8 @@ private:
      *  @param  forwardHitAssociationMap the forward hit association map
      *  @param  backwardHitAssociationMap the backward hit association map
      */
-    void CreatePrimaryAssociation(const pandora::CaloHit *const pCaloHitI, const pandora::CaloHit *const pCaloHitJ, HitAssociationMap &forwardHitAssociationMap,
-        HitAssociationMap &backwardHitAssociationMap) const;
+    void CreatePrimaryAssociation(const pandora::CaloHit *const pCaloHitI, const pandora::CaloHit *const pCaloHitJ,
+        HitAssociationMap &forwardHitAssociationMap, HitAssociationMap &backwardHitAssociationMap) const;
 
     /**
      *  @brief  Create secondary association if appropriate, hitI<->hitJ
@@ -168,8 +170,8 @@ private:
      *  @param  forwardHitAssociationMap the forward hit association map
      *  @param  backwardHitAssociationMap the backward hit association map
      */
-    void CreateSecondaryAssociation(const pandora::CaloHit *const pCaloHitI, const pandora::CaloHit *const pCaloHitJ, HitAssociationMap &forwardHitAssociationMap,
-        HitAssociationMap &backwardHitAssociationMap) const;
+    void CreateSecondaryAssociation(const pandora::CaloHit *const pCaloHitI, const pandora::CaloHit *const pCaloHitJ,
+        HitAssociationMap &forwardHitAssociationMap, HitAssociationMap &backwardHitAssociationMap) const;
 
     /**
      *  @brief  Get hit to join by tracing associations via map I, checking via map J
@@ -180,7 +182,8 @@ private:
      *
      *  @return the hit to join
      */
-    const pandora::CaloHit *GetJoinHit(const pandora::CaloHit *const pCaloHit, const HitAssociationMap &hitAssociationMapI, const HitAssociationMap &hitAssociationMapJ) const;
+    const pandora::CaloHit *GetJoinHit(const pandora::CaloHit *const pCaloHit, const HitAssociationMap &hitAssociationMapI,
+        const HitAssociationMap &hitAssociationMapJ) const;
 
     /**
      *  @brief  Get last hit obtained by tracing associations via map I, checking via map J
@@ -192,14 +195,14 @@ private:
      *
      *  @return the last hit obtained in the chain of associations
      */
-    const pandora::CaloHit *TraceHitAssociation(const pandora::CaloHit *const pCaloHit, const HitAssociationMap &hitAssociationMapI, const HitAssociationMap &hitAssociationMapJ,
-        unsigned int &nSteps) const;
+    const pandora::CaloHit *TraceHitAssociation(const pandora::CaloHit *const pCaloHit, const HitAssociationMap &hitAssociationMapI,
+        const HitAssociationMap &hitAssociationMapJ, unsigned int &nSteps) const;
 
-    bool                m_mergeBackFilteredHits;        ///< Merge rejected hits into their associated clusters
-    unsigned int        m_maxGapLayers;                 ///< Maximum number of layers for a gap
-    float               m_maxCaloHitSeparationSquared;  ///< Square of maximum calo hit separation
-    float               m_minCaloHitSeparationSquared;  ///< Square of minimum calo hit separation
-    float               m_closeSeparationSquared;       ///< Length scale (squared) for close hit separation
+    bool m_mergeBackFilteredHits;        ///< Merge rejected hits into their associated clusters
+    unsigned int m_maxGapLayers;         ///< Maximum number of layers for a gap
+    float m_maxCaloHitSeparationSquared; ///< Square of maximum calo hit separation
+    float m_minCaloHitSeparationSquared; ///< Square of minimum calo hit separation
+    float m_closeSeparationSquared;      ///< Length scale (squared) for close hit separation
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/BoundedClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/BoundedClusterMopUpAlgorithm.cc
@@ -65,10 +65,10 @@ void BoundedClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BoundedClusterMopUpAlgorithm::GetShowerPositionMap(const TwoDSlidingShowerFitResult &fitResult, const XSampling &xSampling,
-    ShowerPositionMap &showerPositionMap) const
+void BoundedClusterMopUpAlgorithm::GetShowerPositionMap(
+    const TwoDSlidingShowerFitResult &fitResult, const XSampling &xSampling, ShowerPositionMap &showerPositionMap) const
 {
-    for (int n=0; n <= xSampling.m_nPoints; ++n)
+    for (int n = 0; n <= xSampling.m_nPoints; ++n)
     {
         const float x(xSampling.m_minX + (xSampling.m_maxX - xSampling.m_minX) * static_cast<float>(n) / static_cast<float>(xSampling.m_nPoints));
 
@@ -93,10 +93,10 @@ void BoundedClusterMopUpAlgorithm::GetShowerPositionMap(const TwoDSlidingShowerF
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float BoundedClusterMopUpAlgorithm::GetBoundedFraction(const Cluster *const pCluster, const XSampling &xSampling, const ShowerPositionMap &showerPositionMap) const
+float BoundedClusterMopUpAlgorithm::GetBoundedFraction(
+    const Cluster *const pCluster, const XSampling &xSampling, const ShowerPositionMap &showerPositionMap) const
 {
-  if (((xSampling.m_maxX - xSampling.m_minX) < std::numeric_limits<float>::epsilon()) || (0 >= xSampling.m_nPoints) ||
-      (0 == pCluster->GetNCaloHits()))
+    if (((xSampling.m_maxX - xSampling.m_minX) < std::numeric_limits<float>::epsilon()) || (0 >= xSampling.m_nPoints) || (0 == pCluster->GetNCaloHits()))
     {
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
     }
@@ -158,14 +158,14 @@ int BoundedClusterMopUpAlgorithm::XSampling::GetBin(const float x) const
 
 StatusCode BoundedClusterMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerEdgeMultiplier", m_showerEdgeMultiplier));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowerEdgeMultiplier", m_showerEdgeMultiplier));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinBoundedFraction", m_minBoundedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinBoundedFraction", m_minBoundedFraction));
 
     return ClusterMopUpBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/BoundedClusterMopUpAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/BoundedClusterMopUpAlgorithm.h
@@ -50,9 +50,9 @@ private:
          */
         int GetBin(const float x) const;
 
-        float     m_minX;          ///< The min x value
-        float     m_maxX;          ///< The max x value
-        int       m_nPoints;       ///< The number of sampling points to be used
+        float m_minX;  ///< The min x value
+        float m_maxX;  ///< The max x value
+        int m_nPoints; ///< The number of sampling points to be used
     };
 
     void ClusterMopUp(const pandora::ClusterList &pfoClusters, const pandora::ClusterList &remnantClusters) const;
@@ -79,9 +79,9 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_slidingFitWindow;             ///< The layer window for the sliding linear fits
-    float           m_showerEdgeMultiplier;         ///< Artificially tune width of shower envelope so as to make it more/less inclusive
-    float           m_minBoundedFraction;           ///< The minimum cluster bounded fraction for merging
+    unsigned int m_slidingFitWindow; ///< The layer window for the sliding linear fits
+    float m_showerEdgeMultiplier;    ///< Artificially tune width of shower envelope so as to make it more/less inclusive
+    float m_minBoundedFraction;      ///< The minimum cluster bounded fraction for merging
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/ClusterMopUpBaseAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/ClusterMopUpBaseAlgorithm.cc
@@ -18,8 +18,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ClusterMopUpBaseAlgorithm::ClusterMopUpBaseAlgorithm() :
-    m_excludePfosContainingTracks(true)
+ClusterMopUpBaseAlgorithm::ClusterMopUpBaseAlgorithm() : m_excludePfosContainingTracks(true)
 {
 }
 
@@ -104,7 +103,8 @@ void ClusterMopUpBaseAlgorithm::GetClusterLists(const ClusterList &inputClusterL
 void ClusterMopUpBaseAlgorithm::MakeClusterMerges(const ClusterAssociationMap &clusterAssociationMap) const
 {
     ClusterVector sortedRemnantClusters;
-    for (const auto &remnantMapEntry : clusterAssociationMap) sortedRemnantClusters.push_back(remnantMapEntry.first);
+    for (const auto &remnantMapEntry : clusterAssociationMap)
+        sortedRemnantClusters.push_back(remnantMapEntry.first);
     std::sort(sortedRemnantClusters.begin(), sortedRemnantClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pRemnantCluster : sortedRemnantClusters)
@@ -114,7 +114,8 @@ void ClusterMopUpBaseAlgorithm::MakeClusterMerges(const ClusterAssociationMap &c
         float bestFigureOfMerit(-std::numeric_limits<float>::max());
 
         ClusterVector sortedPfoClusters;
-        for (const auto &pfoMapEntry : associationDetails) sortedPfoClusters.push_back(pfoMapEntry.first);
+        for (const auto &pfoMapEntry : associationDetails)
+            sortedPfoClusters.push_back(pfoMapEntry.first);
         std::sort(sortedPfoClusters.begin(), sortedPfoClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pPfoCluster : sortedPfoClusters)
@@ -131,8 +132,9 @@ void ClusterMopUpBaseAlgorithm::MakeClusterMerges(const ClusterAssociationMap &c
         if (!pBestPfoCluster)
             continue;
 
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pBestPfoCluster, pRemnantCluster,
-            this->GetListName(pBestPfoCluster), this->GetListName(pRemnantCluster)));
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+            PandoraContentApi::MergeAndDeleteClusters(
+                *this, pBestPfoCluster, pRemnantCluster, this->GetListName(pBestPfoCluster), this->GetListName(pRemnantCluster)));
     }
 }
 
@@ -140,11 +142,10 @@ void ClusterMopUpBaseAlgorithm::MakeClusterMerges(const ClusterAssociationMap &c
 
 StatusCode ClusterMopUpBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "PfoListNames", m_pfoListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ExcludePfosContainingTracks", m_excludePfosContainingTracks));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ExcludePfosContainingTracks", m_excludePfosContainingTracks));
 
     return MopUpBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/ClusterMopUpBaseAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/ClusterMopUpBaseAlgorithm.h
@@ -57,8 +57,8 @@ protected:
      *  @param  clusterListV to receive the list of clusters in the v view
      *  @param  clusterListW to receive the list of clusters in the w view
      */
-    virtual void GetClusterLists(const pandora::ClusterList &inputClusterList, const bool availabilityFlag, pandora::ClusterList &clusterListU,
-        pandora::ClusterList &clusterListV, pandora::ClusterList &clusterListW) const;
+    virtual void GetClusterLists(const pandora::ClusterList &inputClusterList, const bool availabilityFlag,
+        pandora::ClusterList &clusterListU, pandora::ClusterList &clusterListV, pandora::ClusterList &clusterListW) const;
 
     /**
      *  @brief  Cluster mop up for a single view. This function is responsible for instructing pandora to make cluster alterations
@@ -68,8 +68,8 @@ protected:
      */
     virtual void ClusterMopUp(const pandora::ClusterList &pfoClusters, const pandora::ClusterList &remnantClusters) const = 0;
 
-    typedef std::unordered_map<const pandora::Cluster*, float> AssociationDetails;
-    typedef std::unordered_map<const pandora::Cluster*, AssociationDetails> ClusterAssociationMap;
+    typedef std::unordered_map<const pandora::Cluster *, float> AssociationDetails;
+    typedef std::unordered_map<const pandora::Cluster *, AssociationDetails> ClusterAssociationMap;
 
     /**
      *  @brief  Make the cluster merges specified in the cluster association map, using list name information in the cluster list name map
@@ -80,8 +80,8 @@ protected:
 
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector   m_pfoListNames;                 ///< The list of pfo list names
-    bool                    m_excludePfosContainingTracks;  ///< Whether to exclude any pfos containing clusters flagged as fixed tracks
+    pandora::StringVector m_pfoListNames; ///< The list of pfo list names
+    bool m_excludePfosContainingTracks;   ///< Whether to exclude any pfos containing clusters flagged as fixed tracks
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/ConeClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/ConeClusterMopUpAlgorithm.cc
@@ -70,7 +70,8 @@ void ConeClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, con
 
             const HitType hitType(LArClusterHelper::GetClusterHitType(pPfoCluster));
             const CartesianVector vertexPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
-            const bool vertexAtMinL((vertexPosition2D - minLayerPositionOnAxis).GetMagnitudeSquared() < (vertexPosition2D - maxLayerPositionOnAxis).GetMagnitudeSquared());
+            const bool vertexAtMinL((vertexPosition2D - minLayerPositionOnAxis).GetMagnitudeSquared() <
+                                    (vertexPosition2D - maxLayerPositionOnAxis).GetMagnitudeSquared());
 
             // Cone edges
             CoordinateList coordinateListP, coordinateListN;
@@ -94,12 +95,14 @@ void ConeClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, con
             std::sort(coordinateListN.begin(), coordinateListN.end(), ConeClusterMopUpAlgorithm::SortCoordinates);
 
             const Coordinate maxP(coordinateListP.at(m_coneAngleCentile * coordinateListP.size()));
-            const Coordinate minP(vertexAtMinL ? Coordinate(layerFitResultMapP.begin()->second.GetL(), layerFitResultMapP.begin()->second.GetFitT()) :
-                Coordinate(layerFitResultMapP.rbegin()->second.GetL(), layerFitResultMapP.rbegin()->second.GetFitT()));
+            const Coordinate minP(vertexAtMinL
+                                      ? Coordinate(layerFitResultMapP.begin()->second.GetL(), layerFitResultMapP.begin()->second.GetFitT())
+                                      : Coordinate(layerFitResultMapP.rbegin()->second.GetL(), layerFitResultMapP.rbegin()->second.GetFitT()));
 
             const Coordinate maxN(coordinateListN.at((1.f - m_coneAngleCentile) * coordinateListN.size()));
-            const Coordinate minN(vertexAtMinL ? Coordinate(layerFitResultMapN.begin()->second.GetL(), layerFitResultMapN.begin()->second.GetFitT()) :
-                Coordinate(layerFitResultMapN.rbegin()->second.GetL(), layerFitResultMapN.rbegin()->second.GetFitT()));
+            const Coordinate minN(vertexAtMinL
+                                      ? Coordinate(layerFitResultMapN.begin()->second.GetL(), layerFitResultMapN.begin()->second.GetFitT())
+                                      : Coordinate(layerFitResultMapN.rbegin()->second.GetL(), layerFitResultMapN.rbegin()->second.GetFitT()));
 
             const float minL(layerFitResultMapS.begin()->second.GetL());
             const float maxL(minL + m_maxConeLengthMultiplier * std::fabs(layerFitResultMapS.rbegin()->second.GetL() - minL));
@@ -171,20 +174,20 @@ bool ConeClusterMopUpAlgorithm::SortCoordinates(const Coordinate &lhs, const Coo
 
 StatusCode ConeClusterMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerEdgeMultiplier", m_showerEdgeMultiplier));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowerEdgeMultiplier", m_showerEdgeMultiplier));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeAngleCentile", m_coneAngleCentile));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeAngleCentile", m_coneAngleCentile));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxConeLengthMultiplier", m_maxConeLengthMultiplier));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxConeLengthMultiplier", m_maxConeLengthMultiplier));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinBoundedFraction", m_minBoundedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinBoundedFraction", m_minBoundedFraction));
 
     return ClusterMopUpBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/ConeClusterMopUpAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/ConeClusterMopUpAlgorithm.h
@@ -44,11 +44,11 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_slidingFitWindow;         ///< The layer window for the sliding linear fits
-    float           m_showerEdgeMultiplier;     ///< Artificially tune width of shower envelope so as to make it more/less inclusive
-    float           m_coneAngleCentile;         ///< Cluster cone angle is defined using specified centile of distribution of hit half angles
-    float           m_maxConeLengthMultiplier;  ///< Consider hits as bound if inside cone, with projected distance less than N times cone length
-    float           m_minBoundedFraction;       ///< The minimum cluster bounded fraction for merging
+    unsigned int m_slidingFitWindow; ///< The layer window for the sliding linear fits
+    float m_showerEdgeMultiplier;    ///< Artificially tune width of shower envelope so as to make it more/less inclusive
+    float m_coneAngleCentile;        ///< Cluster cone angle is defined using specified centile of distribution of hit half angles
+    float m_maxConeLengthMultiplier; ///< Consider hits as bound if inside cone, with projected distance less than N times cone length
+    float m_minBoundedFraction;      ///< The minimum cluster bounded fraction for merging
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/IsolatedClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/IsolatedClusterMopUpAlgorithm.cc
@@ -40,7 +40,8 @@ void IsolatedClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters,
     this->GetCaloHitToClusterMap(caloHitList, pfoClusters, caloHitToClusterMap);
 
     CaloHitList sortedCaloHitList;
-    for (const auto &mapEntry : caloHitToClusterMap) sortedCaloHitList.push_back(mapEntry.first);
+    for (const auto &mapEntry : caloHitToClusterMap)
+        sortedCaloHitList.push_back(mapEntry.first);
     sortedCaloHitList.sort(LArClusterHelper::SortHitsByPosition);
 
     for (const CaloHit *pCaloHit : sortedCaloHitList)
@@ -73,7 +74,8 @@ void IsolatedClusterMopUpAlgorithm::DissolveClustersToHits(const ClusterList &cl
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void IsolatedClusterMopUpAlgorithm::GetCaloHitToClusterMap(const CaloHitList &caloHitList, const ClusterList &clusterList, CaloHitToClusterMap &caloHitToClusterMap) const
+void IsolatedClusterMopUpAlgorithm::GetCaloHitToClusterMap(
+    const CaloHitList &caloHitList, const ClusterList &clusterList, CaloHitToClusterMap &caloHitToClusterMap) const
 {
     CaloHitList allCaloHits;
     CaloHitToClusterMap hitToParentClusterMap;
@@ -85,7 +87,7 @@ void IsolatedClusterMopUpAlgorithm::GetCaloHitToClusterMap(const CaloHitList &ca
         allCaloHits.insert(allCaloHits.end(), daughterHits.begin(), daughterHits.end());
 
         for (const CaloHit *const pCaloHit : daughterHits)
-            (void) hitToParentClusterMap.insert(CaloHitToClusterMap::value_type(pCaloHit, pCluster));
+            (void)hitToParentClusterMap.insert(CaloHitToClusterMap::value_type(pCaloHit, pCluster));
     }
 
     HitKDTree2D kdTree;
@@ -105,7 +107,7 @@ void IsolatedClusterMopUpAlgorithm::GetCaloHitToClusterMap(const CaloHitList &ca
         kdTree.findNearestNeighbour(targetHit, pResultHit, resultDistance);
 
         if (pResultHit && (resultDistance < m_maxHitClusterDistance))
-            (void) caloHitToClusterMap.insert(CaloHitToClusterMap::value_type(pCaloHit, hitToParentClusterMap.at(pResultHit->data)));
+            (void)caloHitToClusterMap.insert(CaloHitToClusterMap::value_type(pCaloHit, hitToParentClusterMap.at(pResultHit->data)));
     }
 }
 
@@ -113,14 +115,14 @@ void IsolatedClusterMopUpAlgorithm::GetCaloHitToClusterMap(const CaloHitList &ca
 
 StatusCode IsolatedClusterMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCaloHitsInCluster", m_maxCaloHitsInCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCaloHitsInCluster", m_maxCaloHitsInCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxHitClusterDistance", m_maxHitClusterDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxHitClusterDistance", m_maxHitClusterDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "AddHitsAsIsolated", m_addHitsAsIsolated));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "AddHitsAsIsolated", m_addHitsAsIsolated));
 
     return ClusterMopUpBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/IsolatedClusterMopUpAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/IsolatedClusterMopUpAlgorithm.h
@@ -17,8 +17,10 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -44,7 +46,7 @@ private:
      */
     void DissolveClustersToHits(const pandora::ClusterList &clusterList, pandora::CaloHitList &caloHitList) const;
 
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::Cluster*> CaloHitToClusterMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> CaloHitToClusterMap;
 
     /**
      *  @brief  Look for isolated hit additions, considering a list of candidate hits and a list of host clusters
@@ -53,17 +55,18 @@ private:
      *  @param  clusterList the list of clusters to consider
      *  @param  caloHitToClusterMap to receive the calo hit to cluster map
      */
-    void GetCaloHitToClusterMap(const pandora::CaloHitList &caloHitList, const pandora::ClusterList &clusterList, CaloHitToClusterMap &caloHitToClusterMap) const;
+    void GetCaloHitToClusterMap(
+        const pandora::CaloHitList &caloHitList, const pandora::ClusterList &clusterList, CaloHitToClusterMap &caloHitToClusterMap) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef KDTreeLinkerAlgo<const pandora::CaloHit*, 2> HitKDTree2D;
-    typedef KDTreeNodeInfoT<const pandora::CaloHit*, 2> HitKDNode2D;
+    typedef KDTreeLinkerAlgo<const pandora::CaloHit *, 2> HitKDTree2D;
+    typedef KDTreeNodeInfoT<const pandora::CaloHit *, 2> HitKDNode2D;
     typedef std::vector<HitKDNode2D> HitKDNode2DList;
 
-    unsigned int    m_maxCaloHitsInCluster;     ///< The maximum number of hits in a cluster to be dissolved
-    float           m_maxHitClusterDistance;    ///< The maximum hit to cluster distance for isolated hit merging
-    bool            m_addHitsAsIsolated;        ///< Whether to add hits to clusters as "isolated" (don't contribute to spatial properties)
+    unsigned int m_maxCaloHitsInCluster; ///< The maximum number of hits in a cluster to be dissolved
+    float m_maxHitClusterDistance;       ///< The maximum hit to cluster distance for isolated hit merging
+    bool m_addHitsAsIsolated;            ///< Whether to add hits to clusters as "isolated" (don't contribute to spatial properties)
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/NearbyClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/NearbyClusterMopUpAlgorithm.cc
@@ -34,7 +34,8 @@ void NearbyClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, c
 
     const VertexList *pVertexList(NULL);
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pVertexList));
-    const Vertex *const pVertex(((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : NULL);
+    const Vertex *const pVertex(
+        ((pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : NULL);
 
     ClusterVector sortedPfoClusters(pfoClusters.begin(), pfoClusters.end());
     std::sort(sortedPfoClusters.begin(), sortedPfoClusters.end(), LArClusterHelper::SortByNHits);
@@ -45,8 +46,8 @@ void NearbyClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, c
     for (const Cluster *const pClusterP : sortedPfoClusters)
     {
         const HitType hitType(LArClusterHelper::GetClusterHitType(pClusterP));
-        const CartesianVector vertexPosition2D(!pVertex ? CartesianVector(0.f, 0.f, 0.f) :
-            LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
+        const CartesianVector vertexPosition2D(
+            !pVertex ? CartesianVector(0.f, 0.f, 0.f) : LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
 
         const float innerPV((vertexPosition2D - pClusterP->GetCentroid(pClusterP->GetInnerPseudoLayer())).GetMagnitude());
         const float outerPV((vertexPosition2D - pClusterP->GetCentroid(pClusterP->GetOuterPseudoLayer())).GetMagnitude());
@@ -60,7 +61,8 @@ void NearbyClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, c
             const float outerRV((vertexPosition2D - pClusterR->GetCentroid(pClusterR->GetOuterPseudoLayer())).GetMagnitude());
 
             // ATTN Could use pointing clusters here, for consistency with other vertex association mechanics
-            if (pVertex && (((innerPV < m_vertexProximity) || (outerPV < m_vertexProximity)) && ((innerRV < m_vertexProximity) || (outerRV < m_vertexProximity))))
+            if (pVertex && (((innerPV < m_vertexProximity) || (outerPV < m_vertexProximity)) &&
+                               ((innerRV < m_vertexProximity) || (outerRV < m_vertexProximity))))
                 continue;
 
             const float innerRP(LArClusterHelper::GetClosestDistance(pClusterR->GetCentroid(pClusterR->GetInnerPseudoLayer()), pClusterP));
@@ -90,17 +92,16 @@ void NearbyClusterMopUpAlgorithm::ClusterMopUp(const ClusterList &pfoClusters, c
 
 StatusCode NearbyClusterMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsInCluster", m_minHitsInCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinHitsInCluster", m_minHitsInCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexProximity", m_vertexProximity));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexProximity", m_vertexProximity));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterSeparation", m_minClusterSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterSeparation", m_minClusterSeparation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TouchingDistance", m_touchingDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TouchingDistance", m_touchingDistance));
 
     return ClusterMopUpBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/NearbyClusterMopUpAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/NearbyClusterMopUpAlgorithm.h
@@ -32,10 +32,10 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    unsigned int    m_minHitsInCluster;         ///< Minimum number of hits in order to consider a cluster
-    float           m_vertexProximity;          ///< Distance between cluster inner/outer centroid and vtx to declare cluster vtx associated
-    float           m_minClusterSeparation;     ///< Minimum distance between parent and daughter clusters to declare clusters associated
-    float           m_touchingDistance;         ///< Threshold (small) distance below which parent and daughter clusters are declated touching
+    unsigned int m_minHitsInCluster; ///< Minimum number of hits in order to consider a cluster
+    float m_vertexProximity;         ///< Distance between cluster inner/outer centroid and vtx to declare cluster vtx associated
+    float m_minClusterSeparation;    ///< Minimum distance between parent and daughter clusters to declare clusters associated
+    float m_touchingDistance;        ///< Threshold (small) distance below which parent and daughter clusters are declated touching
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/SlidingConeClusterMopUpAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/SlidingConeClusterMopUpAlgorithm.cc
@@ -76,7 +76,8 @@ void SlidingConeClusterMopUpAlgorithm::GetInteractionVertex(const Vertex *&pVert
     const VertexList *pVertexList = nullptr;
     PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetCurrentList(*this, pVertexList));
 
-    pVertex = ((pVertexList && (pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
+    pVertex =
+        ((pVertexList && (pVertexList->size() == 1) && (VERTEX_3D == (*(pVertexList->begin()))->GetVertexType())) ? *(pVertexList->begin()) : nullptr);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -162,11 +163,15 @@ void SlidingConeClusterMopUpAlgorithm::GetClusterMergeMap(const Vertex *const pV
 
             const float vertexToMinLayer(!pVertex ? 0.f : (pVertex->GetPosition() - minLayerPosition).GetMagnitude());
             const float vertexToMaxLayer(!pVertex ? 0.f : (pVertex->GetPosition() - maxLayerPosition).GetMagnitude());
-            const ConeSelection coneSelection(!pVertex ? CONE_BOTH_DIRECTIONS : (vertexToMaxLayer > vertexToMinLayer) ? CONE_FORWARD_ONLY : CONE_BACKWARD_ONLY);
+            const ConeSelection coneSelection(
+                !pVertex ? CONE_BOTH_DIRECTIONS : (vertexToMaxLayer > vertexToMinLayer) ? CONE_FORWARD_ONLY : CONE_BACKWARD_ONLY);
 
             slidingConeFitResult3D.GetSimpleConeList(m_nConeFitLayers, m_nConeFits, coneSelection, simpleConeList3D);
         }
-        catch (const StatusCodeException &) {continue;}
+        catch (const StatusCodeException &)
+        {
+            continue;
+        }
 
         for (const Cluster *const pNearbyCluster2D : availableClusters2D)
         {
@@ -181,7 +186,8 @@ void SlidingConeClusterMopUpAlgorithm::GetClusterMergeMap(const Vertex *const pV
 
                 const CartesianVector apexToBase2D(coneBaseCentre2D - coneApex2D);
                 const SimpleCone simpleCone2D(coneApex2D, apexToBase2D.GetUnitVector(), apexToBase2D.GetMagnitude(), m_coneTanHalfAngle);
-                const ClusterMerge clusterMerge(pShowerCluster, simpleCone2D.GetBoundedHitFraction(pNearbyCluster2D), simpleCone2D.GetMeanRT(pNearbyCluster2D));
+                const ClusterMerge clusterMerge(
+                    pShowerCluster, simpleCone2D.GetBoundedHitFraction(pNearbyCluster2D), simpleCone2D.GetMeanRT(pNearbyCluster2D));
 
                 if (clusterMerge < bestClusterMerge)
                     bestClusterMerge = clusterMerge;
@@ -201,7 +207,8 @@ void SlidingConeClusterMopUpAlgorithm::GetClusterMergeMap(const Vertex *const pV
 void SlidingConeClusterMopUpAlgorithm::MakeClusterMerges(const ClusterToPfoMap &clusterToPfoMap, const ClusterMergeMap &clusterMergeMap) const
 {
     ClusterVector daughterClusters;
-    for (const ClusterMergeMap::value_type &mapEntry : clusterMergeMap) daughterClusters.push_back(mapEntry.first);
+    for (const ClusterMergeMap::value_type &mapEntry : clusterMergeMap)
+        daughterClusters.push_back(mapEntry.first);
     std::sort(daughterClusters.begin(), daughterClusters.end(), LArClusterHelper::SortByNHits);
 
     for (ClusterVector::const_reverse_iterator rIter = daughterClusters.rbegin(), rIterEnd = daughterClusters.rend(); rIter != rIterEnd; ++rIter)
@@ -215,8 +222,9 @@ void SlidingConeClusterMopUpAlgorithm::MakeClusterMerges(const ClusterToPfoMap &
 
         if (pParentCluster)
         {
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pDaughterCluster,
-                this->GetListName(pParentCluster), this->GetListName(pDaughterCluster)));
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::MergeAndDeleteClusters(
+                    *this, pParentCluster, pDaughterCluster, this->GetListName(pParentCluster), this->GetListName(pDaughterCluster)));
         }
         else
         {
@@ -253,44 +261,39 @@ bool SlidingConeClusterMopUpAlgorithm::ClusterMerge::operator<(const ClusterMerg
 
 StatusCode SlidingConeClusterMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputPfoListNames", m_inputPfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputPfoListNames", m_inputPfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseVertex", m_useVertex));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseVertex", m_useVertex));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxIterations", m_maxIterations));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxIterations", m_maxIterations));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxHitsToConsider3DTrack", m_maxHitsToConsider3DTrack));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxHitsToConsider3DTrack", m_maxHitsToConsider3DTrack));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsToConsider3DShower", m_minHitsToConsider3DShower));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitsToConsider3DShower", m_minHitsToConsider3DShower));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxHitsToConsider2DCluster", m_maxHitsToConsider2DCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxHitsToConsider2DCluster", m_maxHitsToConsider2DCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_halfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NConeFitLayers", m_nConeFitLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NConeFitLayers", m_nConeFitLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NConeFits", m_nConeFits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NConeFits", m_nConeFits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeLengthMultiplier", m_coneLengthMultiplier));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeLengthMultiplier", m_coneLengthMultiplier));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxConeLength", m_maxConeLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxConeLength", m_maxConeLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeTanHalfAngle", m_coneTanHalfAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeTanHalfAngle", m_coneTanHalfAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ConeBoundedFraction", m_coneBoundedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConeBoundedFraction", m_coneBoundedFraction));
 
     return PfoMopUpBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterMopUp/SlidingConeClusterMopUpAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterMopUp/SlidingConeClusterMopUpAlgorithm.h
@@ -73,9 +73,9 @@ private:
         bool operator<(const ClusterMerge &rhs) const;
 
     private:
-        const pandora::Cluster *m_pParentCluster;       ///< The address of the candidate parent (shower) cluster
-        float                   m_boundedFraction;      ///< The bounded fraction for algorithm-specified cone angle
-        float                   m_meanRT;               ///< The mean transverse distance of all hits (whether contained or not)
+        const pandora::Cluster *m_pParentCluster; ///< The address of the candidate parent (shower) cluster
+        float m_boundedFraction;                  ///< The bounded fraction for algorithm-specified cone angle
+        float m_meanRT;                           ///< The mean transverse distance of all hits (whether contained or not)
     };
 
     typedef std::vector<ClusterMerge> ClusterMergeList;
@@ -89,7 +89,7 @@ private:
      */
     void GetInteractionVertex(const pandora::Vertex *&pVertex) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, const pandora::ParticleFlowObject*> ClusterToPfoMap;
+    typedef std::unordered_map<const pandora::Cluster *, const pandora::ParticleFlowObject *> ClusterToPfoMap;
 
     /**
      *  @brief  Get all 3d clusters contained in the input pfo lists and a mapping from clusters to pfos
@@ -106,7 +106,7 @@ private:
      */
     void GetAvailableTwoDClusters(pandora::ClusterVector &availableClusters2D) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, ClusterMergeList> ClusterMergeMap;
+    typedef std::unordered_map<const pandora::Cluster *, ClusterMergeList> ClusterMergeMap;
 
     /**
      *  @brief  Get the cluster merge map describing all potential 3d cluster merges
@@ -116,8 +116,8 @@ private:
      *  @param  availableClusters2D the sorted list of available 2d clusters
      *  @param  clusterMergeMap to receive the populated cluster merge map
      */
-    void GetClusterMergeMap(const pandora::Vertex *const pVertex, const pandora::ClusterVector &clusters3D, const pandora::ClusterVector &availableClusters2D,
-        ClusterMergeMap &clusterMergeMap) const;
+    void GetClusterMergeMap(const pandora::Vertex *const pVertex, const pandora::ClusterVector &clusters3D,
+        const pandora::ClusterVector &availableClusters2D, ClusterMergeMap &clusterMergeMap) const;
 
     /**
      *  @brief  Make cluster merges based on the provided cluster merge map
@@ -129,24 +129,25 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector   m_inputPfoListNames;            ///< The input pfo list names
-    bool                    m_useVertex;                    ///< Whether to use the interaction vertex to select useful cone directions
-    unsigned int            m_maxIterations;                ///< The maximum allowed number of algorithm iterations
-    unsigned int            m_maxHitsToConsider3DTrack;     ///< The maximum number of hits in a 3d track cluster to warrant inclusion in algorithm
-    unsigned int            m_minHitsToConsider3DShower;    ///< The minimum number of hits in a 3d shower cluster to attempt cone fits
-    unsigned int            m_maxHitsToConsider2DCluster;   ///< The maximum number of hits in a 2d cluster to allow pick-up via sliding cone fits
-    unsigned int            m_halfWindowLayers;             ///< The number of layers to use for half-window of sliding fit
-    unsigned int            m_nConeFitLayers;               ///< The number of layers over which to sum fitted direction to obtain cone fit
-    unsigned int            m_nConeFits;                    ///< The number of cone fits to perform, spread roughly uniformly along the shower length
-    float                   m_coneLengthMultiplier;         ///< The cone length multiplier to use when calculating bounded cluster fractions
-    float                   m_maxConeLength;                ///< The maximum allowed cone length to use when calculating bounded cluster fractions
-    float                   m_coneTanHalfAngle;             ///< The cone tan half angle to use when calculating bounded cluster fractions
-    float                   m_coneBoundedFraction;          ///< The minimum cluster bounded fraction for association
+    pandora::StringVector m_inputPfoListNames; ///< The input pfo list names
+    bool m_useVertex;                          ///< Whether to use the interaction vertex to select useful cone directions
+    unsigned int m_maxIterations;              ///< The maximum allowed number of algorithm iterations
+    unsigned int m_maxHitsToConsider3DTrack;   ///< The maximum number of hits in a 3d track cluster to warrant inclusion in algorithm
+    unsigned int m_minHitsToConsider3DShower;  ///< The minimum number of hits in a 3d shower cluster to attempt cone fits
+    unsigned int m_maxHitsToConsider2DCluster; ///< The maximum number of hits in a 2d cluster to allow pick-up via sliding cone fits
+    unsigned int m_halfWindowLayers;           ///< The number of layers to use for half-window of sliding fit
+    unsigned int m_nConeFitLayers;             ///< The number of layers over which to sum fitted direction to obtain cone fit
+    unsigned int m_nConeFits;                  ///< The number of cone fits to perform, spread roughly uniformly along the shower length
+    float m_coneLengthMultiplier;              ///< The cone length multiplier to use when calculating bounded cluster fractions
+    float m_maxConeLength;                     ///< The maximum allowed cone length to use when calculating bounded cluster fractions
+    float m_coneTanHalfAngle;                  ///< The cone tan half angle to use when calculating bounded cluster fractions
+    float m_coneBoundedFraction;               ///< The minimum cluster bounded fraction for association
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline SlidingConeClusterMopUpAlgorithm::ClusterMerge::ClusterMerge(const pandora::Cluster *const pParentCluster, const float boundedFraction, const float meanRT) :
+inline SlidingConeClusterMopUpAlgorithm::ClusterMerge::ClusterMerge(
+    const pandora::Cluster *const pParentCluster, const float boundedFraction, const float meanRT) :
     m_pParentCluster(pParentCluster),
     m_boundedFraction(boundedFraction),
     m_meanRT(meanRT)

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/BranchSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/BranchSplittingAlgorithm.cc
@@ -38,18 +38,24 @@ void BranchSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult 
     //     possible assignments of vertex and end position until a split is found
     for (unsigned int principalForward = 0; principalForward < 2; ++principalForward)
     {
-        const CartesianVector principalVertexPosition(1==principalForward ? principalSlidingFit.GetGlobalMinLayerPosition() : principalSlidingFit.GetGlobalMaxLayerPosition());
-        const CartesianVector principalEndPosition(1!=principalForward ? principalSlidingFit.GetGlobalMinLayerPosition() : principalSlidingFit.GetGlobalMaxLayerPosition());
-        const CartesianVector principalVertexDirection(1==principalForward ? principalSlidingFit.GetGlobalMinLayerDirection() : principalSlidingFit.GetGlobalMaxLayerDirection() * -1.f);
+        const CartesianVector principalVertexPosition(
+            1 == principalForward ? principalSlidingFit.GetGlobalMinLayerPosition() : principalSlidingFit.GetGlobalMaxLayerPosition());
+        const CartesianVector principalEndPosition(
+            1 != principalForward ? principalSlidingFit.GetGlobalMinLayerPosition() : principalSlidingFit.GetGlobalMaxLayerPosition());
+        const CartesianVector principalVertexDirection(1 == principalForward ? principalSlidingFit.GetGlobalMinLayerDirection()
+                                                                             : principalSlidingFit.GetGlobalMaxLayerDirection() * -1.f);
 
-        CartesianVector projectedBranchPosition(0.f,0.f,0.f);
+        CartesianVector projectedBranchPosition(0.f, 0.f, 0.f);
         bool projectedPositionFound(false), projectedPositionFail(false);
 
         for (unsigned int branchForward = 0; branchForward < 2; ++branchForward)
         {
-            const CartesianVector branchVertexPosition(1==branchForward ? branchSlidingFit.GetGlobalMinLayerPosition() : branchSlidingFit.GetGlobalMaxLayerPosition());
-            const CartesianVector branchEndPosition(1!=branchForward ? branchSlidingFit.GetGlobalMinLayerPosition() : branchSlidingFit.GetGlobalMaxLayerPosition());
-            const CartesianVector branchEndDirection(1!=branchForward ? branchSlidingFit.GetGlobalMinLayerDirection() : branchSlidingFit.GetGlobalMaxLayerDirection() * -1.f);
+            const CartesianVector branchVertexPosition(
+                1 == branchForward ? branchSlidingFit.GetGlobalMinLayerPosition() : branchSlidingFit.GetGlobalMaxLayerPosition());
+            const CartesianVector branchEndPosition(
+                1 != branchForward ? branchSlidingFit.GetGlobalMinLayerPosition() : branchSlidingFit.GetGlobalMaxLayerPosition());
+            const CartesianVector branchEndDirection(
+                1 != branchForward ? branchSlidingFit.GetGlobalMinLayerDirection() : branchSlidingFit.GetGlobalMaxLayerDirection() * -1.f);
 
             if (principalVertexDirection.GetDotProduct(branchEndDirection) < 0.5f)
                 continue;
@@ -62,7 +68,8 @@ void BranchSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult 
             {
                 if (!projectedPositionFound && !projectedPositionFail)
                 {
-                    projectedBranchPosition = LArPointingClusterHelper::GetProjectedPosition(principalVertexPosition, principalVertexDirection, branchSlidingFit.GetCluster(), m_projectionAngularAllowance);
+                    projectedBranchPosition = LArPointingClusterHelper::GetProjectedPosition(
+                        principalVertexPosition, principalVertexDirection, branchSlidingFit.GetCluster(), m_projectionAngularAllowance);
                     projectedPositionFound = true;
                 }
             }
@@ -98,16 +105,16 @@ void BranchSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult 
             bool foundSplit(false);
 
             const float halfWindowLength(branchSlidingFit.GetLayerFitHalfWindowLength());
-            const float deltaL(1==branchForward ? +halfWindowLength : -halfWindowLength);
+            const float deltaL(1 == branchForward ? +halfWindowLength : -halfWindowLength);
 
             float localL(0.f), localT(0.f);
-            CartesianVector forwardDirection(0.f,0.f,0.f);
+            CartesianVector forwardDirection(0.f, 0.f, 0.f);
             branchSlidingFit.GetLocalPosition(projectedBranchPosition, localL, localT);
 
             if (STATUS_CODE_SUCCESS != branchSlidingFit.GetGlobalFitDirection(localL + deltaL, forwardDirection))
                 continue;
 
-            CartesianVector projectedBranchDirection(1==branchForward ? forwardDirection : forwardDirection * -1.f);
+            CartesianVector projectedBranchDirection(1 == branchForward ? forwardDirection : forwardDirection * -1.f);
             const float cosTheta(-projectedBranchDirection.GetDotProduct(principalVertexDirection));
 
             try
@@ -145,20 +152,20 @@ void BranchSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult 
 
 StatusCode BranchSplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinLongitudinalExtension", m_minLongitudinalExtension));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinLongitudinalExtension", m_minLongitudinalExtension));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCosRelativeAngle", m_minCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosRelativeAngle", m_minCosRelativeAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ProjectionAngularAllowance", m_projectionAngularAllowance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ProjectionAngularAllowance", m_projectionAngularAllowance));
 
     return TwoDSlidingFitSplittingAndSplicingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/BranchSplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/BranchSplittingAlgorithm.h
@@ -31,11 +31,11 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float           m_maxTransverseDisplacement;        ///<
-    float           m_maxLongitudinalDisplacement;      ///<
-    float           m_minLongitudinalExtension;         ///<
-    float           m_minCosRelativeAngle;              ///<
-    float           m_projectionAngularAllowance;       ///<
+    float m_maxTransverseDisplacement;   ///<
+    float m_maxLongitudinalDisplacement; ///<
+    float m_minLongitudinalExtension;    ///<
+    float m_minCosRelativeAngle;         ///<
+    float m_projectionAngularAllowance;  ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/ClusterSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/ClusterSplittingAlgorithm.cc
@@ -89,8 +89,8 @@ StatusCode ClusterSplittingAlgorithm::SplitCluster(const Cluster *const pCluster
     const ClusterList clusterList(1, pCluster);
     std::string clusterListToSaveName, clusterListToDeleteName;
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, clusterList, clusterListToDeleteName,
-        clusterListToSaveName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::InitializeFragmentation(*this, clusterList, clusterListToDeleteName, clusterListToSaveName));
 
     // Create new clusters
     const Cluster *pFirstCluster(NULL), *pSecondCluster(NULL);
@@ -110,8 +110,8 @@ StatusCode ClusterSplittingAlgorithm::SplitCluster(const Cluster *const pCluster
 
 StatusCode ClusterSplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputClusterListNames", m_inputClusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/ClusterSplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/ClusterSplittingAlgorithm.h
@@ -36,8 +36,8 @@ protected:
      *  @param  firstCaloHitList the hits in the first fragment
      *  @param  secondCaloHitList the hits in the second fragment
      */
-    virtual pandora::StatusCode DivideCaloHits(const pandora::Cluster *const pCluster, pandora::CaloHitList &firstCaloHitList,
-        pandora::CaloHitList &secondCaloHitList) const = 0;
+    virtual pandora::StatusCode DivideCaloHits(
+        const pandora::Cluster *const pCluster, pandora::CaloHitList &firstCaloHitList, pandora::CaloHitList &secondCaloHitList) const = 0;
 
 private:
     /**
@@ -48,7 +48,7 @@ private:
      */
     pandora::StatusCode SplitCluster(const pandora::Cluster *const pCluster, pandora::ClusterList &clusterSplittingList) const;
 
-    pandora::StringVector   m_inputClusterListNames;    ///< The list of input cluster list names - if empty, use the current cluster list
+    pandora::StringVector m_inputClusterListNames; ///< The list of input cluster list names - if empty, use the current cluster list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/CrossedTrackSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/CrossedTrackSplittingAlgorithm.cc
@@ -43,7 +43,7 @@ StatusCode CrossedTrackSplittingAlgorithm::PreparationStep(const ClusterVector &
         allCaloHits.insert(allCaloHits.end(), daughterHits.begin(), daughterHits.end());
 
         for (const CaloHit *const pCaloHit : daughterHits)
-            (void) hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHit, pCluster));
+            (void)hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHit, pCluster));
     }
 
     HitKDTree2D kdTree;
@@ -65,7 +65,7 @@ StatusCode CrossedTrackSplittingAlgorithm::PreparationStep(const ClusterVector &
             kdTree.search(searchRegionHits, found);
 
             for (const auto &hit : found)
-                (void) m_nearbyClusters[pCluster].insert(hitToClusterMap.at(hit.data));
+                (void)m_nearbyClusters[pCluster].insert(hitToClusterMap.at(hit.data));
         }
     }
 
@@ -83,12 +83,11 @@ StatusCode CrossedTrackSplittingAlgorithm::TidyUpStep()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode CrossedTrackSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult &slidingFitResult1, const TwoDSlidingFitResult &slidingFitResult2,
-    CartesianVector &splitPosition, CartesianVector &firstDirection, CartesianVector &secondDirection) const
+StatusCode CrossedTrackSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult &slidingFitResult1,
+    const TwoDSlidingFitResult &slidingFitResult2, CartesianVector &splitPosition, CartesianVector &firstDirection, CartesianVector &secondDirection) const
 {
     // Use cached results from kd-tree to avoid expensive calculations
-    if (!m_nearbyClusters.count(slidingFitResult1.GetCluster()) ||
-        !m_nearbyClusters.count(slidingFitResult2.GetCluster()) ||
+    if (!m_nearbyClusters.count(slidingFitResult1.GetCluster()) || !m_nearbyClusters.count(slidingFitResult2.GetCluster()) ||
         !m_nearbyClusters.at(slidingFitResult1.GetCluster()).count(slidingFitResult2.GetCluster()) ||
         !m_nearbyClusters.at(slidingFitResult2.GetCluster()).count(slidingFitResult1.GetCluster()))
     {
@@ -96,11 +95,11 @@ StatusCode CrossedTrackSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidi
     }
 
     // Identify crossed-track topology and find candidate intersection positions
-    const CartesianVector& minPosition1(slidingFitResult1.GetGlobalMinLayerPosition());
-    const CartesianVector& maxPosition1(slidingFitResult1.GetGlobalMaxLayerPosition());
+    const CartesianVector &minPosition1(slidingFitResult1.GetGlobalMinLayerPosition());
+    const CartesianVector &maxPosition1(slidingFitResult1.GetGlobalMaxLayerPosition());
 
-    const CartesianVector& minPosition2(slidingFitResult2.GetGlobalMinLayerPosition());
-    const CartesianVector& maxPosition2(slidingFitResult2.GetGlobalMaxLayerPosition());
+    const CartesianVector &minPosition2(slidingFitResult2.GetGlobalMinLayerPosition());
+    const CartesianVector &maxPosition2(slidingFitResult2.GetGlobalMaxLayerPosition());
 
     if (LArClusterHelper::GetClosestDistance(minPosition1, slidingFitResult2.GetCluster()) < 2.f * m_maxClusterSeparation ||
         LArClusterHelper::GetClosestDistance(maxPosition1, slidingFitResult2.GetCluster()) < 2.f * m_maxClusterSeparation ||
@@ -118,7 +117,6 @@ StatusCode CrossedTrackSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidi
 
     if (candidateVector.empty())
         return STATUS_CODE_NOT_FOUND;
-
 
     // Loop over candidate positions and find best split position
     bool foundSplit(false);
@@ -187,7 +185,7 @@ StatusCode CrossedTrackSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidi
         const CartesianVector a1(B1);
         const CartesianVector a2(F1);
 
-        for (unsigned int iForward = 0; iForward<2; ++iForward)
+        for (unsigned int iForward = 0; iForward < 2; ++iForward)
         {
             const CartesianVector b1((0 == iForward) ? F2 : B2);
             const CartesianVector b2((0 == iForward) ? B2 : F2);
@@ -197,15 +195,15 @@ StatusCode CrossedTrackSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidi
             const CartesianVector s2((b2 - R2).GetUnitVector());
             const CartesianVector t2((R1 - a2).GetUnitVector());
 
-            if (s1.GetDotProduct(t1) < std::max(m_minCosRelativeAngle,-s1.GetDotProduct(s2)) ||
-                s2.GetDotProduct(t2) < std::max(m_minCosRelativeAngle,-t1.GetDotProduct(t2)))
+            if (s1.GetDotProduct(t1) < std::max(m_minCosRelativeAngle, -s1.GetDotProduct(s2)) ||
+                s2.GetDotProduct(t2) < std::max(m_minCosRelativeAngle, -t1.GetDotProduct(t2)))
                 continue;
 
             const CartesianVector p1((b1 - a1).GetUnitVector());
             const CartesianVector p2((b2 - a2).GetUnitVector());
 
             float mu1(0.f), mu2(0.f);
-            CartesianVector C1(0.f,0.f,0.f);
+            CartesianVector C1(0.f, 0.f, 0.f);
 
             try
             {
@@ -240,8 +238,8 @@ StatusCode CrossedTrackSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CrossedTrackSplittingAlgorithm::FindCandidateSplitPositions(const Cluster *const pCluster1, const Cluster *const pCluster2,
-    CartesianPointVector &candidateVector) const
+void CrossedTrackSplittingAlgorithm::FindCandidateSplitPositions(
+    const Cluster *const pCluster1, const Cluster *const pCluster2, CartesianPointVector &candidateVector) const
 {
     // ATTN The following is double-double counting
     CaloHitList caloHitList1, caloHitList2;
@@ -275,15 +273,14 @@ void CrossedTrackSplittingAlgorithm::FindCandidateSplitPositions(const Cluster *
 
 StatusCode CrossedTrackSplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClusterSeparation", m_maxClusterSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClusterSeparation", m_maxClusterSeparation));
     m_maxClusterSeparationSquared = m_maxClusterSeparation * m_maxClusterSeparation;
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCosRelativeAngle", m_minCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosRelativeAngle", m_minCosRelativeAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SearchRegion1D", m_searchRegion1D));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SearchRegion1D", m_searchRegion1D));
 
     return TwoDSlidingFitSplittingAndSwitchingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/CrossedTrackSplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/CrossedTrackSplittingAlgorithm.h
@@ -15,8 +15,10 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -32,12 +34,12 @@ public:
     CrossedTrackSplittingAlgorithm();
 
 private:
-    typedef KDTreeLinkerAlgo<const pandora::CaloHit*, 2> HitKDTree2D;
-    typedef KDTreeNodeInfoT<const pandora::CaloHit*, 2> HitKDNode2D;
+    typedef KDTreeLinkerAlgo<const pandora::CaloHit *, 2> HitKDTree2D;
+    typedef KDTreeNodeInfoT<const pandora::CaloHit *, 2> HitKDNode2D;
     typedef std::vector<HitKDNode2D> HitKDNode2DList;
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::ClusterSet> ClusterToClustersMap;
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::Cluster*> HitToClusterMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterSet> ClusterToClustersMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterMap;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
     pandora::StatusCode PreparationStep(const pandora::ClusterVector &clusterVector);
@@ -55,12 +57,12 @@ private:
     void FindCandidateSplitPositions(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2,
         pandora::CartesianPointVector &candidateVector) const;
 
-    float                   m_maxClusterSeparation;             ///< maximum separation of two clusters
-    float                   m_maxClusterSeparationSquared;      ///< maximum separation of two clusters (squared)
-    float                   m_minCosRelativeAngle;              ///< maximum relative angle between tracks after un-crossing
+    float m_maxClusterSeparation;        ///< maximum separation of two clusters
+    float m_maxClusterSeparationSquared; ///< maximum separation of two clusters (squared)
+    float m_minCosRelativeAngle;         ///< maximum relative angle between tracks after un-crossing
 
-    float                   m_searchRegion1D;                   ///< Search region, applied to each dimension, for look-up from kd-trees
-    ClusterToClustersMap    m_nearbyClusters;                   ///< The nearby clusters map
+    float m_searchRegion1D;                ///< Search region, applied to each dimension, for look-up from kd-trees
+    ClusterToClustersMap m_nearbyClusters; ///< The nearby clusters map
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/DeltaRaySplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/DeltaRaySplittingAlgorithm.cc
@@ -38,18 +38,24 @@ void DeltaRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResul
 
     for (unsigned int principalForward = 0; principalForward < 2; ++principalForward)
     {
-        const CartesianVector principalVertex(1==principalForward ? principalSlidingFit.GetGlobalMinLayerPosition() : principalSlidingFit.GetGlobalMaxLayerPosition());
-        const CartesianVector principalEnd(1==principalForward ? principalSlidingFit.GetGlobalMaxLayerPosition() : principalSlidingFit.GetGlobalMinLayerPosition());
-        const CartesianVector principalDirection(1==principalForward ? principalSlidingFit.GetGlobalMinLayerDirection() : principalSlidingFit.GetGlobalMaxLayerDirection() * -1.f);
+        const CartesianVector principalVertex(
+            1 == principalForward ? principalSlidingFit.GetGlobalMinLayerPosition() : principalSlidingFit.GetGlobalMaxLayerPosition());
+        const CartesianVector principalEnd(
+            1 == principalForward ? principalSlidingFit.GetGlobalMaxLayerPosition() : principalSlidingFit.GetGlobalMinLayerPosition());
+        const CartesianVector principalDirection(1 == principalForward ? principalSlidingFit.GetGlobalMinLayerDirection()
+                                                                       : principalSlidingFit.GetGlobalMaxLayerDirection() * -1.f);
 
         if (LArClusterHelper::GetClosestDistance(principalVertex, branchSlidingFit.GetCluster()) > m_maxLongitudinalDisplacement)
             continue;
 
         for (unsigned int branchForward = 0; branchForward < 2; ++branchForward)
         {
-            const CartesianVector branchVertex(1==branchForward ? branchSlidingFit.GetGlobalMinLayerPosition() : branchSlidingFit.GetGlobalMaxLayerPosition());
-            const CartesianVector branchEnd(1==branchForward ? branchSlidingFit.GetGlobalMaxLayerPosition() : branchSlidingFit.GetGlobalMinLayerPosition());
-            const CartesianVector branchDirection(1==branchForward ? branchSlidingFit.GetGlobalMinLayerDirection() : branchSlidingFit.GetGlobalMaxLayerDirection() * -1.f);
+            const CartesianVector branchVertex(
+                1 == branchForward ? branchSlidingFit.GetGlobalMinLayerPosition() : branchSlidingFit.GetGlobalMaxLayerPosition());
+            const CartesianVector branchEnd(
+                1 == branchForward ? branchSlidingFit.GetGlobalMaxLayerPosition() : branchSlidingFit.GetGlobalMinLayerPosition());
+            const CartesianVector branchDirection(
+                1 == branchForward ? branchSlidingFit.GetGlobalMinLayerDirection() : branchSlidingFit.GetGlobalMaxLayerDirection() * -1.f);
 
             // Require vertices to be closest two ends
             const float vertex_to_vertex((principalVertex - branchVertex).GetMagnitudeSquared());
@@ -77,9 +83,9 @@ void DeltaRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResul
             bool foundSplit(false);
 
             const float halfWindowLength(branchSlidingFit.GetLayerFitHalfWindowLength());
-            const float deltaL(1==branchForward ? +halfWindowLength : -halfWindowLength);
+            const float deltaL(1 == branchForward ? +halfWindowLength : -halfWindowLength);
 
-            float branchDistance(std::max(0.f,vertexProjection) + 0.5f * m_stepSize);
+            float branchDistance(std::max(0.f, vertexProjection) + 0.5f * m_stepSize);
 
             while (!foundSplit)
             {
@@ -94,8 +100,8 @@ void DeltaRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResul
                     break;
 
                 float localL(0.f), localT(0.f);
-                CartesianVector truncatedPosition(0.f,0.f,0.f);
-                CartesianVector forwardDirection(0.f,0.f,0.f);
+                CartesianVector truncatedPosition(0.f, 0.f, 0.f);
+                CartesianVector forwardDirection(0.f, 0.f, 0.f);
                 branchSlidingFit.GetLocalPosition(linearProjection, localL, localT);
 
                 if ((STATUS_CODE_SUCCESS != branchSlidingFit.GetGlobalFitPosition(localL, truncatedPosition)) ||
@@ -104,7 +110,7 @@ void DeltaRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResul
                     continue;
                 }
 
-                CartesianVector truncatedDirection(1==branchForward ? forwardDirection : forwardDirection * -1.f);
+                CartesianVector truncatedDirection(1 == branchForward ? forwardDirection : forwardDirection * -1.f);
                 const float cosTheta(-truncatedDirection.GetDotProduct(principalDirection));
 
                 float rT1(0.f), rL1(0.f), rT2(0.f), rL2(0.f);
@@ -132,17 +138,16 @@ void DeltaRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResul
 
 StatusCode DeltaRaySplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "StepSize", m_stepSize));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "StepSize", m_stepSize));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCosRelativeAngle", m_minCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosRelativeAngle", m_minCosRelativeAngle));
 
     return TwoDSlidingFitSplittingAndSplicingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/DeltaRaySplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/DeltaRaySplittingAlgorithm.h
@@ -31,10 +31,10 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float         m_stepSize;                       ///<
-    float         m_maxTransverseDisplacement;      ///<
-    float         m_maxLongitudinalDisplacement;    ///<
-    float         m_minCosRelativeAngle;            ///<
+    float m_stepSize;                    ///<
+    float m_maxTransverseDisplacement;   ///<
+    float m_maxLongitudinalDisplacement; ///<
+    float m_minCosRelativeAngle;         ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/KinkSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/KinkSplittingAlgorithm.cc
@@ -15,16 +15,13 @@ using namespace pandora;
 namespace lar_content
 {
 
-KinkSplittingAlgorithm::KinkSplittingAlgorithm() :
-    m_maxScatterRms(0.2f),
-    m_maxScatterCosTheta(0.905f),
-    m_maxSlidingCosTheta(0.985f)
+KinkSplittingAlgorithm::KinkSplittingAlgorithm() : m_maxScatterRms(0.2f), m_maxScatterCosTheta(0.905f), m_maxSlidingCosTheta(0.985f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode KinkSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult &slidingFitResult, CartesianVector& splitPosition) const
+StatusCode KinkSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult &slidingFitResult, CartesianVector &splitPosition) const
 {
     // Search for scatters by scanning over the layers in the sliding fit result
     const LayerFitResultMap &layerFitResultMap(slidingFitResult.GetLayerFitResultMap());
@@ -48,7 +45,7 @@ StatusCode KinkSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitRes
         const float rL1(slidingFitResult.GetL(iLayer - nLayersHalfWindow));
         const float rL2(slidingFitResult.GetL(iLayer + nLayersHalfWindow));
 
-        CartesianVector centralPosition(0.f,0.f,0.f), firstDirection(0.f,0.f,0.f), secondDirection(0.f,0.f,0.f);
+        CartesianVector centralPosition(0.f, 0.f, 0.f), firstDirection(0.f, 0.f, 0.f), secondDirection(0.f, 0.f, 0.f);
 
         if ((STATUS_CODE_SUCCESS != slidingFitResult.GetGlobalFitPosition(rL, centralPosition)) ||
             (STATUS_CODE_SUCCESS != slidingFitResult.GetGlobalFitDirection(rL1, firstDirection)) ||
@@ -66,8 +63,7 @@ StatusCode KinkSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitRes
 
         if (cosTheta > m_maxScatterCosTheta)
         {
-            rmsCut *= ((m_maxSlidingCosTheta > cosTheta) ? (m_maxSlidingCosTheta - cosTheta) /
-                    (m_maxSlidingCosTheta - m_maxScatterCosTheta) : 0.f);
+            rmsCut *= ((m_maxSlidingCosTheta > cosTheta) ? (m_maxSlidingCosTheta - cosTheta) / (m_maxSlidingCosTheta - m_maxScatterCosTheta) : 0.f);
         }
 
         if (rms < rmsCut && cosTheta < bestCosTheta)
@@ -88,14 +84,13 @@ StatusCode KinkSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitRes
 
 StatusCode KinkSplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxScatterRms", m_maxScatterRms));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxScatterRms", m_maxScatterRms));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxScatterCosTheta", m_maxScatterCosTheta));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxScatterCosTheta", m_maxScatterCosTheta));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxSlidingCosTeta", m_maxSlidingCosTheta));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxSlidingCosTeta", m_maxSlidingCosTheta));
 
     return TwoDSlidingFitSplittingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/KinkSplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/KinkSplittingAlgorithm.h
@@ -37,9 +37,9 @@ private:
      */
     pandora::StatusCode FindBestSplitPosition(const TwoDSlidingFitResult &slidingFitResult, pandora::CartesianVector &splitPosition) const;
 
-    float           m_maxScatterRms;          ///<
-    float           m_maxScatterCosTheta;     ///<
-    float           m_maxSlidingCosTheta;     ///<
+    float m_maxScatterRms;      ///<
+    float m_maxScatterCosTheta; ///<
+    float m_maxSlidingCosTheta; ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/LayerSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/LayerSplittingAlgorithm.cc
@@ -48,7 +48,7 @@ StatusCode LayerSplittingAlgorithm::FindBestSplitLayer(const Cluster *const pClu
     bool foundSplit(false);
 
     float bestCosTheta(1.f);
-    CartesianVector bestPosition(0.f,0.f,0.f);
+    CartesianVector bestPosition(0.f, 0.f, 0.f);
 
     for (unsigned int iLayer = pCluster->GetInnerPseudoLayer() + 4; iLayer + 4 <= pCluster->GetOuterPseudoLayer(); ++iLayer)
     {
@@ -58,13 +58,13 @@ StatusCode LayerSplittingAlgorithm::FindBestSplitLayer(const Cluster *const pClu
         unsigned int innerLayer((pCluster->GetInnerPseudoLayer() + m_layerWindow > iLayer) ? pCluster->GetInnerPseudoLayer() : iLayer - m_layerWindow);
         unsigned int outerLayer((iLayer + m_layerWindow > pCluster->GetOuterPseudoLayer()) ? pCluster->GetOuterPseudoLayer() : iLayer + m_layerWindow);
 
-        for ( ; innerLayer >= pCluster->GetInnerPseudoLayer(); --innerLayer)
+        for (; innerLayer >= pCluster->GetInnerPseudoLayer(); --innerLayer)
         {
             if (orderedCaloHitList.find(innerLayer) != orderedCaloHitList.end())
                 break;
         }
 
-        for ( ; outerLayer <= pCluster->GetOuterPseudoLayer(); ++outerLayer)
+        for (; outerLayer <= pCluster->GetOuterPseudoLayer(); ++outerLayer)
         {
             if (orderedCaloHitList.find(outerLayer) != orderedCaloHitList.end())
                 break;
@@ -92,8 +92,7 @@ StatusCode LayerSplittingAlgorithm::FindBestSplitLayer(const Cluster *const pClu
 
             if (cosTheta > m_maxScatterCosTheta)
             {
-            rmsCut *= ((m_maxSlidingCosTheta > cosTheta) ? (m_maxSlidingCosTheta - cosTheta) /
-                    (m_maxSlidingCosTheta - m_maxScatterCosTheta) : 0.f);
+                rmsCut *= ((m_maxSlidingCosTheta > cosTheta) ? (m_maxSlidingCosTheta - cosTheta) / (m_maxSlidingCosTheta - m_maxScatterCosTheta) : 0.f);
             }
         }
 
@@ -115,7 +114,7 @@ StatusCode LayerSplittingAlgorithm::FindBestSplitLayer(const Cluster *const pClu
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float LayerSplittingAlgorithm::CalculateRms(const Cluster *const pCluster, const unsigned int &firstLayer, const unsigned int& secondLayer) const
+float LayerSplittingAlgorithm::CalculateRms(const Cluster *const pCluster, const unsigned int &firstLayer, const unsigned int &secondLayer) const
 {
     const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
 
@@ -142,14 +141,15 @@ float LayerSplittingAlgorithm::CalculateRms(const Cluster *const pCluster, const
     }
 
     if (totalLayers > 0.f)
-        return std::sqrt(totalChi2/totalLayers);
+        return std::sqrt(totalChi2 / totalLayers);
 
     return 0.f;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode LayerSplittingAlgorithm::DivideCaloHits(const Cluster *const pCluster, const unsigned int &splitLayer, CaloHitList &firstHitList, CaloHitList &secondHitList) const
+StatusCode LayerSplittingAlgorithm::DivideCaloHits(
+    const Cluster *const pCluster, const unsigned int &splitLayer, CaloHitList &firstHitList, CaloHitList &secondHitList) const
 {
     const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
 
@@ -182,20 +182,18 @@ StatusCode LayerSplittingAlgorithm::DivideCaloHits(const Cluster *const pCluster
 
 StatusCode LayerSplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLayers", m_minClusterLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLayers", m_minClusterLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LayerWindow", m_layerWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LayerWindow", m_layerWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxScatterRms", m_maxScatterRms));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxScatterRms", m_maxScatterRms));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxScatterCosTheta", m_maxScatterCosTheta));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxScatterCosTheta", m_maxScatterCosTheta));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxSlidingCosTheta", m_maxSlidingCosTheta));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxSlidingCosTheta", m_maxSlidingCosTheta));
 
     return ClusterSplittingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/LayerSplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/LayerSplittingAlgorithm.h
@@ -26,8 +26,8 @@ public:
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
-    pandora::StatusCode DivideCaloHits(const pandora::Cluster *const pCluster, pandora::CaloHitList &firstCaloHitList,
-        pandora::CaloHitList &secondCaloHitList) const;
+    pandora::StatusCode DivideCaloHits(
+        const pandora::Cluster *const pCluster, pandora::CaloHitList &firstCaloHitList, pandora::CaloHitList &secondCaloHitList) const;
 
     /**
      *  @brief Find the best layer for splitting the cluster
@@ -55,13 +55,13 @@ private:
      *  @param  firstLayer the first extremal layer
      *  @param  secondLayer the second extremal layer
      */
-    float CalculateRms(const pandora::Cluster *const pCluster, const unsigned int &firstLayer, const unsigned int& secondLayer) const;
+    float CalculateRms(const pandora::Cluster *const pCluster, const unsigned int &firstLayer, const unsigned int &secondLayer) const;
 
-    unsigned int    m_minClusterLayers;       ///<
-    unsigned int    m_layerWindow;            ///<
-    float           m_maxScatterRms;          ///<
-    float           m_maxScatterCosTheta;     ///<
-    float           m_maxSlidingCosTheta;     ///<
+    unsigned int m_minClusterLayers; ///<
+    unsigned int m_layerWindow;      ///<
+    float m_maxScatterRms;           ///<
+    float m_maxScatterCosTheta;      ///<
+    float m_maxSlidingCosTheta;      ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/OvershootSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/OvershootSplittingAlgorithm.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
 
 #include "larpandoracontent/LArObjects/LArPointingCluster.h"
 
@@ -49,8 +49,7 @@ void OvershootSplittingAlgorithm::GetListOfCleanClusters(const ClusterList *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void OvershootSplittingAlgorithm::FindBestSplitPositions(const TwoDSlidingFitResultMap &slidingFitResultMap,
-    ClusterPositionMap &clusterSplittingMap) const
+void OvershootSplittingAlgorithm::FindBestSplitPositions(const TwoDSlidingFitResultMap &slidingFitResultMap, ClusterPositionMap &clusterSplittingMap) const
 {
     // Use sliding fit results to build a list of intersection points
     ClusterPositionMap clusterIntersectionMap;
@@ -66,11 +65,11 @@ void OvershootSplittingAlgorithm::FindBestSplitPositions(const TwoDSlidingFitRes
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void OvershootSplittingAlgorithm::BuildIntersectionMap(const TwoDSlidingFitResultMap &slidingFitResultMap,
-    ClusterPositionMap &clusterIntersectionMap) const
+void OvershootSplittingAlgorithm::BuildIntersectionMap(const TwoDSlidingFitResultMap &slidingFitResultMap, ClusterPositionMap &clusterIntersectionMap) const
 {
     ClusterList clusterList;
-    for (const auto &mapEntry : slidingFitResultMap) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : slidingFitResultMap)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster1 : clusterList)
@@ -95,8 +94,7 @@ void OvershootSplittingAlgorithm::BuildIntersectionMap(const TwoDSlidingFitResul
                 const float outerDisplacement(LArClusterHelper::GetClosestDistance(outerPosition, pCluster1));
                 const bool useInner((innerDisplacement < outerDisplacement) ? true : false);
 
-                const LArPointingCluster::Vertex &clusterVertex = (useInner ? pointingCluster.GetInnerVertex() :
-                    pointingCluster.GetOuterVertex());
+                const LArPointingCluster::Vertex &clusterVertex = (useInner ? pointingCluster.GetInnerVertex() : pointingCluster.GetOuterVertex());
 
                 float rL2(0.f), rT2(0.f);
                 CartesianVector intersectPosition2(0.f, 0.f, 0.f);
@@ -135,8 +133,8 @@ void OvershootSplittingAlgorithm::BuildIntersectionMap(const TwoDSlidingFitResul
 
                 try
                 {
-                    LArPointingClusterHelper::GetIntersection(projectedPosition1, projectedDirection1, projectedPosition2, projectedDirection2,
-                        intersectPosition1, firstDisplacement, secondDisplacement);
+                    LArPointingClusterHelper::GetIntersection(projectedPosition1, projectedDirection1, projectedPosition2,
+                        projectedDirection2, intersectPosition1, firstDisplacement, secondDisplacement);
                 }
                 catch (const StatusCodeException &)
                 {
@@ -178,7 +176,8 @@ void OvershootSplittingAlgorithm::BuildSortedIntersectionMap(const TwoDSlidingFi
     const ClusterPositionMap &clusterIntersectionMap, ClusterPositionMap &sortedIntersectionMap) const
 {
     ClusterList clusterList;
-    for (const auto &mapEntry : clusterIntersectionMap) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterIntersectionMap)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster : clusterList)
@@ -195,8 +194,7 @@ void OvershootSplittingAlgorithm::BuildSortedIntersectionMap(const TwoDSlidingFi
         const TwoDSlidingFitResult &slidingFitResult = sIter->second;
 
         MyTrajectoryPointList trajectoryPointList;
-        for (CartesianPointVector::const_iterator pIter = inputPositionVector.begin(), pIterEnd = inputPositionVector.end();
-            pIter != pIterEnd; ++pIter)
+        for (CartesianPointVector::const_iterator pIter = inputPositionVector.begin(), pIterEnd = inputPositionVector.end(); pIter != pIterEnd; ++pIter)
         {
             const CartesianVector &position = *pIter;
             float rL(0.f), rT(0.f);
@@ -209,8 +207,7 @@ void OvershootSplittingAlgorithm::BuildSortedIntersectionMap(const TwoDSlidingFi
         if (trajectoryPointList.empty())
             throw StatusCodeException(STATUS_CODE_FAILURE);
 
-        for (MyTrajectoryPointList::const_iterator qIter = trajectoryPointList.begin(), qIterEnd = trajectoryPointList.end();
-            qIter != qIterEnd; ++qIter)
+        for (MyTrajectoryPointList::const_iterator qIter = trajectoryPointList.begin(), qIterEnd = trajectoryPointList.end(); qIter != qIterEnd; ++qIter)
         {
             const CartesianVector &clusterPosition = qIter->second;
             sortedIntersectionMap[pCluster].push_back(clusterPosition);
@@ -220,11 +217,11 @@ void OvershootSplittingAlgorithm::BuildSortedIntersectionMap(const TwoDSlidingFi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void OvershootSplittingAlgorithm::PopulateSplitPositionMap(const ClusterPositionMap &clusterIntersectionMap,
-    ClusterPositionMap &clusterSplittingMap) const
+void OvershootSplittingAlgorithm::PopulateSplitPositionMap(const ClusterPositionMap &clusterIntersectionMap, ClusterPositionMap &clusterSplittingMap) const
 {
     ClusterList clusterList;
-    for (const auto &mapEntry : clusterIntersectionMap) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterIntersectionMap)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster : clusterList)
@@ -240,8 +237,7 @@ void OvershootSplittingAlgorithm::PopulateSplitPositionMap(const ClusterPosition
         bool foundPrevPosition(false);
         CartesianVector prevPosition(0.f, 0.f, 0.f);
 
-        for (CartesianPointVector::const_iterator pIter = inputPositionVector.begin(), pIterEnd = inputPositionVector.end();
-             pIter != pIterEnd; ++pIter)
+        for (CartesianPointVector::const_iterator pIter = inputPositionVector.begin(), pIterEnd = inputPositionVector.end(); pIter != pIterEnd; ++pIter)
         {
             const CartesianVector &nextPosition = *pIter;
 
@@ -274,7 +270,7 @@ void OvershootSplittingAlgorithm::PopulateSplitPositionMap(const ClusterPosition
 
             if (foundPrevCandidate)
             {
-                if((nextCandidate - prevCandidate).GetMagnitudeSquared() < m_minSplitDisplacement * m_minSplitDisplacement)
+                if ((nextCandidate - prevCandidate).GetMagnitudeSquared() < m_minSplitDisplacement * m_minSplitDisplacement)
                     continue;
             }
 
@@ -299,20 +295,20 @@ bool OvershootSplittingAlgorithm::SortByHitProjection(const MyTrajectoryPoint &l
 
 StatusCode OvershootSplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClusterSeparation", m_maxClusterSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClusterSeparation", m_maxClusterSeparation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexDisplacement", m_minVertexDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinVertexDisplacement", m_minVertexDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxIntersectDisplacement", m_maxIntersectDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxIntersectDisplacement", m_maxIntersectDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSplitDisplacement", m_minSplitDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinSplitDisplacement", m_minSplitDisplacement));
 
     return TwoDSlidingFitMultiSplitAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/OvershootSplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/OvershootSplittingAlgorithm.h
@@ -67,11 +67,11 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float           m_minClusterLength;          ///<
-    float           m_maxClusterSeparation;      ///<
-    float           m_minVertexDisplacement;     ///<
-    float           m_maxIntersectDisplacement;
-    float           m_minSplitDisplacement;
+    float m_minClusterLength;      ///<
+    float m_maxClusterSeparation;  ///<
+    float m_minVertexDisplacement; ///<
+    float m_maxIntersectDisplacement;
+    float m_minSplitDisplacement;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TrackConsolidationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TrackConsolidationAlgorithm.cc
@@ -111,7 +111,8 @@ void TrackConsolidationAlgorithm::GetReclusteredHits(const TwoDSlidingFitResult 
     }
 
     const float associatedSpan(maxL - minL);
-    const float associatedFraction(associatedHits.empty() ? 0.f : static_cast<float>(associatedHits.size()) / static_cast<float>(pClusterJ->GetNCaloHits()));
+    const float associatedFraction(
+        associatedHits.empty() ? 0.f : static_cast<float>(associatedHits.size()) / static_cast<float>(pClusterJ->GetNCaloHits()));
 
     if (associatedSpan > m_minAssociatedSpan || associatedFraction > m_minAssociatedFraction)
     {
@@ -133,14 +134,14 @@ void TrackConsolidationAlgorithm::GetReclusteredHits(const TwoDSlidingFitResult 
 
 StatusCode TrackConsolidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinAssociatedSpan", m_minAssociatedSpan));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinAssociatedSpan", m_minAssociatedSpan));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinAssociatedFraction", m_minAssociatedFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinAssociatedFraction", m_minAssociatedFraction));
 
     return TwoDSlidingFitConsolidationAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TrackConsolidationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TrackConsolidationAlgorithm.h
@@ -48,12 +48,12 @@ private:
      *  @param caloHitsToAdd  the output map of hits to be added to clusters
      *  @param caloHitsToRemove  the output map of hits to be removed from clusters
      */
-    void GetReclusteredHits(const TwoDSlidingFitResult& slidingFitResult, const pandora::Cluster *const pTargetCluster,
+    void GetReclusteredHits(const TwoDSlidingFitResult &slidingFitResult, const pandora::Cluster *const pTargetCluster,
         ClusterToHitMap &caloHitsToAdd, ClusterToHitMap &caloHitsToRemove) const;
 
-    float        m_maxTransverseDisplacement;  ///<
-    float        m_minAssociatedSpan;          ///<
-    float        m_minAssociatedFraction;      ///<
+    float m_maxTransverseDisplacement; ///<
+    float m_minAssociatedSpan;         ///<
+    float m_minAssociatedFraction;     ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitConsolidationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitConsolidationAlgorithm.cc
@@ -55,8 +55,8 @@ StatusCode TwoDSlidingFitConsolidationAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDSlidingFitConsolidationAlgorithm::SortInputClusters(const ClusterList *const pClusterList, ClusterVector &trackClusters,
-    ClusterVector &showerClusters) const
+void TwoDSlidingFitConsolidationAlgorithm::SortInputClusters(
+    const ClusterList *const pClusterList, ClusterVector &trackClusters, ClusterVector &showerClusters) const
 {
     for (ClusterList::const_iterator iter = pClusterList->begin(), iterEnd = pClusterList->end(); iter != iterEnd; ++iter)
     {
@@ -101,7 +101,8 @@ void TwoDSlidingFitConsolidationAlgorithm::BuildSlidingLinearFits(const ClusterV
 StatusCode TwoDSlidingFitConsolidationAlgorithm::RemoveHitsFromClusters(const ClusterToHitMap &clustersToContract, ClusterSet &unavailableClusters) const
 {
     ClusterList clusterList;
-    for (const auto &mapEntry : clustersToContract) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : clustersToContract)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster : clusterList)
@@ -205,8 +206,8 @@ StatusCode TwoDSlidingFitConsolidationAlgorithm::RebuildClusters(const ClusterTo
 
         const ClusterList *pClusterList = NULL;
         std::string newClusterListName;
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RunClusteringAlgorithm(*this, m_reclusteringAlgorithmName,
-            pClusterList, newClusterListName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+            PandoraContentApi::RunClusteringAlgorithm(*this, m_reclusteringAlgorithmName, pClusterList, newClusterListName));
 
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, newClusterListName, currentClusterListName));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Cluster>(*this, currentClusterListName));
@@ -219,17 +220,15 @@ StatusCode TwoDSlidingFitConsolidationAlgorithm::RebuildClusters(const ClusterTo
 
 StatusCode TwoDSlidingFitConsolidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithm(*this, xmlHandle,
-        "ClusterRebuilding", m_reclusteringAlgorithmName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithm(*this, xmlHandle, "ClusterRebuilding", m_reclusteringAlgorithmName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinTrackLength", m_minTrackLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinTrackLength", m_minTrackLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClusterLength", m_maxClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClusterLength", m_maxClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_halfWindowLayers));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitConsolidationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitConsolidationAlgorithm.h
@@ -32,7 +32,7 @@ protected:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::CaloHitList> ClusterToHitMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::CaloHitList> ClusterToHitMap;
 
     /**
      *  @brief Get the list of hits to be added or removed from clusters
@@ -53,8 +53,8 @@ private:
      *  @param trackClusters  the output vector of track-like clusters
      *  @param showerClusters  the output vector of shower-like clusters
      */
-    void SortInputClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &trackClusters,
-        pandora::ClusterVector &showerClusters) const;
+    void SortInputClusters(
+        const pandora::ClusterList *const pClusterList, pandora::ClusterVector &trackClusters, pandora::ClusterVector &showerClusters) const;
 
     /**
      *  @brief Apply sliding linear fits to track clusters
@@ -88,10 +88,10 @@ private:
      */
     pandora::StatusCode RebuildClusters(const ClusterToHitMap &clustersAtStart, const pandora::ClusterSet &unavailableClusters) const;
 
-    std::string  m_reclusteringAlgorithmName;  ///< Name of daughter algorithm to use for cluster re-building
-    float        m_minTrackLength;             ///< Minimum length of track clusters to consolidate
-    float        m_maxClusterLength;           ///< Maximum length of shower clusters to use in re-building
-    unsigned int m_halfWindowLayers;           ///< Size of layer window for sliding fit results
+    std::string m_reclusteringAlgorithmName; ///< Name of daughter algorithm to use for cluster re-building
+    float m_minTrackLength;                  ///< Minimum length of track clusters to consolidate
+    float m_maxClusterLength;                ///< Maximum length of shower clusters to use in re-building
+    unsigned int m_halfWindowLayers;         ///< Size of layer window for sliding fit results
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitMultiSplitAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitMultiSplitAlgorithm.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 #include "larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitMultiSplitAlgorithm.h"
 
@@ -18,9 +18,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoDSlidingFitMultiSplitAlgorithm::TwoDSlidingFitMultiSplitAlgorithm() :
-    m_slidingFitHalfWindow(15),
-    m_inputClusterList("")
+TwoDSlidingFitMultiSplitAlgorithm::TwoDSlidingFitMultiSplitAlgorithm() : m_slidingFitHalfWindow(15), m_inputClusterList("")
 {
 }
 
@@ -71,8 +69,8 @@ StatusCode TwoDSlidingFitMultiSplitAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDSlidingFitMultiSplitAlgorithm::BuildSlidingFitResultMap(const ClusterVector &clusterVector, const unsigned int halfWindowLayers,
-    TwoDSlidingFitResultMap &slidingFitResultMap) const
+void TwoDSlidingFitMultiSplitAlgorithm::BuildSlidingFitResultMap(
+    const ClusterVector &clusterVector, const unsigned int halfWindowLayers, TwoDSlidingFitResultMap &slidingFitResultMap) const
 {
     const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
@@ -98,11 +96,12 @@ void TwoDSlidingFitMultiSplitAlgorithm::BuildSlidingFitResultMap(const ClusterVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TwoDSlidingFitMultiSplitAlgorithm::SplitClusters(const TwoDSlidingFitResultMap &slidingFitResultMap,
-    const ClusterPositionMap &clusterSplittingMap) const
+StatusCode TwoDSlidingFitMultiSplitAlgorithm::SplitClusters(
+    const TwoDSlidingFitResultMap &slidingFitResultMap, const ClusterPositionMap &clusterSplittingMap) const
 {
     ClusterList clusterList;
-    for (const auto &mapEntry : clusterSplittingMap) clusterList.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterSplittingMap)
+        clusterList.push_back(mapEntry.first);
     clusterList.sort(LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster : clusterList)
@@ -129,16 +128,14 @@ StatusCode TwoDSlidingFitMultiSplitAlgorithm::SplitClusters(const TwoDSlidingFit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TwoDSlidingFitMultiSplitAlgorithm::SplitCluster(const TwoDSlidingFitResult &slidingFitResult,
-    const CartesianPointVector &splitPositionVector) const
+StatusCode TwoDSlidingFitMultiSplitAlgorithm::SplitCluster(const TwoDSlidingFitResult &slidingFitResult, const CartesianPointVector &splitPositionVector) const
 {
     const Cluster *const pCluster = slidingFitResult.GetCluster();
 
     // Get split positions for this cluster
     FloatVector displacementVector;
 
-    for (CartesianPointVector::const_iterator pIter = splitPositionVector.begin(), pIterEnd = splitPositionVector.end();
-        pIter != pIterEnd; ++pIter)
+    for (CartesianPointVector::const_iterator pIter = splitPositionVector.begin(), pIterEnd = splitPositionVector.end(); pIter != pIterEnd; ++pIter)
     {
         const CartesianVector &splitPosition = *pIter;
 
@@ -157,8 +154,8 @@ StatusCode TwoDSlidingFitMultiSplitAlgorithm::SplitCluster(const TwoDSlidingFitR
     const ClusterList clusterList(1, pCluster);
     std::string clusterListToSave, clusterListToDelete;
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, clusterList,
-        clusterListToDelete, clusterListToSave));
+    PANDORA_RETURN_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, clusterList, clusterListToDelete, clusterListToSave));
 
     CaloHitList oldCaloHitList;
     pCluster->GetOrderedCaloHitList().FillCaloHitList(oldCaloHitList);
@@ -211,11 +208,11 @@ StatusCode TwoDSlidingFitMultiSplitAlgorithm::SplitCluster(const TwoDSlidingFitR
 
 StatusCode TwoDSlidingFitMultiSplitAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "InputClusterListName", m_inputClusterList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InputClusterListName", m_inputClusterList));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_slidingFitHalfWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_slidingFitHalfWindow));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitMultiSplitAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitMultiSplitAlgorithm.h
@@ -27,7 +27,7 @@ public:
     TwoDSlidingFitMultiSplitAlgorithm();
 
 protected:
-    typedef std::unordered_map<const pandora::Cluster*, pandora::CartesianPointVector> ClusterPositionMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::CartesianPointVector> ClusterPositionMap;
 
     /**
      *  @brief  Populate cluster vector with subset of cluster list, containing clusters judged to be clean
@@ -76,8 +76,8 @@ private:
      */
     pandora::StatusCode SplitCluster(const TwoDSlidingFitResult &slidingFitResult, const pandora::CartesianPointVector &splitPositionList) const;
 
-    unsigned int    m_slidingFitHalfWindow;      ///<
-    std::string     m_inputClusterList;          ///<
+    unsigned int m_slidingFitHalfWindow; ///<
+    std::string m_inputClusterList;      ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAlgorithm.cc
@@ -18,9 +18,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoDSlidingFitSplittingAlgorithm::TwoDSlidingFitSplittingAlgorithm() :
-    m_slidingFitHalfWindow(20),
-    m_minClusterLength(10.f)
+TwoDSlidingFitSplittingAlgorithm::TwoDSlidingFitSplittingAlgorithm() : m_slidingFitHalfWindow(20), m_minClusterLength(10.f)
 {
 }
 
@@ -54,8 +52,8 @@ StatusCode TwoDSlidingFitSplittingAlgorithm::DivideCaloHits(const Cluster *const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TwoDSlidingFitSplittingAlgorithm::DivideCaloHits(const TwoDSlidingFitResult &slidingFitResult, const CartesianVector &splitPosition,
-    CaloHitList &firstCaloHitList, CaloHitList &secondCaloHitList) const
+StatusCode TwoDSlidingFitSplittingAlgorithm::DivideCaloHits(const TwoDSlidingFitResult &slidingFitResult,
+    const CartesianVector &splitPosition, CaloHitList &firstCaloHitList, CaloHitList &secondCaloHitList) const
 {
     float rL(0.f), rT(0.f);
     slidingFitResult.GetLocalPosition(splitPosition, rL, rT);
@@ -93,11 +91,11 @@ StatusCode TwoDSlidingFitSplittingAlgorithm::DivideCaloHits(const TwoDSlidingFit
 
 StatusCode TwoDSlidingFitSplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_slidingFitHalfWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_slidingFitHalfWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
     return ClusterSplittingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAlgorithm.h
@@ -37,15 +37,14 @@ protected:
      *
      *  @return pandora::StatusCode
      */
-    virtual pandora::StatusCode FindBestSplitPosition(const TwoDSlidingFitResult &slidingFitResult,
-        pandora::CartesianVector& splitPosition) const = 0;
+    virtual pandora::StatusCode FindBestSplitPosition(const TwoDSlidingFitResult &slidingFitResult, pandora::CartesianVector &splitPosition) const = 0;
 
-    unsigned int    m_slidingFitHalfWindow;   ///<
-    float           m_minClusterLength;       ///<
+    unsigned int m_slidingFitHalfWindow; ///<
+    float m_minClusterLength;            ///<
 
 private:
-    pandora::StatusCode DivideCaloHits(const pandora::Cluster *const pCluster, pandora::CaloHitList &firstCaloHitList,
-        pandora::CaloHitList &secondCaloHitList) const;
+    pandora::StatusCode DivideCaloHits(
+        const pandora::Cluster *const pCluster, pandora::CaloHitList &firstCaloHitList, pandora::CaloHitList &secondCaloHitList) const;
 
     /**
      *  @brief  Use sliding linear fit to separate cluster into two fragments
@@ -57,7 +56,7 @@ private:
      *
      *  @return pandora::StatusCode
      */
-    pandora::StatusCode DivideCaloHits(const TwoDSlidingFitResult &slidingFitResult, const pandora::CartesianVector& splitPosition,
+    pandora::StatusCode DivideCaloHits(const TwoDSlidingFitResult &slidingFitResult, const pandora::CartesianVector &splitPosition,
         pandora::CaloHitList &firstCaloHitList, pandora::CaloHitList &secondCaloHitList) const;
 };
 

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSplicingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSplicingAlgorithm.cc
@@ -91,8 +91,8 @@ void TwoDSlidingFitSplittingAndSplicingAlgorithm::GetListOfCleanClusters(const C
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDSlidingFitSplittingAndSplicingAlgorithm::BuildSlidingFitResultMap(const ClusterVector &clusterVector, const unsigned int halfWindowLayers,
-    TwoDSlidingFitResultMap &slidingFitResultMap) const
+void TwoDSlidingFitSplittingAndSplicingAlgorithm::BuildSlidingFitResultMap(
+    const ClusterVector &clusterVector, const unsigned int halfWindowLayers, TwoDSlidingFitResultMap &slidingFitResultMap) const
 {
     const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
@@ -189,8 +189,7 @@ void TwoDSlidingFitSplittingAndSplicingAlgorithm::BuildClusterExtensionList(cons
             {
                 const CartesianVector relativeDirection((branchSplitPositionJ - branchSplitPositionI).GetUnitVector());
 
-                if (branchSplitDirectionI.GetDotProduct(relativeDirection) > 0.f &&
-                    branchSplitDirectionJ.GetDotProduct(relativeDirection) < 0.f )
+                if (branchSplitDirectionI.GetDotProduct(relativeDirection) > 0.f && branchSplitDirectionJ.GetDotProduct(relativeDirection) < 0.f)
                 {
                     try
                     {
@@ -208,12 +207,14 @@ void TwoDSlidingFitSplittingAndSplicingAlgorithm::BuildClusterExtensionList(cons
             // Select the overall best split position
             if (branchChisqI > branchChisqJ)
             {
-                clusterExtensionList.push_back(ClusterExtension(pClusterI, pClusterJ, replacementStartPositionJ, branchSplitPositionI, branchSplitDirectionI));
+                clusterExtensionList.push_back(
+                    ClusterExtension(pClusterI, pClusterJ, replacementStartPositionJ, branchSplitPositionI, branchSplitDirectionI));
             }
 
             else if (branchChisqJ > branchChisqI)
             {
-                clusterExtensionList.push_back(ClusterExtension(pClusterJ, pClusterI, replacementStartPositionI, branchSplitPositionJ, branchSplitDirectionJ));
+                clusterExtensionList.push_back(
+                    ClusterExtension(pClusterJ, pClusterI, replacementStartPositionI, branchSplitPositionJ, branchSplitDirectionJ));
             }
         }
     }
@@ -225,11 +226,13 @@ void TwoDSlidingFitSplittingAndSplicingAlgorithm::PruneClusterExtensionList(cons
     const TwoDSlidingFitResultMap &branchMap, const TwoDSlidingFitResultMap &replacementMap, ClusterExtensionList &outputList) const
 {
     ClusterList branchList;
-    for (const auto &mapEntry : branchMap) branchList.push_back(mapEntry.first);
+    for (const auto &mapEntry : branchMap)
+        branchList.push_back(mapEntry.first);
     branchList.sort(LArClusterHelper::SortByNHits);
 
     ClusterList replacementList;
-    for (const auto &mapEntry : replacementMap) replacementList.push_back(mapEntry.first);
+    for (const auto &mapEntry : replacementMap)
+        replacementList.push_back(mapEntry.first);
     replacementList.sort(LArClusterHelper::SortByNHits);
 
     for (const ClusterExtension &thisSplit : inputList)
@@ -287,8 +290,8 @@ void TwoDSlidingFitSplittingAndSplicingAlgorithm::PruneClusterExtensionList(cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float TwoDSlidingFitSplittingAndSplicingAlgorithm::CalculateBranchChi2(const Cluster* const pCluster, const CartesianVector &splitPosition,
-    const CartesianVector &splitDirection) const
+float TwoDSlidingFitSplittingAndSplicingAlgorithm::CalculateBranchChi2(
+    const Cluster *const pCluster, const CartesianVector &splitPosition, const CartesianVector &splitDirection) const
 {
     CaloHitList principalCaloHitList, branchCaloHitList;
 
@@ -309,14 +312,14 @@ float TwoDSlidingFitSplittingAndSplicingAlgorithm::CalculateBranchChi2(const Clu
     }
 
     if (totalHits > 0.f)
-        return std::sqrt(totalChi2/totalHits);
+        return std::sqrt(totalChi2 / totalHits);
 
     throw StatusCodeException(STATUS_CODE_NOT_ALLOWED);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDSlidingFitSplittingAndSplicingAlgorithm::SplitBranchCluster(const Cluster* const pCluster, const CartesianVector &splitPosition,
+void TwoDSlidingFitSplittingAndSplicingAlgorithm::SplitBranchCluster(const Cluster *const pCluster, const CartesianVector &splitPosition,
     const CartesianVector &splitDirection, CaloHitList &principalCaloHitList, CaloHitList &branchCaloHitList) const
 {
     // Distribute hits in branch cluster between new principal and residual clusters
@@ -343,8 +346,8 @@ void TwoDSlidingFitSplittingAndSplicingAlgorithm::SplitBranchCluster(const Clust
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::RunSplitAndExtension(const ClusterExtensionList &splitList,
-    TwoDSlidingFitResultMap &branchResultMap, TwoDSlidingFitResultMap &replacementResultMap) const
+StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::RunSplitAndExtension(
+    const ClusterExtensionList &splitList, TwoDSlidingFitResultMap &branchResultMap, TwoDSlidingFitResultMap &replacementResultMap) const
 {
     bool foundSplit(false);
 
@@ -367,8 +370,8 @@ StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::RunSplitAndExtension(con
             replacementResultMap.end() == iterReplacement1 || replacementResultMap.end() == iterReplacement2)
             continue;
 
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReplaceBranch(pBranchCluster, pReplacementCluster,
-                                                                              branchSplitPosition, branchSplitDirection));
+        PANDORA_RETURN_RESULT_IF(
+            STATUS_CODE_SUCCESS, !=, this->ReplaceBranch(pBranchCluster, pReplacementCluster, branchSplitPosition, branchSplitDirection));
         branchResultMap.erase(iterBranch1);
         branchResultMap.erase(iterBranch2);
 
@@ -386,16 +389,16 @@ StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::RunSplitAndExtension(con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::ReplaceBranch(const Cluster *const pBranchCluster, const Cluster *const pReplacementCluster,
-    const CartesianVector &branchSplitPosition, const CartesianVector &branchSplitDirection) const
+StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::ReplaceBranch(const Cluster *const pBranchCluster,
+    const Cluster *const pReplacementCluster, const CartesianVector &branchSplitPosition, const CartesianVector &branchSplitDirection) const
 {
     ClusterList clusterList;
     clusterList.push_back(pBranchCluster);
     clusterList.push_back(pReplacementCluster);
 
     std::string clusterListToSaveName, clusterListToDeleteName;
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, clusterList, clusterListToDeleteName,
-        clusterListToSaveName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::InitializeFragmentation(*this, clusterList, clusterListToDeleteName, clusterListToSaveName));
 
     // Entire replacement cluster goes into new principal cluster
     PandoraContentApi::Cluster::Parameters principalParameters;
@@ -403,7 +406,8 @@ StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::ReplaceBranch(const Clus
 
     // Distribute hits in branch cluster between new principal and residual clusters
     PandoraContentApi::Cluster::Parameters residualParameters;
-    this->SplitBranchCluster(pBranchCluster, branchSplitPosition, branchSplitDirection, principalParameters.m_caloHitList, residualParameters.m_caloHitList);
+    this->SplitBranchCluster(
+        pBranchCluster, branchSplitPosition, branchSplitDirection, principalParameters.m_caloHitList, residualParameters.m_caloHitList);
 
     const Cluster *pPrincipalCluster(NULL), *pResidualCluster(NULL);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, principalParameters, pPrincipalCluster));
@@ -417,20 +421,19 @@ StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::ReplaceBranch(const Clus
 
 StatusCode TwoDSlidingFitSplittingAndSplicingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShortHalfWindow", m_shortHalfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShortHalfWindow", m_shortHalfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LongHalfWindow", m_longHalfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LongHalfWindow", m_longHalfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VetoDisplacement", m_vetoDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VetoDisplacement", m_vetoDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CosmicMode", m_runCosmicMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CosmicMode", m_runCosmicMode));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSplicingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSplicingAlgorithm.h
@@ -52,12 +52,12 @@ protected:
         /**
          *  @brief  return the address of the branch Cluster
          */
-        const pandora::Cluster* GetBranchCluster() const;
+        const pandora::Cluster *GetBranchCluster() const;
 
         /**
          *  @brief  return the address of the replacement Cluster
          */
-        const pandora::Cluster* GetReplacementCluster() const;
+        const pandora::Cluster *GetReplacementCluster() const;
 
         /**
          *  @brief  return the start position of the replacement cluster
@@ -74,12 +74,12 @@ protected:
          */
         const pandora::CartesianVector &GetBranchDirection() const;
 
-        private:
-        const pandora::Cluster     *m_pBranchCluster;            ///<
-        const pandora::Cluster     *m_pReplacementCluster;       ///<
-        pandora::CartesianVector    m_replacementVertex;         ///<
-        pandora::CartesianVector    m_branchVertex;              ///<
-        pandora::CartesianVector    m_branchDirection;           ///<
+    private:
+        const pandora::Cluster *m_pBranchCluster;      ///<
+        const pandora::Cluster *m_pReplacementCluster; ///<
+        pandora::CartesianVector m_replacementVertex;  ///<
+        pandora::CartesianVector m_branchVertex;       ///<
+        pandora::CartesianVector m_branchDirection;    ///<
     };
 
     typedef std::vector<ClusterExtension> ClusterExtensionList;
@@ -93,12 +93,11 @@ protected:
      *  @param  branchSplitPosition the outputted start position of the branch
      *  @param  branchSplitDirection the outputted start direction of the branch
      */
-    virtual void FindBestSplitPosition(const TwoDSlidingFitResult &branchSlidingFit,
-        const TwoDSlidingFitResult &replacementSlidingFit, pandora::CartesianVector &replacementStartPosition,
-        pandora::CartesianVector &branchSplitPosition, pandora::CartesianVector &branchSplitDirection) const = 0;
+    virtual void FindBestSplitPosition(const TwoDSlidingFitResult &branchSlidingFit, const TwoDSlidingFitResult &replacementSlidingFit,
+        pandora::CartesianVector &replacementStartPosition, pandora::CartesianVector &branchSplitPosition,
+        pandora::CartesianVector &branchSplitDirection) const = 0;
 
 private:
-
     /**
      *  @brief  Populate cluster vector with subset of cluster list, containing clusters judged to be clean
      *
@@ -146,7 +145,7 @@ private:
      *  @param  splitPosition the start position of the branch
      *  @param  splitDirection the start direction of the branch
      */
-    float CalculateBranchChi2(const pandora::Cluster* const pCluster, const pandora::CartesianVector &splitPosition,
+    float CalculateBranchChi2(const pandora::Cluster *const pCluster, const pandora::CartesianVector &splitPosition,
         const pandora::CartesianVector &splitDirection) const;
 
     /**
@@ -158,9 +157,8 @@ private:
      *  @param  principalCaloHitList the hits to be added to the principal cluster
      *  @param  branchCaloHitList the hits to be split off into the output branch cluster
      */
-    void SplitBranchCluster(const pandora::Cluster* const pCluster, const pandora::CartesianVector &splitPosition,
-        const pandora::CartesianVector &splitDirection, pandora::CaloHitList &principalCaloHitList,
-        pandora::CaloHitList &branchCaloHitList) const;
+    void SplitBranchCluster(const pandora::Cluster *const pCluster, const pandora::CartesianVector &splitPosition,
+        const pandora::CartesianVector &splitDirection, pandora::CaloHitList &principalCaloHitList, pandora::CaloHitList &branchCaloHitList) const;
 
     /**
      *  @brief  Run the machinary that performs the cluster splitting and extending
@@ -172,7 +170,7 @@ private:
     pandora::StatusCode RunSplitAndExtension(const ClusterExtensionList &splitList, TwoDSlidingFitResultMap &branchResultMap,
         TwoDSlidingFitResultMap &replacementResultMap) const;
 
-   /**
+    /**
      *  @brief  Remove a branch from a cluster and replace it with a second cluster
      *
      *  @param  pBranchCluster the cluster containing a branch to be removed
@@ -183,26 +181,25 @@ private:
     pandora::StatusCode ReplaceBranch(const pandora::Cluster *const pBranchCluster, const pandora::Cluster *const pReplacementCluster,
         const pandora::CartesianVector &branchSplitPosition, const pandora::CartesianVector &branchSplitDirection) const;
 
-    unsigned int  m_shortHalfWindowLayers;          ///<
-    unsigned int  m_longHalfWindowLayers;           ///<
-    float         m_minClusterLength;               ///<
-    float         m_vetoDisplacement;               ///<
-    bool          m_runCosmicMode;                  ///<
+    unsigned int m_shortHalfWindowLayers; ///<
+    unsigned int m_longHalfWindowLayers;  ///<
+    float m_minClusterLength;             ///<
+    float m_vetoDisplacement;             ///<
+    bool m_runCosmicMode;                 ///<
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline TwoDSlidingFitSplittingAndSplicingAlgorithm::ClusterExtension::ClusterExtension(const pandora::Cluster *const pBranchCluster,
-        const pandora::Cluster *const pReplacementCluster, const pandora::CartesianVector &replacementVertex,
-        const pandora::CartesianVector &branchVertex, const pandora::CartesianVector &branchDirection) :
+    const pandora::Cluster *const pReplacementCluster, const pandora::CartesianVector &replacementVertex,
+    const pandora::CartesianVector &branchVertex, const pandora::CartesianVector &branchDirection) :
     m_pBranchCluster(pBranchCluster),
     m_pReplacementCluster(pReplacementCluster),
     m_replacementVertex(replacementVertex),
     m_branchVertex(branchVertex),
     m_branchDirection(branchDirection)
 {
-
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSwitchingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSwitchingAlgorithm.cc
@@ -70,9 +70,9 @@ StatusCode TwoDSlidingFitSplittingAndSwitchingAlgorithm::Run()
             if (slidingFitResult1.GetCluster() == slidingFitResult2.GetCluster())
                 continue;
 
-            CartesianVector splitPosition(0.f,0.f,0.f);
-            CartesianVector firstDirection(0.f,0.f,0.f);
-            CartesianVector secondDirection(0.f,0.f,0.f);
+            CartesianVector splitPosition(0.f, 0.f, 0.f);
+            CartesianVector firstDirection(0.f, 0.f, 0.f);
+            CartesianVector secondDirection(0.f, 0.f, 0.f);
 
             if (STATUS_CODE_SUCCESS != this->FindBestSplitPosition(slidingFitResult1, slidingFitResult2, splitPosition, firstDirection, secondDirection))
                 continue;
@@ -98,7 +98,7 @@ StatusCode TwoDSlidingFitSplittingAndSwitchingAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode TwoDSlidingFitSplittingAndSwitchingAlgorithm::PreparationStep(const ClusterVector &/*clusterVector*/)
+StatusCode TwoDSlidingFitSplittingAndSwitchingAlgorithm::PreparationStep(const ClusterVector & /*clusterVector*/)
 {
     return STATUS_CODE_SUCCESS;
 }
@@ -129,8 +129,8 @@ void TwoDSlidingFitSplittingAndSwitchingAlgorithm::GetListOfCleanClusters(const 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TwoDSlidingFitSplittingAndSwitchingAlgorithm::BuildSlidingFitResultMap(const ClusterVector &clusterVector,
-    TwoDSlidingFitResultMap &slidingFitResultMap) const
+void TwoDSlidingFitSplittingAndSwitchingAlgorithm::BuildSlidingFitResultMap(
+    const ClusterVector &clusterVector, TwoDSlidingFitResultMap &slidingFitResultMap) const
 {
     const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
@@ -197,8 +197,8 @@ StatusCode TwoDSlidingFitSplittingAndSwitchingAlgorithm::ReplaceClusters(const C
     clusterList.push_back(pCluster2);
 
     std::string clusterListToSaveName, clusterListToDeleteName;
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, clusterList,
-        clusterListToDeleteName, clusterListToSaveName));
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::InitializeFragmentation(*this, clusterList, clusterListToDeleteName, clusterListToSaveName));
 
     // Create new clusters
     const Cluster *pFirstCluster(NULL), *pSecondCluster(NULL);
@@ -215,11 +215,11 @@ StatusCode TwoDSlidingFitSplittingAndSwitchingAlgorithm::ReplaceClusters(const C
 
 StatusCode TwoDSlidingFitSplittingAndSwitchingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HalfWindowLayers", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HalfWindowLayers", m_halfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSwitchingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/TwoDSlidingFitSplittingAndSwitchingAlgorithm.h
@@ -81,8 +81,7 @@ private:
      *  @param  secondCaloHitList the hits to be added to the second new cluster
      */
     void SplitCluster(const pandora::Cluster *const pCluster, const pandora::CartesianVector &splitPosition,
-        const pandora::CartesianVector &splitDirection, pandora::CaloHitList &firstCaloHitList,
-        pandora::CaloHitList &secondCaloHitList) const;
+        const pandora::CartesianVector &splitDirection, pandora::CaloHitList &firstCaloHitList, pandora::CaloHitList &secondCaloHitList) const;
 
     /**
      *  @brief  Replace crossed clusters with un-crossed clusters
@@ -97,8 +96,8 @@ private:
         const pandora::CartesianVector &splitPosition, const pandora::CartesianVector &firstDirection,
         const pandora::CartesianVector &secondDirection) const;
 
-    unsigned int  m_halfWindowLayers;     ///< half window layers for sliding linear fot
-    float         m_minClusterLength;     ///< minimum length of clusters
+    unsigned int m_halfWindowLayers; ///< half window layers for sliding linear fot
+    float m_minClusterLength;        ///< minimum length of clusters
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/VertexSplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/VertexSplittingAlgorithm.cc
@@ -18,9 +18,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-VertexSplittingAlgorithm::VertexSplittingAlgorithm() :
-    m_splitDisplacementSquared(4.f * 4.f),
-    m_vertexDisplacementSquared(1.f * 1.f)
+VertexSplittingAlgorithm::VertexSplittingAlgorithm() : m_splitDisplacementSquared(4.f * 4.f), m_vertexDisplacementSquared(1.f * 1.f)
 {
     // ATTN Some default values differ from base class
     m_minClusterLength = 1.f;
@@ -63,7 +61,8 @@ StatusCode VertexSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitR
         return statusCode;
 
     const float splitDisplacementSquared((splitPosition - theVertex2D).GetMagnitudeSquared());
-    const float vertexDisplacementSquared(std::min((splitPosition - innerVertex2D).GetMagnitudeSquared(), (splitPosition - outerVertex2D).GetMagnitudeSquared()));
+    const float vertexDisplacementSquared(
+        std::min((splitPosition - innerVertex2D).GetMagnitudeSquared(), (splitPosition - outerVertex2D).GetMagnitudeSquared()));
 
     if ((splitDisplacementSquared < m_splitDisplacementSquared) && (vertexDisplacementSquared > m_vertexDisplacementSquared) &&
         (splitDisplacementSquared < vertexDisplacementSquared))
@@ -82,13 +81,13 @@ StatusCode VertexSplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitR
 StatusCode VertexSplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     float splitDisplacement = std::sqrt(m_splitDisplacementSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SplitDisplacement", splitDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SplitDisplacement", splitDisplacement));
     m_splitDisplacementSquared = splitDisplacement * splitDisplacement;
 
     float vertexDisplacement = std::sqrt(m_vertexDisplacementSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexDisplacement", vertexDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexDisplacement", vertexDisplacement));
     m_vertexDisplacementSquared = vertexDisplacement * vertexDisplacement;
 
     return TwoDSlidingFitSplittingAlgorithm::ReadSettings(xmlHandle);

--- a/larpandoracontent/LArTwoDReco/LArClusterSplitting/VertexSplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterSplitting/VertexSplittingAlgorithm.h
@@ -30,8 +30,8 @@ private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
     pandora::StatusCode FindBestSplitPosition(const TwoDSlidingFitResult &slidingFitResult, pandora::CartesianVector &splitPosition) const;
 
-    float           m_splitDisplacementSquared;     ///< Maximum displacement squared
-    float           m_vertexDisplacementSquared;    ///< Maximum displacement squared
+    float m_splitDisplacementSquared;  ///< Maximum displacement squared
+    float m_vertexDisplacementSquared; ///< Maximum displacement squared
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/ClusterAssociation.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/ClusterAssociation.h
@@ -31,7 +31,7 @@ public:
      *  @param  downstreamMergePoint the downstream merge point
      *  @param  downstreamMergeDirection the cluster direction at the downstream merge point
      */
-     ClusterAssociation(const pandora::CartesianVector &upstreamMergePoint, const pandora::CartesianVector &upstreamMergeDirection,
+    ClusterAssociation(const pandora::CartesianVector &upstreamMergePoint, const pandora::CartesianVector &upstreamMergeDirection,
         const pandora::CartesianVector &downstreamMergePoint, const pandora::CartesianVector &downstreamMergeDirection);
 
     /**
@@ -60,7 +60,7 @@ public:
      *
      *  @return  the cluster direction at the downstream merge point
      */
-     const pandora::CartesianVector GetDownstreamMergeDirection() const;
+    const pandora::CartesianVector GetDownstreamMergeDirection() const;
 
     /**
      *  @brief  Returns the unit vector of the line connecting the upstream and downstream merge points (upstream -> downstream)
@@ -92,11 +92,11 @@ protected:
      */
     void UpdateConnectingLine();
 
-    pandora::CartesianVector    m_upstreamMergePoint;          ///< The upstream cluster point to be used in the merging process
-    pandora::CartesianVector    m_upstreamMergeDirection;      ///< The upstream cluster direction at the upstream merge point (points in the direction of the downstream cluster)
-    pandora::CartesianVector    m_downstreamMergePoint;        ///< The downstream cluster point to be used in the merging process
-    pandora::CartesianVector    m_downstreamMergeDirection;    ///< The downstream cluster direction at the downstream merge point (points in the direction of the upstream cluster)
-    pandora::CartesianVector    m_connectingLineDirection;     ///< The unit vector of the line connecting the upstream and downstream merge points (upstream -> downstream)
+    pandora::CartesianVector m_upstreamMergePoint; ///< The upstream cluster point to be used in the merging process
+    pandora::CartesianVector m_upstreamMergeDirection; ///< The upstream cluster direction at the upstream merge point (points in the direction of the downstream cluster)
+    pandora::CartesianVector m_downstreamMergePoint; ///< The downstream cluster point to be used in the merging process
+    pandora::CartesianVector m_downstreamMergeDirection; ///< The downstream cluster direction at the downstream merge point (points in the direction of the upstream cluster)
+    pandora::CartesianVector m_connectingLineDirection; ///< The unit vector of the line connecting the upstream and downstream merge points (upstream -> downstream)
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -124,8 +124,8 @@ public:
      *  @param  pDownstreamCluster the address of the downstream cluster
      */
     ClusterPairAssociation(const pandora::CartesianVector &upstreamMergePoint, const pandora::CartesianVector &upstreamMergeDirection,
-        const pandora::CartesianVector &downstreamMergePoint, const pandora::CartesianVector &downstreamMergeDirection, const pandora::Cluster *pUpstreamCluster,
-        const pandora::Cluster *pDownstreamCluster);
+        const pandora::CartesianVector &downstreamMergePoint, const pandora::CartesianVector &downstreamMergeDirection,
+        const pandora::Cluster *pUpstreamCluster, const pandora::Cluster *pDownstreamCluster);
 
     /**
      *  @brief  Returns the address of the upstream cluster
@@ -142,8 +142,8 @@ public:
     const pandora::Cluster *GetDownstreamCluster() const;
 
 private:
-    const pandora::Cluster    *m_pUpstreamCluster;      ///< The address of the upstream cluster
-    const pandora::Cluster    *m_pDownstreamCluster;    ///< The address of the downstream cluster
+    const pandora::Cluster *m_pUpstreamCluster;   ///< The address of the upstream cluster
+    const pandora::Cluster *m_pDownstreamCluster; ///< The address of the downstream cluster
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -160,14 +160,15 @@ inline ClusterAssociation::ClusterAssociation() :
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline ClusterAssociation::ClusterAssociation(const pandora::CartesianVector &upstreamMergePoint, const pandora::CartesianVector &upstreamMergeDirection,
-        const pandora::CartesianVector &downstreamMergePoint, const pandora::CartesianVector &downstreamMergeDirection) :
+    const pandora::CartesianVector &downstreamMergePoint, const pandora::CartesianVector &downstreamMergeDirection) :
     m_upstreamMergePoint(upstreamMergePoint),
     m_upstreamMergeDirection(upstreamMergeDirection),
     m_downstreamMergePoint(downstreamMergePoint),
     m_downstreamMergeDirection(downstreamMergeDirection),
     m_connectingLineDirection(0.f, 0.f, 0.f)
 {
-    const pandora::CartesianVector connectingLineDirection(m_downstreamMergePoint.GetX() - m_upstreamMergePoint.GetX(), 0.f, m_downstreamMergePoint.GetZ() - m_upstreamMergePoint.GetZ());
+    const pandora::CartesianVector connectingLineDirection(
+        m_downstreamMergePoint.GetX() - m_upstreamMergePoint.GetX(), 0.f, m_downstreamMergePoint.GetZ() - m_upstreamMergePoint.GetZ());
     m_connectingLineDirection = connectingLineDirection.GetUnitVector();
 }
 
@@ -175,8 +176,10 @@ inline ClusterAssociation::ClusterAssociation(const pandora::CartesianVector &up
 
 inline bool ClusterAssociation::operator==(const ClusterAssociation &clusterAssociation) const
 {
-    return (m_upstreamMergePoint == clusterAssociation.GetUpstreamMergePoint() &&  m_upstreamMergeDirection == clusterAssociation.GetUpstreamMergeDirection() &&
-        m_downstreamMergePoint == clusterAssociation.GetDownstreamMergePoint() &&  m_downstreamMergeDirection == clusterAssociation.GetDownstreamMergeDirection());
+    return (m_upstreamMergePoint == clusterAssociation.GetUpstreamMergePoint() &&
+            m_upstreamMergeDirection == clusterAssociation.GetUpstreamMergeDirection() &&
+            m_downstreamMergePoint == clusterAssociation.GetDownstreamMergePoint() &&
+            m_downstreamMergeDirection == clusterAssociation.GetDownstreamMergeDirection());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -241,28 +244,26 @@ inline void ClusterAssociation::SetDownstreamMergePoint(const pandora::Cartesian
 
 inline void ClusterAssociation::UpdateConnectingLine()
 {
-    const pandora::CartesianVector connectingLineDirection(m_downstreamMergePoint.GetX() - m_upstreamMergePoint.GetX(), 0.f, m_downstreamMergePoint.GetZ() - m_upstreamMergePoint.GetZ());
+    const pandora::CartesianVector connectingLineDirection(
+        m_downstreamMergePoint.GetX() - m_upstreamMergePoint.GetX(), 0.f, m_downstreamMergePoint.GetZ() - m_upstreamMergePoint.GetZ());
     m_connectingLineDirection = connectingLineDirection.GetUnitVector();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline ClusterPairAssociation::ClusterPairAssociation(const pandora::CartesianVector &upstreamMergePoint, const pandora::CartesianVector &upstreamMergeDirection,
-    const pandora::CartesianVector &downstreamMergePoint, const pandora::CartesianVector &downstreamMergeDirection, const pandora::Cluster *pUpstreamCluster,
-    const pandora::Cluster *pDownstreamCluster) :
-        ClusterAssociation(upstreamMergePoint, upstreamMergeDirection, downstreamMergePoint, downstreamMergeDirection),
-        m_pUpstreamCluster(pUpstreamCluster),
-        m_pDownstreamCluster(pDownstreamCluster)
+inline ClusterPairAssociation::ClusterPairAssociation(const pandora::CartesianVector &upstreamMergePoint,
+    const pandora::CartesianVector &upstreamMergeDirection, const pandora::CartesianVector &downstreamMergePoint,
+    const pandora::CartesianVector &downstreamMergeDirection, const pandora::Cluster *pUpstreamCluster, const pandora::Cluster *pDownstreamCluster) :
+    ClusterAssociation(upstreamMergePoint, upstreamMergeDirection, downstreamMergePoint, downstreamMergeDirection),
+    m_pUpstreamCluster(pUpstreamCluster),
+    m_pDownstreamCluster(pDownstreamCluster)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline ClusterPairAssociation::ClusterPairAssociation() :
-        ClusterAssociation(),
-        m_pUpstreamCluster(nullptr),
-        m_pDownstreamCluster(nullptr)
+inline ClusterPairAssociation::ClusterPairAssociation() : ClusterAssociation(), m_pUpstreamCluster(nullptr), m_pDownstreamCluster(nullptr)
 {
 }
 

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRayExtensionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRayExtensionAlgorithm.cc
@@ -73,7 +73,7 @@ void CosmicRayExtensionAlgorithm::FillClusterAssociationMatrix(const ClusterVect
             const LArPointingCluster &clusterJ = *iterJ;
 
             if (clusterI.GetCluster() == clusterJ.GetCluster())
-            continue;
+                continue;
 
             this->FillClusterAssociationMatrix(clusterI, clusterJ, clusterAssociationMatrix);
         }
@@ -82,8 +82,8 @@ void CosmicRayExtensionAlgorithm::FillClusterAssociationMatrix(const ClusterVect
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRayExtensionAlgorithm::FillClusterAssociationMatrix(const LArPointingCluster &clusterI, const LArPointingCluster &clusterJ,
-    ClusterAssociationMatrix &clusterAssociationMatrix) const
+void CosmicRayExtensionAlgorithm::FillClusterAssociationMatrix(
+    const LArPointingCluster &clusterI, const LArPointingCluster &clusterJ, ClusterAssociationMatrix &clusterAssociationMatrix) const
 {
     const Cluster *const pClusterI(clusterI.GetCluster());
     const Cluster *const pClusterJ(clusterJ.GetCluster());
@@ -162,11 +162,11 @@ void CosmicRayExtensionAlgorithm::FillClusterAssociationMatrix(const LArPointing
     const ClusterAssociation::VertexType vertexTypeJ(clusterVertexJ.IsInnerVertex() ? ClusterAssociation::INNER : ClusterAssociation::OUTER);
     const ClusterAssociation::AssociationType associationType(ClusterAssociation::STRONG);
 
-    (void) clusterAssociationMatrix[pClusterI].insert(ClusterAssociationMap::value_type(pClusterJ,
-        ClusterAssociation(vertexTypeI, vertexTypeJ, associationType, lengthSquaredJ)));
+    (void)clusterAssociationMatrix[pClusterI].insert(
+        ClusterAssociationMap::value_type(pClusterJ, ClusterAssociation(vertexTypeI, vertexTypeJ, associationType, lengthSquaredJ)));
 
-    (void) clusterAssociationMatrix[pClusterJ].insert(ClusterAssociationMap::value_type(pClusterI,
-        ClusterAssociation(vertexTypeJ, vertexTypeI, associationType, lengthSquaredI)));
+    (void)clusterAssociationMatrix[pClusterJ].insert(
+        ClusterAssociationMap::value_type(pClusterI, ClusterAssociation(vertexTypeJ, vertexTypeI, associationType, lengthSquaredI)));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -182,7 +182,8 @@ void CosmicRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
     ClusterAssociationMatrix clusterAssociationMatrix;
 
     ClusterVector sortedInputClusters;
-    for (const auto &mapEntry : inputAssociationMatrix) sortedInputClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : inputAssociationMatrix)
+        sortedInputClusters.push_back(mapEntry.first);
     std::sort(sortedInputClusters.begin(), sortedInputClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pCluster1 : sortedInputClusters)
@@ -210,7 +211,8 @@ void CosmicRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
             bool isAssociated(true);
 
             ClusterVector sortedAssociationClusters;
-            for (const auto &mapEntry : associationMap1) sortedAssociationClusters.push_back(mapEntry.first);
+            for (const auto &mapEntry : associationMap1)
+                sortedAssociationClusters.push_back(mapEntry.first);
             std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
             for (const Cluster *const pCluster3 : sortedAssociationClusters)
@@ -223,8 +225,7 @@ void CosmicRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
 
                 const ClusterAssociation &association23(iter23->second);
 
-                if (association12.GetParent() == association13.GetParent() &&
-                    association23.GetParent() == association21.GetParent() &&
+                if (association12.GetParent() == association13.GetParent() && association23.GetParent() == association21.GetParent() &&
                     association13.GetDaughter() != association23.GetDaughter())
                 {
                     isAssociated = false;
@@ -234,18 +235,18 @@ void CosmicRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
 
             if (isAssociated)
             {
-                (void) clusterAssociationMatrix[pCluster1].insert(ClusterAssociationMap::value_type(pCluster2, association12));
-                (void) clusterAssociationMatrix[pCluster2].insert(ClusterAssociationMap::value_type(pCluster1, association21));
+                (void)clusterAssociationMatrix[pCluster1].insert(ClusterAssociationMap::value_type(pCluster2, association12));
+                (void)clusterAssociationMatrix[pCluster2].insert(ClusterAssociationMap::value_type(pCluster1, association21));
             }
         }
     }
-
 
     // Second step: find the best associations A -> X and B -> Y
     ClusterAssociationMatrix intermediateAssociationMatrix;
 
     ClusterVector sortedClusters;
-    for (const auto &mapEntry : clusterAssociationMatrix) sortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : clusterAssociationMatrix)
+        sortedClusters.push_back(mapEntry.first);
     std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : sortedClusters)
@@ -259,7 +260,8 @@ void CosmicRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
         ClusterAssociation bestAssociationOuter(ClusterAssociation::UNDEFINED, ClusterAssociation::UNDEFINED, ClusterAssociation::NONE, 0.f);
 
         ClusterVector sortedAssociationClusters;
-        for (const auto &mapEntry : clusterAssociationMap) sortedAssociationClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : clusterAssociationMap)
+            sortedAssociationClusters.push_back(mapEntry.first);
         std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedAssociationClusters)
@@ -288,16 +290,16 @@ void CosmicRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
         }
 
         if (pBestClusterInner)
-            (void) intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterInner, bestAssociationInner));
+            (void)intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterInner, bestAssociationInner));
 
         if (pBestClusterOuter)
-            (void) intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterOuter, bestAssociationOuter));
+            (void)intermediateAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pBestClusterOuter, bestAssociationOuter));
     }
-
 
     // Third step: make the merge if A -> X and B -> Y is in fact A -> B and B -> A
     ClusterVector intermediateSortedClusters;
-    for (const auto &mapEntry : intermediateAssociationMatrix) intermediateSortedClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : intermediateAssociationMatrix)
+        intermediateSortedClusters.push_back(mapEntry.first);
     std::sort(intermediateSortedClusters.begin(), intermediateSortedClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : intermediateSortedClusters)
@@ -305,7 +307,8 @@ void CosmicRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMa
         const ClusterAssociationMap &parentAssociationMap(intermediateAssociationMatrix.at(pParentCluster));
 
         ClusterVector sortedAssociationClusters;
-        for (const auto &mapEntry : parentAssociationMap) sortedAssociationClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : parentAssociationMap)
+            sortedAssociationClusters.push_back(mapEntry.first);
         std::sort(sortedAssociationClusters.begin(), sortedAssociationClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedAssociationClusters)
@@ -360,7 +363,7 @@ float CosmicRayExtensionAlgorithm::CalculateRms(const Cluster *const pCluster, c
     }
 
     if (totalHits > 0.f)
-        return std::sqrt(totalChi2/totalHits);
+        return std::sqrt(totalChi2 / totalHits);
 
     return 0.f;
 }
@@ -369,23 +372,22 @@ float CosmicRayExtensionAlgorithm::CalculateRms(const Cluster *const pCluster, c
 
 StatusCode CosmicRayExtensionAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSeedClusterLength", m_minSeedClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinSeedClusterLength", m_minSeedClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCosRelativeAngle", m_minCosRelativeAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosRelativeAngle", m_minCosRelativeAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAverageRms", m_maxAverageRms));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAverageRms", m_maxAverageRms));
 
     return ClusterExtensionAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRayExtensionAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRayExtensionAlgorithm.h
@@ -40,8 +40,8 @@ private:
      *  @param  clusterJ the second pointing cluster
      *  @param  clusterAssociationMatrix the matrix of cluster associations
      */
-    void FillClusterAssociationMatrix(const LArPointingCluster &clusterI, const LArPointingCluster &clusterJ,
-        ClusterAssociationMatrix &clusterAssociationMatrix) const;
+    void FillClusterAssociationMatrix(
+        const LArPointingCluster &clusterI, const LArPointingCluster &clusterJ, ClusterAssociationMatrix &clusterAssociationMatrix) const;
 
     /**
      *  @brief  Calculate RMS deviation of a cluster with respect to the reference line
@@ -50,17 +50,16 @@ private:
      *  @param  position the intercept of the reference line
      *  @param  direction the direction of the reference line
      */
-    float CalculateRms(const pandora::Cluster *const pCluster, const pandora::CartesianVector &position,
-        const  pandora::CartesianVector &direction) const;
+    float CalculateRms(const pandora::Cluster *const pCluster, const pandora::CartesianVector &position, const pandora::CartesianVector &direction) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float    m_minClusterLength;                ///<
-    float    m_minSeedClusterLength;            ///<
-    float    m_maxLongitudinalDisplacement;     ///<
-    float    m_maxTransverseDisplacement;       ///<
-    float    m_minCosRelativeAngle;             ///<
-    float    m_maxAverageRms;                   ///<
+    float m_minClusterLength;            ///<
+    float m_minSeedClusterLength;        ///<
+    float m_maxLongitudinalDisplacement; ///<
+    float m_maxTransverseDisplacement;   ///<
+    float m_minCosRelativeAngle;         ///<
+    float m_maxAverageRms;               ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRaySplittingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRaySplittingAlgorithm.cc
@@ -62,9 +62,9 @@ StatusCode CosmicRaySplittingAlgorithm::Run()
         const TwoDSlidingFitResult &branchSlidingFitResult(bFitIter->second);
 
         // Find best split position for candidate branch cluster
-        CartesianVector splitPosition(0.f,0.f,0.f);
-        CartesianVector splitDirection1(0.f,0.f,0.f);
-        CartesianVector splitDirection2(0.f,0.f,0.f);
+        CartesianVector splitPosition(0.f, 0.f, 0.f);
+        CartesianVector splitDirection1(0.f, 0.f, 0.f);
+        CartesianVector splitDirection2(0.f, 0.f, 0.f);
 
         if (STATUS_CODE_SUCCESS != this->FindBestSplitPosition(branchSlidingFitResult, splitPosition, splitDirection1, splitDirection2))
             continue;
@@ -94,8 +94,8 @@ StatusCode CosmicRaySplittingAlgorithm::Run()
             float lengthSquared1(std::numeric_limits<float>::max());
             float lengthSquared2(std::numeric_limits<float>::max());
 
-            if (STATUS_CODE_SUCCESS != this->ConfirmSplitPosition(branchSlidingFitResult, replacementSlidingFitResult,
-                splitPosition, splitDirection1, splitDirection2, lengthSquared1, lengthSquared2))
+            if (STATUS_CODE_SUCCESS != this->ConfirmSplitPosition(branchSlidingFitResult, replacementSlidingFitResult, splitPosition,
+                                           splitDirection1, splitDirection2, lengthSquared1, lengthSquared2))
                 continue;
 
             if (lengthSquared1 < bestLengthSquared1)
@@ -131,19 +131,19 @@ StatusCode CosmicRaySplittingAlgorithm::Run()
             if (!(this->IdentifyCrossedTracks(pBranchCluster, pReplacementCluster1, pReplacementCluster2, splitPosition)))
                 continue;
 
-            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->PerformDoubleSplit(pBranchCluster, pReplacementCluster1,
-                pReplacementCluster2, splitPosition, splitDirection1, splitDirection2));
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                this->PerformDoubleSplit(pBranchCluster, pReplacementCluster1, pReplacementCluster2, splitPosition, splitDirection1, splitDirection2));
         }
         // Single scatter
         else if (pReplacementCluster1)
         {
-            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->PerformSingleSplit(pBranchCluster, pReplacementCluster1,
-                splitPosition, splitDirection1, splitDirection2));
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                this->PerformSingleSplit(pBranchCluster, pReplacementCluster1, splitPosition, splitDirection1, splitDirection2));
         }
         else if (pReplacementCluster2)
         {
-            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->PerformSingleSplit(pBranchCluster, pReplacementCluster2,
-                splitPosition, splitDirection2, splitDirection1));
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                this->PerformSingleSplit(pBranchCluster, pReplacementCluster2, splitPosition, splitDirection2, splitDirection1));
         }
 
         // Choose not to re-use clusters (for now)
@@ -178,8 +178,7 @@ void CosmicRaySplittingAlgorithm::GetListOfCleanClusters(const ClusterList *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CosmicRaySplittingAlgorithm::BuildSlidingFitResultMap(const ClusterVector &clusterVector,
-    TwoDSlidingFitResultMap &slidingFitResultMap) const
+void CosmicRaySplittingAlgorithm::BuildSlidingFitResultMap(const ClusterVector &clusterVector, TwoDSlidingFitResultMap &slidingFitResultMap) const
 {
     const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
@@ -205,8 +204,8 @@ void CosmicRaySplittingAlgorithm::BuildSlidingFitResultMap(const ClusterVector &
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode CosmicRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult &branchSlidingFitResult, CartesianVector &splitPosition,
-    CartesianVector &splitDirection1, CartesianVector &splitDirection2) const
+StatusCode CosmicRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingFitResult &branchSlidingFitResult,
+    CartesianVector &splitPosition, CartesianVector &splitDirection1, CartesianVector &splitDirection2) const
 {
     // Find position of greatest scatter for this cluster
     float splitCosTheta(m_maxCosSplittingAngle);
@@ -220,14 +219,14 @@ StatusCode CosmicRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingF
     branchSlidingFitResult.GetLocalPosition(minPosition, minL, minT);
     branchSlidingFitResult.GetLocalPosition(maxPosition, maxL, maxT);
 
-    const unsigned int nSamplingPoints = static_cast<unsigned int>((maxL - minL)/ m_samplingPitch);
+    const unsigned int nSamplingPoints = static_cast<unsigned int>((maxL - minL) / m_samplingPitch);
 
     for (unsigned int n = 0; n < nSamplingPoints; ++n)
     {
         const float alpha((0.5f + static_cast<float>(n)) / static_cast<float>(nSamplingPoints));
         const float rL(minL + (maxL - minL) * alpha);
 
-        CartesianVector centralPosition(0.f,0.f,0.f), forwardDirection(0.f,0.f,0.f), backwardDirection(0.f,0.f,0.f);
+        CartesianVector centralPosition(0.f, 0.f, 0.f), forwardDirection(0.f, 0.f, 0.f), backwardDirection(0.f, 0.f, 0.f);
 
         if ((STATUS_CODE_SUCCESS != branchSlidingFitResult.GetGlobalFitPosition(rL, centralPosition)) ||
             (STATUS_CODE_SUCCESS != branchSlidingFitResult.GetGlobalFitDirection(rL + halfWindowLength, forwardDirection)) ||
@@ -240,8 +239,8 @@ StatusCode CosmicRaySplittingAlgorithm::FindBestSplitPosition(const TwoDSlidingF
 
         if (cosTheta < splitCosTheta)
         {
-            CartesianVector forwardPosition(0.f,0.f,0.f);
-            CartesianVector backwardPosition(0.f,0.f,0.f);
+            CartesianVector forwardPosition(0.f, 0.f, 0.f);
+            CartesianVector backwardPosition(0.f, 0.f, 0.f);
 
             if ((STATUS_CODE_SUCCESS != branchSlidingFitResult.GetGlobalFitPosition(rL + halfWindowLength, forwardPosition)) ||
                 (STATUS_CODE_SUCCESS != branchSlidingFitResult.GetGlobalFitPosition(rL - halfWindowLength, backwardPosition)))
@@ -298,8 +297,8 @@ StatusCode CosmicRaySplittingAlgorithm::ConfirmSplitPosition(const TwoDSlidingFi
         const CartesianVector pAxis((0 == iFwd) ? (maxPosition - minPosition) : (minPosition - maxPosition));
         const CartesianVector vtxPosition((0 == iFwd) ? minPosition : maxPosition);
         const CartesianVector endPosition((0 == iFwd) ? maxPosition : minPosition);
-        const CartesianVector vtxDirection((0 == iFwd) ? (pAxis.GetDotProduct(minDirection) > 0 ? minDirection : minDirection * -1.f) :
-            (pAxis.GetDotProduct(maxDirection) > 0 ? maxDirection : maxDirection * -1.f));
+        const CartesianVector vtxDirection((0 == iFwd) ? (pAxis.GetDotProduct(minDirection) > 0 ? minDirection : minDirection * -1.f)
+                                                       : (pAxis.GetDotProduct(maxDirection) > 0 ? maxDirection : maxDirection * -1.f));
 
         // Choose the correct end of the replacement cluster and require proximity to the branch cluster
         const float vtxDisplacement(LArClusterHelper::GetClosestDistance(vtxPosition, branchSlidingFitResult.GetCluster()));
@@ -312,19 +311,19 @@ StatusCode CosmicRaySplittingAlgorithm::ConfirmSplitPosition(const TwoDSlidingFi
         if (vtxDisplacement > endDisplacement)
             continue;
 
-        if (std::min(lengthSquared,std::min(lengthSquared1,lengthSquared2)) > std::min(branchLengthSquared, replacementLengthSquared))
+        if (std::min(lengthSquared, std::min(lengthSquared1, lengthSquared2)) > std::min(branchLengthSquared, replacementLengthSquared))
             continue;
 
         // Require good pointing information between replacement cluster and candidate split position
         float impactL(0.f), impactT(0.f);
         LArPointingClusterHelper::GetImpactParameters(vtxPosition, vtxDirection, splitPosition, impactL, impactT);
 
-        if (impactT > m_maxTransverseDisplacement || impactL > m_maxLongitudinalDisplacement ||
-            impactL < -1.f || impactT > std::max(1.5f, 0.577f * (1.f + impactL)))
+        if (impactT > m_maxTransverseDisplacement || impactL > m_maxLongitudinalDisplacement || impactL < -1.f ||
+            impactT > std::max(1.5f, 0.577f * (1.f + impactL)))
             continue;
 
         // Check the segment of the branch cluster above the split position
-        if (vtxDirection.GetDotProduct(branchDirection1) > std::max(m_minCosMergingAngle,cosSplittingAngle))
+        if (vtxDirection.GetDotProduct(branchDirection1) > std::max(m_minCosMergingAngle, cosSplittingAngle))
         {
             if (lengthSquared < bestLengthSquared1)
             {
@@ -334,7 +333,7 @@ StatusCode CosmicRaySplittingAlgorithm::ConfirmSplitPosition(const TwoDSlidingFi
         }
 
         // Check the segment of the branch cluster below the split position
-        if (vtxDirection.GetDotProduct(branchDirection2) > std::max(m_minCosMergingAngle,cosSplittingAngle))
+        if (vtxDirection.GetDotProduct(branchDirection2) > std::max(m_minCosMergingAngle, cosSplittingAngle))
         {
             if (lengthSquared < bestLengthSquared2)
             {
@@ -369,8 +368,9 @@ StatusCode CosmicRaySplittingAlgorithm::PerformSingleSplit(const Cluster *const 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode CosmicRaySplittingAlgorithm::PerformDoubleSplit(const Cluster *const pBranchCluster, const Cluster *const pReplacementCluster1, const Cluster *const pReplacementCluster2,
-    const CartesianVector &splitPosition, const CartesianVector &splitDirection1, const CartesianVector &splitDirection2) const
+StatusCode CosmicRaySplittingAlgorithm::PerformDoubleSplit(const Cluster *const pBranchCluster, const Cluster *const pReplacementCluster1,
+    const Cluster *const pReplacementCluster2, const CartesianVector &splitPosition, const CartesianVector &splitDirection1,
+    const CartesianVector &splitDirection2) const
 {
     CaloHitList caloHitListToMove1, caloHitListToMove2;
     this->GetCaloHitListsToMove(pBranchCluster, splitPosition, splitDirection1, splitDirection2, caloHitListToMove1, caloHitListToMove2);
@@ -398,8 +398,8 @@ void CosmicRaySplittingAlgorithm::GetCaloHitListToMove(const Cluster *const pBra
     const CartesianVector &splitPosition, const CartesianVector &forwardDirection, const CartesianVector &backwardDirection,
     CaloHitList &caloHitListToMove) const
 {
-    const CartesianVector forwardPosition(LArClusterHelper::GetClosestPosition(splitPosition,pBranchCluster));
-    const CartesianVector vtxPosition(LArClusterHelper::GetClosestPosition(splitPosition,pReplacementCluster));
+    const CartesianVector forwardPosition(LArClusterHelper::GetClosestPosition(splitPosition, pBranchCluster));
+    const CartesianVector vtxPosition(LArClusterHelper::GetClosestPosition(splitPosition, pReplacementCluster));
     const CartesianVector vtxDirection((forwardPosition - vtxPosition).GetUnitVector());
 
     CaloHitList caloHitListToSort, caloHitListToCheck;
@@ -413,7 +413,7 @@ void CosmicRaySplittingAlgorithm::GetCaloHitListToMove(const Cluster *const pBra
         {
             caloHitListToMove.push_back(pCaloHit);
         }
-        else if(forwardDirection.GetDotProduct(pCaloHit->GetPositionVector() - vtxPosition) > -1.25f)
+        else if (forwardDirection.GetDotProduct(pCaloHit->GetPositionVector() - vtxPosition) > -1.25f)
         {
             caloHitListToCheck.push_back(pCaloHit);
         }
@@ -474,11 +474,11 @@ void CosmicRaySplittingAlgorithm::GetCaloHitListsToMove(const Cluster *const pBr
 bool CosmicRaySplittingAlgorithm::IdentifyCrossedTracks(const Cluster *const pBranchCluster, const Cluster *const pReplacementCluster1,
     const Cluster *const pReplacementCluster2, const pandora::CartesianVector &splitPosition) const
 {
-    CartesianVector branchVertex1(0.f,0.f,0.f), branchVertex2(0.f,0.f,0.f);
-    LArClusterHelper::GetExtremalCoordinates(pBranchCluster,branchVertex1,branchVertex2);
+    CartesianVector branchVertex1(0.f, 0.f, 0.f), branchVertex2(0.f, 0.f, 0.f);
+    LArClusterHelper::GetExtremalCoordinates(pBranchCluster, branchVertex1, branchVertex2);
 
-    const CartesianVector replacementVertex1(LArClusterHelper::GetClosestPosition(splitPosition,pReplacementCluster1));
-    const CartesianVector replacementVertex2(LArClusterHelper::GetClosestPosition(splitPosition,pReplacementCluster2));
+    const CartesianVector replacementVertex1(LArClusterHelper::GetClosestPosition(splitPosition, pReplacementCluster1));
+    const CartesianVector replacementVertex2(LArClusterHelper::GetClosestPosition(splitPosition, pReplacementCluster2));
 
     if ((replacementVertex2 - replacementVertex1).GetMagnitudeSquared() > (branchVertex2 - branchVertex1).GetMagnitudeSquared())
         return false;
@@ -488,8 +488,8 @@ bool CosmicRaySplittingAlgorithm::IdentifyCrossedTracks(const Cluster *const pBr
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode CosmicRaySplittingAlgorithm::GetCaloHitListToKeep(const Cluster *const pBranchCluster, const CaloHitList &caloHitListToMove,
-    CaloHitList &caloHitListToKeep) const
+StatusCode CosmicRaySplittingAlgorithm::GetCaloHitListToKeep(
+    const Cluster *const pBranchCluster, const CaloHitList &caloHitListToMove, CaloHitList &caloHitListToKeep) const
 {
     if (caloHitListToMove.empty())
         return STATUS_CODE_FAILURE;
@@ -510,7 +510,8 @@ StatusCode CosmicRaySplittingAlgorithm::GetCaloHitListToKeep(const Cluster *cons
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode CosmicRaySplittingAlgorithm::SplitCluster(const Cluster *const pBranchCluster, const Cluster *const pReplacementCluster, const CaloHitList &caloHitListToMove) const
+StatusCode CosmicRaySplittingAlgorithm::SplitCluster(
+    const Cluster *const pBranchCluster, const Cluster *const pReplacementCluster, const CaloHitList &caloHitListToMove) const
 {
     if (caloHitListToMove.empty())
         return STATUS_CODE_FAILURE;
@@ -529,29 +530,28 @@ StatusCode CosmicRaySplittingAlgorithm::SplitCluster(const Cluster *const pBranc
 
 StatusCode CosmicRaySplittingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterMinLength", m_clusterMinLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterMinLength", m_clusterMinLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitHalfWindow", m_halfWindowLayers));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitHalfWindow", m_halfWindowLayers));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SamplingPitch", m_samplingPitch));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SamplingPitch", m_samplingPitch));
 
     if (m_samplingPitch < std::numeric_limits<float>::epsilon())
         return STATUS_CODE_INVALID_PARAMETER;
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCosSplittingAngle", m_maxCosSplittingAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCosSplittingAngle", m_maxCosSplittingAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCosMergingAngle", m_minCosMergingAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosMergingAngle", m_minCosMergingAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
     m_maxLongitudinalDisplacementSquared = m_maxLongitudinalDisplacement * m_maxLongitudinalDisplacement;
 
     return STATUS_CODE_SUCCESS;

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRaySplittingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/CosmicRaySplittingAlgorithm.h
@@ -68,10 +68,9 @@ private:
      *  @param  lengthSquared1 figure of merit for association with first track direction
      *  @param  lengthSquared2 figure of merit for association with second track direction
      */
-    pandora::StatusCode ConfirmSplitPosition(const TwoDSlidingFitResult &branchSlidingFitResult,
-        const TwoDSlidingFitResult &replacementSlidingFitResult, const pandora::CartesianVector &splitPosition,
-        const pandora::CartesianVector &splitDirection1, const pandora::CartesianVector &splitDirection2,
-        float &lengthSquared1, float &lengthSquared2) const;
+    pandora::StatusCode ConfirmSplitPosition(const TwoDSlidingFitResult &branchSlidingFitResult, const TwoDSlidingFitResult &replacementSlidingFitResult,
+        const pandora::CartesianVector &splitPosition, const pandora::CartesianVector &splitDirection1,
+        const pandora::CartesianVector &splitDirection2, float &lengthSquared1, float &lengthSquared2) const;
 
     /**
      *  @brief  Split a branch cluster for case of one replacement cluster
@@ -83,7 +82,7 @@ private:
      *  @param  backwardDirection the direction of the branch cluster just below the split position
      */
     pandora::StatusCode PerformSingleSplit(const pandora::Cluster *const pBranchCluster, const pandora::Cluster *const pReplacementCluster,
-        const pandora::CartesianVector &splitPosition, const  pandora::CartesianVector &forwardDirection,
+        const pandora::CartesianVector &splitPosition, const pandora::CartesianVector &forwardDirection,
         const pandora::CartesianVector &backwardDirection) const;
 
     /**
@@ -159,14 +158,14 @@ private:
     pandora::StatusCode SplitCluster(const pandora::Cluster *const pBranchCluster, const pandora::Cluster *const pReplacementCluster,
         const pandora::CaloHitList &caloHitListToMove) const;
 
-    float          m_clusterMinLength;                     ///< minimum length of clusters for this algorithm
-    unsigned int   m_halfWindowLayers;                     ///< number of layers to use for half-window of sliding fit
-    float          m_samplingPitch;                        ///< sampling pitch for walking along sliding linear fit
-    float          m_maxCosSplittingAngle;                 ///< smallest scatter angle allowed when splitting cluster
-    float          m_minCosMergingAngle;                   ///< largest relative angle allowed when merging clusters
-    float          m_maxTransverseDisplacement;            ///< maximum transverse displacement of associated clusters
-    float          m_maxLongitudinalDisplacement;          ///< maximum longitudinal displacement of associated clusters
-    float          m_maxLongitudinalDisplacementSquared;   ///< longitudinal displacement squared
+    float m_clusterMinLength;                   ///< minimum length of clusters for this algorithm
+    unsigned int m_halfWindowLayers;            ///< number of layers to use for half-window of sliding fit
+    float m_samplingPitch;                      ///< sampling pitch for walking along sliding linear fit
+    float m_maxCosSplittingAngle;               ///< smallest scatter angle allowed when splitting cluster
+    float m_minCosMergingAngle;                 ///< largest relative angle allowed when merging clusters
+    float m_maxTransverseDisplacement;          ///< maximum transverse displacement of associated clusters
+    float m_maxLongitudinalDisplacement;        ///< maximum longitudinal displacement of associated clusters
+    float m_maxLongitudinalDisplacementSquared; ///< longitudinal displacement squared
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayExtensionAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayExtensionAlgorithm.cc
@@ -71,8 +71,8 @@ void DeltaRayExtensionAlgorithm::GetExtremalCoordinatesFromCache(const Cluster *
     if ((innerCoordinateMap.end() == innerIter) || (outerCoordinateMap.end() == outerIter))
     {
         LArClusterHelper::GetExtremalCoordinates(pCluster, innerCoordinate, outerCoordinate);
-        (void) innerCoordinateMap.insert(ClusterToCoordinateMap::value_type(pCluster, innerCoordinate));
-        (void) outerCoordinateMap.insert(ClusterToCoordinateMap::value_type(pCluster, outerCoordinate));
+        (void)innerCoordinateMap.insert(ClusterToCoordinateMap::value_type(pCluster, innerCoordinate));
+        (void)outerCoordinateMap.insert(ClusterToCoordinateMap::value_type(pCluster, outerCoordinate));
     }
     else
     {
@@ -117,7 +117,7 @@ void DeltaRayExtensionAlgorithm::FillClusterAssociationMatrix(const Cluster *con
 
         // Cut on proximity of daughter cluster to parent cluster
         if (daughterVertexDistanceSquared > std::min(m_maxLongitudinalDisplacement * m_maxLongitudinalDisplacement,
-            std::min(daughterEndDistanceSquared, daughterLengthSquared)))
+                                                std::min(daughterEndDistanceSquared, daughterLengthSquared)))
             continue;
 
         const ClusterAssociation::VertexType daughterVertexType(useInnerD == 1 ? ClusterAssociation::INNER : ClusterAssociation::OUTER);
@@ -144,7 +144,7 @@ void DeltaRayExtensionAlgorithm::FillClusterAssociationMatrix(const Cluster *con
 
             // Require an end-to-end join between parent and daughter cluster
             if (parentVertexDistanceSquared > std::min(m_maxTransverseDisplacement * m_maxTransverseDisplacement,
-                std::min(parentEndDistanceSquared, daughterEndDistanceSquared)))
+                                                  std::min(parentEndDistanceSquared, daughterEndDistanceSquared)))
                 continue;
 
             // Cut on pointing information
@@ -166,8 +166,8 @@ void DeltaRayExtensionAlgorithm::FillClusterAssociationMatrix(const Cluster *con
 
         if (parentVertexType > ClusterAssociation::UNDEFINED)
         {
-            (void) clusterAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(pDaughterCluster,
-                ClusterAssociation(parentVertexType, daughterVertexType, associationType, figureOfMerit)));
+            (void)clusterAssociationMatrix[pParentCluster].insert(ClusterAssociationMap::value_type(
+                pDaughterCluster, ClusterAssociation(parentVertexType, daughterVertexType, associationType, figureOfMerit)));
         }
     }
 }
@@ -183,7 +183,8 @@ void DeltaRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMat
     ClusterAssociationMatrix daughterToParentMatrix;
 
     ClusterVector sortedParentClusters;
-    for (const auto &mapEntry : parentToDaughterMatrix) sortedParentClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : parentToDaughterMatrix)
+        sortedParentClusters.push_back(mapEntry.first);
     std::sort(sortedParentClusters.begin(), sortedParentClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : sortedParentClusters)
@@ -191,21 +192,22 @@ void DeltaRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMat
         const ClusterAssociationMap &daughterToAssociationMap(parentToDaughterMatrix.at(pParentCluster));
 
         ClusterVector sortedLocalDaughterClusters;
-        for (const auto &mapEntry : daughterToAssociationMap) sortedLocalDaughterClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : daughterToAssociationMap)
+            sortedLocalDaughterClusters.push_back(mapEntry.first);
         std::sort(sortedLocalDaughterClusters.begin(), sortedLocalDaughterClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedLocalDaughterClusters)
         {
             const ClusterAssociation &clusterAssociation(daughterToAssociationMap.at(pDaughterCluster));
-            (void) daughterToParentMatrix[pDaughterCluster].insert(ClusterAssociationMap::value_type(pParentCluster, clusterAssociation));
+            (void)daughterToParentMatrix[pDaughterCluster].insert(ClusterAssociationMap::value_type(pParentCluster, clusterAssociation));
         }
     }
-
 
     ClusterAssociationMatrix reducedParentToDaughterMatrix;
 
     ClusterVector sortedDaughterClusters;
-    for (const auto &mapEntry : daughterToParentMatrix) sortedDaughterClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : daughterToParentMatrix)
+        sortedDaughterClusters.push_back(mapEntry.first);
     std::sort(sortedDaughterClusters.begin(), sortedDaughterClusters.end(), LArClusterHelper::SortByNHits);
 
     // Loop over parent clusters and select nearby daughter clusters that are closer than another parent cluster
@@ -220,7 +222,8 @@ void DeltaRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMat
         float bestFomOuter(std::numeric_limits<float>::max());
 
         ClusterVector sortedLocalParentClusters;
-        for (const auto &mapEntry : parentToAssociationMap) sortedLocalParentClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : parentToAssociationMap)
+            sortedLocalParentClusters.push_back(mapEntry.first);
         std::sort(sortedLocalParentClusters.begin(), sortedLocalParentClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pParentCluster : sortedLocalParentClusters)
@@ -276,7 +279,7 @@ void DeltaRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMat
                 throw pandora::StatusCodeException(STATUS_CODE_FAILURE);
 
             const ClusterAssociation &bestAssociationInner(iter3B->second);
-            (void) reducedParentToDaughterMatrix[pBestInner].insert(ClusterAssociationMap::value_type(pDaughterCluster, bestAssociationInner));
+            (void)reducedParentToDaughterMatrix[pBestInner].insert(ClusterAssociationMap::value_type(pDaughterCluster, bestAssociationInner));
         }
 
         if (pBestOuter)
@@ -293,13 +296,13 @@ void DeltaRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMat
                 throw pandora::StatusCodeException(STATUS_CODE_FAILURE);
 
             const ClusterAssociation &bestAssociationOuter(iter3B->second);
-            (void) reducedParentToDaughterMatrix[pBestOuter].insert(ClusterAssociationMap::value_type(pDaughterCluster, bestAssociationOuter));
+            (void)reducedParentToDaughterMatrix[pBestOuter].insert(ClusterAssociationMap::value_type(pDaughterCluster, bestAssociationOuter));
         }
     }
 
-
     ClusterVector sortedReducedParentClusters;
-    for (const auto &mapEntry : reducedParentToDaughterMatrix) sortedReducedParentClusters.push_back(mapEntry.first);
+    for (const auto &mapEntry : reducedParentToDaughterMatrix)
+        sortedReducedParentClusters.push_back(mapEntry.first);
     std::sort(sortedReducedParentClusters.begin(), sortedReducedParentClusters.end(), LArClusterHelper::SortByNHits);
 
     for (const Cluster *const pParentCluster : sortedReducedParentClusters)
@@ -313,7 +316,8 @@ void DeltaRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMat
         float bestFomOuter(std::numeric_limits<float>::max());
 
         ClusterVector sortedLocalDaughterClusters;
-        for (const auto &mapEntry : daughterToAssociationMap) sortedLocalDaughterClusters.push_back(mapEntry.first);
+        for (const auto &mapEntry : daughterToAssociationMap)
+            sortedLocalDaughterClusters.push_back(mapEntry.first);
         std::sort(sortedLocalDaughterClusters.begin(), sortedLocalDaughterClusters.end(), LArClusterHelper::SortByNHits);
 
         for (const Cluster *const pDaughterCluster : sortedLocalDaughterClusters)
@@ -387,17 +391,17 @@ void DeltaRayExtensionAlgorithm::FillClusterMergeMap(const ClusterAssociationMat
 
 StatusCode DeltaRayExtensionAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxClusterLength", m_maxClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxClusterLength", m_maxClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxLongitudinalDisplacement", m_maxLongitudinalDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTransverseDisplacement", m_maxTransverseDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxTransverseDisplacement", m_maxTransverseDisplacement));
 
     return ClusterExtensionAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayExtensionAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayExtensionAlgorithm.h
@@ -31,7 +31,7 @@ private:
     void FillClusterAssociationMatrix(const pandora::ClusterVector &clusterVector, ClusterAssociationMatrix &clusterAssociationMatrix) const;
     void FillClusterMergeMap(const ClusterAssociationMatrix &clusterAssociationMatrix, ClusterMergeMap &clusterMergeMap) const;
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::CartesianVector> ClusterToCoordinateMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::CartesianVector> ClusterToCoordinateMap;
 
     /**
      *  @brief  Reduce number of extremal coordinates calculations by caching results when they are first obtained
@@ -59,11 +59,11 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float    m_minClusterLength;                ///<
-    float    m_maxClusterLength;                ///<
+    float m_minClusterLength; ///<
+    float m_maxClusterLength; ///<
 
-    float    m_maxLongitudinalDisplacement;     ///<
-    float    m_maxTransverseDisplacement;       ///<
+    float m_maxLongitudinalDisplacement; ///<
+    float m_maxTransverseDisplacement;   ///<
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayGrowingAlgorithm.cc
@@ -63,10 +63,10 @@ void DeltaRayGrowingAlgorithm::GetListOfSeedClusters(const ClusterVector &inputC
     for (const Pfo *const pDaughterPfo : daughterPfos)
         LArPfoHelper::GetClusters(pDaughterPfo, clusterHitType, daughterClusters);
 
-     // Select short parent clusters
+    // Select short parent clusters
     for (const Cluster *const pCluster : parentClusters)
     {
-        if (LArClusterHelper::GetLengthSquared(pCluster) < m_maxSeedClusterLength  * m_maxSeedClusterLength)
+        if (LArClusterHelper::GetLengthSquared(pCluster) < m_maxSeedClusterLength * m_maxSeedClusterLength)
             seedClusters.push_back(pCluster);
     }
 
@@ -82,12 +82,14 @@ void DeltaRayGrowingAlgorithm::GetListOfSeedClusters(const ClusterVector &inputC
         if (pCluster->GetNCaloHits() < m_minSeedClusterCaloHits)
             continue;
 
-        const float parentDistance(parentClusters.empty() ? std::numeric_limits<float>::max() : LArClusterHelper::GetClosestDistance(pCluster, parentClusters));
+        const float parentDistance(
+            parentClusters.empty() ? std::numeric_limits<float>::max() : LArClusterHelper::GetClosestDistance(pCluster, parentClusters));
 
         if (parentDistance > m_maxSeedClusterDisplacement)
             continue;
 
-        const float daughterDistance(daughterClusters.empty() ? std::numeric_limits<float>::max() : LArClusterHelper::GetClosestDistance(pCluster, daughterClusters));
+        const float daughterDistance(
+            daughterClusters.empty() ? std::numeric_limits<float>::max() : LArClusterHelper::GetClosestDistance(pCluster, daughterClusters));
 
         if (daughterDistance < m_maxSeedClusterDisplacement)
             continue;
@@ -121,17 +123,17 @@ StatusCode DeltaRayGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ParentPfoListName", m_parentPfoListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "DaughterPfoListName", m_daughterPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCaloHitsPerCluster", m_minCaloHitsPerCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinSeedClusterCaloHits", m_minSeedClusterCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinSeedClusterCaloHits", m_minSeedClusterCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxSeedClusterLength", m_maxSeedClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxSeedClusterLength", m_maxSeedClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxSeedClusterDisplacement", m_maxSeedClusterDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxSeedClusterDisplacement", m_maxSeedClusterDisplacement));
 
     return ClusterGrowingAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayGrowingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/DeltaRayGrowingAlgorithm.h
@@ -40,13 +40,13 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string  m_parentPfoListName;               ///< The parent Pfo list name
-    std::string  m_daughterPfoListName;             ///< The daughter Pfo list name
+    std::string m_parentPfoListName;   ///< The parent Pfo list name
+    std::string m_daughterPfoListName; ///< The daughter Pfo list name
 
-    unsigned int m_minCaloHitsPerCluster;           ///< The minimum number of calo hits per candidate cluster
-    unsigned int m_minSeedClusterCaloHits;          ///< The minimum number of calo hits for seed clusters
-    float        m_maxSeedClusterLength;            ///< The maximum length of a parent clusters
-    float        m_maxSeedClusterDisplacement;      ///< The maximum distance between parent and daughter clusters
+    unsigned int m_minCaloHitsPerCluster;  ///< The minimum number of calo hits per candidate cluster
+    unsigned int m_minSeedClusterCaloHits; ///< The minimum number of calo hits for seed clusters
+    float m_maxSeedClusterLength;          ///< The maximum length of a parent clusters
+    float m_maxSeedClusterDisplacement;    ///< The maximum distance between parent and daughter clusters
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackMergeRefinementAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackMergeRefinementAlgorithm.h
@@ -15,10 +15,10 @@ namespace lar_content
 /**
  *  @brief TrackMergeRefinementAlgorithm class
  */
-class TrackMergeRefinementAlgorithm :  public TrackRefinementBaseAlgorithm
+class TrackMergeRefinementAlgorithm : public TrackRefinementBaseAlgorithm
 {
 public:
-   /**
+    /**
      *  @brief  Default constructor
      */
     TrackMergeRefinementAlgorithm();
@@ -59,8 +59,8 @@ private:
      *  @param  createdMainTrackClusters the list of main track clusters that have hitherto collected
      *  @param  unavailableProtectedClusters the output list of protected clusters
      */
-    void GetUnavailableProtectedClusters(const ClusterPairAssociation &clusterAssociation, const pandora::ClusterList &createdMainTrackClusters,
-        pandora::ClusterList &unavailableProtectedClusters) const;
+    void GetUnavailableProtectedClusters(const ClusterPairAssociation &clusterAssociation,
+        const pandora::ClusterList &createdMainTrackClusters, pandora::ClusterList &unavailableProtectedClusters) const;
 
     /**
      *  @brief  Check the separation of the extremal extrapolated hits with the cluster merge points or, in the case of no hits, the cluster merge point separation
@@ -96,13 +96,13 @@ private:
     const pandora::Cluster *CreateMainTrack(const ClusterPairAssociation &clusterAssociation, const ClusterToCaloHitListMap &clusterToCaloHitListMap,
         const pandora::ClusterList *pClusterList, pandora::ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const;
 
-    unsigned int m_maxLoopIterations;         ///< The maximum number of main loop iterations
-    float m_minClusterLengthSum;              ///< The threshold cluster and associated cluster length sum
-    float m_minSeparationDistance;            ///< The threshold separation distance between associated clusters
-    float m_minDirectionDeviationCosAngle;    ///< The threshold cos opening angle of the associated cluster directions
-    float m_maxPredictedMergePointOffset;     ///< The threshold separation distance between the predicted and true cluster merge points
-    float m_distanceToLine;                   ///< The threshold hit distance of an extrapolated hit from the segment connecting line
-    float m_boundaryTolerance;                ///< The maximum allowed distance of an extremal extrapolate hit to a cluster merge point
+    unsigned int m_maxLoopIterations;      ///< The maximum number of main loop iterations
+    float m_minClusterLengthSum;           ///< The threshold cluster and associated cluster length sum
+    float m_minSeparationDistance;         ///< The threshold separation distance between associated clusters
+    float m_minDirectionDeviationCosAngle; ///< The threshold cos opening angle of the associated cluster directions
+    float m_maxPredictedMergePointOffset;  ///< The threshold separation distance between the predicted and true cluster merge points
+    float m_distanceToLine;                ///< The threshold hit distance of an extrapolated hit from the segment connecting line
+    float m_boundaryTolerance;             ///< The maximum allowed distance of an extremal extrapolate hit to a cluster merge point
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.cc
@@ -9,8 +9,8 @@
 
 #include "larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArHitWidthHelper.h"
 
 using namespace pandora;
@@ -36,8 +36,9 @@ TrackRefinementBaseAlgorithm::TrackRefinementBaseAlgorithm() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
-void TrackRefinementBaseAlgorithm::InitialiseContainers(const ClusterList *pClusterList, const T sortFunction, ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const
+template <typename T>
+void TrackRefinementBaseAlgorithm::InitialiseContainers(const ClusterList *pClusterList, const T sortFunction, ClusterVector &clusterVector,
+    SlidingFitResultMapPair &slidingFitResultMapPair) const
 {
     const float slidingFitPitch(LArGeometryHelper::GetWireZPitch(this->GetPandora()));
 
@@ -55,7 +56,9 @@ void TrackRefinementBaseAlgorithm::InitialiseContainers(const ClusterList *pClus
             slidingFitResultMapPair.second->insert(TwoDSlidingFitResultMap::value_type(pCluster, macroSlidingFitResult));
             clusterVector.push_back(pCluster);
         }
-        catch (const StatusCodeException &) {}
+        catch (const StatusCodeException &)
+        {
+        }
     }
 
     std::sort(clusterVector.begin(), clusterVector.end(), sortFunction);
@@ -63,8 +66,9 @@ void TrackRefinementBaseAlgorithm::InitialiseContainers(const ClusterList *pClus
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackRefinementBaseAlgorithm::GetClusterMergingCoordinates(const TwoDSlidingFitResult &clusterMicroFitResult, const TwoDSlidingFitResult &clusterMacroFitResult,
-    const TwoDSlidingFitResult &associatedMacroFitResult, const bool isEndUpstream, CartesianVector &clusterMergePosition, CartesianVector &clusterMergeDirection) const
+bool TrackRefinementBaseAlgorithm::GetClusterMergingCoordinates(const TwoDSlidingFitResult &clusterMicroFitResult,
+    const TwoDSlidingFitResult &clusterMacroFitResult, const TwoDSlidingFitResult &associatedMacroFitResult, const bool isEndUpstream,
+    CartesianVector &clusterMergePosition, CartesianVector &clusterMergeDirection) const
 {
     CartesianVector clusterAverageDirection(0.f, 0.f, 0.f), associatedAverageDirection(0.f, 0.f, 0.f);
     clusterMacroFitResult.GetGlobalDirection(clusterMacroFitResult.GetLayerFitResultMap().begin()->second.GetGradient(), clusterAverageDirection);
@@ -77,7 +81,7 @@ bool TrackRefinementBaseAlgorithm::GetClusterMergingCoordinates(const TwoDSlidin
     const int step(isEndUpstream ? 1 : -1);
 
     // ATTN: Search for stable region for which the local layer gradient agrees well with associated cluster global gradient
-    unsigned int gradientStabilityWindow(std::ceil(clusterMicroLayerFitResultMap.size() *  m_stableRegionClusterFraction));
+    unsigned int gradientStabilityWindow(std::ceil(clusterMicroLayerFitResultMap.size() * m_stableRegionClusterFraction));
     unsigned int goodLayerCount(0);
 
     clusterMicroLayerFitResultMap.at(endLayer);
@@ -99,7 +103,8 @@ bool TrackRefinementBaseAlgorithm::GetClusterMergingCoordinates(const TwoDSlidin
             if (goodLayerCount == 0)
             {
                 clusterMergeDirection = clusterAverageDirection;
-                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, clusterMicroFitResult.GetGlobalFitPosition(microIter->second.GetL(), clusterMergePosition));
+                PANDORA_THROW_RESULT_IF(
+                    STATUS_CODE_SUCCESS, !=, clusterMicroFitResult.GetGlobalFitPosition(microIter->second.GetL(), clusterMergePosition));
             }
 
             ++goodLayerCount;
@@ -122,8 +127,9 @@ bool TrackRefinementBaseAlgorithm::GetClusterMergingCoordinates(const TwoDSlidin
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackRefinementBaseAlgorithm::GetHitsInBoundingBox(const CartesianVector &firstCorner, const CartesianVector &secondCorner, const ClusterList *const pClusterList,
-    ClusterToCaloHitListMap &clusterToCaloHitListMap, const ClusterList &unavailableProtectedClusters, const float distanceToLine) const
+void TrackRefinementBaseAlgorithm::GetHitsInBoundingBox(const CartesianVector &firstCorner, const CartesianVector &secondCorner,
+    const ClusterList *const pClusterList, ClusterToCaloHitListMap &clusterToCaloHitListMap,
+    const ClusterList &unavailableProtectedClusters, const float distanceToLine) const
 {
     const float minX(std::min(firstCorner.GetX(), secondCorner.GetX())), maxX(std::max(firstCorner.GetX(), secondCorner.GetX()));
     const float minZ(std::min(firstCorner.GetZ(), secondCorner.GetZ())), maxZ(std::max(firstCorner.GetZ(), secondCorner.GetZ()));
@@ -141,9 +147,8 @@ void TrackRefinementBaseAlgorithm::GetHitsInBoundingBox(const CartesianVector &f
         {
             for (const CaloHit *const pCaloHit : *mapEntry.second)
             {
-                CartesianVector hitPosition(m_hitWidthMode ?
-                    LArHitWidthHelper::GetClosestPointToLine2D(firstCorner, connectingLineDirection, pCaloHit) :
-                    pCaloHit->GetPositionVector());
+                CartesianVector hitPosition(m_hitWidthMode ? LArHitWidthHelper::GetClosestPointToLine2D(firstCorner, connectingLineDirection, pCaloHit)
+                                                           : pCaloHit->GetPositionVector());
 
                 if (!this->IsInBoundingBox(minX, maxX, minZ, maxZ, hitPosition))
                     continue;
@@ -162,14 +167,16 @@ void TrackRefinementBaseAlgorithm::GetHitsInBoundingBox(const CartesianVector &f
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackRefinementBaseAlgorithm::IsInBoundingBox(const float minX, const float maxX, const float minZ, const float maxZ, const CartesianVector &hitPosition) const
+bool TrackRefinementBaseAlgorithm::IsInBoundingBox(
+    const float minX, const float maxX, const float minZ, const float maxZ, const CartesianVector &hitPosition) const
 {
     return !((hitPosition.GetX() < minX) || (hitPosition.GetX() > maxX) || (hitPosition.GetZ() < minZ) || (hitPosition.GetZ() > maxZ));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackRefinementBaseAlgorithm::IsCloseToLine(const CartesianVector &hitPosition, const CartesianVector &lineStart, const CartesianVector &lineDirection, const float distanceToLine) const
+bool TrackRefinementBaseAlgorithm::IsCloseToLine(const CartesianVector &hitPosition, const CartesianVector &lineStart,
+    const CartesianVector &lineDirection, const float distanceToLine) const
 {
     const float transverseDistanceFromLine(lineDirection.GetCrossProduct(hitPosition - lineStart).GetMagnitude());
 
@@ -185,8 +192,8 @@ bool TrackRefinementBaseAlgorithm::AreExtrapolatedHitsGood(const ClusterToCaloHi
         extrapolatedHitVector.insert(extrapolatedHitVector.begin(), entry.second.begin(), entry.second.end());
 
     // ATTN: Extrapolated hit checks require extrapolatedHitVector to be ordered from upstream -> downstream merge point
-    std::sort(extrapolatedHitVector.begin(), extrapolatedHitVector.end(), SortByDistanceAlongLine(clusterAssociation.GetUpstreamMergePoint(),
-        clusterAssociation.GetConnectingLineDirection(), m_hitWidthMode));
+    std::sort(extrapolatedHitVector.begin(), extrapolatedHitVector.end(),
+        SortByDistanceAlongLine(clusterAssociation.GetUpstreamMergePoint(), clusterAssociation.GetConnectingLineDirection(), m_hitWidthMode));
 
     if (!this->AreExtrapolatedHitsNearBoundaries(extrapolatedHitVector, clusterAssociation))
         return false;
@@ -224,9 +231,9 @@ bool TrackRefinementBaseAlgorithm::IsTrackContinuous(const ClusterAssociation &c
 
     unsigned int segmentsWithoutHits(0);
     CaloHitVector::const_iterator caloHitIter(extrapolatedCaloHitVector.begin());
-    CartesianVector hitPosition(m_hitWidthMode ?
-        LArHitWidthHelper::GetClosestPointToLine2D(clusterAssociation.GetUpstreamMergePoint(), clusterAssociation.GetConnectingLineDirection(), *caloHitIter) :
-        (*caloHitIter)->GetPositionVector());
+    CartesianVector hitPosition(m_hitWidthMode ? LArHitWidthHelper::GetClosestPointToLine2D(clusterAssociation.GetUpstreamMergePoint(),
+                                                     clusterAssociation.GetConnectingLineDirection(), *caloHitIter)
+                                               : (*caloHitIter)->GetPositionVector());
 
     for (unsigned int i = 0; i < (trackSegmentBoundaries.size() - 1); ++i)
     {
@@ -249,9 +256,9 @@ bool TrackRefinementBaseAlgorithm::IsTrackContinuous(const ClusterAssociation &c
             if (caloHitIter == extrapolatedCaloHitVector.end())
                 break;
 
-            hitPosition = m_hitWidthMode ?
-                LArHitWidthHelper::GetClosestPointToLine2D(clusterAssociation.GetUpstreamMergePoint(), clusterAssociation.GetConnectingLineDirection(), *caloHitIter) :
-                (*caloHitIter)->GetPositionVector();
+            hitPosition = m_hitWidthMode ? LArHitWidthHelper::GetClosestPointToLine2D(clusterAssociation.GetUpstreamMergePoint(),
+                                               clusterAssociation.GetConnectingLineDirection(), *caloHitIter)
+                                         : (*caloHitIter)->GetPositionVector();
         }
 
         segmentsWithoutHits = hitsInSegment ? 0 : segmentsWithoutHits + 1;
@@ -278,7 +285,8 @@ void TrackRefinementBaseAlgorithm::GetTrackSegmentBoundaries(const ClusterAssoci
 
     // ATTN: Consider the existence of gaps where no hits will be found
     DetectorGapList consideredGaps;
-    trackLength -= this->DistanceInGap(clusterAssociation.GetUpstreamMergePoint(), clusterAssociation.GetDownstreamMergePoint(), trackDirection, consideredGaps);
+    trackLength -= this->DistanceInGap(
+        clusterAssociation.GetUpstreamMergePoint(), clusterAssociation.GetDownstreamMergePoint(), trackDirection, consideredGaps);
     consideredGaps.clear();
 
     const int fullSegments(std::floor(trackLength / m_lineSegmentLength));
@@ -335,7 +343,7 @@ void TrackRefinementBaseAlgorithm::RepositionIfInGap(const CartesianVector &merg
     const DetectorGapList detectorGapList(this->GetPandora().GetGeometry()->GetDetectorGapList());
     for (const DetectorGap *const pDetectorGap : detectorGapList)
     {
-        const LineGap *const pLineGap(dynamic_cast<const LineGap*>(pDetectorGap));
+        const LineGap *const pLineGap(dynamic_cast<const LineGap *>(pDetectorGap));
 
         if (pLineGap)
         {
@@ -350,7 +358,8 @@ void TrackRefinementBaseAlgorithm::RepositionIfInGap(const CartesianVector &merg
 
                     const float gradient(mergeDirection.GetZ() / mergeDirection.GetX());
 
-                    trackPoint = CartesianVector(pLineGap->GetLineEndX(), 0.f, trackPoint.GetZ() + (gradient * (pLineGap->GetLineEndX() - trackPoint.GetX())));
+                    trackPoint = CartesianVector(
+                        pLineGap->GetLineEndX(), 0.f, trackPoint.GetZ() + (gradient * (pLineGap->GetLineEndX() - trackPoint.GetX())));
                 }
             }
 
@@ -363,7 +372,8 @@ void TrackRefinementBaseAlgorithm::RepositionIfInGap(const CartesianVector &merg
 
                     const float gradient(mergeDirection.GetX() / mergeDirection.GetZ());
 
-                    trackPoint = CartesianVector(trackPoint.GetX() + (gradient * (pLineGap->GetLineEndZ() - trackPoint.GetZ())), 0.f, pLineGap->GetLineEndZ());
+                    trackPoint = CartesianVector(
+                        trackPoint.GetX() + (gradient * (pLineGap->GetLineEndZ() - trackPoint.GetZ())), 0.f, pLineGap->GetLineEndZ());
                 }
             }
         }
@@ -388,7 +398,7 @@ float TrackRefinementBaseAlgorithm::DistanceInGap(const CartesianVector &upstrea
         if (std::find(consideredGaps.begin(), consideredGaps.end(), pDetectorGap) != consideredGaps.end())
             continue;
 
-        const LineGap *const pLineGap(dynamic_cast<const LineGap*>(pDetectorGap));
+        const LineGap *const pLineGap(dynamic_cast<const LineGap *>(pDetectorGap));
 
         if (pLineGap)
         {
@@ -459,8 +469,8 @@ float TrackRefinementBaseAlgorithm::DistanceInGap(const CartesianVector &upstrea
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-
-bool TrackRefinementBaseAlgorithm::IsInLineSegment(const CartesianVector &lowerBoundary, const CartesianVector &upperBoundary, const CartesianVector &point) const
+bool TrackRefinementBaseAlgorithm::IsInLineSegment(
+    const CartesianVector &lowerBoundary, const CartesianVector &upperBoundary, const CartesianVector &point) const
 {
     const float segmentBoundaryGradient = (-1.f) * (upperBoundary.GetX() - lowerBoundary.GetX()) / (upperBoundary.GetZ() - lowerBoundary.GetZ());
     const float xPointOnUpperLine((point.GetZ() - upperBoundary.GetZ()) / segmentBoundaryGradient + upperBoundary.GetX());
@@ -484,8 +494,8 @@ bool TrackRefinementBaseAlgorithm::IsInLineSegment(const CartesianVector &lowerB
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 const Cluster *TrackRefinementBaseAlgorithm::RemoveOffAxisHitsFromTrack(const Cluster *const pCluster, const CartesianVector &splitPosition,
-    const bool isEndUpstream, const ClusterToCaloHitListMap &clusterToCaloHitListMap, ClusterList &remnantClusterList, TwoDSlidingFitResultMap &microSlidingFitResultMap,
-    TwoDSlidingFitResultMap &macroSlidingFitResultMap) const
+    const bool isEndUpstream, const ClusterToCaloHitListMap &clusterToCaloHitListMap, ClusterList &remnantClusterList,
+    TwoDSlidingFitResultMap &microSlidingFitResultMap, TwoDSlidingFitResultMap &macroSlidingFitResultMap) const
 {
     float rL(0.f), rT(0.f);
     const TwoDSlidingFitResult &microFitResult(microSlidingFitResultMap.at(pCluster));
@@ -502,7 +512,8 @@ const Cluster *TrackRefinementBaseAlgorithm::RemoveOffAxisHitsFromTrack(const Cl
     // Fragmentation initialisation
     std::string originalListName, fragmentListName;
     const ClusterList originalClusterList(1, pCluster);
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, originalClusterList, originalListName, fragmentListName));
+    PANDORA_THROW_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, originalClusterList, originalListName, fragmentListName));
 
     const Cluster *pMainTrackCluster(nullptr), *pAboveCluster(nullptr), *pBelowCluster(nullptr);
 
@@ -520,7 +531,8 @@ const Cluster *TrackRefinementBaseAlgorithm::RemoveOffAxisHitsFromTrack(const Cl
             const auto extrapolatedCaloHitIter(clusterToCaloHitListMap.find(pCluster));
 
             if (extrapolatedCaloHitIter != clusterToCaloHitListMap.end())
-                isAnExtrapolatedHit = std::find(extrapolatedCaloHitIter->second.begin(), extrapolatedCaloHitIter->second.end(), pCaloHit) != extrapolatedCaloHitIter->second.end();
+                isAnExtrapolatedHit = std::find(extrapolatedCaloHitIter->second.begin(), extrapolatedCaloHitIter->second.end(), pCaloHit) !=
+                                      extrapolatedCaloHitIter->second.end();
 
             const bool isAbove(((clusterGradient * hitPosition.GetX()) + clusterIntercept) < (isVertical ? hitPosition.GetX() : hitPosition.GetZ()));
             const bool isToRemove(!isAnExtrapolatedHit && (((thisL < rL) && isEndUpstream) || ((thisL > rL) && !isEndUpstream)));
@@ -556,11 +568,10 @@ const Cluster *TrackRefinementBaseAlgorithm::RemoveOffAxisHitsFromTrack(const Cl
     }
 }
 
-
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackRefinementBaseAlgorithm::AddHitsToMainTrack(const Cluster *const pMainTrackCluster, const Cluster *const pShowerCluster, const CaloHitList &caloHitsToMerge,
-    const ClusterAssociation &clusterAssociation, ClusterList &remnantClusterList) const
+void TrackRefinementBaseAlgorithm::AddHitsToMainTrack(const Cluster *const pMainTrackCluster, const Cluster *const pShowerCluster,
+    const CaloHitList &caloHitsToMerge, const ClusterAssociation &clusterAssociation, ClusterList &remnantClusterList) const
 {
     // To ignore crossing CR muon or test beam tracks
     if (((static_cast<float>(caloHitsToMerge.size()) / static_cast<float>(pShowerCluster->GetNCaloHits())) < m_minHitFractionForHitRemoval) &&
@@ -576,14 +587,17 @@ void TrackRefinementBaseAlgorithm::AddHitsToMainTrack(const Cluster *const pMain
     // Fragmentation initialisation
     std::string originalListName, fragmentListName;
     const ClusterList originalClusterList(1, pShowerCluster);
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, originalClusterList, originalListName, fragmentListName));
+    PANDORA_THROW_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, originalClusterList, originalListName, fragmentListName));
 
     const Cluster *pAboveCluster(nullptr), *pBelowCluster(nullptr);
 
     const bool isVertical(std::fabs(clusterAssociation.GetConnectingLineDirection().GetX()) < std::numeric_limits<float>::epsilon());
-    const float connectingLineGradient(isVertical ? 0.f : clusterAssociation.GetConnectingLineDirection().GetZ() / clusterAssociation.GetConnectingLineDirection().GetX());
-    const float connectingLineIntercept(isVertical ? clusterAssociation.GetUpstreamMergePoint().GetX() :
-        clusterAssociation.GetUpstreamMergePoint().GetZ() - (connectingLineGradient * clusterAssociation.GetUpstreamMergePoint().GetX()));
+    const float connectingLineGradient(
+        isVertical ? 0.f : clusterAssociation.GetConnectingLineDirection().GetZ() / clusterAssociation.GetConnectingLineDirection().GetX());
+    const float connectingLineIntercept(isVertical ? clusterAssociation.GetUpstreamMergePoint().GetX()
+                                                   : clusterAssociation.GetUpstreamMergePoint().GetZ() -
+                                                         (connectingLineGradient * clusterAssociation.GetUpstreamMergePoint().GetX()));
 
     const OrderedCaloHitList orderedCaloHitList(pShowerCluster->GetOrderedCaloHitList());
     for (const OrderedCaloHitList::value_type &mapEntry : orderedCaloHitList)
@@ -599,7 +613,8 @@ void TrackRefinementBaseAlgorithm::AddHitsToMainTrack(const Cluster *const pMain
             else
             {
                 const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
-                const bool isAbove(((connectingLineGradient * hitPosition.GetX()) + connectingLineIntercept) < (isVertical ? hitPosition.GetX() : hitPosition.GetZ()));
+                const bool isAbove(((connectingLineGradient * hitPosition.GetX()) + connectingLineIntercept) <
+                                   (isVertical ? hitPosition.GetX() : hitPosition.GetZ()));
                 const Cluster *&pClusterToModify(isAbove ? pAboveCluster : pBelowCluster);
 
                 if (pClusterToModify)
@@ -623,7 +638,8 @@ void TrackRefinementBaseAlgorithm::AddHitsToMainTrack(const Cluster *const pMain
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackRefinementBaseAlgorithm::ProcessRemnantClusters(const ClusterList &remnantClusterList, const Cluster *const pMainTrackCluster, const ClusterList *const pClusterList, ClusterList &createdClusters) const
+void TrackRefinementBaseAlgorithm::ProcessRemnantClusters(const ClusterList &remnantClusterList, const Cluster *const pMainTrackCluster,
+    const ClusterList *const pClusterList, ClusterList &createdClusters) const
 {
     ClusterList fragmentedClusters;
     for (const Cluster *const pRemnantCluster : remnantClusterList)
@@ -649,7 +665,8 @@ void TrackRefinementBaseAlgorithm::ProcessRemnantClusters(const ClusterList &rem
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackRefinementBaseAlgorithm::AddToNearestCluster(const Cluster *const pClusterToMerge, const Cluster *const pMainTrackCluster, const ClusterList *const pClusterList) const
+bool TrackRefinementBaseAlgorithm::AddToNearestCluster(
+    const Cluster *const pClusterToMerge, const Cluster *const pMainTrackCluster, const ClusterList *const pClusterList) const
 {
     const Cluster *pClosestCluster(nullptr);
     float closestDistance(std::numeric_limits<float>::max());
@@ -716,7 +733,8 @@ void TrackRefinementBaseAlgorithm::FragmentRemnantCluster(const Cluster *const p
     // Fragmentation initialisation
     std::string originalListName, fragmentListName;
     const ClusterList originalClusterList(1, pRemnantCluster);
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, originalClusterList, originalListName, fragmentListName));
+    PANDORA_THROW_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, originalClusterList, originalListName, fragmentListName));
 
     ClusterList createdClusters;
 
@@ -771,8 +789,9 @@ void TrackRefinementBaseAlgorithm::FragmentRemnantCluster(const Cluster *const p
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
-void TrackRefinementBaseAlgorithm::UpdateContainers(const ClusterList &clustersToAdd, const ClusterList &clustersToDelete, const T sortFunction, ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const
+template <typename T>
+void TrackRefinementBaseAlgorithm::UpdateContainers(const ClusterList &clustersToAdd, const ClusterList &clustersToDelete,
+    const T sortFunction, ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const
 {
     //ATTN: Very important to first delete pointers from containers
     for (const Cluster *const pClusterToDelete : clustersToDelete)
@@ -783,7 +802,8 @@ void TrackRefinementBaseAlgorithm::UpdateContainers(const ClusterList &clustersT
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackRefinementBaseAlgorithm::RemoveClusterFromContainers(const Cluster *const pClusterToRemove, ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const
+void TrackRefinementBaseAlgorithm::RemoveClusterFromContainers(
+    const Cluster *const pClusterToRemove, ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const
 {
     const TwoDSlidingFitResultMap::const_iterator microFitToDelete(slidingFitResultMapPair.first->find(pClusterToRemove));
     if (microFitToDelete != slidingFitResultMapPair.first->end())
@@ -802,38 +822,37 @@ void TrackRefinementBaseAlgorithm::RemoveClusterFromContainers(const Cluster *co
 
 StatusCode TrackRefinementBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", m_minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", m_minClusterLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MicroSlidingFitWindow", m_microSlidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MicroSlidingFitWindow", m_microSlidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MacroSlidingFitWindow", m_macroSlidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MacroSlidingFitWindow", m_macroSlidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "StableRegionClusterFraction", m_stableRegionClusterFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "StableRegionClusterFraction", m_stableRegionClusterFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MergePointMinCosAngleDeviation", m_mergePointMinCosAngleDeviation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MergePointMinCosAngleDeviation", m_mergePointMinCosAngleDeviation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitFractionForHitRemoval", m_minHitFractionForHitRemoval));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinHitFractionForHitRemoval", m_minHitFractionForHitRemoval));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxDistanceFromMainTrack", m_maxDistanceFromMainTrack));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxDistanceFromMainTrack", m_maxDistanceFromMainTrack));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxHitDistanceFromCluster", m_maxHitDistanceFromCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxHitDistanceFromCluster", m_maxHitDistanceFromCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxHitSeparationForConnectedCluster", m_maxHitSeparationForConnectedCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxHitSeparationForConnectedCluster", m_maxHitSeparationForConnectedCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTrackGaps", m_maxTrackGaps));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxTrackGaps", m_maxTrackGaps));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LineSegmentLength", m_lineSegmentLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LineSegmentLength", m_lineSegmentLength));
 
     if (m_lineSegmentLength < std::numeric_limits<float>::epsilon())
     {
@@ -841,8 +860,7 @@ StatusCode TrackRefinementBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
         throw STATUS_CODE_INVALID_PARAMETER;
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "HitWidthMode", m_hitWidthMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitWidthMode", m_hitWidthMode));
 
     return STATUS_CODE_SUCCESS;
 }
@@ -850,13 +868,13 @@ StatusCode TrackRefinementBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrackRefinementBaseAlgorithm::SortByDistanceAlongLine::operator() (const pandora::CaloHit *const pLhs, const pandora::CaloHit *const pRhs) const
+bool TrackRefinementBaseAlgorithm::SortByDistanceAlongLine::operator()(const pandora::CaloHit *const pLhs, const pandora::CaloHit *const pRhs) const
 {
-    const CartesianVector lhsHitPosition(m_hitWidthMode ? LArHitWidthHelper::GetClosestPointToLine2D(m_startPoint, m_lineDirection, pLhs) :
-        pLhs->GetPositionVector());
+    const CartesianVector lhsHitPosition(
+        m_hitWidthMode ? LArHitWidthHelper::GetClosestPointToLine2D(m_startPoint, m_lineDirection, pLhs) : pLhs->GetPositionVector());
 
-    const CartesianVector rhsHitPosition(m_hitWidthMode ? LArHitWidthHelper::GetClosestPointToLine2D(m_startPoint, m_lineDirection, pRhs) :
-        pRhs->GetPositionVector());
+    const CartesianVector rhsHitPosition(
+        m_hitWidthMode ? LArHitWidthHelper::GetClosestPointToLine2D(m_startPoint, m_lineDirection, pRhs) : pRhs->GetPositionVector());
 
     const float lhsLongitudinal = m_lineDirection.GetDotProduct(lhsHitPosition - m_startPoint);
     const float rhsLongitudinal = m_lineDirection.GetDotProduct(rhsHitPosition - m_startPoint);
@@ -873,10 +891,11 @@ bool TrackRefinementBaseAlgorithm::SortByDistanceAlongLine::operator() (const pa
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-typedef bool (*SortFunction)(const Cluster*, const Cluster*);
+typedef bool (*SortFunction)(const Cluster *, const Cluster *);
 
-template void TrackRefinementBaseAlgorithm::UpdateContainers<SortFunction>(const ClusterList&, const ClusterList&, const SortFunction, ClusterVector&, SlidingFitResultMapPair&) const;
-template void TrackRefinementBaseAlgorithm::InitialiseContainers<SortFunction>(const ClusterList*, const SortFunction, ClusterVector&, SlidingFitResultMapPair&) const;
+template void TrackRefinementBaseAlgorithm::UpdateContainers<SortFunction>(
+    const ClusterList &, const ClusterList &, const SortFunction, ClusterVector &, SlidingFitResultMapPair &) const;
+template void TrackRefinementBaseAlgorithm::InitialiseContainers<SortFunction>(
+    const ClusterList *, const SortFunction, ClusterVector &, SlidingFitResultMapPair &) const;
 
 } // namespace lar_content
-

--- a/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArCosmicRay/TrackRefinementBaseAlgorithm.h
@@ -10,8 +10,8 @@
 
 #include "Pandora/Algorithm.h"
 
-#include "larpandoracontent/LArTwoDReco/LArCosmicRay/ClusterAssociation.h"
 #include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
+#include "larpandoracontent/LArTwoDReco/LArCosmicRay/ClusterAssociation.h"
 
 namespace lar_content
 {
@@ -27,8 +27,8 @@ public:
     TrackRefinementBaseAlgorithm();
 
 protected:
-    typedef std::pair<TwoDSlidingFitResultMap*, TwoDSlidingFitResultMap*> SlidingFitResultMapPair;
-    typedef std::unordered_map<const pandora::Cluster*, pandora::CaloHitList> ClusterToCaloHitListMap;
+    typedef std::pair<TwoDSlidingFitResultMap *, TwoDSlidingFitResultMap *> SlidingFitResultMapPair;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::CaloHitList> ClusterToCaloHitListMap;
 
     /**
       *  @brief  SortByDistanceAlongLine class
@@ -43,7 +43,7 @@ protected:
          *  @param  lineDirection the line direction unit vector
          *  @param  hitWidthMode whether to consider hit widths or not
          */
-	    SortByDistanceAlongLine(const pandora::CartesianVector &startPoint, const pandora::CartesianVector &lineDirection, const bool hitWidthMode);
+        SortByDistanceAlongLine(const pandora::CartesianVector &startPoint, const pandora::CartesianVector &lineDirection, const bool hitWidthMode);
 
         /**
          *  @brief  Sort hits by their projected distance along a line from a start point
@@ -53,12 +53,12 @@ protected:
          *
          *  @return  whether lhs hit has a smaller projected distance along the line than rhs hit
          */
-        bool operator() (const pandora::CaloHit *const pLhs, const pandora::CaloHit *const pRhs) const;
+        bool operator()(const pandora::CaloHit *const pLhs, const pandora::CaloHit *const pRhs) const;
 
     private:
-        pandora::CartesianVector    m_startPoint;        ///< The line start point
-        pandora::CartesianVector    m_lineDirection;     ///< The line end point
-        bool                        m_hitWidthMode;      ///< Wether to consider hit widths or not
+        pandora::CartesianVector m_startPoint;    ///< The line start point
+        pandora::CartesianVector m_lineDirection; ///< The line end point
+        bool m_hitWidthMode;                      ///< Wether to consider hit widths or not
     };
 
     virtual pandora::StatusCode Run() = 0;
@@ -72,8 +72,9 @@ protected:
      *  @param  clusterVector the input vector to store clusters considered within the algorithm
      *  @param  slidingFitResultMapPair the {micro, macro} pair of [cluster -> TwoDSlidingFitResult] maps
      */
-    template<typename T>
-    void InitialiseContainers(const pandora::ClusterList *pClusterList, const T sortFunction, pandora::ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const;
+    template <typename T>
+    void InitialiseContainers(const pandora::ClusterList *pClusterList, const T sortFunction, pandora::ClusterVector &clusterVector,
+        SlidingFitResultMapPair &slidingFitResultMapPair) const;
 
     /**
      *  @brief  Get the merging coordinate and direction for an input cluster with respect to an associated cluster
@@ -101,8 +102,9 @@ protected:
      *  @param  unavailableProtectedClusters the list of clusters whose hits are protected
      *  @param  distanceToLine the maximum perpendicular distance of a collected hit from the connecting line
      */
-    void GetHitsInBoundingBox(const pandora::CartesianVector &firstCorner, const pandora::CartesianVector &secondCorner, const pandora::ClusterList *const pClusterList,
-        ClusterToCaloHitListMap &clusterToCaloHitListMap, const pandora::ClusterList &unavailableProtectedClusters = pandora::ClusterList(), const float distanceToLine = -1.f) const;
+    void GetHitsInBoundingBox(const pandora::CartesianVector &firstCorner, const pandora::CartesianVector &secondCorner,
+        const pandora::ClusterList *const pClusterList, ClusterToCaloHitListMap &clusterToCaloHitListMap,
+        const pandora::ClusterList &unavailableProtectedClusters = pandora::ClusterList(), const float distanceToLine = -1.f) const;
 
     /**
      *  @brief  check whether a hit is contained within a defined square region
@@ -127,7 +129,8 @@ protected:
      *
      *  @return  whether the hit is close to the line
      */
-    bool IsCloseToLine(const pandora::CartesianVector &hitPosition, const pandora::CartesianVector &lineStart, const pandora::CartesianVector &lineDirection, const float distanceToLine) const;
+    bool IsCloseToLine(const pandora::CartesianVector &hitPosition, const pandora::CartesianVector &lineStart,
+        const pandora::CartesianVector &lineDirection, const float distanceToLine) const;
 
     /**
      *  @brief  Perform topological checks on the collected hits to ensure no gaps are present
@@ -197,7 +200,6 @@ protected:
     float DistanceInGap(const pandora::CartesianVector &upstreamPoint, const pandora::CartesianVector &downstreamPoint,
         const pandora::CartesianVector &connectingLine, pandora::DetectorGapList &consideredGaps) const;
 
-
     /**
      *  @brief  Whether a position falls within a specified segment of the cluster connecting line
      *
@@ -207,7 +209,8 @@ protected:
      *
      *  @return  whether the position falls within segment
      */
-    bool IsInLineSegment(const pandora::CartesianVector &lowerBoundary, const pandora::CartesianVector &upperBoundary, const pandora::CartesianVector &point) const;
+    bool IsInLineSegment(const pandora::CartesianVector &lowerBoundary, const pandora::CartesianVector &upperBoundary,
+        const pandora::CartesianVector &point) const;
 
     /**
      *  @brief  Remove any hits in the upstream/downstream cluster that lie off of the main track axis (i.e. clustering errors)
@@ -222,9 +225,9 @@ protected:
      *
      *  @return  the address of the (possibly) modified cluster
      */
-    const pandora::Cluster *RemoveOffAxisHitsFromTrack(const pandora::Cluster *const pCluster, const pandora::CartesianVector &splitPosition, const bool isEndUpstream,
-        const ClusterToCaloHitListMap &clusterToCaloHitListMap, pandora::ClusterList &remnantClusterList, TwoDSlidingFitResultMap &microSlidingFitResultMap,
-        TwoDSlidingFitResultMap &macroSlidingFitResultMap) const;
+    const pandora::Cluster *RemoveOffAxisHitsFromTrack(const pandora::Cluster *const pCluster, const pandora::CartesianVector &splitPosition,
+        const bool isEndUpstream, const ClusterToCaloHitListMap &clusterToCaloHitListMap, pandora::ClusterList &remnantClusterList,
+        TwoDSlidingFitResultMap &microSlidingFitResultMap, TwoDSlidingFitResultMap &macroSlidingFitResultMap) const;
 
     /**
      *  @brief  Remove the hits from a shower cluster that belong to the main track and add them into the main track cluster
@@ -235,8 +238,8 @@ protected:
      *  @param  clusterAssociation the clusterAssociation
      *  @param  remnantClusterList the input list to store the remnant clusters
      */
-    void AddHitsToMainTrack(const pandora::Cluster *const pMainTrackCluster, const pandora::Cluster *const pShowerTrackCluster, const pandora::CaloHitList &caloHitsToMerge,
-        const ClusterAssociation &clusterAssociation, pandora::ClusterList &remnantClusterList) const;
+    void AddHitsToMainTrack(const pandora::Cluster *const pMainTrackCluster, const pandora::Cluster *const pShowerTrackCluster,
+        const pandora::CaloHitList &caloHitsToMerge, const ClusterAssociation &clusterAssociation, pandora::ClusterList &remnantClusterList) const;
 
     /**
      *  @brief  Process the remnant clusters separating those that stradle the main track
@@ -246,8 +249,8 @@ protected:
      *  @param  pClusterList the list of all clusters
      *  @param  createdClusters the input list to store the final remnant clusters
      */
-    void ProcessRemnantClusters(const pandora::ClusterList &remnantClusterList, const pandora::Cluster *const pMainTrackCluster, const pandora::ClusterList *const pClusterList,
-        pandora::ClusterList &createdClusters) const;
+    void ProcessRemnantClusters(const pandora::ClusterList &remnantClusterList, const pandora::Cluster *const pMainTrackCluster,
+        const pandora::ClusterList *const pClusterList, pandora::ClusterList &createdClusters) const;
 
     /**
      *  @brief  Add a cluster to the nearest cluster satisfying separation distance thresholds
@@ -258,7 +261,8 @@ protected:
      *
      *  @return  whether cluster was added to a nearby cluster
      */
-    bool AddToNearestCluster(const pandora::Cluster *const pClusterToMerge, const pandora::Cluster *const pMainTrackCluster, const pandora::ClusterList *const pClusterList) const;
+    bool AddToNearestCluster(const pandora::Cluster *const pClusterToMerge, const pandora::Cluster *const pMainTrackCluster,
+        const pandora::ClusterList *const pClusterList) const;
 
     /**
      *  @brief  Whether a remnant cluster is considered to be disconnected and therefore should undergo further fragmentation
@@ -286,9 +290,9 @@ protected:
      *  @param  clusterVector the vector to store clusters considered within the algorithm
      *  @param  slidingFitResultMapPair the {micro, macro} pair of [cluster -> TwoDSlidingFitResult] maps
      */
-    template<typename T>
-    void UpdateContainers(const pandora::ClusterList &clustersToAdd, const pandora::ClusterList &clustersToDelete, const T sortFunction, pandora::ClusterVector &clusterVector,
-        SlidingFitResultMapPair &slidingFitResultMapPair) const;
+    template <typename T>
+    void UpdateContainers(const pandora::ClusterList &clustersToAdd, const pandora::ClusterList &clustersToDelete, const T sortFunction,
+        pandora::ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const;
 
     /**
      *  @brief  Remove a cluster from the cluster vector and sliding fit maps
@@ -297,26 +301,27 @@ protected:
      *  @param  clusterVector the vector to store clusters considered within the algorithm
      *  @param  slidingFitResultMapPair the {micro, macro} pair of [cluster -> TwoDSlidingFitResult] maps
      */
-    void RemoveClusterFromContainers(const pandora::Cluster *const pClustertoRemove, pandora::ClusterVector &clusterVector, SlidingFitResultMapPair &slidingFitResultMapPair) const;
+    void RemoveClusterFromContainers(const pandora::Cluster *const pClustertoRemove, pandora::ClusterVector &clusterVector,
+        SlidingFitResultMapPair &slidingFitResultMapPair) const;
 
-    float            m_minClusterLength;                      ///< The minimum length of a considered cluster
-    unsigned int     m_microSlidingFitWindow;                 ///< The sliding fit window used in the fits contained within the microSlidingFitResultMap
-    unsigned int     m_macroSlidingFitWindow;                 ///< The sliding fit window used in the fits contained within the macroSlidingFitResultMap
-    float            m_stableRegionClusterFraction;           ///< The threshold fraction of fit contributing layers which defines the stable region
-    float            m_mergePointMinCosAngleDeviation;        ///< The threshold cos opening angle between the cluster local gradient and the associated cluster global gradient used to determine merge points
-    float            m_minHitFractionForHitRemoval;           ///< The threshold fraction of hits to be removed from the cluster for hit removal to proceed
-    float            m_maxDistanceFromMainTrack;              ///< The threshold distance for a hit to be added to the main track
-    float            m_maxHitDistanceFromCluster;             ///< The threshold separation between a hit and cluster for the hit to be merged into the cluster
-    float            m_maxHitSeparationForConnectedCluster;   ///< The maximum separation between two adjacent (in z) hits in a connected cluster
-    unsigned int     m_maxTrackGaps;                          ///< The maximum number of graps allowed in the extrapolated hit vector
-    float            m_lineSegmentLength;                     ///< The length of a track gap
-    bool             m_hitWidthMode;                          ///< Whether to consider the width of hits
+    float m_minClusterLength;               ///< The minimum length of a considered cluster
+    unsigned int m_microSlidingFitWindow;   ///< The sliding fit window used in the fits contained within the microSlidingFitResultMap
+    unsigned int m_macroSlidingFitWindow;   ///< The sliding fit window used in the fits contained within the macroSlidingFitResultMap
+    float m_stableRegionClusterFraction;    ///< The threshold fraction of fit contributing layers which defines the stable region
+    float m_mergePointMinCosAngleDeviation; ///< The threshold cos opening angle between the cluster local gradient and the associated cluster global gradient used to determine merge points
+    float m_minHitFractionForHitRemoval;    ///< The threshold fraction of hits to be removed from the cluster for hit removal to proceed
+    float m_maxDistanceFromMainTrack;       ///< The threshold distance for a hit to be added to the main track
+    float m_maxHitDistanceFromCluster; ///< The threshold separation between a hit and cluster for the hit to be merged into the cluster
+    float m_maxHitSeparationForConnectedCluster; ///< The maximum separation between two adjacent (in z) hits in a connected cluster
+    unsigned int m_maxTrackGaps;                 ///< The maximum number of graps allowed in the extrapolated hit vector
+    float m_lineSegmentLength;                   ///< The length of a track gap
+    bool m_hitWidthMode;                         ///< Whether to consider the width of hits
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline TrackRefinementBaseAlgorithm::SortByDistanceAlongLine::SortByDistanceAlongLine(const pandora::CartesianVector &startPoint, const pandora::CartesianVector &lineDirection,
-        const bool hitWidthMode) :
+inline TrackRefinementBaseAlgorithm::SortByDistanceAlongLine::SortByDistanceAlongLine(
+    const pandora::CartesianVector &startPoint, const pandora::CartesianVector &lineDirection, const bool hitWidthMode) :
     m_startPoint(startPoint),
     m_lineDirection(lineDirection.GetUnitVector()),
     m_hitWidthMode(hitWidthMode)

--- a/larpandoracontent/LArTwoDReco/TwoDParticleCreationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/TwoDParticleCreationAlgorithm.cc
@@ -15,9 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-TwoDParticleCreationAlgorithm::TwoDParticleCreationAlgorithm() :
-    m_minHitsInCluster(5),
-    m_minClusterEnergy(0.f)
+TwoDParticleCreationAlgorithm::TwoDParticleCreationAlgorithm() : m_minHitsInCluster(5), m_minClusterEnergy(0.f)
 {
 }
 
@@ -25,7 +23,8 @@ TwoDParticleCreationAlgorithm::TwoDParticleCreationAlgorithm() :
 
 StatusCode TwoDParticleCreationAlgorithm::Run()
 {
-    const PfoList *pPfoList = nullptr; std::string pfoListName;
+    const PfoList *pPfoList = nullptr;
+    std::string pfoListName;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
 
     if (!m_inputClusterListNameU.empty())
@@ -110,23 +109,22 @@ StatusCode TwoDParticleCreationAlgorithm::CreatePFOs(const ClusterList *const pC
 
 StatusCode TwoDParticleCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputPfoListName", m_outputPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputPfoListName", m_outputPfoListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterListNameU", m_inputClusterListNameU));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameU", m_inputClusterListNameU));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterListNameV", m_inputClusterListNameV));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameV", m_inputClusterListNameV));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ClusterListNameW", m_inputClusterListNameW));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameW", m_inputClusterListNameW));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinHitsInCluster", m_minHitsInCluster));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinHitsInCluster", m_minHitsInCluster));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterEnergy", m_minClusterEnergy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterEnergy", m_minClusterEnergy));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArTwoDReco/TwoDParticleCreationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/TwoDParticleCreationAlgorithm.h
@@ -35,13 +35,13 @@ private:
      */
     pandora::StatusCode CreatePFOs(const pandora::ClusterList *const pClusterList) const;
 
-    std::string     m_inputClusterListNameU;                 ///< The input cluster list name for the U view
-    std::string     m_inputClusterListNameV;                 ///< The input cluster list name for the V view
-    std::string     m_inputClusterListNameW;                 ///< The input cluster list name for the W view
+    std::string m_inputClusterListNameU; ///< The input cluster list name for the U view
+    std::string m_inputClusterListNameV; ///< The input cluster list name for the V view
+    std::string m_inputClusterListNameW; ///< The input cluster list name for the W view
 
-    std::string     m_outputPfoListName;                    ///< The output pfo list name
-    unsigned int    m_minHitsInCluster;                     ///< Min number of hits for clusters to form pfos
-    float           m_minClusterEnergy;                     ///< Min energy for clusters to form pfos
+    std::string m_outputPfoListName; ///< The output pfo list name
+    unsigned int m_minHitsInCluster; ///< Min number of hits for clusters to form pfos
+    float m_minClusterEnergy;        ///< Min energy for clusters to form pfos
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArUtility/KDTreeLinkerAlgoT.h
+++ b/larpandoracontent/LArUtility/KDTreeLinkerAlgoT.h
@@ -38,7 +38,7 @@ public:
      *  @param  eltList
      *  @param  region
      */
-    void build(std::vector<KDTreeNodeInfoT<DATA, DIM> > &eltList, const KDTreeBoxT<DIM> &region);
+    void build(std::vector<KDTreeNodeInfoT<DATA, DIM>> &eltList, const KDTreeBoxT<DIM> &region);
 
     /**
      *  @brief  Search in the KDTree for all points that would be contained in the given searchbox
@@ -47,7 +47,7 @@ public:
      *  @param  searchBox
      *  @param  resRecHitList
      */
-    void search(const KDTreeBoxT<DIM> &searchBox, std::vector<KDTreeNodeInfoT<DATA, DIM> > &resRecHitList);
+    void search(const KDTreeBoxT<DIM> &searchBox, std::vector<KDTreeNodeInfoT<DATA, DIM>> &resRecHitList);
 
     /**
      *  @brief  findNearestNeighbour
@@ -122,7 +122,7 @@ private:
      *  @param  best_dist
      */
     void recNearestNeighbour(unsigned depth, const KDTreeNodeT<DATA, DIM> *current, const KDTreeNodeInfoT<DATA, DIM> &point,
-          const KDTreeNodeT<DATA, DIM> *&best_match, float &best_dist);
+        const KDTreeNodeT<DATA, DIM> *&best_match, float &best_dist);
 
     /**
      *  @brief  Add all elements of an subtree to the closest elements. Used during the recSearch().
@@ -146,13 +146,13 @@ private:
      */
     void clearTree();
 
-    KDTreeNodeT<DATA, DIM>                     *root_;              ///< The KDTree root
-    KDTreeNodeT<DATA, DIM>                     *nodePool_;          ///< Node pool allows us to do just 1 call to new for each tree building
-    int                                         nodePoolSize_;      ///< The node pool size
-    int                                         nodePoolPos_;       ///< The node pool position
+    KDTreeNodeT<DATA, DIM> *root_;     ///< The KDTree root
+    KDTreeNodeT<DATA, DIM> *nodePool_; ///< Node pool allows us to do just 1 call to new for each tree building
+    int nodePoolSize_;                 ///< The node pool size
+    int nodePoolPos_;                  ///< The node pool position
 
-    std::vector<KDTreeNodeInfoT<DATA, DIM> >   *closestNeighbour;   ///< The closest neighbour
-    std::vector<KDTreeNodeInfoT<DATA, DIM> >   *initialEltList;     ///< The initial element list
+    std::vector<KDTreeNodeInfoT<DATA, DIM>> *closestNeighbour; ///< The closest neighbour
+    std::vector<KDTreeNodeInfoT<DATA, DIM>> *initialEltList;   ///< The initial element list
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -180,7 +180,7 @@ inline KDTreeLinkerAlgo<DATA, DIM>::~KDTreeLinkerAlgo()
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename DATA, unsigned DIM>
-inline void KDTreeLinkerAlgo<DATA, DIM>::build(std::vector<KDTreeNodeInfoT<DATA, DIM> > &eltList, const KDTreeBoxT<DIM> &region)
+inline void KDTreeLinkerAlgo<DATA, DIM>::build(std::vector<KDTreeNodeInfoT<DATA, DIM>> &eltList, const KDTreeBoxT<DIM> &region)
 {
     if (eltList.size())
     {
@@ -221,8 +221,10 @@ inline int KDTreeLinkerAlgo<DATA, DIM>::medianSearch(int low, int high, int tree
         {
             // The even depth is associated to dim1 dimension, the odd one to dim2 dimension
             const unsigned thedim = treeDepth % DIM;
-            while ((*initialEltList)[i].dims[thedim] < elt.dims[thedim]) ++i;
-            while ((*initialEltList)[j].dims[thedim] > elt.dims[thedim]) --j;
+            while ((*initialEltList)[i].dims[thedim] < elt.dims[thedim])
+                ++i;
+            while ((*initialEltList)[j].dims[thedim] > elt.dims[thedim])
+                --j;
 
             if (i <= j)
             {
@@ -230,11 +232,12 @@ inline int KDTreeLinkerAlgo<DATA, DIM>::medianSearch(int low, int high, int tree
                 i++;
                 j--;
             }
-        }
-        while (i <= j);
+        } while (i <= j);
 
-        if (j < median) l = i;
-        if (i > median) m = j;
+        if (j < median)
+            l = i;
+        if (i > median)
+            m = j;
     }
 
     return median;
@@ -243,7 +246,7 @@ inline int KDTreeLinkerAlgo<DATA, DIM>::medianSearch(int low, int high, int tree
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename DATA, unsigned DIM>
-inline void KDTreeLinkerAlgo<DATA, DIM>::search(const KDTreeBoxT<DIM> &trackBox, std::vector<KDTreeNodeInfoT<DATA, DIM> > &recHits)
+inline void KDTreeLinkerAlgo<DATA, DIM>::search(const KDTreeBoxT<DIM> &trackBox, std::vector<KDTreeNodeInfoT<DATA, DIM>> &recHits)
 {
     if (root_)
     {
@@ -290,7 +293,7 @@ inline void KDTreeLinkerAlgo<DATA, DIM>::recSearch(const KDTreeNodeT<DATA, DIM> 
             const auto regionmin = current->left->region.dimmin[i];
             const auto regionmax = current->left->region.dimmax[i];
             isFullyContained = isFullyContained && (regionmin >= trackBox.dimmin[i] && regionmax <= trackBox.dimmax[i]);
-            hasIntersection  = hasIntersection  && (regionmin <  trackBox.dimmax[i] && regionmax >  trackBox.dimmin[i]);
+            hasIntersection = hasIntersection && (regionmin < trackBox.dimmax[i] && regionmax > trackBox.dimmin[i]);
         }
 
         if (isFullyContained)
@@ -311,7 +314,7 @@ inline void KDTreeLinkerAlgo<DATA, DIM>::recSearch(const KDTreeNodeT<DATA, DIM> 
             const auto regionmin = current->right->region.dimmin[i];
             const auto regionmax = current->right->region.dimmax[i];
             isFullyContained = isFullyContained && (regionmin >= trackBox.dimmin[i] && regionmax <= trackBox.dimmax[i]);
-            hasIntersection  = hasIntersection  && (regionmin <  trackBox.dimmax[i] && regionmax >  trackBox.dimmin[i]);
+            hasIntersection = hasIntersection && (regionmin < trackBox.dimmax[i] && regionmax > trackBox.dimmin[i]);
         }
 
         if (isFullyContained)
@@ -328,8 +331,8 @@ inline void KDTreeLinkerAlgo<DATA, DIM>::recSearch(const KDTreeNodeT<DATA, DIM> 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename DATA, unsigned DIM>
-inline void KDTreeLinkerAlgo<DATA, DIM>::findNearestNeighbour(const KDTreeNodeInfoT<DATA, DIM> &point, const KDTreeNodeInfoT<DATA, DIM> *&result,
-    float &distance)
+inline void KDTreeLinkerAlgo<DATA, DIM>::findNearestNeighbour(
+    const KDTreeNodeInfoT<DATA, DIM> &point, const KDTreeNodeInfoT<DATA, DIM> *&result, float &distance)
 {
     if (nullptr != result || distance != std::numeric_limits<float>::max())
     {
@@ -414,7 +417,7 @@ inline void KDTreeLinkerAlgo<DATA, DIM>::recNearestNeighbour(unsigned int depth,
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template < typename DATA, unsigned DIM >
+template <typename DATA, unsigned DIM>
 inline void KDTreeLinkerAlgo<DATA, DIM>::addSubtree(const KDTreeNodeT<DATA, DIM> *current)
 {
     // By construction, current can't be null
@@ -440,7 +443,7 @@ inline float KDTreeLinkerAlgo<DATA, DIM>::dist2(const KDTreeNodeInfoT<DATA, DIM>
 {
     double d = 0.;
 
-    for (unsigned i = 0 ; i < DIM; ++i)
+    for (unsigned i = 0; i < DIM; ++i)
     {
         const double diff = a.dims[i] - b.dims[i];
         d += diff * diff;

--- a/larpandoracontent/LArUtility/KDTreeLinkerToolsT.h
+++ b/larpandoracontent/LArUtility/KDTreeLinkerToolsT.h
@@ -18,7 +18,10 @@
 #include <array>
 #include <vector>
 
-namespace pandora { class Algorithm; }
+namespace pandora
+{
+class Algorithm;
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -29,7 +32,7 @@ namespace lar_content
  *  @brief  Box structure used to define 2D field. It's used in KDTree building step to divide the detector space (ECAL, HCAL...) and
  *          in searching step to create a bounding box around the demanded point (Track collision point, PS projection...).
  */
-template<unsigned DIM>
+template <unsigned DIM>
 class KDTreeBoxT
 {
 public:
@@ -43,11 +46,11 @@ public:
      *
      *  @param  dimargs
      */
-    template<typename... Ts>
+    template <typename... Ts>
     KDTreeBoxT(Ts... dimargs);
 
-    std::array<float, DIM>      dimmin;     ///<
-    std::array<float, DIM>      dimmax;     ///<
+    std::array<float, DIM> dimmin; ///<
+    std::array<float, DIM> dimmax; ///<
 };
 
 typedef KDTreeBoxT<2> KDTreeBox;
@@ -59,7 +62,7 @@ typedef KDTreeBoxT<3> KDTreeCube;
  *  @brief  Data stored in each KDTree node. The dim1/dim2 fields are usually the duplication of some PFRecHit values
  *          (eta/phi or x/y). But in some situations, phi field is shifted by +-2.Pi
  */
-template<typename DATA, unsigned DIM>
+template <typename DATA, unsigned DIM>
 class KDTreeNodeInfoT
 {
 public:
@@ -74,11 +77,11 @@ public:
      *  @param  d
      *  @param  dimargs
      */
-    template<typename... Ts>
+    template <typename... Ts>
     KDTreeNodeInfoT(const DATA &d, Ts... dimargs);
 
-    DATA                        data;       ///<
-    std::array<float, DIM>      dims;       ///<
+    DATA data;                   ///<
+    std::array<float, DIM> dims; ///<
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -110,10 +113,10 @@ public:
      */
     void setAttributs(const KDTreeBoxT<DIM> &regionBox);
 
-    KDTreeNodeInfoT<DATA, DIM>  info;       ///< Data
-    KDTreeNodeT<DATA, DIM>     *left;       ///< Left son
-    KDTreeNodeT<DATA, DIM>     *right;      ///< Right son
-    KDTreeBoxT<DIM>             region;     ///< Region bounding box.
+    KDTreeNodeInfoT<DATA, DIM> info; ///< Data
+    KDTreeNodeT<DATA, DIM> *left;    ///< Left son
+    KDTreeNodeT<DATA, DIM> *right;   ///< Right son
+    KDTreeBoxT<DIM> region;          ///< Region bounding box.
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -121,7 +124,7 @@ public:
 /**
  *  @brief  kdtree_type_adaptor
  */
-template<typename T>
+template <typename T>
 class kdtree_type_adaptor
 {
 public:
@@ -145,7 +148,7 @@ public:
  *
  *  @return minmax
  */
-std::pair<float,float> minmax(const float a, const float b);
+std::pair<float, float> minmax(const float a, const float b);
 
 /**
  *  @brief  fill_and_bound_2d_kd_tree
@@ -155,8 +158,8 @@ std::pair<float,float> minmax(const float a, const float b);
  *
  *  @return KDTreeCube
  */
-template<typename T>
-KDTreeBox fill_and_bound_2d_kd_tree(const MANAGED_CONTAINER<const T*> &points, std::vector<KDTreeNodeInfoT<const T*, 2> > &nodes);
+template <typename T>
+KDTreeBox fill_and_bound_2d_kd_tree(const MANAGED_CONTAINER<const T *> &points, std::vector<KDTreeNodeInfoT<const T *, 2>> &nodes);
 
 /**
  *  @brief  fill_and_bound_3d_kd_tree
@@ -166,8 +169,8 @@ KDTreeBox fill_and_bound_2d_kd_tree(const MANAGED_CONTAINER<const T*> &points, s
  *
  *  @return KDTreeCube
  */
-template<typename T>
-KDTreeCube fill_and_bound_3d_kd_tree(const MANAGED_CONTAINER<const T*> &points, std::vector<KDTreeNodeInfoT<const T*, 3> > &nodes);
+template <typename T>
+KDTreeCube fill_and_bound_3d_kd_tree(const MANAGED_CONTAINER<const T *> &points, std::vector<KDTreeNodeInfoT<const T *, 3>> &nodes);
 
 /**
  *  @brief  build_2d_kd_search_region
@@ -218,15 +221,15 @@ KDTreeCube build_3d_kd_search_region(const pandora::CartesianVector &pos, const 
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<unsigned DIM>
+template <unsigned DIM>
 inline KDTreeBoxT<DIM>::KDTreeBoxT()
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<unsigned DIM>
-template<typename... Ts>
+template <unsigned DIM>
+template <typename... Ts>
 inline KDTreeBoxT<DIM>::KDTreeBoxT(Ts... dimargs)
 {
     static_assert(sizeof...(dimargs) == 2 * DIM, "Constructor requires 2*DIM args");
@@ -242,19 +245,16 @@ inline KDTreeBoxT<DIM>::KDTreeBoxT(Ts... dimargs)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename DATA, unsigned DIM>
-inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT() :
-    data()
+template <typename DATA, unsigned DIM>
+inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT() : data()
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename DATA, unsigned DIM>
-template<typename... Ts>
-inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT(const DATA &d, Ts... dimargs) :
-    data(d),
-    dims{ {dimargs...} }
+template <typename DATA, unsigned DIM>
+template <typename... Ts>
+inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT(const DATA &d, Ts... dimargs) : data(d), dims{{dimargs...}}
 {
 }
 
@@ -262,9 +262,7 @@ inline KDTreeNodeInfoT<DATA, DIM>::KDTreeNodeInfoT(const DATA &d, Ts... dimargs)
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename DATA, unsigned DIM>
-inline KDTreeNodeT<DATA, DIM>::KDTreeNodeT() :
-    left(nullptr),
-    right(nullptr)
+inline KDTreeNodeT<DATA, DIM>::KDTreeNodeT() : left(nullptr), right(nullptr)
 {
 }
 
@@ -287,19 +285,19 @@ inline void KDTreeNodeT<DATA, DIM>::setAttributs(const KDTreeBoxT<DIM> &regionBo
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 inline const pandora::CartesianVector &kdtree_type_adaptor<T>::position(const T *const t)
 {
     return t->GetPosition();
 }
 
-template<>
+template <>
 inline const pandora::CartesianVector &kdtree_type_adaptor<const pandora::CaloHit>::position(const pandora::CaloHit *const t)
 {
     return t->GetPositionVector();
 }
 
-template<>
+template <>
 inline const pandora::CartesianVector &kdtree_type_adaptor<const pandora::CartesianVector>::position(const pandora::CartesianVector *const t)
 {
     return *t;
@@ -307,10 +305,10 @@ inline const pandora::CartesianVector &kdtree_type_adaptor<const pandora::Cartes
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
-KDTreeBox fill_and_bound_2d_kd_tree(const MANAGED_CONTAINER<const T*> &points, std::vector<KDTreeNodeInfoT<const T*, 2> > &nodes)
+template <typename T>
+KDTreeBox fill_and_bound_2d_kd_tree(const MANAGED_CONTAINER<const T *> &points, std::vector<KDTreeNodeInfoT<const T *, 2>> &nodes)
 {
-    std::array<float, 2> minpos{ {0.f, 0.f} }, maxpos{ {0.f, 0.f} };
+    std::array<float, 2> minpos{{0.f, 0.f}}, maxpos{{0.f, 0.f}};
 
     unsigned i = 0;
 
@@ -321,8 +319,10 @@ KDTreeBox fill_and_bound_2d_kd_tree(const MANAGED_CONTAINER<const T*> &points, s
 
         if (0 == i)
         {
-            minpos[0] = pos.GetX(); minpos[1] = pos.GetZ();
-            maxpos[0] = pos.GetX(); maxpos[1] = pos.GetZ();
+            minpos[0] = pos.GetX();
+            minpos[1] = pos.GetZ();
+            maxpos[0] = pos.GetX();
+            maxpos[1] = pos.GetZ();
         }
         else
         {
@@ -340,10 +340,10 @@ KDTreeBox fill_and_bound_2d_kd_tree(const MANAGED_CONTAINER<const T*> &points, s
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
-KDTreeCube fill_and_bound_3d_kd_tree(const MANAGED_CONTAINER<const T*> &points, std::vector<KDTreeNodeInfoT<const T*, 3> > &nodes)
+template <typename T>
+KDTreeCube fill_and_bound_3d_kd_tree(const MANAGED_CONTAINER<const T *> &points, std::vector<KDTreeNodeInfoT<const T *, 3>> &nodes)
 {
-    std::array<float, 3> minpos{ {0.f, 0.f, 0.f} }, maxpos{ {0.f, 0.f, 0.f} };
+    std::array<float, 3> minpos{{0.f, 0.f, 0.f}}, maxpos{{0.f, 0.f, 0.f}};
 
     unsigned i = 0;
 
@@ -354,8 +354,12 @@ KDTreeCube fill_and_bound_3d_kd_tree(const MANAGED_CONTAINER<const T*> &points, 
 
         if (0 == i)
         {
-            minpos[0] = pos.GetX(); minpos[1] = pos.GetY(); minpos[2] = pos.GetZ();
-            maxpos[0] = pos.GetX(); maxpos[1] = pos.GetY(); maxpos[2] = pos.GetZ();
+            minpos[0] = pos.GetX();
+            minpos[1] = pos.GetY();
+            minpos[2] = pos.GetZ();
+            maxpos[0] = pos.GetX();
+            maxpos[1] = pos.GetY();
+            maxpos[2] = pos.GetZ();
         }
         else
         {

--- a/larpandoracontent/LArUtility/ListChangingAlgorithm.h
+++ b/larpandoracontent/LArUtility/ListChangingAlgorithm.h
@@ -22,10 +22,10 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string     m_caloHitListName;  ///< The calo hit list name to set as the current calo hit list
-    std::string     m_clusterListName;  ///< The cluster list name to set as the current cluster list
-    std::string     m_vertexListName;   ///< The vertex list name to set as the current vertex list
-    std::string     m_pfoListName;      ///< The pfo list name to set as the current pfo list
+    std::string m_caloHitListName; ///< The calo hit list name to set as the current calo hit list
+    std::string m_clusterListName; ///< The cluster list name to set as the current cluster list
+    std::string m_vertexListName;  ///< The vertex list name to set as the current vertex list
+    std::string m_pfoListName;     ///< The pfo list name to set as the current pfo list
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArUtility/ListDeletionAlgorithm.cc
+++ b/larpandoracontent/LArUtility/ListDeletionAlgorithm.cc
@@ -60,14 +60,14 @@ StatusCode ListDeletionAlgorithm::Run()
 
 StatusCode ListDeletionAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "PfoListNames", m_pfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "ClusterListNames", m_clusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "VertexListNames", m_vertexListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "VertexListNames", m_vertexListNames));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArUtility/ListDeletionAlgorithm.h
+++ b/larpandoracontent/LArUtility/ListDeletionAlgorithm.h
@@ -22,9 +22,9 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector   m_pfoListNames;         ///< The list of pfo list names
-    pandora::StringVector   m_clusterListNames;     ///< The list of cluster list names
-    pandora::StringVector   m_vertexListNames;      ///< The list of vertex list names
+    pandora::StringVector m_pfoListNames;     ///< The list of pfo list names
+    pandora::StringVector m_clusterListNames; ///< The list of cluster list names
+    pandora::StringVector m_vertexListNames;  ///< The list of vertex list names
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArUtility/ListMergingAlgorithm.cc
+++ b/larpandoracontent/LArUtility/ListMergingAlgorithm.cc
@@ -33,7 +33,8 @@ StatusCode ListMergingAlgorithm::Run()
             if (STATUS_CODE_NOT_FOUND == statusCode)
             {
                 if (this->GetPandora().GetSettings()->ShouldDisplayAlgorithmInfo())
-                    std::cout << "ListMergingAlgorithm: cluster list not found, source: " << sourceListName << ", target: " << targetListName << std::endl;
+                    std::cout << "ListMergingAlgorithm: cluster list not found, source: " << sourceListName
+                              << ", target: " << targetListName << std::endl;
             }
             else if (STATUS_CODE_NOT_INITIALIZED == statusCode)
             {
@@ -42,7 +43,8 @@ StatusCode ListMergingAlgorithm::Run()
             }
             else
             {
-                std::cout << "ListMergingAlgorithm: error in cluster merging, source: " << sourceListName << ", target: " << targetListName << std::endl;
+                std::cout << "ListMergingAlgorithm: error in cluster merging, source: " << sourceListName << ", target: " << targetListName
+                          << std::endl;
                 return statusCode;
             }
         }
@@ -86,17 +88,17 @@ StatusCode ListMergingAlgorithm::Run()
 
 StatusCode ListMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "SourceClusterListNames", m_sourceClusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "SourceClusterListNames", m_sourceClusterListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "TargetClusterListNames", m_targetClusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "TargetClusterListNames", m_targetClusterListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "SourcePfoListNames", m_sourcePfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "SourcePfoListNames", m_sourcePfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "TargetPfoListNames", m_targetPfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "TargetPfoListNames", m_targetPfoListNames));
 
     if ((m_sourceClusterListNames.size() != m_targetClusterListNames.size()) || (m_sourcePfoListNames.size() != m_targetPfoListNames.size()))
     {

--- a/larpandoracontent/LArUtility/ListMergingAlgorithm.h
+++ b/larpandoracontent/LArUtility/ListMergingAlgorithm.h
@@ -22,11 +22,11 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector   m_sourceClusterListNames;   ///< The source cluster list names
-    pandora::StringVector   m_targetClusterListNames;   ///< The target cluster list names
+    pandora::StringVector m_sourceClusterListNames; ///< The source cluster list names
+    pandora::StringVector m_targetClusterListNames; ///< The target cluster list names
 
-    pandora::StringVector   m_sourcePfoListNames;       ///< The source pfo list names
-    pandora::StringVector   m_targetPfoListNames;       ///< The target pfo list names
+    pandora::StringVector m_sourcePfoListNames; ///< The source pfo list names
+    pandora::StringVector m_targetPfoListNames; ///< The target pfo list names
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArUtility/ListPruningAlgorithm.cc
+++ b/larpandoracontent/LArUtility/ListPruningAlgorithm.cc
@@ -15,8 +15,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-ListPruningAlgorithm::ListPruningAlgorithm() :
-    m_warnIfObjectsUnavailable(true)
+ListPruningAlgorithm::ListPruningAlgorithm() : m_warnIfObjectsUnavailable(true)
 {
 }
 
@@ -112,17 +111,17 @@ StatusCode ListPruningAlgorithm::Run()
 
 StatusCode ListPruningAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "PfoListNames", m_pfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "ClusterListNames", m_clusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "VertexListNames", m_vertexListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "VertexListNames", m_vertexListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "WarnIfObjectsUnavailable", m_warnIfObjectsUnavailable));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "WarnIfObjectsUnavailable", m_warnIfObjectsUnavailable));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArUtility/ListPruningAlgorithm.h
+++ b/larpandoracontent/LArUtility/ListPruningAlgorithm.h
@@ -28,10 +28,10 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector   m_pfoListNames;                 ///< The pfo list names
-    pandora::StringVector   m_clusterListNames;             ///< The cluster list names
-    pandora::StringVector   m_vertexListNames;              ///< The vertex list names
-    bool                    m_warnIfObjectsUnavailable;     ///< Whether to print warning if attempt made to delete unavailable objects
+    pandora::StringVector m_pfoListNames;     ///< The pfo list names
+    pandora::StringVector m_clusterListNames; ///< The cluster list names
+    pandora::StringVector m_vertexListNames;  ///< The vertex list names
+    bool m_warnIfObjectsUnavailable;          ///< Whether to print warning if attempt made to delete unavailable objects
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArUtility/MopUpBaseAlgorithm.cc
+++ b/larpandoracontent/LArUtility/MopUpBaseAlgorithm.cc
@@ -19,16 +19,16 @@ template <typename T>
 const std::string MopUpBaseAlgorithm::GetListName(const T *const pT) const
 {
     std::string currentListName;
-    const MANAGED_CONTAINER<const T*> *pCurrentList(nullptr);
-    (void) PandoraContentApi::GetCurrentList(*this, pCurrentList, currentListName);
+    const MANAGED_CONTAINER<const T *> *pCurrentList(nullptr);
+    (void)PandoraContentApi::GetCurrentList(*this, pCurrentList, currentListName);
 
     if (pCurrentList && (pCurrentList->end() != std::find(pCurrentList->begin(), pCurrentList->end(), pT)))
         return currentListName;
 
     for (const std::string &listName : m_daughterListNames)
     {
-        const MANAGED_CONTAINER<const T*> *pList(nullptr);
-        (void) PandoraContentApi::GetList(*this, listName, pList);
+        const MANAGED_CONTAINER<const T *> *pList(nullptr);
+        (void)PandoraContentApi::GetList(*this, listName, pList);
 
         if (pList && (pList->end() != std::find(pList->begin(), pList->end(), pT)))
             return listName;
@@ -41,8 +41,8 @@ const std::string MopUpBaseAlgorithm::GetListName(const T *const pT) const
 
 StatusCode MopUpBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "DaughterListNames", m_daughterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "DaughterListNames", m_daughterListNames));
 
     if (m_daughterListNames.empty())
     {

--- a/larpandoracontent/LArUtility/MopUpBaseAlgorithm.h
+++ b/larpandoracontent/LArUtility/MopUpBaseAlgorithm.h
@@ -32,7 +32,7 @@ public:
 protected:
     virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector   m_daughterListNames;                ///< The list of potential daughter object list names
+    pandora::StringVector m_daughterListNames; ///< The list of potential daughter object list names
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArUtility/PfoMopUpBaseAlgorithm.cc
+++ b/larpandoracontent/LArUtility/PfoMopUpBaseAlgorithm.cc
@@ -33,7 +33,7 @@ void PfoMopUpBaseAlgorithm::MergeAndDeletePfos(const ParticleFlowObject *const p
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SetPfoParentDaughterRelationship(*this, pPfoToEnlarge, pDaughterPfo));
     }
 
-    for (const  Vertex *const pDaughterVertex : daughterVertices)
+    for (const Vertex *const pDaughterVertex : daughterVertices)
     {
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete(*this, pDaughterVertex, this->GetListName(pDaughterVertex)));
     }
@@ -45,8 +45,9 @@ void PfoMopUpBaseAlgorithm::MergeAndDeletePfos(const ParticleFlowObject *const p
 
         if (pParentCluster)
         {
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pParentCluster, pDaughterCluster,
-                this->GetListName(pParentCluster), this->GetListName(pDaughterCluster)));
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::MergeAndDeleteClusters(
+                    *this, pParentCluster, pDaughterCluster, this->GetListName(pParentCluster), this->GetListName(pDaughterCluster)));
         }
         else
         {

--- a/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.cc
+++ b/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.cc
@@ -50,7 +50,8 @@ StatusCode CandidateVertexCreationAlgorithm::Run()
         ClusterVector clusterVectorU, clusterVectorV, clusterVectorW;
         this->SelectClusters(clusterVectorU, clusterVectorV, clusterVectorW);
 
-        const VertexList *pVertexList(NULL); std::string temporaryListName;
+        const VertexList *pVertexList(NULL);
+        std::string temporaryListName;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pVertexList, temporaryListName));
 
         if (m_enableEndpointCandidates)
@@ -89,7 +90,8 @@ void CandidateVertexCreationAlgorithm::SelectClusters(ClusterVector &clusterVect
     for (const std::string &clusterListName : m_inputClusterListNames)
     {
         const ClusterList *pClusterList(NULL);
-        PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
+        PANDORA_THROW_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
 
         if (!pClusterList || pClusterList->empty())
         {
@@ -139,7 +141,8 @@ void CandidateVertexCreationAlgorithm::SelectClusters(ClusterVector &clusterVect
             if (pCluster->GetParticleId() == E_MINUS && m_reducedCandidates)
             {
                 selectionCutFactor = (m_selectionCutFactorMax + 1.f) * 0.5f +
-                    (m_selectionCutFactorMax - 1.f) * 0.5f * std::tanh(static_cast<float>(nClustersPassingMaxCuts) - m_nClustersPassingMaxCutsPar);
+                                     (m_selectionCutFactorMax - 1.f) * 0.5f *
+                                         std::tanh(static_cast<float>(nClustersPassingMaxCuts) - m_nClustersPassingMaxCutsPar);
             }
 
             if (pCluster->GetNCaloHits() < m_minClusterCaloHits * selectionCutFactor)
@@ -192,13 +195,14 @@ void CandidateVertexCreationAlgorithm::CreateEndpointCandidates(const ClusterVec
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CandidateVertexCreationAlgorithm::CreateEndpointVertex(const CartesianVector &position1, const HitType hitType1, const TwoDSlidingFitResult &fitResult2) const
+void CandidateVertexCreationAlgorithm::CreateEndpointVertex(
+    const CartesianVector &position1, const HitType hitType1, const TwoDSlidingFitResult &fitResult2) const
 {
     const CartesianVector minLayerPosition2(fitResult2.GetGlobalMinLayerPosition());
     const CartesianVector maxLayerPosition2(fitResult2.GetGlobalMaxLayerPosition());
 
     if ((((position1.GetX() < minLayerPosition2.GetX()) && (position1.GetX() < maxLayerPosition2.GetX())) ||
-        ((position1.GetX() > minLayerPosition2.GetX()) && (position1.GetX() > maxLayerPosition2.GetX()))) &&
+            ((position1.GetX() > minLayerPosition2.GetX()) && (position1.GetX() > maxLayerPosition2.GetX()))) &&
         (std::fabs(position1.GetX() - minLayerPosition2.GetX()) > m_maxEndpointXDiscrepancy) &&
         (std::fabs(position1.GetX() - maxLayerPosition2.GetX()) > m_maxEndpointXDiscrepancy))
     {
@@ -229,8 +233,8 @@ void CandidateVertexCreationAlgorithm::CreateEndpointVertex(const CartesianVecto
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CandidateVertexCreationAlgorithm::CreateCrossingCandidates(const ClusterVector &clusterVectorU, const ClusterVector &clusterVectorV,
-    const ClusterVector &clusterVectorW) const
+void CandidateVertexCreationAlgorithm::CreateCrossingCandidates(
+    const ClusterVector &clusterVectorU, const ClusterVector &clusterVectorV, const ClusterVector &clusterVectorW) const
 {
     CartesianPointVector crossingsU, crossingsV, crossingsW;
     this->FindCrossingPoints(clusterVectorU, crossingsU);
@@ -277,7 +281,7 @@ void CandidateVertexCreationAlgorithm::GetSpacepoints(const Cluster *const pClus
     const float minLayerRL(fitResult.GetL(fitResult.GetMinLayer()));
     const float maxLayerRL(fitResult.GetL(fitResult.GetMaxLayer()));
 
-    for (unsigned int iStep = 0; iStep < m_extrapolationNSteps; ++ iStep)
+    for (unsigned int iStep = 0; iStep < m_extrapolationNSteps; ++iStep)
     {
         const float deltaRL(static_cast<float>(iStep) * m_extrapolationStepSize);
 
@@ -294,16 +298,16 @@ void CandidateVertexCreationAlgorithm::GetSpacepoints(const Cluster *const pClus
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CandidateVertexCreationAlgorithm::FindCrossingPoints(const CartesianPointVector &spacepoints1, const CartesianPointVector &spacepoints2,
-    CartesianPointVector &crossingPoints) const
+void CandidateVertexCreationAlgorithm::FindCrossingPoints(
+    const CartesianPointVector &spacepoints1, const CartesianPointVector &spacepoints2, CartesianPointVector &crossingPoints) const
 {
     bool bestCrossingFound(false);
     float bestSeparationSquared(m_maxCrossingSeparationSquared);
     CartesianVector bestPosition1(0.f, 0.f, 0.f), bestPosition2(0.f, 0.f, 0.f);
 
-    for (const CartesianVector &position1: spacepoints1)
+    for (const CartesianVector &position1 : spacepoints1)
     {
-        for (const CartesianVector &position2: spacepoints2)
+        for (const CartesianVector &position2 : spacepoints2)
         {
             const float separationSquared((position1 - position2).GetMagnitudeSquared());
 
@@ -321,7 +325,7 @@ void CandidateVertexCreationAlgorithm::FindCrossingPoints(const CartesianPointVe
     {
         bool alreadyPopulated(false);
 
-        for (const CartesianVector &existingPosition: crossingPoints)
+        for (const CartesianVector &existingPosition : crossingPoints)
         {
             if (((existingPosition - bestPosition1).GetMagnitudeSquared() < m_minNearbyCrossingDistanceSquared) ||
                 ((existingPosition - bestPosition2).GetMagnitudeSquared() < m_minNearbyCrossingDistanceSquared))
@@ -341,13 +345,13 @@ void CandidateVertexCreationAlgorithm::FindCrossingPoints(const CartesianPointVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void CandidateVertexCreationAlgorithm::CreateCrossingVertices(const CartesianPointVector &crossingPoints1, const CartesianPointVector &crossingPoints2,
-    const HitType hitType1, const HitType hitType2, unsigned int &nCrossingCandidates) const
+void CandidateVertexCreationAlgorithm::CreateCrossingVertices(const CartesianPointVector &crossingPoints1,
+    const CartesianPointVector &crossingPoints2, const HitType hitType1, const HitType hitType2, unsigned int &nCrossingCandidates) const
 {
 
-    for (const CartesianVector &position1: crossingPoints1)
+    for (const CartesianVector &position1 : crossingPoints1)
     {
-        for (const CartesianVector &position2: crossingPoints2)
+        for (const CartesianVector &position2 : crossingPoints2)
         {
             if (nCrossingCandidates > m_nMaxCrossingCandidates)
                 return;
@@ -408,67 +412,63 @@ void CandidateVertexCreationAlgorithm::TidyUp()
 
 StatusCode CandidateVertexCreationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputClusterListNames", m_inputClusterListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputVertexListName", m_outputVertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_outputVertexListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ReplaceCurrentVertexList", m_replaceCurrentVertexList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ReplaceCurrentVertexList", m_replaceCurrentVertexList));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterCaloHits", m_minClusterCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterCaloHits", m_minClusterCaloHits));
 
     float minClusterLength = std::sqrt(m_minClusterLengthSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterLength", minClusterLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterLength", minClusterLength));
     m_minClusterLengthSquared = minClusterLength * minClusterLength;
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ChiSquaredCut", m_chiSquaredCut));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ChiSquaredCut", m_chiSquaredCut));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EnableEndpointCandidates", m_enableEndpointCandidates));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "EnableEndpointCandidates", m_enableEndpointCandidates));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxEndpointXDiscrepancy", m_maxEndpointXDiscrepancy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxEndpointXDiscrepancy", m_maxEndpointXDiscrepancy));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EnableCrossingCandidates", m_enableCrossingCandidates));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "EnableCrossingCandidates", m_enableCrossingCandidates));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NMaxCrossingCandidates", m_nMaxCrossingCandidates));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NMaxCrossingCandidates", m_nMaxCrossingCandidates));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCrossingXDiscrepancy", m_maxCrossingXDiscrepancy));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxCrossingXDiscrepancy", m_maxCrossingXDiscrepancy));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ExtrapolationNSteps", m_extrapolationNSteps));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ExtrapolationNSteps", m_extrapolationNSteps));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ExtrapolationStepSize", m_extrapolationStepSize));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ExtrapolationStepSize", m_extrapolationStepSize));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ReducedCandidates", m_reducedCandidates));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ReducedCandidates", m_reducedCandidates));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectionCutFactorMax", m_selectionCutFactorMax));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SelectionCutFactorMax", m_selectionCutFactorMax));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NClustersPassingMaxCutsPar", m_nClustersPassingMaxCutsPar));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "NClustersPassingMaxCutsPar", m_nClustersPassingMaxCutsPar));
 
     float maxCrossingSeparation = std::sqrt(m_maxCrossingSeparationSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxCrossingSeparation", maxCrossingSeparation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCrossingSeparation", maxCrossingSeparation));
     m_maxCrossingSeparationSquared = maxCrossingSeparation * maxCrossingSeparation;
 
     float minNearbyCrossingDistance = std::sqrt(m_minNearbyCrossingDistanceSquared);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinNearbyCrossingDistance", minNearbyCrossingDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinNearbyCrossingDistance", minNearbyCrossingDistance));
     m_minNearbyCrossingDistanceSquared = minNearbyCrossingDistance * minNearbyCrossingDistance;
 
     return STATUS_CODE_SUCCESS;

--- a/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.h
+++ b/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.h
@@ -64,7 +64,8 @@ private:
      *  @param  clusterVectorV the clusters in the v view
      *  @param  clusterVectorW the clusters in the w view
      */
-    void CreateCrossingCandidates(const pandora::ClusterVector &clusterVectorU, const pandora::ClusterVector &clusterVectorV, const pandora::ClusterVector &clusterVectorW) const;
+    void CreateCrossingCandidates(const pandora::ClusterVector &clusterVectorU, const pandora::ClusterVector &clusterVectorV,
+        const pandora::ClusterVector &clusterVectorW) const;
 
     /**
      *  @brief  Identify where (extrapolated) clusters plausibly cross in 2D
@@ -125,33 +126,33 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    typedef std::unordered_map<const pandora::Cluster*, pandora::CartesianPointVector> ClusterToSpacepointsMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::CartesianPointVector> ClusterToSpacepointsMap;
 
-    pandora::StringVector   m_inputClusterListNames;            ///< The list of cluster list names
-    std::string             m_outputVertexListName;             ///< The name under which to save the output vertex list
-    bool                    m_replaceCurrentVertexList;         ///< Whether to replace the current vertex list with the output list
+    pandora::StringVector m_inputClusterListNames; ///< The list of cluster list names
+    std::string m_outputVertexListName;            ///< The name under which to save the output vertex list
+    bool m_replaceCurrentVertexList;               ///< Whether to replace the current vertex list with the output list
 
-    unsigned int            m_slidingFitWindow;                 ///< The layer window for the sliding linear fits
-    TwoDSlidingFitResultMap m_slidingFitResultMap;              ///< The sliding fit result map
+    unsigned int m_slidingFitWindow;               ///< The layer window for the sliding linear fits
+    TwoDSlidingFitResultMap m_slidingFitResultMap; ///< The sliding fit result map
 
-    unsigned int            m_minClusterCaloHits;               ///< The min number of hits in base cluster selection method
-    float                   m_minClusterLengthSquared;          ///< The min length (squared) in base cluster selection method
-    float                   m_chiSquaredCut;                    ///< The chi squared cut (accept only 3D vertex positions with values below cut)
+    unsigned int m_minClusterCaloHits; ///< The min number of hits in base cluster selection method
+    float m_minClusterLengthSquared;   ///< The min length (squared) in base cluster selection method
+    float m_chiSquaredCut;             ///< The chi squared cut (accept only 3D vertex positions with values below cut)
 
-    bool                    m_enableEndpointCandidates;         ///< Whether to create endpoint-based candidates
-    float                   m_maxEndpointXDiscrepancy;          ///< The max cluster endpoint discrepancy
+    bool m_enableEndpointCandidates; ///< Whether to create endpoint-based candidates
+    float m_maxEndpointXDiscrepancy; ///< The max cluster endpoint discrepancy
 
-    bool                    m_enableCrossingCandidates;         ///< Whether to create crossing vertex candidates
-    unsigned int            m_nMaxCrossingCandidates;           ///< The max number of crossing candidates to create
-    float                   m_maxCrossingXDiscrepancy;          ///< The max cluster endpoint discrepancy
-    unsigned int            m_extrapolationNSteps;              ///< Number of extrapolation steps, at each end of cluster, of specified size
-    float                   m_extrapolationStepSize;            ///< The extrapolation step size in cm
-    float                   m_maxCrossingSeparationSquared;     ///< The separation (squared) between spacepoints below which a crossing can be identified
-    float                   m_minNearbyCrossingDistanceSquared; ///< The minimum allowed distance between identified crossing positions
+    bool m_enableCrossingCandidates;          ///< Whether to create crossing vertex candidates
+    unsigned int m_nMaxCrossingCandidates;    ///< The max number of crossing candidates to create
+    float m_maxCrossingXDiscrepancy;          ///< The max cluster endpoint discrepancy
+    unsigned int m_extrapolationNSteps;       ///< Number of extrapolation steps, at each end of cluster, of specified size
+    float m_extrapolationStepSize;            ///< The extrapolation step size in cm
+    float m_maxCrossingSeparationSquared;     ///< The separation (squared) between spacepoints below which a crossing can be identified
+    float m_minNearbyCrossingDistanceSquared; ///< The minimum allowed distance between identified crossing positions
 
-    bool                    m_reducedCandidates;                ///< Whether to reduce the number of candidates
-    float                   m_selectionCutFactorMax;            ///< Maximum factor to multiply the base cluster selection cuts
-    float                   m_nClustersPassingMaxCutsPar;       ///< Parameter for number of clusters passing the max base cluster selection cuts
+    bool m_reducedCandidates;           ///< Whether to reduce the number of candidates
+    float m_selectionCutFactorMax;      ///< Maximum factor to multiply the base cluster selection cuts
+    float m_nClustersPassingMaxCutsPar; ///< Parameter for number of clusters passing the max base cluster selection cuts
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/EnergyKickFeatureTool.cc
+++ b/larpandoracontent/LArVertex/EnergyKickFeatureTool.cc
@@ -17,39 +17,38 @@ using namespace pandora;
 namespace lar_content
 {
 
-EnergyKickFeatureTool::EnergyKickFeatureTool() :
-    m_rOffset(10.f),
-    m_xOffset(0.06f)
+EnergyKickFeatureTool::EnergyKickFeatureTool() : m_rOffset(10.f), m_xOffset(0.06f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void EnergyKickFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const Vertex * const pVertex,
-    const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-    const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
+void EnergyKickFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+    const Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap,
+    const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
+    const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     float energyKick(0.f);
 
-    energyKick += this->GetEnergyKickForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U),
-        slidingFitDataListMap.at(TPC_VIEW_U));
+    energyKick += this->GetEnergyKickForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U), slidingFitDataListMap.at(TPC_VIEW_U));
 
-    energyKick += this->GetEnergyKickForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V),
-        slidingFitDataListMap.at(TPC_VIEW_V));
+    energyKick += this->GetEnergyKickForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V), slidingFitDataListMap.at(TPC_VIEW_V));
 
-    energyKick += this->GetEnergyKickForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W),
-        slidingFitDataListMap.at(TPC_VIEW_W));
+    energyKick += this->GetEnergyKickForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W), slidingFitDataListMap.at(TPC_VIEW_W));
 
     featureVector.push_back(energyKick);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float EnergyKickFeatureTool::GetEnergyKickForView(const CartesianVector &vertexPosition2D,
-    const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
+float EnergyKickFeatureTool::GetEnergyKickForView(
+    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
 {
     unsigned int totHits(0);
     bool useEnergy(true);
@@ -101,11 +100,9 @@ void EnergyKickFeatureTool::IncrementEnergyKickParameters(const Cluster *const p
 
 StatusCode EnergyKickFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ROffset", m_rOffset));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ROffset", m_rOffset));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "XOffset", m_xOffset));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "XOffset", m_xOffset));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArVertex/EnergyKickFeatureTool.h
+++ b/larpandoracontent/LArVertex/EnergyKickFeatureTool.h
@@ -33,7 +33,7 @@ public:
      *
      *  @return the energy kick feature
      */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm * const pAlgorithm, const pandora::Vertex * const pVertex,
+    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const pandora::Vertex *const pVertex,
         const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
         const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &);
 
@@ -48,7 +48,8 @@ private:
      *
      *  @return the energy kick feature
      */
-    float GetEnergyKickForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
+    float GetEnergyKickForView(
+        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
 
     /**
      *  @brief  Increment the energy kick parameters for a given cluster
@@ -64,8 +65,8 @@ private:
     void IncrementEnergyKickParameters(const pandora::Cluster *const pCluster, const pandora::CartesianVector &clusterDisplacement,
         const pandora::CartesianVector &clusterDirection, float &totEnergyKick, float &totEnergy, float &totHitKick, unsigned int &totHits) const;
 
-    float    m_rOffset;    ///< The r offset parameter in the energy score
-    float    m_xOffset;    ///< The x offset parameter in the energy score
+    float m_rOffset; ///< The r offset parameter in the energy score
+    float m_xOffset; ///< The x offset parameter in the energy score
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.h
@@ -32,11 +32,11 @@ private:
 
     VertexFeatureTool::FeatureToolVector m_featureToolVector; ///< The feature tool map
 
-    pandora::StringVector   m_inputClusterListNames;        ///< The list of cluster list names
-    unsigned int            m_minClusterCaloHits;           ///< The min number of hits parameter in the energy score
-    unsigned int            m_slidingFitWindow;             ///< The layer window for the sliding linear fits
-    float                   m_epsilon;                      ///< The epsilon parameter in the energy score
-    float                   m_asymmetryConstant;            ///< The asymmetry constant parameter in the energy score
+    pandora::StringVector m_inputClusterListNames; ///< The list of cluster list names
+    unsigned int m_minClusterCaloHits;             ///< The min number of hits parameter in the energy score
+    unsigned int m_slidingFitWindow;               ///< The layer window for the sliding linear fits
+    float m_epsilon;                               ///< The epsilon parameter in the energy score
+    float m_asymmetryConstant;                     ///< The asymmetry constant parameter in the energy score
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
@@ -6,48 +6,48 @@
  *  $Log: $
  */
 
-#include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h"
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 using namespace pandora;
 
 namespace lar_content
 {
 
-GlobalAsymmetryFeatureTool::GlobalAsymmetryFeatureTool() :
-    m_maxAsymmetryDistance(5.f)
+GlobalAsymmetryFeatureTool::GlobalAsymmetryFeatureTool() : m_maxAsymmetryDistance(5.f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void GlobalAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const Vertex * const pVertex,
-    const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-    const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
+void GlobalAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+    const Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap,
+    const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
+    const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     float globalAsymmetry(0.f);
 
-    globalAsymmetry += this->GetGlobalAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U),
-        slidingFitDataListMap.at(TPC_VIEW_U));
+    globalAsymmetry += this->GetGlobalAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U), slidingFitDataListMap.at(TPC_VIEW_U));
 
-    globalAsymmetry += this->GetGlobalAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V),
-        slidingFitDataListMap.at(TPC_VIEW_V));
+    globalAsymmetry += this->GetGlobalAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V), slidingFitDataListMap.at(TPC_VIEW_V));
 
-    globalAsymmetry += this->GetGlobalAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W),
-        slidingFitDataListMap.at(TPC_VIEW_W));
+    globalAsymmetry += this->GetGlobalAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W), slidingFitDataListMap.at(TPC_VIEW_W));
 
     featureVector.push_back(globalAsymmetry);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float GlobalAsymmetryFeatureTool::GetGlobalAsymmetryForView(const CartesianVector &vertexPosition2D,
-    const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
+float GlobalAsymmetryFeatureTool::GetGlobalAsymmetryForView(
+    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
 {
     bool useEnergy(true);
     CartesianVector energyWeightedDirectionSum(0.f, 0.f, 0.f), hitWeightedDirectionSum(0.f, 0.f, 0.f);
@@ -82,8 +82,8 @@ float GlobalAsymmetryFeatureTool::GetGlobalAsymmetryForView(const CartesianVecto
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void GlobalAsymmetryFeatureTool::IncrementAsymmetryParameters(const float weight, const CartesianVector &clusterDirection,
-    CartesianVector &localWeightedDirectionSum) const
+void GlobalAsymmetryFeatureTool::IncrementAsymmetryParameters(
+    const float weight, const CartesianVector &clusterDirection, CartesianVector &localWeightedDirectionSum) const
 {
     // If the new axis direction is at an angle of greater than 90 deg to the current axis direction, flip it 180 degs.
     CartesianVector newDirection(clusterDirection);
@@ -111,7 +111,7 @@ float GlobalAsymmetryFeatureTool::CalculateGlobalAsymmetry(const bool useEnergyM
 
     for (const VertexSelectionBaseAlgorithm::SlidingFitData &slidingFitData : slidingFitDataList)
     {
-        const Cluster * const pCluster(slidingFitData.GetCluster());
+        const Cluster *const pCluster(slidingFitData.GetCluster());
 
         CaloHitList caloHitList;
         pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
@@ -152,8 +152,8 @@ float GlobalAsymmetryFeatureTool::CalculateGlobalAsymmetry(const bool useEnergyM
 
 StatusCode GlobalAsymmetryFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAsymmetryDistance", m_maxAsymmetryDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAsymmetryDistance", m_maxAsymmetryDistance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h
@@ -33,7 +33,7 @@ public:
      *
      *  @return the global asymmetry feature
      */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm * const pAlgorithm, const pandora::Vertex * const pVertex,
+    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const pandora::Vertex *const pVertex,
         const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
         const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &);
 
@@ -48,7 +48,8 @@ private:
      *
      *  @return the global asymmetry feature
      */
-    float GetGlobalAsymmetryForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
+    float GetGlobalAsymmetryForView(
+        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
 
     /**
      *  @brief  Increment the asymmetry parameters
@@ -57,7 +58,8 @@ private:
      *  @param  clusterDirection the direction of the cluster
      *  @param  localWeightedDirectionSum the current energy-weighted local cluster direction vector
      */
-    void IncrementAsymmetryParameters(const float weight, const pandora::CartesianVector &clusterDirection, pandora::CartesianVector &localWeightedDirectionSum) const;
+    void IncrementAsymmetryParameters(
+        const float weight, const pandora::CartesianVector &clusterDirection, pandora::CartesianVector &localWeightedDirectionSum) const;
 
     /**
      *  @brief  Calculate the global asymmetry feature
@@ -72,7 +74,7 @@ private:
     float CalculateGlobalAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
         const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, const pandora::CartesianVector &localWeightedDirectionSum) const;
 
-    float     m_maxAsymmetryDistance;    ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
+    float m_maxAsymmetryDistance; ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/HitAngleVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/HitAngleVertexSelectionAlgorithm.cc
@@ -27,17 +27,17 @@ HitAngleVertexSelectionAlgorithm::HitAngleVertexSelectionAlgorithm()
 void HitAngleVertexSelectionAlgorithm::GetVertexScoreList(const VertexVector &vertexVector, const BeamConstants &beamConstants,
     HitKDTree2D &kdTreeU, HitKDTree2D &kdTreeV, HitKDTree2D &kdTreeW, VertexScoreList &vertexScoreList) const
 {
-    const KDTreeMap kdTreeMap{{TPC_VIEW_U, kdTreeU},
-                              {TPC_VIEW_V, kdTreeV},
-                              {TPC_VIEW_W, kdTreeW}};
+    const KDTreeMap kdTreeMap{{TPC_VIEW_U, kdTreeU}, {TPC_VIEW_V, kdTreeV}, {TPC_VIEW_W, kdTreeW}};
 
     float bestFastScore(0.f);
     for (const Vertex *const pVertex : vertexVector)
     {
         const float beamDeweightingScore(this->IsBeamModeOn() ? std::exp(this->GetBeamDeweightingScore(beamConstants, pVertex)) : 1.f);
 
-        const float rPhiScore(LArMvaHelper::CalculateFeaturesOfType<RPhiFeatureTool>(m_featureToolVector, this, pVertex, SlidingFitDataListMap(),
-            ClusterListMap(), kdTreeMap, ShowerClusterListMap(), beamDeweightingScore, bestFastScore).at(0).Get());
+        const float rPhiScore(LArMvaHelper::CalculateFeaturesOfType<RPhiFeatureTool>(m_featureToolVector, this, pVertex,
+            SlidingFitDataListMap(), ClusterListMap(), kdTreeMap, ShowerClusterListMap(), beamDeweightingScore, bestFastScore)
+                                  .at(0)
+                                  .Get());
 
         vertexScoreList.emplace_back(pVertex, beamDeweightingScore * rPhiScore);
     }

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
@@ -8,8 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 #include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 
@@ -27,31 +27,32 @@ LocalAsymmetryFeatureTool::LocalAsymmetryFeatureTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LocalAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const Vertex * const pVertex,
-    const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-    const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
+void LocalAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+    const Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap,
+    const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
+    const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     float localAsymmetry(0.f);
 
-    localAsymmetry += this->GetLocalAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U),
-        slidingFitDataListMap.at(TPC_VIEW_U));
+    localAsymmetry += this->GetLocalAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U), slidingFitDataListMap.at(TPC_VIEW_U));
 
-    localAsymmetry += this->GetLocalAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V),
-        slidingFitDataListMap.at(TPC_VIEW_V));
+    localAsymmetry += this->GetLocalAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V), slidingFitDataListMap.at(TPC_VIEW_V));
 
-    localAsymmetry += this->GetLocalAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W),
-        slidingFitDataListMap.at(TPC_VIEW_W));
+    localAsymmetry += this->GetLocalAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W), slidingFitDataListMap.at(TPC_VIEW_W));
 
     featureVector.push_back(localAsymmetry);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(const CartesianVector &vertexPosition2D,
-    const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
+float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(
+    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
 {
     bool useEnergy(true), useAsymmetry(true);
     CartesianVector energyWeightedDirectionSum(0.f, 0.f, 0.f), hitWeightedDirectionSum(0.f, 0.f, 0.f);
@@ -82,7 +83,8 @@ float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(const CartesianVector 
     }
 
     // Default: maximum asymmetry (i.e. not suppressed), zero for energy kick (i.e. not suppressed)
-    if ((useEnergy && energyWeightedDirectionSum == CartesianVector(0.f, 0.f, 0.f)) || (!useEnergy && hitWeightedDirectionSum == CartesianVector(0.f, 0.f, 0.f)))
+    if ((useEnergy && energyWeightedDirectionSum == CartesianVector(0.f, 0.f, 0.f)) ||
+        (!useEnergy && hitWeightedDirectionSum == CartesianVector(0.f, 0.f, 0.f)))
         return 1.f;
 
     const CartesianVector &localWeightedDirectionSum(useEnergy ? energyWeightedDirectionSum : hitWeightedDirectionSum);
@@ -91,8 +93,8 @@ float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(const CartesianVector 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool LocalAsymmetryFeatureTool::IncrementAsymmetryParameters(const float weight, const CartesianVector &clusterDirection,
-    CartesianVector &localWeightedDirectionSum) const
+bool LocalAsymmetryFeatureTool::IncrementAsymmetryParameters(
+    const float weight, const CartesianVector &clusterDirection, CartesianVector &localWeightedDirectionSum) const
 {
     // If the new axis direction is at an angle of greater than 90 deg to the current axis direction, flip it 180 degs.
     CartesianVector newDirection(clusterDirection);
@@ -171,14 +173,14 @@ float LocalAsymmetryFeatureTool::CalculateLocalAsymmetry(const bool useEnergyMet
 
 StatusCode LocalAsymmetryFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAsymmetryDistance", m_maxAsymmetryDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAsymmetryDistance", m_maxAsymmetryDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinAsymmetryCosAngle", m_minAsymmetryCosAngle));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinAsymmetryCosAngle", m_minAsymmetryCosAngle));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxAsymmetryNClusters", m_maxAsymmetryNClusters));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAsymmetryNClusters", m_maxAsymmetryNClusters));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h
@@ -33,8 +33,8 @@ public:
      *
      *  @return the energy kick feature
      */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm * const pAlgorithm, const pandora::Vertex * const pVertex,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap,const VertexSelectionBaseAlgorithm::ClusterListMap &,
+    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const pandora::Vertex *const pVertex,
+        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
         const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &);
 
 private:
@@ -48,7 +48,8 @@ private:
      *
      *  @return the local asymmetry feature
      */
-    float GetLocalAsymmetryForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
+    float GetLocalAsymmetryForView(
+        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
 
     /**
      *  @brief  Increment the asymmetry parameters
@@ -59,8 +60,8 @@ private:
      *
      *  @return whether the energy asymmetry score is still viable
      */
-    bool IncrementAsymmetryParameters(const float weight, const pandora::CartesianVector &clusterDirection,
-        pandora::CartesianVector &localWeightedDirectionSum) const;
+    bool IncrementAsymmetryParameters(
+        const float weight, const pandora::CartesianVector &clusterDirection, pandora::CartesianVector &localWeightedDirectionSum) const;
 
     /**
      *  @brief  Calculate the local asymmetry feature
@@ -75,9 +76,9 @@ private:
     float CalculateLocalAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
         const pandora::ClusterVector &asymmetryClusters, const pandora::CartesianVector &localWeightedDirectionSum) const;
 
-    float           m_maxAsymmetryDistance;     ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
-    float           m_minAsymmetryCosAngle;     ///< The min opening angle cosine used to determine viability of asymmetry score
-    unsigned int    m_maxAsymmetryNClusters;    ///< The max number of associated clusters to calculate the asymmetry
+    float m_maxAsymmetryDistance;         ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
+    float m_minAsymmetryCosAngle;         ///< The min opening angle cosine used to determine viability of asymmetry score
+    unsigned int m_maxAsymmetryNClusters; ///< The max number of associated clusters to calculate the asymmetry
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.cc
@@ -16,10 +16,10 @@
 #include "larpandoracontent/LArHelpers/LArMvaHelper.h"
 
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
-#include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h"
-#include "larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h"
+#include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/RPhiFeatureTool.h"
+#include "larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h"
 
 #include "larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.h"
 
@@ -32,7 +32,7 @@ using namespace pandora;
 namespace lar_content
 {
 
-template<typename T>
+template <typename T>
 MvaVertexSelectionAlgorithm<T>::MvaVertexSelectionAlgorithm() :
     TrainedVertexSelectionAlgorithm(),
     m_filePathEnvironmentVariable("FW_SEARCH_PATH")
@@ -41,7 +41,7 @@ MvaVertexSelectionAlgorithm<T>::MvaVertexSelectionAlgorithm() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 void MvaVertexSelectionAlgorithm<T>::GetVertexScoreList(const VertexVector &vertexVector, const BeamConstants &beamConstants,
     HitKDTree2D &kdTreeU, HitKDTree2D &kdTreeV, HitKDTree2D &kdTreeW, VertexScoreList &vertexScoreList) const
 {
@@ -59,21 +59,14 @@ void MvaVertexSelectionAlgorithm<T>::GetVertexScoreList(const VertexVector &vert
     this->CalculateShowerClusterList(clustersW, showerClusterListW);
 
     // Create maps from hit types to objects for passing to feature tools.
-    const ClusterListMap clusterListMap{{TPC_VIEW_U, clustersU},
-                                        {TPC_VIEW_V, clustersV},
-                                        {TPC_VIEW_W, clustersW}};
+    const ClusterListMap clusterListMap{{TPC_VIEW_U, clustersU}, {TPC_VIEW_V, clustersV}, {TPC_VIEW_W, clustersW}};
 
-    const SlidingFitDataListMap slidingFitDataListMap{{TPC_VIEW_U, slidingFitDataListU},
-                                                      {TPC_VIEW_V, slidingFitDataListV},
-                                                      {TPC_VIEW_W, slidingFitDataListW}};
+    const SlidingFitDataListMap slidingFitDataListMap{
+        {TPC_VIEW_U, slidingFitDataListU}, {TPC_VIEW_V, slidingFitDataListV}, {TPC_VIEW_W, slidingFitDataListW}};
 
-    const ShowerClusterListMap showerClusterListMap{{TPC_VIEW_U, showerClusterListU},
-                                                    {TPC_VIEW_V, showerClusterListV},
-                                                    {TPC_VIEW_W, showerClusterListW}};
+    const ShowerClusterListMap showerClusterListMap{{TPC_VIEW_U, showerClusterListU}, {TPC_VIEW_V, showerClusterListV}, {TPC_VIEW_W, showerClusterListW}};
 
-    const KDTreeMap kdTreeMap{{TPC_VIEW_U, kdTreeU},
-                              {TPC_VIEW_V, kdTreeV},
-                              {TPC_VIEW_W, kdTreeW}};
+    const KDTreeMap kdTreeMap{{TPC_VIEW_U, kdTreeU}, {TPC_VIEW_V, kdTreeV}, {TPC_VIEW_W, kdTreeW}};
 
     // Calculate the event feature list and the vertex feature map.
     EventFeatureInfo eventFeatureInfo(this->CalculateEventFeatures(clustersU, clustersV, clustersW, vertexVector));
@@ -84,8 +77,8 @@ void MvaVertexSelectionAlgorithm<T>::GetVertexScoreList(const VertexVector &vert
     VertexFeatureInfoMap vertexFeatureInfoMap;
     for (const Vertex *const pVertex : vertexVector)
     {
-        this->PopulateVertexFeatureInfoMap(beamConstants, clusterListMap, slidingFitDataListMap, showerClusterListMap, kdTreeMap, pVertex,
-            vertexFeatureInfoMap);
+        this->PopulateVertexFeatureInfoMap(
+            beamConstants, clusterListMap, slidingFitDataListMap, showerClusterListMap, kdTreeMap, pVertex, vertexFeatureInfoMap);
     }
 
     // Use a simple score to get the list of vertices representing good regions.
@@ -102,8 +95,8 @@ void MvaVertexSelectionAlgorithm<T>::GetVertexScoreList(const VertexVector &vert
     if ((!m_trainingSetMode || m_allowClassifyDuringTraining) && !bestRegionVertices.empty())
     {
         // Use mva to choose the region.
-        const Vertex *const pBestRegionVertex(this->CompareVertices(bestRegionVertices, vertexFeatureInfoMap, eventFeatureList, m_mvaRegion,
-            m_useRPhiFeatureForRegion));
+        const Vertex *const pBestRegionVertex(
+            this->CompareVertices(bestRegionVertices, vertexFeatureInfoMap, eventFeatureList, m_mvaRegion, m_useRPhiFeatureForRegion));
 
         // Get all the vertices in the best region.
         VertexVector regionalVertices{pBestRegionVertex};
@@ -129,9 +122,9 @@ void MvaVertexSelectionAlgorithm<T>::GetVertexScoreList(const VertexVector &vert
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
-const pandora::Vertex * MvaVertexSelectionAlgorithm<T>::CompareVertices(const VertexVector &vertexVector, const VertexFeatureInfoMap &vertexFeatureInfoMap,
-    const LArMvaHelper::MvaFeatureVector &eventFeatureList, const T &t, const bool useRPhi) const
+template <typename T>
+const pandora::Vertex *MvaVertexSelectionAlgorithm<T>::CompareVertices(const VertexVector &vertexVector,
+    const VertexFeatureInfoMap &vertexFeatureInfoMap, const LArMvaHelper::MvaFeatureVector &eventFeatureList, const T &t, const bool useRPhi) const
 {
     const Vertex *pBestVertex(vertexVector.front());
     LArMvaHelper::MvaFeatureVector chosenFeatureList;
@@ -158,22 +151,19 @@ const pandora::Vertex * MvaVertexSelectionAlgorithm<T>::CompareVertices(const Ve
     return pBestVertex;
 }
 
-//------------------------------------------------------------------------------------------------------------------------------------------ 
+//------------------------------------------------------------------------------------------------------------------------------------------
 
-template<typename T>
+template <typename T>
 StatusCode MvaVertexSelectionAlgorithm<T>::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MvaFileName", m_mvaFileName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MvaFileName", m_mvaFileName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "RegionMvaName", m_regionMvaName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "RegionMvaName", m_regionMvaName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexMvaName", m_vertexMvaName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexMvaName", m_vertexMvaName));
 
     // ATTN : Need access to base class member variables at this point, so call read settings prior to end of this function
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, TrainedVertexSelectionAlgorithm::ReadSettings(xmlHandle));
@@ -182,8 +172,8 @@ StatusCode MvaVertexSelectionAlgorithm<T>::ReadSettings(const TiXmlHandle xmlHan
     {
         if (m_mvaFileName.empty() || m_regionMvaName.empty() || m_vertexMvaName.empty())
         {
-            std::cout << "MvaVertexSelectionAlgorithm: MvaFileName, RegionMvaName and VertexMvaName must be set if training set mode is" <<
-                         "off or we allow classification during training" << std::endl;
+            std::cout << "MvaVertexSelectionAlgorithm: MvaFileName, RegionMvaName and VertexMvaName must be set if training set mode is"
+                      << "off or we allow classification during training" << std::endl;
             return STATUS_CODE_INVALID_PARAMETER;
         }
 

--- a/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.h
@@ -23,15 +23,17 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
  *  @brief  MvaVertexSelectionAlgorithm class
  */
-template<typename T>
+template <typename T>
 class MvaVertexSelectionAlgorithm : public TrainedVertexSelectionAlgorithm
 {
 public:
@@ -68,15 +70,15 @@ private:
      *
      *  @return address of the best vertex
      */
-    const pandora::Vertex * CompareVertices(const pandora::VertexVector &vertexVector, const VertexFeatureInfoMap &vertexFeatureInfoMap,
+    const pandora::Vertex *CompareVertices(const pandora::VertexVector &vertexVector, const VertexFeatureInfoMap &vertexFeatureInfoMap,
         const LArMvaHelper::MvaFeatureVector &eventFeatureList, const T &t, const bool useRPhi) const;
 
-    std::string                             m_filePathEnvironmentVariable;  ///< The environment variable providing a list of paths to mva files
-    std::string                             m_mvaFileName;                  ///< The mva file name
-    std::string                             m_regionMvaName;                ///< The name of the region mva to find
-    std::string                             m_vertexMvaName;                ///< The name of the vertex mva to find
-    T                                       m_mvaRegion;                    ///< The region mva
-    T                                       m_mvaVertex;                    ///< The vertex mva
+    std::string m_filePathEnvironmentVariable; ///< The environment variable providing a list of paths to mva files
+    std::string m_mvaFileName;                 ///< The mva file name
+    std::string m_regionMvaName;               ///< The name of the region mva to find
+    std::string m_vertexMvaName;               ///< The name of the vertex mva to find
+    T m_mvaRegion;                             ///< The region mva
+    T m_mvaVertex;                             ///< The vertex mva
 };
 
 typedef MvaVertexSelectionAlgorithm<AdaBoostDecisionTree> BdtVertexSelectionAlgorithm;

--- a/larpandoracontent/LArVertex/RPhiFeatureTool.cc
+++ b/larpandoracontent/LArVertex/RPhiFeatureTool.cc
@@ -6,10 +6,10 @@
  *  $Log: $
  */
 
-#include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArVertex/RPhiFeatureTool.h"
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 #include "larpandoracontent/LArUtility/KDTreeLinkerAlgoT.h"
 
@@ -35,13 +35,13 @@ RPhiFeatureTool::RPhiFeatureTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void RPhiFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const Vertex * const pVertex,
-    const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-    const VertexSelectionBaseAlgorithm::KDTreeMap &kdTreeMap, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &,
-    const float beamDeweightingScore, float &bestFastScore)
+void RPhiFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+    const Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &,
+    const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &kdTreeMap,
+    const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float beamDeweightingScore, float &bestFastScore)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     KernelEstimate kernelEstimateU(m_kernelEstimateSigma);
     KernelEstimate kernelEstimateV(m_kernelEstimateSigma);
@@ -73,14 +73,13 @@ void RPhiFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const V
             bestFastScore = expBeamDeweightingScore * fastScore;
     }
 
-    featureVector.push_back(m_fullScore ? this->GetFullScore(kernelEstimateU, kernelEstimateV, kernelEstimateW) :
-        this->GetMidwayScore(kernelEstimateU, kernelEstimateV, kernelEstimateW));
+    featureVector.push_back(m_fullScore ? this->GetFullScore(kernelEstimateU, kernelEstimateV, kernelEstimateW)
+                                        : this->GetMidwayScore(kernelEstimateU, kernelEstimateV, kernelEstimateW));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float RPhiFeatureTool::GetFastScore(const KernelEstimate &kernelEstimateU, const KernelEstimate &kernelEstimateV,
-    const KernelEstimate &kernelEstimateW) const
+float RPhiFeatureTool::GetFastScore(const KernelEstimate &kernelEstimateU, const KernelEstimate &kernelEstimateV, const KernelEstimate &kernelEstimateW) const
 {
     Histogram histogramU(m_fastHistogramNPhiBins, m_fastHistogramPhiMin, m_fastHistogramPhiMax);
     Histogram histogramV(m_fastHistogramNPhiBins, m_fastHistogramPhiMin, m_fastHistogramPhiMax);
@@ -96,9 +95,9 @@ float RPhiFeatureTool::GetFastScore(const KernelEstimate &kernelEstimateU, const
         histogramW.Fill(contribution.first, contribution.second);
 
     // Is the below correct?
-    histogramU.Scale(1.f/histogramU.GetCumulativeSum());
-    histogramV.Scale(1.f/histogramV.GetCumulativeSum());
-    histogramW.Scale(1.f/histogramW.GetCumulativeSum());
+    histogramU.Scale(1.f / histogramU.GetCumulativeSum());
+    histogramV.Scale(1.f / histogramV.GetCumulativeSum());
+    histogramW.Scale(1.f / histogramW.GetCumulativeSum());
 
     // ATTN Need to renormalise histograms if ever want to directly compare fast and full scores
     float figureOfMerit(0.f);
@@ -116,8 +115,7 @@ float RPhiFeatureTool::GetFastScore(const KernelEstimate &kernelEstimateU, const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float RPhiFeatureTool::GetMidwayScore(const KernelEstimate &kernelEstimateU, const KernelEstimate &kernelEstimateV,
-    const KernelEstimate &kernelEstimateW) const
+float RPhiFeatureTool::GetMidwayScore(const KernelEstimate &kernelEstimateU, const KernelEstimate &kernelEstimateV, const KernelEstimate &kernelEstimateW) const
 {
     Histogram histogramU(m_fastHistogramNPhiBins, m_fastHistogramPhiMin, m_fastHistogramPhiMax);
     Histogram histogramV(m_fastHistogramNPhiBins, m_fastHistogramPhiMin, m_fastHistogramPhiMax);
@@ -147,8 +145,7 @@ float RPhiFeatureTool::GetMidwayScore(const KernelEstimate &kernelEstimateU, con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float RPhiFeatureTool::GetFullScore(const KernelEstimate &kernelEstimateU, const KernelEstimate &kernelEstimateV,
-    const KernelEstimate &kernelEstimateW) const
+float RPhiFeatureTool::GetFullScore(const KernelEstimate &kernelEstimateU, const KernelEstimate &kernelEstimateV, const KernelEstimate &kernelEstimateW) const
 {
     float figureOfMerit(0.f);
 
@@ -166,8 +163,8 @@ float RPhiFeatureTool::GetFullScore(const KernelEstimate &kernelEstimateU, const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void RPhiFeatureTool::FillKernelEstimate(const Vertex *const pVertex, const HitType hitType, VertexSelectionBaseAlgorithm::HitKDTree2D &kdTree,
-    KernelEstimate &kernelEstimate) const
+void RPhiFeatureTool::FillKernelEstimate(const Vertex *const pVertex, const HitType hitType,
+    VertexSelectionBaseAlgorithm::HitKDTree2D &kdTree, KernelEstimate &kernelEstimate) const
 {
     const CartesianVector vertexPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
     KDTreeBox searchRegionHits = build_2d_kd_search_region(vertexPosition2D, m_maxHitVertexDisplacement1D, m_maxHitVertexDisplacement1D);
@@ -245,38 +242,33 @@ void RPhiFeatureTool::KernelEstimate::AddContribution(const float x, const float
 
 StatusCode RPhiFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FastScoreCheck", m_fastScoreCheck));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FastScoreCheck", m_fastScoreCheck));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FastScoreOnly", m_fastScoreOnly));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FastScoreOnly", m_fastScoreOnly));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FullScore", m_fullScore));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FullScore", m_fullScore));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "KernelEstimateSigma", m_kernelEstimateSigma));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "KernelEstimateSigma", m_kernelEstimateSigma));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "Kappa", m_kappa));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "Kappa", m_kappa));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxHitVertexDisplacement1D", m_maxHitVertexDisplacement1D));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxHitVertexDisplacement1D", m_maxHitVertexDisplacement1D));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinFastScoreFraction", m_minFastScoreFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinFastScoreFraction", m_minFastScoreFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FastHistogramNPhiBins", m_fastHistogramNPhiBins));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FastHistogramNPhiBins", m_fastHistogramNPhiBins));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FastHistogramPhiMin", m_fastHistogramPhiMin));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FastHistogramPhiMin", m_fastHistogramPhiMin));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "FastHistogramPhiMax", m_fastHistogramPhiMax));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FastHistogramPhiMax", m_fastHistogramPhiMax));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EnableFolding", m_enableFolding));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EnableFolding", m_enableFolding));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArVertex/RPhiFeatureTool.h
+++ b/larpandoracontent/LArVertex/RPhiFeatureTool.h
@@ -37,10 +37,10 @@ public:
      *
      *  @return the r/phi feature
      */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm * const pAlgorithm, const pandora::Vertex * const pVertex,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-        const VertexSelectionBaseAlgorithm::KDTreeMap &kdTreeMap, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &,
-        const float beamDeweightingScore, float &bestFastScore);
+    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+        const pandora::Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &,
+        const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &kdTreeMap,
+        const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float beamDeweightingScore, float &bestFastScore);
 
 private:
     /**
@@ -65,7 +65,7 @@ private:
          */
         float Sample(const float x) const;
 
-        typedef std::multimap<float, float> ContributionList;   ///< Map from x coord to weight, ATTN avoid map.find, etc. with float key
+        typedef std::multimap<float, float> ContributionList; ///< Map from x coord to weight, ATTN avoid map.find, etc. with float key
 
         /**
          *  @brief  Get the contribution list
@@ -90,8 +90,8 @@ private:
         void AddContribution(const float x, const float weight);
 
     private:
-        ContributionList            m_contributionList;         ///< The contribution list
-        const float                 m_sigma;                    ///< The assigned width
+        ContributionList m_contributionList; ///< The contribution list
+        const float m_sigma;                 ///< The assigned width
     };
 
     //--------------------------------------------------------------------------------------------------------------------------------------
@@ -139,7 +139,8 @@ private:
      *  @param  kdTree the relevant kd tree
      *  @param  kernelEstimate to receive the populated kernel estimate
      */
-    void FillKernelEstimate(const pandora::Vertex *const pVertex, const pandora::HitType hitType, VertexSelectionBaseAlgorithm::HitKDTree2D &kdTree, KernelEstimate &kernelEstimate) const;
+    void FillKernelEstimate(const pandora::Vertex *const pVertex, const pandora::HitType hitType,
+        VertexSelectionBaseAlgorithm::HitKDTree2D &kdTree, KernelEstimate &kernelEstimate) const;
 
     /**
      *  @brief  Whether to accept a candidate vertex, based on its spatial position in relation to other selected candidates
@@ -161,26 +162,25 @@ private:
      */
     float atan2Fast(const float y, const float x) const;
 
-    bool            m_fastScoreCheck;               ///< Whether to use the fast histogram based score to selectively avoid calling full or midway scores
-    bool            m_fastScoreOnly;                ///< Whether to use the fast histogram based score only
-    bool            m_fullScore;                    ///< Whether to use the full kernel density estimation score, as opposed to the midway score
+    bool m_fastScoreCheck; ///< Whether to use the fast histogram based score to selectively avoid calling full or midway scores
+    bool m_fastScoreOnly;  ///< Whether to use the fast histogram based score only
+    bool m_fullScore;      ///< Whether to use the full kernel density estimation score, as opposed to the midway score
 
-    float           m_kernelEstimateSigma;          ///< The Gaussian width to use for kernel estimation
-    float           m_kappa;                        ///< Hit-deweighting offset, of form: weight = 1 / sqrt(distance + kappa), units cm
-    float           m_maxHitVertexDisplacement1D;   ///< Max hit-vertex displacement in *any one dimension* for contribution to kernel estimation
+    float m_kernelEstimateSigma;        ///< The Gaussian width to use for kernel estimation
+    float m_kappa;                      ///< Hit-deweighting offset, of form: weight = 1 / sqrt(distance + kappa), units cm
+    float m_maxHitVertexDisplacement1D; ///< Max hit-vertex displacement in *any one dimension* for contribution to kernel estimation
 
-    float           m_minFastScoreFraction;         ///< Fast score must be at least this fraction of best fast score to calculate full score
-    unsigned int    m_fastHistogramNPhiBins;        ///< Number of bins to use for fast score histograms
-    float           m_fastHistogramPhiMin;          ///< Min value for fast score histograms
-    float           m_fastHistogramPhiMax;          ///< Max value for fast score histograms
+    float m_minFastScoreFraction;         ///< Fast score must be at least this fraction of best fast score to calculate full score
+    unsigned int m_fastHistogramNPhiBins; ///< Number of bins to use for fast score histograms
+    float m_fastHistogramPhiMin;          ///< Min value for fast score histograms
+    float m_fastHistogramPhiMax;          ///< Max value for fast score histograms
 
-    bool            m_enableFolding;                ///< Whether to enable folding of -pi -> +pi phi distribution into 0 -> +pi region only
+    bool m_enableFolding; ///< Whether to enable folding of -pi -> +pi phi distribution into 0 -> +pi region only
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline RPhiFeatureTool::KernelEstimate::KernelEstimate(const float sigma) :
-    m_sigma(sigma)
+inline RPhiFeatureTool::KernelEstimate::KernelEstimate(const float sigma) : m_sigma(sigma)
 {
     if (m_sigma < std::numeric_limits<float>::epsilon())
         throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
@@ -6,48 +6,48 @@
  *  $Log: $
  */
 
-#include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h"
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 using namespace pandora;
 
 namespace lar_content
 {
 
-ShowerAsymmetryFeatureTool::ShowerAsymmetryFeatureTool() :
-    m_vertexClusterDistance(4.f)
+ShowerAsymmetryFeatureTool::ShowerAsymmetryFeatureTool() : m_vertexClusterDistance(4.f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ShowerAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const Vertex * const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &,
-                const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
-                const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap, const float, float &)
+void ShowerAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+    const Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &,
+    const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
+    const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap, const float, float &)
 {
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
     float showerAsymmetry(0.f);
 
-    showerAsymmetry += this->GetShowerAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U),
-        showerClusterListMap.at(TPC_VIEW_U));
+    showerAsymmetry += this->GetShowerAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U), showerClusterListMap.at(TPC_VIEW_U));
 
-    showerAsymmetry += this->GetShowerAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V),
-        showerClusterListMap.at(TPC_VIEW_V));
+    showerAsymmetry += this->GetShowerAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V), showerClusterListMap.at(TPC_VIEW_V));
 
-    showerAsymmetry += this->GetShowerAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W),
-        showerClusterListMap.at(TPC_VIEW_W));
+    showerAsymmetry += this->GetShowerAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W), showerClusterListMap.at(TPC_VIEW_W));
 
     featureVector.push_back(showerAsymmetry);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ShowerAsymmetryFeatureTool::GetShowerAsymmetryForView(const CartesianVector &vertexPosition2D,
-    const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const
+float ShowerAsymmetryFeatureTool::GetShowerAsymmetryForView(
+    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const
 {
     float showerAsymmetry(1.f);
 
@@ -81,10 +81,10 @@ float ShowerAsymmetryFeatureTool::GetShowerAsymmetryForView(const CartesianVecto
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool ShowerAsymmetryFeatureTool::ShouldUseShowerCluster(const CartesianVector &vertexPosition,
-    const VertexSelectionBaseAlgorithm::ShowerCluster &showerCluster) const
+bool ShowerAsymmetryFeatureTool::ShouldUseShowerCluster(
+    const CartesianVector &vertexPosition, const VertexSelectionBaseAlgorithm::ShowerCluster &showerCluster) const
 {
-    for (const Cluster * const pCluster : showerCluster.GetClusters())
+    for (const Cluster *const pCluster : showerCluster.GetClusters())
     {
         if (LArClusterHelper::GetClosestDistance(vertexPosition, pCluster) < m_vertexClusterDistance)
             return true;
@@ -101,7 +101,7 @@ void ShowerAsymmetryFeatureTool::CalculateAsymmetryParameters(const VertexSelect
     beforeVtxEnergy = 0.f;
     afterVtxEnergy = 0.f;
 
-    for (const Cluster * const pCluster : showerCluster.GetClusters())
+    for (const Cluster *const pCluster : showerCluster.GetClusters())
     {
         CaloHitList caloHitList;
         pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
@@ -125,8 +125,8 @@ void ShowerAsymmetryFeatureTool::CalculateAsymmetryParameters(const VertexSelect
 
 StatusCode ShowerAsymmetryFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "VertexClusterDistance", m_vertexClusterDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexClusterDistance", m_vertexClusterDistance));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h
@@ -35,10 +35,10 @@ public:
      *
      *  @return the shower asymmetry feature
      */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm * const pAlgorithm, const pandora::Vertex * const pVertex,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-        const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap,
-        const float, float &);
+    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+        const pandora::Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &,
+        const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
+        const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap, const float, float &);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -51,7 +51,8 @@ private:
      *
      *  @return the shower asymmetry feature
      */
-    float GetShowerAsymmetryForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const;
+    float GetShowerAsymmetryForView(
+        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const;
 
     /**
      *  @brief  Get whether we should use a given shower cluster for asymmetry calculation
@@ -75,7 +76,7 @@ private:
     void CalculateAsymmetryParameters(const VertexSelectionBaseAlgorithm::ShowerCluster &showerCluster, const float projectedVtxPosition,
         const pandora::CartesianVector &showerDirection, float &beforeVtxEnergy, float &afterVtxEnergy) const;
 
-    float   m_vertexClusterDistance;    ///< The distance around the vertex to look for shower clusters
+    float m_vertexClusterDistance; ///< The distance around the vertex to look for shower clusters
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
@@ -16,10 +16,10 @@
 #include "larpandoracontent/LArHelpers/LArMvaHelper.h"
 
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
-#include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h"
-#include "larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h"
+#include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/RPhiFeatureTool.h"
+#include "larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h"
 
 #include "larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h"
 
@@ -113,8 +113,8 @@ void TrainedVertexSelectionAlgorithm::CalculateShowerClusterList(const ClusterLi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::GetShowerLikeClusterEndPoints(const ClusterList &clusterList, ClusterList &showerLikeClusters,
-    ClusterEndPointsMap &clusterEndPointsMap) const
+void TrainedVertexSelectionAlgorithm::GetShowerLikeClusterEndPoints(
+    const ClusterList &clusterList, ClusterList &showerLikeClusters, ClusterEndPointsMap &clusterEndPointsMap) const
 {
     for (const Cluster *const pCluster : clusterList)
     {
@@ -151,7 +151,7 @@ void TrainedVertexSelectionAlgorithm::PopulateKdTree(const ClusterList &clusterL
         allCaloHits.insert(allCaloHits.end(), daughterHits.begin(), daughterHits.end());
 
         for (const CaloHit *const pCaloHit : daughterHits)
-            (void) hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHit, pCluster));
+            (void)hitToClusterMap.insert(HitToClusterMap::value_type(pCaloHit, pCluster));
     }
 
     HitKDNode2DList hitKDNode2DList;
@@ -161,8 +161,8 @@ void TrainedVertexSelectionAlgorithm::PopulateKdTree(const ClusterList &clusterL
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrainedVertexSelectionAlgorithm::AddClusterToShower(const ClusterEndPointsMap &clusterEndPointsMap, ClusterList &availableShowerLikeClusters,
-    const Cluster *const pCluster, ClusterList &showerCluster) const
+bool TrainedVertexSelectionAlgorithm::AddClusterToShower(const ClusterEndPointsMap &clusterEndPointsMap,
+    ClusterList &availableShowerLikeClusters, const Cluster *const pCluster, ClusterList &showerCluster) const
 {
     const auto existingEndPointsIter(clusterEndPointsMap.find(pCluster));
     if (existingEndPointsIter == clusterEndPointsMap.end())
@@ -214,7 +214,7 @@ bool TrainedVertexSelectionAlgorithm::AddClusterToShower(HitKDTree2D &kdTree, co
         kdTree.search(searchRegionHits, found);
 
         for (const auto &hit : found)
-            (void) nearbyClusters.insert(hitToClusterMap.at(hit.data));
+            (void)nearbyClusters.insert(hitToClusterMap.at(hit.data));
     }
 
     for (auto iter = availableShowerLikeClusters.begin(); iter != availableShowerLikeClusters.end(); ++iter)
@@ -234,8 +234,8 @@ bool TrainedVertexSelectionAlgorithm::AddClusterToShower(HitKDTree2D &kdTree, co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-typename TrainedVertexSelectionAlgorithm::EventFeatureInfo TrainedVertexSelectionAlgorithm::CalculateEventFeatures(const ClusterList &clusterListU,
-    const ClusterList &clusterListV, const ClusterList &clusterListW, const VertexVector &vertexVector) const
+typename TrainedVertexSelectionAlgorithm::EventFeatureInfo TrainedVertexSelectionAlgorithm::CalculateEventFeatures(
+    const ClusterList &clusterListU, const ClusterList &clusterListV, const ClusterList &clusterListW, const VertexVector &vertexVector) const
 {
     float eventEnergy(0.f);
     unsigned int nShoweryHits(0), nHits(0);
@@ -259,8 +259,8 @@ typename TrainedVertexSelectionAlgorithm::EventFeatureInfo TrainedVertexSelectio
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::IncrementShoweryParameters(const ClusterList &clusterList, unsigned int &nShoweryHits, unsigned int &nHits,
-    float &eventEnergy) const
+void TrainedVertexSelectionAlgorithm::IncrementShoweryParameters(
+    const ClusterList &clusterList, unsigned int &nShoweryHits, unsigned int &nHits, float &eventEnergy) const
 {
     for (const Cluster *const pCluster : clusterList)
     {
@@ -302,27 +302,27 @@ void TrainedVertexSelectionAlgorithm::GetEventShapeFeatures(const ClusterList &c
     // Calculate the volume and longitudinality of the event (ySpan often 0 - to be investigated).
     if ((xSpan > std::numeric_limits<float>::epsilon()) && (ySpan > std::numeric_limits<float>::epsilon()))
     {
-        eventVolume     = xSpan * ySpan * zSpan;
+        eventVolume = xSpan * ySpan * zSpan;
         longitudinality = zSpan / (xSpan + ySpan);
     }
 
     else if (ySpan > std::numeric_limits<float>::epsilon())
     {
-        eventVolume     = ySpan * ySpan * zSpan;
+        eventVolume = ySpan * ySpan * zSpan;
         longitudinality = zSpan / (ySpan + ySpan);
     }
 
     else if (xSpan > std::numeric_limits<float>::epsilon())
     {
-        eventVolume     = xSpan * xSpan * zSpan;
+        eventVolume = xSpan * xSpan * zSpan;
         longitudinality = zSpan / (xSpan + xSpan);
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline void TrainedVertexSelectionAlgorithm::UpdateSpanCoordinate(const float minPositionCoord, const float maxPositionCoord, InputFloat &minCoord,
-    InputFloat &maxCoord) const
+inline void TrainedVertexSelectionAlgorithm::UpdateSpanCoordinate(
+    const float minPositionCoord, const float maxPositionCoord, InputFloat &minCoord, InputFloat &maxCoord) const
 {
     if (!minCoord.IsInitialized() || minPositionCoord < minCoord.Get())
         minCoord = minPositionCoord;
@@ -335,7 +335,7 @@ inline void TrainedVertexSelectionAlgorithm::UpdateSpanCoordinate(const float mi
 
 inline float TrainedVertexSelectionAlgorithm::GetCoordinateSpan(const InputFloat &minCoord, const InputFloat &maxCoord) const
 {
-   if (minCoord.IsInitialized() && maxCoord.IsInitialized())
+    if (minCoord.IsInitialized() && maxCoord.IsInitialized())
         return std::fabs(maxCoord.Get() - minCoord.Get());
 
     return 0.f;
@@ -343,8 +343,7 @@ inline float TrainedVertexSelectionAlgorithm::GetCoordinateSpan(const InputFloat
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::AddEventFeaturesToVector(const EventFeatureInfo &eventFeatureInfo,
-    LArMvaHelper::MvaFeatureVector &featureVector) const
+void TrainedVertexSelectionAlgorithm::AddEventFeaturesToVector(const EventFeatureInfo &eventFeatureInfo, LArMvaHelper::MvaFeatureVector &featureVector) const
 {
     featureVector.push_back(static_cast<double>(eventFeatureInfo.m_eventShoweryness));
     featureVector.push_back(static_cast<double>(eventFeatureInfo.m_eventEnergy));
@@ -366,16 +365,24 @@ void TrainedVertexSelectionAlgorithm::PopulateVertexFeatureInfoMap(const BeamCon
     const double beamDeweighting(this->GetBeamDeweightingScore(beamConstants, pVertex));
 
     const double energyKick(LArMvaHelper::CalculateFeaturesOfType<EnergyKickFeatureTool>(m_featureToolVector, this, pVertex,
-        slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore).at(0).Get());
+        slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore)
+                                .at(0)
+                                .Get());
 
     const double localAsymmetry(LArMvaHelper::CalculateFeaturesOfType<LocalAsymmetryFeatureTool>(m_featureToolVector, this, pVertex,
-        slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore).at(0).Get());
+        slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore)
+                                    .at(0)
+                                    .Get());
 
     const double globalAsymmetry(LArMvaHelper::CalculateFeaturesOfType<GlobalAsymmetryFeatureTool>(m_featureToolVector, this, pVertex,
-        slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore).at(0).Get());
+        slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore)
+                                     .at(0)
+                                     .Get());
 
     const double showerAsymmetry(LArMvaHelper::CalculateFeaturesOfType<ShowerAsymmetryFeatureTool>(m_featureToolVector, this, pVertex,
-        slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore).at(0).Get());
+        slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore)
+                                     .at(0)
+                                     .Get());
 
     //const double rPhiFeature(LArMvaHelper::CalculateFeaturesOfType<RPhiFeatureTool>(m_featureToolVector, this, pVertex,
     //    slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore).at(0).Get());
@@ -386,8 +393,8 @@ void TrainedVertexSelectionAlgorithm::PopulateVertexFeatureInfoMap(const BeamCon
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::PopulateInitialScoreList(VertexFeatureInfoMap &vertexFeatureInfoMap, const Vertex *const pVertex,
-                                                           VertexScoreList &initialScoreList) const
+void TrainedVertexSelectionAlgorithm::PopulateInitialScoreList(
+    VertexFeatureInfoMap &vertexFeatureInfoMap, const Vertex *const pVertex, VertexScoreList &initialScoreList) const
 {
     VertexFeatureInfo vertexFeatureInfo = vertexFeatureInfoMap.at(pVertex);
 
@@ -411,7 +418,7 @@ void TrainedVertexSelectionAlgorithm::GetBestRegionVertices(VertexScoreList &ini
         const Vertex *const pVertex(vertexScore.GetVertex());
         bool farEnoughAway(true);
 
-        for (const Vertex *const pRegionVertex: bestRegionVertices)
+        for (const Vertex *const pRegionVertex : bestRegionVertices)
         {
             if (pRegionVertex == pVertex)
             {
@@ -468,24 +475,25 @@ void TrainedVertexSelectionAlgorithm::ProduceTrainingSets(const VertexVector &ve
     // Produce training examples for the final vertices within the best region.
     if (!regionalVertices.empty())
     {
-        this->ProduceTrainingExamples(regionalVertices, vertexFeatureInfoMap, coinFlip, generator, interactionType, m_trainingOutputFileVertex,
-            eventFeatureList, m_maxTrueVertexRadius, true);
+        this->ProduceTrainingExamples(regionalVertices, vertexFeatureInfoMap, coinFlip, generator, interactionType,
+            m_trainingOutputFileVertex, eventFeatureList, m_maxTrueVertexRadius, true);
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::CalculateRPhiScores(VertexVector &vertexVector, VertexFeatureInfoMap &vertexFeatureInfoMap,
-    const KDTreeMap &kdTreeMap) const
+void TrainedVertexSelectionAlgorithm::CalculateRPhiScores(
+    VertexVector &vertexVector, VertexFeatureInfoMap &vertexFeatureInfoMap, const KDTreeMap &kdTreeMap) const
 {
     float bestFastScore(-std::numeric_limits<float>::max());
 
     for (auto iter = vertexVector.begin(); iter != vertexVector.end(); /* no increment */)
     {
         VertexFeatureInfo &vertexFeatureInfo = vertexFeatureInfoMap.at(*iter);
-        vertexFeatureInfo.m_rPhiFeature = static_cast<float>(LArMvaHelper::CalculateFeaturesOfType<RPhiFeatureTool>(m_featureToolVector, this, *iter,
-            SlidingFitDataListMap(), ClusterListMap(), kdTreeMap, ShowerClusterListMap(), vertexFeatureInfo.m_beamDeweighting,
-            bestFastScore).at(0).Get());
+        vertexFeatureInfo.m_rPhiFeature = static_cast<float>(LArMvaHelper::CalculateFeaturesOfType<RPhiFeatureTool>(m_featureToolVector, this,
+            *iter, SlidingFitDataListMap(), ClusterListMap(), kdTreeMap, ShowerClusterListMap(), vertexFeatureInfo.m_beamDeweighting, bestFastScore)
+                                                                 .at(0)
+                                                                 .Get());
 
         if (m_dropFailedRPhiFastScoreCandidates && (vertexFeatureInfo.m_rPhiFeature <= std::numeric_limits<float>::epsilon()))
             iter = vertexVector.erase(iter);
@@ -521,7 +529,8 @@ std::string TrainedVertexSelectionAlgorithm::GetInteractionType() const
     }
 
     MCParticleList mcPrimaryList;
-    for (const auto &mapEntry : targetMCParticlesToGoodHitsMap) mcPrimaryList.push_back(mapEntry.first);
+    for (const auto &mapEntry : targetMCParticlesToGoodHitsMap)
+        mcPrimaryList.push_back(mapEntry.first);
     mcPrimaryList.sort(LArMCParticleHelper::SortByMomentum);
 
     const LArInteractionTypeHelper::InteractionType interactionType(LArInteractionTypeHelper::GetInteractionType(mcPrimaryList));
@@ -530,10 +539,9 @@ std::string TrainedVertexSelectionAlgorithm::GetInteractionType() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-const pandora::Vertex * TrainedVertexSelectionAlgorithm::ProduceTrainingExamples(const VertexVector &vertexVector,
-    const VertexFeatureInfoMap &vertexFeatureInfoMap, std::bernoulli_distribution &coinFlip, std::mt19937 &generator,
-    const std::string &interactionType, const std::string &trainingOutputFile, const LArMvaHelper::MvaFeatureVector &eventFeatureList,
-    const float maxRadius, const bool useRPhi) const
+const pandora::Vertex *TrainedVertexSelectionAlgorithm::ProduceTrainingExamples(const VertexVector &vertexVector,
+    const VertexFeatureInfoMap &vertexFeatureInfoMap, std::bernoulli_distribution &coinFlip, std::mt19937 &generator, const std::string &interactionType,
+    const std::string &trainingOutputFile, const LArMvaHelper::MvaFeatureVector &eventFeatureList, const float maxRadius, const bool useRPhi) const
 {
     const Vertex *pBestVertex(nullptr);
     float bestVertexDr(std::numeric_limits<float>::max());
@@ -557,14 +565,14 @@ const pandora::Vertex * TrainedVertexSelectionAlgorithm::ProduceTrainingExamples
         {
             if (coinFlip(generator))
             {
-                LArMvaHelper::ProduceTrainingExample(trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList,
-                    bestVertexFeatureList, featureList);
+                LArMvaHelper::ProduceTrainingExample(
+                    trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList, bestVertexFeatureList, featureList);
             }
 
             else
             {
-                LArMvaHelper::ProduceTrainingExample(trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList, featureList,
-                    bestVertexFeatureList);
+                LArMvaHelper::ProduceTrainingExample(
+                    trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList, featureList, bestVertexFeatureList);
             }
         }
     }
@@ -597,10 +605,10 @@ void TrainedVertexSelectionAlgorithm::GetBestVertex(const VertexVector &vertexVe
         float mcVertexDr(std::numeric_limits<float>::max());
         for (const MCParticle *const pMCTarget : mcTargetVector)
         {
-            const CartesianVector &mcTargetPosition((m_testBeamMode && std::fabs(pMCTarget->GetParticleId()) == 11) ? pMCTarget->GetVertex() :
-                pMCTarget->GetEndpoint());
-            const CartesianVector mcTargetCorrectedPosition(mcTargetPosition.GetX() + m_mcVertexXCorrection, mcTargetPosition.GetY(),
-                mcTargetPosition.GetZ());
+            const CartesianVector &mcTargetPosition(
+                (m_testBeamMode && std::fabs(pMCTarget->GetParticleId()) == 11) ? pMCTarget->GetVertex() : pMCTarget->GetEndpoint());
+            const CartesianVector mcTargetCorrectedPosition(
+                mcTargetPosition.GetX() + m_mcVertexXCorrection, mcTargetPosition.GetY(), mcTargetPosition.GetZ());
             const float dr = (mcTargetCorrectedPosition - pVertex->GetPosition()).GetMagnitude();
 
             if (dr < mcVertexDr)
@@ -617,8 +625,8 @@ void TrainedVertexSelectionAlgorithm::GetBestVertex(const VertexVector &vertexVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::AddVertexFeaturesToVector(const VertexFeatureInfo &vertexFeatureInfo,
-    LArMvaHelper::MvaFeatureVector &featureVector, const bool useRPhi) const
+void TrainedVertexSelectionAlgorithm::AddVertexFeaturesToVector(
+    const VertexFeatureInfo &vertexFeatureInfo, LArMvaHelper::MvaFeatureVector &featureVector, const bool useRPhi) const
 {
     featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_beamDeweighting));
     featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_energyKick));
@@ -632,8 +640,8 @@ void TrainedVertexSelectionAlgorithm::AddVertexFeaturesToVector(const VertexFeat
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::PopulateFinalVertexScoreList(const VertexFeatureInfoMap &vertexFeatureInfoMap, const Vertex *const pFavouriteVertex,
-    const VertexVector &vertexVector, VertexScoreList &finalVertexScoreList) const
+void TrainedVertexSelectionAlgorithm::PopulateFinalVertexScoreList(const VertexFeatureInfoMap &vertexFeatureInfoMap,
+    const Vertex *const pFavouriteVertex, const VertexVector &vertexVector, VertexScoreList &finalVertexScoreList) const
 {
     if (pFavouriteVertex)
     {
@@ -661,33 +669,31 @@ StatusCode TrainedVertexSelectionAlgorithm::ReadSettings(const TiXmlHandle xmlHa
     for (AlgorithmTool *const pAlgorithmTool : algorithmToolVector)
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, LArMvaHelper::AddFeatureToolToVector(pAlgorithmTool, m_featureToolVector));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrainingSetMode", m_trainingSetMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TrainingSetMode", m_trainingSetMode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "AllowClassifyDuringTraining", m_allowClassifyDuringTraining));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "AllowClassifyDuringTraining", m_allowClassifyDuringTraining));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MCVertexXCorrection", m_mcVertexXCorrection));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MCVertexXCorrection", m_mcVertexXCorrection));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrainingOutputFileRegion", m_trainingOutputFileRegion));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "TrainingOutputFileRegion", m_trainingOutputFileRegion));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TrainingOutputFileVertex", m_trainingOutputFileVertex));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "TrainingOutputFileVertex", m_trainingOutputFileVertex));
 
     if (m_trainingSetMode && (m_trainingOutputFileRegion.empty() || m_trainingOutputFileVertex.empty()))
     {
-        std::cout << "TrainedVertexSelectionAlgorithm: TrainingOutputFileRegion and TrainingOutputFileVertex are required for training set " <<
-                     "mode" << std::endl;
+        std::cout << "TrainedVertexSelectionAlgorithm: TrainingOutputFileRegion and TrainingOutputFileVertex are required for training set "
+                  << "mode" << std::endl;
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MCParticleListName", m_mcParticleListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "CaloHitListName", m_caloHitListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
 
     if (m_trainingSetMode && (m_mcParticleListName.empty() || m_caloHitListName.empty()))
     {
@@ -695,59 +701,56 @@ StatusCode TrainedVertexSelectionAlgorithm::ReadSettings(const TiXmlHandle xmlHa
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputClusterListNames", m_inputClusterListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinClusterCaloHits", m_minClusterCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterCaloHits", m_minClusterCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SlidingFitWindow", m_slidingFitWindow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SlidingFitWindow", m_slidingFitWindow));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinShowerSpineLength", m_minShowerSpineLength));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinShowerSpineLength", m_minShowerSpineLength));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "BeamDeweightingConstant", m_beamDeweightingConstant));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "BeamDeweightingConstant", m_beamDeweightingConstant));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "LocalAsymmetryConstant", m_localAsymmetryConstant));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LocalAsymmetryConstant", m_localAsymmetryConstant));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "GlobalAsymmetryConstant", m_globalAsymmetryConstant));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "GlobalAsymmetryConstant", m_globalAsymmetryConstant));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerAsymmetryConstant", m_showerAsymmetryConstant));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShowerAsymmetryConstant", m_showerAsymmetryConstant));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "EnergyKickConstant", m_energyKickConstant));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EnergyKickConstant", m_energyKickConstant));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ShowerClusteringDistance", m_showerClusteringDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ShowerClusteringDistance", m_showerClusteringDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinShowerClusterHits", m_minShowerClusterHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinShowerClusterHits", m_minShowerClusterHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseShowerClusteringApproximation", m_useShowerClusteringApproximation));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseShowerClusteringApproximation", m_useShowerClusteringApproximation));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "RegionRadius", m_regionRadius));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "RegionRadius", m_regionRadius));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "RPhiFineTuningRadius", m_rPhiFineTuningRadius));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "RPhiFineTuningRadius", m_rPhiFineTuningRadius));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTrueVertexRadius", m_maxTrueVertexRadius));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxTrueVertexRadius", m_maxTrueVertexRadius));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseRPhiFeatureForRegion", m_useRPhiFeatureForRegion));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseRPhiFeatureForRegion", m_useRPhiFeatureForRegion));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "DropFailedRPhiFastScoreCandidates", m_dropFailedRPhiFastScoreCandidates));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "DropFailedRPhiFastScoreCandidates", m_dropFailedRPhiFastScoreCandidates));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "TestBeamMode", m_testBeamMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TestBeamMode", m_testBeamMode));
 
     return VertexSelectionBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
@@ -23,8 +23,10 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -51,14 +53,14 @@ public:
          *  @param  showerAsymmetry the shower asymmetry feature
          */
         VertexFeatureInfo(const float beamDeweighting, const float rPhiFeature, const float energyKick, const float localAsymmetry,
-                          const float globalAsymmetry, const float showerAsymmetry);
+            const float globalAsymmetry, const float showerAsymmetry);
 
-        float    m_beamDeweighting;    ///< The beam deweighting feature
-        float    m_rPhiFeature;        ///< The r/phi feature
-        float    m_energyKick;         ///< The energy kick feature
-        float    m_localAsymmetry;     ///< The local asymmetry feature
-        float    m_globalAsymmetry;    ///< The global asymmetry feature
-        float    m_showerAsymmetry;    ///< The shower asymmetry feature
+        float m_beamDeweighting; ///< The beam deweighting feature
+        float m_rPhiFeature;     ///< The r/phi feature
+        float m_energyKick;      ///< The energy kick feature
+        float m_localAsymmetry;  ///< The local asymmetry feature
+        float m_globalAsymmetry; ///< The global asymmetry feature
+        float m_showerAsymmetry; ///< The shower asymmetry feature
     };
 
     typedef std::map<const pandora::Vertex *const, VertexFeatureInfo> VertexFeatureInfoMap;
@@ -85,13 +87,13 @@ public:
         EventFeatureInfo(const float eventShoweryness, const float eventEnergy, const float eventVolume, const float longitudinality,
             const unsigned int nHits, const unsigned int nClusters, const unsigned int nCandidates);
 
-        float           m_eventShoweryness;        ///< The event showeryness feature
-        float           m_eventEnergy;             ///< The event energy
-        float           m_eventVolume;             ///< The volume of the event
-        float           m_longitudinality;         ///< The longitudinality of the event
-        unsigned int    m_nHits;                   ///< The number of hits in the event
-        unsigned int    m_nClusters;               ///< The number of clusters in the event
-        unsigned int    m_nCandidates;             ///< The total number of vertex candidates
+        float m_eventShoweryness;   ///< The event showeryness feature
+        float m_eventEnergy;        ///< The event energy
+        float m_eventVolume;        ///< The volume of the event
+        float m_longitudinality;    ///< The longitudinality of the event
+        unsigned int m_nHits;       ///< The number of hits in the event
+        unsigned int m_nClusters;   ///< The number of clusters in the event
+        unsigned int m_nCandidates; ///< The total number of vertex candidates
     };
 
     //--------------------------------------------------------------------------------------------------------------------------------------
@@ -135,14 +137,14 @@ protected:
      *  @param  showerLikeClusters the list of shower-like clusters to populate
      *  @param  clusterEndPointsMap the map of shower-like cluster endpoints to populate
      */
-    void GetShowerLikeClusterEndPoints(const pandora::ClusterList &clusterList, pandora::ClusterList &showerLikeClusters,
-        ClusterEndPointsMap &clusterEndPointsMap) const;
+    void GetShowerLikeClusterEndPoints(
+        const pandora::ClusterList &clusterList, pandora::ClusterList &showerLikeClusters, ClusterEndPointsMap &clusterEndPointsMap) const;
 
-    typedef KDTreeLinkerAlgo<const pandora::CaloHit*, 2> HitKDTree2D;
-    typedef KDTreeNodeInfoT<const pandora::CaloHit*, 2> HitKDNode2D;
+    typedef KDTreeLinkerAlgo<const pandora::CaloHit *, 2> HitKDTree2D;
+    typedef KDTreeNodeInfoT<const pandora::CaloHit *, 2> HitKDNode2D;
     typedef std::vector<HitKDNode2D> HitKDNode2DList;
 
-    typedef std::unordered_map<const pandora::CaloHit*, const pandora::Cluster*> HitToClusterMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterMap;
 
     /**
      * @brief   Populate kd tree with information about hits in a provided list of clusters
@@ -201,8 +203,7 @@ protected:
      *  @param  nHits the number of hits
      *  @param  eventEnergy the event energy
      */
-    void IncrementShoweryParameters(const pandora::ClusterList &clusterList, unsigned int &nShoweryHits, unsigned int &nHits,
-       float &eventEnergy) const;
+    void IncrementShoweryParameters(const pandora::ClusterList &clusterList, unsigned int &nShoweryHits, unsigned int &nHits, float &eventEnergy) const;
 
     /**
      *  @brief  Find whether a cluster is shower-like
@@ -230,8 +231,8 @@ protected:
      *  @param  minCoord the current min coordinate
      *  @param  maxCoord the current max coordinate
      */
-    void UpdateSpanCoordinate(const float minPositionCoord, const float maxPositionCoord, pandora::InputFloat &minCoord,
-        pandora::InputFloat &maxCoord) const;
+    void UpdateSpanCoordinate(
+        const float minPositionCoord, const float maxPositionCoord, pandora::InputFloat &minCoord, pandora::InputFloat &maxCoord) const;
 
     /**
      *  @brief  Get the coordinate span
@@ -273,8 +274,7 @@ protected:
      *  @param  pVertex the vertex
      *  @param  initialScoreList the score list to populate
      */
-    void PopulateInitialScoreList(VertexFeatureInfoMap &vertexFeatureInfoMap, const pandora::Vertex *const pVertex,
-        VertexScoreList &initialScoreList) const;
+    void PopulateInitialScoreList(VertexFeatureInfoMap &vertexFeatureInfoMap, const pandora::Vertex *const pVertex, VertexScoreList &initialScoreList) const;
 
     /**
      *  @brief  Get the list of top-N separated vertices
@@ -294,7 +294,7 @@ protected:
      *  @param  kdTreeMap
      */
     void ProduceTrainingSets(const pandora::VertexVector &vertexVector, const pandora::VertexVector &bestRegionVertices,
-        VertexFeatureInfoMap &vertexFeatureInfoMap, const LArMvaHelper::MvaFeatureVector &eventFeatureList,const KDTreeMap &kdTreeMap) const;
+        VertexFeatureInfoMap &vertexFeatureInfoMap, const LArMvaHelper::MvaFeatureVector &eventFeatureList, const KDTreeMap &kdTreeMap) const;
 
     /**
      *  @brief  Calculate the r/phi scores for the vertices in a vector, possibly erasing those that fail the fast score test
@@ -327,7 +327,7 @@ protected:
      *
      *  @return address of the vertex used as the 'best' vertex in the classifier
      */
-    const pandora::Vertex * ProduceTrainingExamples(const pandora::VertexVector &vertexVector, const VertexFeatureInfoMap &vertexFeatureInfoMap,
+    const pandora::Vertex *ProduceTrainingExamples(const pandora::VertexVector &vertexVector, const VertexFeatureInfoMap &vertexFeatureInfoMap,
         std::bernoulli_distribution &coinFlip, std::mt19937 &generator, const std::string &interactionType, const std::string &trainingOutputFile,
         const LArMvaHelper::MvaFeatureVector &eventFeatureList, const float maxRadius, const bool useRPhi) const;
 
@@ -362,41 +362,41 @@ protected:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    VertexFeatureTool::FeatureToolVector m_featureToolVector;     ///< The feature tool vector
-    bool                  m_trainingSetMode;                      ///< Whether to train
-    bool                  m_allowClassifyDuringTraining;          ///< Whether classification is allowed during training
-    float                 m_mcVertexXCorrection;                  ///< The correction to the x-coordinate of the MC vertex position
-    std::string           m_trainingOutputFileRegion;             ///< The training output file for the region mva
-    std::string           m_trainingOutputFileVertex;             ///< The training output file for the vertex mva
-    std::string           m_mcParticleListName;                   ///< The MC particle list for creating training examples
-    std::string           m_caloHitListName;                      ///< The 2D CaloHit list name
+    VertexFeatureTool::FeatureToolVector m_featureToolVector; ///< The feature tool vector
+    bool m_trainingSetMode;                                   ///< Whether to train
+    bool m_allowClassifyDuringTraining;                       ///< Whether classification is allowed during training
+    float m_mcVertexXCorrection;                              ///< The correction to the x-coordinate of the MC vertex position
+    std::string m_trainingOutputFileRegion;                   ///< The training output file for the region mva
+    std::string m_trainingOutputFileVertex;                   ///< The training output file for the vertex mva
+    std::string m_mcParticleListName;                         ///< The MC particle list for creating training examples
+    std::string m_caloHitListName;                            ///< The 2D CaloHit list name
 
-    pandora::StringVector m_inputClusterListNames;                ///< The list of cluster list names
-    unsigned int          m_minClusterCaloHits;                   ///< The min number of hits parameter in the energy score
-    unsigned int          m_slidingFitWindow;                     ///< The layer window for the sliding linear fits
-    float                 m_minShowerSpineLength;                 ///< The minimum length at which all are considered to be tracks
+    pandora::StringVector m_inputClusterListNames; ///< The list of cluster list names
+    unsigned int m_minClusterCaloHits;             ///< The min number of hits parameter in the energy score
+    unsigned int m_slidingFitWindow;               ///< The layer window for the sliding linear fits
+    float m_minShowerSpineLength;                  ///< The minimum length at which all are considered to be tracks
 
-    float                 m_beamDeweightingConstant;              ///< The beam deweighting constant for the initial region score list
-    float                 m_localAsymmetryConstant;               ///< The local asymmetry constant for the initial region score list
-    float                 m_globalAsymmetryConstant;              ///< The global asymmetry constant for the initial region score list
-    float                 m_showerAsymmetryConstant;              ///< The shower asymmetry constant for the initial region score list
-    float                 m_energyKickConstant;                   ///< The energy kick constant for the initial region score list
+    float m_beamDeweightingConstant; ///< The beam deweighting constant for the initial region score list
+    float m_localAsymmetryConstant;  ///< The local asymmetry constant for the initial region score list
+    float m_globalAsymmetryConstant; ///< The global asymmetry constant for the initial region score list
+    float m_showerAsymmetryConstant; ///< The shower asymmetry constant for the initial region score list
+    float m_energyKickConstant;      ///< The energy kick constant for the initial region score list
 
-    float                 m_showerClusteringDistance;             ///< The shower clustering distance
-    unsigned int          m_minShowerClusterHits;                 ///< The minimum number of shower cluster hits
-    bool                  m_useShowerClusteringApproximation;     ///< Whether to use the shower clustering distance approximation
-    float                 m_regionRadius;                         ///< The radius for a vertex region
-    float                 m_rPhiFineTuningRadius;                 ///< The maximum distance the r/phi tune can move a vertex
-    float                 m_maxTrueVertexRadius;                  ///< The maximum distance at which a vertex candidate can be considered the 'true' vertex
-    bool                  m_useRPhiFeatureForRegion;              ///< Whether to use the r/phi feature for the region vertex
-    bool                  m_dropFailedRPhiFastScoreCandidates;    ///< Whether to drop candidates that fail the r/phi fast score test
-    bool                  m_testBeamMode;                         ///< Test beam mode
+    float m_showerClusteringDistance;         ///< The shower clustering distance
+    unsigned int m_minShowerClusterHits;      ///< The minimum number of shower cluster hits
+    bool m_useShowerClusteringApproximation;  ///< Whether to use the shower clustering distance approximation
+    float m_regionRadius;                     ///< The radius for a vertex region
+    float m_rPhiFineTuningRadius;             ///< The maximum distance the r/phi tune can move a vertex
+    float m_maxTrueVertexRadius;              ///< The maximum distance at which a vertex candidate can be considered the 'true' vertex
+    bool m_useRPhiFeatureForRegion;           ///< Whether to use the r/phi feature for the region vertex
+    bool m_dropFailedRPhiFastScoreCandidates; ///< Whether to drop candidates that fail the r/phi fast score test
+    bool m_testBeamMode;                      ///< Test beam mode
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline TrainedVertexSelectionAlgorithm::VertexFeatureInfo::VertexFeatureInfo(const float beamDeweighting, const float rPhiFeature, const float energyKick,
-    const float localAsymmetry, const float globalAsymmetry, const float showerAsymmetry) :
+inline TrainedVertexSelectionAlgorithm::VertexFeatureInfo::VertexFeatureInfo(const float beamDeweighting, const float rPhiFeature,
+    const float energyKick, const float localAsymmetry, const float globalAsymmetry, const float showerAsymmetry) :
     m_beamDeweighting(beamDeweighting),
     m_rPhiFeature(rPhiFeature),
     m_energyKick(energyKick),

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
@@ -88,18 +88,19 @@ void VertexSelectionBaseAlgorithm::GetBeamConstants(const VertexVector &vertexVe
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void VertexSelectionBaseAlgorithm::GetClusterLists(const StringVector &inputClusterListNames, ClusterList &clusterListU, ClusterList &clusterListV,
-    ClusterList &clusterListW) const
+void VertexSelectionBaseAlgorithm::GetClusterLists(
+    const StringVector &inputClusterListNames, ClusterList &clusterListU, ClusterList &clusterListV, ClusterList &clusterListW) const
 {
     for (const std::string &clusterListName : inputClusterListNames)
     {
         const ClusterList *pClusterList(NULL);
-        PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
+        PANDORA_THROW_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
 
         if (!pClusterList || pClusterList->empty())
         {
-             if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
-                 std::cout << "EnergyKickVertexSelectionAlgorithm: unable to find cluster list " << clusterListName << std::endl;
+            if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+                std::cout << "EnergyKickVertexSelectionAlgorithm: unable to find cluster list " << clusterListName << std::endl;
 
             continue;
         }
@@ -124,13 +125,14 @@ void VertexSelectionBaseAlgorithm::CalculateClusterSlidingFits(const ClusterList
     ClusterVector sortedClusters(inputClusterList.begin(), inputClusterList.end());
     std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
 
-    for (const Cluster * const pCluster : sortedClusters)
+    for (const Cluster *const pCluster : sortedClusters)
     {
         if (pCluster->GetNCaloHits() < minClusterCaloHits)
             continue;
 
         // Make sure the window size is such that there are not more layers than hits (following TwoDSlidingLinearFit calculation).
-        const unsigned int newSlidingFitWindow(std::min(static_cast<int>(pCluster->GetNCaloHits()), static_cast<int>(slidingFitPitch * slidingFitWindow)));
+        const unsigned int newSlidingFitWindow(
+            std::min(static_cast<int>(pCluster->GetNCaloHits()), static_cast<int>(slidingFitPitch * slidingFitWindow)));
         slidingFitDataList.emplace_back(pCluster, newSlidingFitWindow, slidingFitPitch);
     }
 }
@@ -186,7 +188,8 @@ void VertexSelectionBaseAlgorithm::InitializeKDTrees(HitKDTree2D &kdTreeU, HitKD
     for (const std::string &caloHitListName : m_inputCaloHitListNames)
     {
         const CaloHitList *pCaloHitList = NULL;
-        PANDORA_THROW_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, caloHitListName, pCaloHitList));
+        PANDORA_THROW_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, caloHitListName, pCaloHitList));
 
         if (!pCaloHitList || pCaloHitList->empty())
         {
@@ -300,8 +303,7 @@ bool VertexSelectionBaseAlgorithm::SortByVertexZPosition(const pandora::Vertex *
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-VertexSelectionBaseAlgorithm::SlidingFitData::SlidingFitData(const pandora::Cluster *const pCluster, const int slidingFitWindow,
-        const float slidingFitPitch) :
+VertexSelectionBaseAlgorithm::SlidingFitData::SlidingFitData(const pandora::Cluster *const pCluster, const int slidingFitWindow, const float slidingFitPitch) :
     m_minLayerDirection(0.f, 0.f, 0.f),
     m_maxLayerDirection(0.f, 0.f, 0.f),
     m_minLayerPosition(0.f, 0.f, 0.f),
@@ -317,8 +319,7 @@ VertexSelectionBaseAlgorithm::SlidingFitData::SlidingFitData(const pandora::Clus
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-VertexSelectionBaseAlgorithm::ShowerCluster::ShowerCluster(const pandora::ClusterList &clusterList, const int slidingFitWindow,
-        const float slidingFitPitch) :
+VertexSelectionBaseAlgorithm::ShowerCluster::ShowerCluster(const pandora::ClusterList &clusterList, const int slidingFitWindow, const float slidingFitPitch) :
     m_clusterList(clusterList),
     m_coordinateVector(this->GetClusterListCoordinateVector(clusterList)),
     m_twoDSlidingFitResult(&m_coordinateVector, slidingFitWindow, slidingFitPitch)
@@ -331,13 +332,13 @@ pandora::CartesianPointVector VertexSelectionBaseAlgorithm::ShowerCluster::GetCl
 {
     CartesianPointVector coordinateVector;
 
-    for (const Cluster * const pCluster : clusterList)
+    for (const Cluster *const pCluster : clusterList)
     {
         CartesianPointVector clusterCoordinateVector;
         LArClusterHelper::GetCoordinateVector(pCluster, clusterCoordinateVector);
 
         coordinateVector.insert(coordinateVector.end(), std::make_move_iterator(clusterCoordinateVector.begin()),
-                                std::make_move_iterator(clusterCoordinateVector.end()));
+            std::make_move_iterator(clusterCoordinateVector.end()));
     }
 
     return coordinateVector;
@@ -348,47 +349,42 @@ pandora::CartesianPointVector VertexSelectionBaseAlgorithm::ShowerCluster::GetCl
 
 StatusCode VertexSelectionBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "InputCaloHitListNames", m_inputCaloHitListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputCaloHitListNames", m_inputCaloHitListNames));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "OutputVertexListName", m_outputVertexListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_outputVertexListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "ReplaceCurrentVertexList", m_replaceCurrentVertexList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "ReplaceCurrentVertexList", m_replaceCurrentVertexList));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "BeamMode", m_beamMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BeamMode", m_beamMode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "NDecayLengthsInZSpan", m_nDecayLengthsInZSpan));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NDecayLengthsInZSpan", m_nDecayLengthsInZSpan));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "SelectSingleVertex", m_selectSingleVertex));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SelectSingleVertex", m_selectSingleVertex));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxTopScoreSelections", m_maxTopScoreSelections));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxTopScoreSelections", m_maxTopScoreSelections));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MaxOnHitDisplacement", m_maxOnHitDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxOnHitDisplacement", m_maxOnHitDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCandidateDisplacement", m_minCandidateDisplacement));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinCandidateDisplacement", m_minCandidateDisplacement));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinCandidateScoreFraction", m_minCandidateScoreFraction));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinCandidateScoreFraction", m_minCandidateScoreFraction));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "UseDetectorGaps", m_useDetectorGaps));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseDetectorGaps", m_useDetectorGaps));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "GapTolerance", m_gapTolerance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "GapTolerance", m_gapTolerance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "IsEmptyViewAcceptable", m_isEmptyViewAcceptable));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IsEmptyViewAcceptable", m_isEmptyViewAcceptable));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
-        "MinVertexAcceptableViews", m_minVertexAcceptableViews));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinVertexAcceptableViews", m_minVertexAcceptableViews));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
@@ -19,8 +19,10 @@
 namespace lar_content
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
+template <typename, unsigned int>
+class KDTreeLinkerAlgo;
+template <typename, unsigned int>
+class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -70,11 +72,11 @@ public:
          *
          *  @return boolean
          */
-        bool operator< (const VertexScore &rhs) const;
+        bool operator<(const VertexScore &rhs) const;
 
     private:
-        const pandora::Vertex  *m_pVertex;          ///< The address of the vertex
-        float                   m_score;            ///< The score
+        const pandora::Vertex *m_pVertex; ///< The address of the vertex
+        float m_score;                    ///< The score
     };
 
     typedef std::vector<VertexScore> VertexScoreList;
@@ -108,8 +110,8 @@ public:
         void SetConstants(const float minZCoordinate, const float decayConstant);
 
     private:
-        pandora::InputFloat     m_minZCoordinate;   ///< The min z coordinate
-        pandora::InputFloat     m_decayConstant;    ///< The decay constant
+        pandora::InputFloat m_minZCoordinate; ///< The min z coordinate
+        pandora::InputFloat m_decayConstant;  ///< The decay constant
     };
 
     /**
@@ -163,11 +165,11 @@ public:
         const pandora::Cluster *GetCluster() const;
 
     private:
-        pandora::CartesianVector    m_minLayerDirection;    ///< The direction of the fit at the min layer
-        pandora::CartesianVector    m_maxLayerDirection;    ///< The direction of the fit at the min layer
-        pandora::CartesianVector    m_minLayerPosition;     ///< The position of the fit at the max layer
-        pandora::CartesianVector    m_maxLayerPosition;     ///< The position of the fit at the max layer
-        const pandora::Cluster     *m_pCluster;             ///< Pointer to the corresponding cluster
+        pandora::CartesianVector m_minLayerDirection; ///< The direction of the fit at the min layer
+        pandora::CartesianVector m_maxLayerDirection; ///< The direction of the fit at the min layer
+        pandora::CartesianVector m_minLayerPosition;  ///< The position of the fit at the max layer
+        pandora::CartesianVector m_maxLayerPosition;  ///< The position of the fit at the max layer
+        const pandora::Cluster *m_pCluster;           ///< Pointer to the corresponding cluster
     };
 
     typedef std::vector<SlidingFitData> SlidingFitDataList;
@@ -211,24 +213,25 @@ public:
         pandora::CartesianPointVector GetClusterListCoordinateVector(const pandora::ClusterList &clusterList) const;
 
     private:
-        pandora::ClusterList             m_clusterList;             ///< The list of clusters
-        pandora::CartesianPointVector    m_coordinateVector;        ///< The coordinate vector
-        TwoDSlidingFitResult             m_twoDSlidingFitResult;    ///< The fit to the hits of the cluster list
+        pandora::ClusterList m_clusterList;               ///< The list of clusters
+        pandora::CartesianPointVector m_coordinateVector; ///< The coordinate vector
+        TwoDSlidingFitResult m_twoDSlidingFitResult;      ///< The fit to the hits of the cluster list
     };
 
     typedef std::vector<ShowerCluster> ShowerClusterList;
 
-    typedef KDTreeNodeInfoT<const pandora::CaloHit*, 2> HitKDNode2D;
+    typedef KDTreeNodeInfoT<const pandora::CaloHit *, 2> HitKDNode2D;
     typedef std::vector<HitKDNode2D> HitKDNode2DList;
-    typedef KDTreeLinkerAlgo<const pandora::CaloHit*, 2> HitKDTree2D;
+    typedef KDTreeLinkerAlgo<const pandora::CaloHit *, 2> HitKDTree2D;
 
-    typedef std::map<pandora::HitType, const pandora::ClusterList &>              ClusterListMap;        ///< Map array of cluster lists for passing to tools
-    typedef std::map<pandora::HitType, const SlidingFitDataList>                  SlidingFitDataListMap; ///< Map of sliding fit data lists for passing to tools
-    typedef std::map<pandora::HitType, const ShowerClusterList>                   ShowerClusterListMap;  ///< Map of shower cluster lists for passing to tools
-    typedef std::map<pandora::HitType, const std::reference_wrapper<HitKDTree2D> > KDTreeMap;             ///< Map array of hit kd trees for passing to tools
+    typedef std::map<pandora::HitType, const pandora::ClusterList &> ClusterListMap;    ///< Map array of cluster lists for passing to tools
+    typedef std::map<pandora::HitType, const SlidingFitDataList> SlidingFitDataListMap; ///< Map of sliding fit data lists for passing to tools
+    typedef std::map<pandora::HitType, const ShowerClusterList> ShowerClusterListMap; ///< Map of shower cluster lists for passing to tools
+    typedef std::map<pandora::HitType, const std::reference_wrapper<HitKDTree2D>> KDTreeMap; ///< Map array of hit kd trees for passing to tools
 
-    typedef MvaFeatureTool<const VertexSelectionBaseAlgorithm *const, const pandora::Vertex * const, const SlidingFitDataListMap &,
-        const ClusterListMap &, const KDTreeMap &, const ShowerClusterListMap &, const float, float &>  VertexFeatureTool; ///< The base type for the vertex feature tools
+    typedef MvaFeatureTool<const VertexSelectionBaseAlgorithm *const, const pandora::Vertex *const, const SlidingFitDataListMap &,
+        const ClusterListMap &, const KDTreeMap &, const ShowerClusterListMap &, const float, float &>
+        VertexFeatureTool; ///< The base type for the vertex feature tools
 
 protected:
     /**
@@ -272,8 +275,8 @@ protected:
      *  @param  clusterListV the V-view cluster list to populate
      *  @param  clusterListW the W-view cluster list to populate
      */
-    void GetClusterLists(const pandora::StringVector &inputClusterListNames, pandora::ClusterList &clusterListU, pandora::ClusterList &clusterListV,
-        pandora::ClusterList &clusterListW) const;
+    void GetClusterLists(const pandora::StringVector &inputClusterListNames, pandora::ClusterList &clusterListU,
+        pandora::ClusterList &clusterListV, pandora::ClusterList &clusterListW) const;
 
     /**
      *  @brief  Calculate the cluster sliding fits
@@ -294,7 +297,7 @@ protected:
      *
      *  @return the score
      */
-    float GetBeamDeweightingScore(const BeamConstants &beamConstants, const pandora::Vertex * const pVertex) const;
+    float GetBeamDeweightingScore(const BeamConstants &beamConstants, const pandora::Vertex *const pVertex) const;
 
     /**
      *  @brief  Whether algorithm is running in beam mode, assuming neutrinos travel in positive z-direction
@@ -367,32 +370,32 @@ private:
     static bool SortByVertexZPosition(const pandora::Vertex *const pLhs, const pandora::Vertex *const pRhs);
 
 private:
-    pandora::StringVector   m_inputCaloHitListNames;        ///< The list of calo hit list names
-    std::string             m_outputVertexListName;         ///< The name under which to save the output vertex list
+    pandora::StringVector m_inputCaloHitListNames; ///< The list of calo hit list names
+    std::string m_outputVertexListName;            ///< The name under which to save the output vertex list
 
-    bool                    m_replaceCurrentVertexList;     ///< Whether to replace the current vertex list with the output list
+    bool m_replaceCurrentVertexList; ///< Whether to replace the current vertex list with the output list
 
-    bool                    m_beamMode;                     ///< Whether to run in beam mode, assuming neutrinos travel in positive z-direction
-    float                   m_nDecayLengthsInZSpan;         ///< The number of score decay lengths to use over the course of the vertex z-span
+    bool m_beamMode;              ///< Whether to run in beam mode, assuming neutrinos travel in positive z-direction
+    float m_nDecayLengthsInZSpan; ///< The number of score decay lengths to use over the course of the vertex z-span
 
-    bool                    m_selectSingleVertex;           ///< Whether to make a final decision and select just one vertex candidate
-    unsigned int            m_maxTopScoreSelections;        ///< Max number of top-scoring vertex candidate to select for output
+    bool m_selectSingleVertex;            ///< Whether to make a final decision and select just one vertex candidate
+    unsigned int m_maxTopScoreSelections; ///< Max number of top-scoring vertex candidate to select for output
 
-    float                   m_maxOnHitDisplacement;         ///< Max hit-vertex displacement for declaring vertex to lie on a hit in each view
+    float m_maxOnHitDisplacement; ///< Max hit-vertex displacement for declaring vertex to lie on a hit in each view
 
-    float                   m_minCandidateDisplacement;     ///< Ignore other top-scoring candidates located in close proximity to original
-    float                   m_minCandidateScoreFraction;    ///< Ignore other top-scoring candidates with score less than a fraction of original
+    float m_minCandidateDisplacement;  ///< Ignore other top-scoring candidates located in close proximity to original
+    float m_minCandidateScoreFraction; ///< Ignore other top-scoring candidates with score less than a fraction of original
 
-    bool                    m_useDetectorGaps;              ///< Whether to account for registered detector gaps in vertex selection
-    float                   m_gapTolerance;                 ///< The tolerance to use when querying whether a sampling point is in a gap, units cm
+    bool m_useDetectorGaps; ///< Whether to account for registered detector gaps in vertex selection
+    float m_gapTolerance;   ///< The tolerance to use when querying whether a sampling point is in a gap, units cm
 
-    bool                    m_isEmptyViewAcceptable;        ///< Whether views entirely empty of hits are classed as 'acceptable' for candidate filtration
-    unsigned int            m_minVertexAcceptableViews;     ///< The minimum number of views in which a candidate must sit on/near a hit or in a gap (or view can be empty)
+    bool m_isEmptyViewAcceptable; ///< Whether views entirely empty of hits are classed as 'acceptable' for candidate filtration
+    unsigned int m_minVertexAcceptableViews; ///< The minimum number of views in which a candidate must sit on/near a hit or in a gap (or view can be empty)
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline float VertexSelectionBaseAlgorithm::GetBeamDeweightingScore(const BeamConstants &beamConstants, const pandora::Vertex * const pVertex) const
+inline float VertexSelectionBaseAlgorithm::GetBeamDeweightingScore(const BeamConstants &beamConstants, const pandora::Vertex *const pVertex) const
 {
     const float vertexMinZ(std::max(pVertex->GetPosition().GetZ(), beamConstants.GetMinZCoordinate()));
     return (beamConstants.GetMinZCoordinate() - vertexMinZ) * beamConstants.GetDecayConstant();
@@ -430,7 +433,7 @@ inline float VertexSelectionBaseAlgorithm::VertexScore::GetScore() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline bool VertexSelectionBaseAlgorithm::VertexScore::operator< (const VertexScore &rhs) const
+inline bool VertexSelectionBaseAlgorithm::VertexScore::operator<(const VertexScore &rhs) const
 {
     return (this->GetScore() > rhs.GetScore());
 }

--- a/larpandoradlcontent/LArControlFlow/DLMasterAlgorithm.cc
+++ b/larpandoradlcontent/LArControlFlow/DLMasterAlgorithm.cc
@@ -10,8 +10,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
-#include "larpandoradlcontent/LArDLContent.h"
 #include "larpandoradlcontent/LArControlFlow/DLMasterAlgorithm.h"
+#include "larpandoradlcontent/LArDLContent.h"
 
 using namespace pandora;
 

--- a/larpandoradlcontent/LArDLContent.cc
+++ b/larpandoradlcontent/LArDLContent.cc
@@ -18,10 +18,8 @@
 
 #include "larpandoradlcontent/LArDLContent.h"
 
-#define LAR_DL_ALGORITHM_LIST(d)                                                                                                   \
-    d("LArDLMaster",                            DLMasterAlgorithm)                                                                 \
-    d("LArDLHitTrackShowerId",                  DlHitTrackShowerIdAlgorithm)                                                       \
-    d("LArDLHitValidation",                     DlHitValidationAlgorithm)
+#define LAR_DL_ALGORITHM_LIST(d)                                                                                                           \
+    d("LArDLMaster", DLMasterAlgorithm) d("LArDLHitTrackShowerId", DlHitTrackShowerIdAlgorithm) d("LArDLHitValidation", DlHitValidationAlgorithm)
 
 #define LAR_DL_ALGORITHM_TOOL_LIST(d)
 
@@ -33,23 +31,29 @@
 namespace lar_dl_content
 {
 
-#define LAR_DL_CONTENT_CREATE_ALGORITHM_FACTORY(a, b)                                                                              \
-class b##DL_FACTORY : public pandora::AlgorithmFactory                                                                             \
-{                                                                                                                               \
-public:                                                                                                                         \
-    pandora::Algorithm *CreateAlgorithm() const {return new b;};                                                                \
-};
+#define LAR_DL_CONTENT_CREATE_ALGORITHM_FACTORY(a, b)                                                                                      \
+    class b##DL_FACTORY : public pandora::AlgorithmFactory                                                                                 \
+    {                                                                                                                                      \
+    public:                                                                                                                                \
+        pandora::Algorithm *CreateAlgorithm() const                                                                                        \
+        {                                                                                                                                  \
+            return new b;                                                                                                                  \
+        };                                                                                                                                 \
+    };
 
 LAR_DL_ALGORITHM_LIST(LAR_DL_CONTENT_CREATE_ALGORITHM_FACTORY)
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-#define LAR_DL_CONTENT_CREATE_ALGORITHM_TOOL_FACTORY(a, b)                                                                         \
-class b##DL_FACTORY : public pandora::AlgorithmToolFactory                                                                         \
-{                                                                                                                               \
-public:                                                                                                                         \
-    pandora::AlgorithmTool *CreateAlgorithmTool() const {return new b;};                                                        \
-};
+#define LAR_DL_CONTENT_CREATE_ALGORITHM_TOOL_FACTORY(a, b)                                                                                 \
+    class b##DL_FACTORY : public pandora::AlgorithmToolFactory                                                                             \
+    {                                                                                                                                      \
+    public:                                                                                                                                \
+        pandora::AlgorithmTool *CreateAlgorithmTool() const                                                                                \
+        {                                                                                                                                  \
+            return new b;                                                                                                                  \
+        };                                                                                                                                 \
+    };
 
 LAR_DL_ALGORITHM_TOOL_LIST(LAR_DL_CONTENT_CREATE_ALGORITHM_TOOL_FACTORY)
 
@@ -58,19 +62,19 @@ LAR_DL_ALGORITHM_TOOL_LIST(LAR_DL_CONTENT_CREATE_ALGORITHM_TOOL_FACTORY)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-#define LAR_DL_CONTENT_REGISTER_ALGORITHM(a, b)                                                                                 \
-{                                                                                                                               \
-    const pandora::StatusCode statusCode(PandoraApi::RegisterAlgorithmFactory(pandora, a, new lar_dl_content::b##DL_FACTORY));  \
-    if (pandora::STATUS_CODE_SUCCESS != statusCode)                                                                             \
-        return statusCode;                                                                                                      \
-}
+#define LAR_DL_CONTENT_REGISTER_ALGORITHM(a, b)                                                                                            \
+    {                                                                                                                                      \
+        const pandora::StatusCode statusCode(PandoraApi::RegisterAlgorithmFactory(pandora, a, new lar_dl_content::b##DL_FACTORY));         \
+        if (pandora::STATUS_CODE_SUCCESS != statusCode)                                                                                    \
+            return statusCode;                                                                                                             \
+    }
 
-#define LAR_DL_CONTENT_REGISTER_ALGORITHM_TOOL(a, b)                                                                                \
-{                                                                                                                                   \
-    const pandora::StatusCode statusCode(PandoraApi::RegisterAlgorithmToolFactory(pandora, a, new lar_dl_content::b##DL_FACTORY));  \
-    if (pandora::STATUS_CODE_SUCCESS != statusCode)                                                                                 \
-        return statusCode;                                                                                                          \
-}
+#define LAR_DL_CONTENT_REGISTER_ALGORITHM_TOOL(a, b)                                                                                       \
+    {                                                                                                                                      \
+        const pandora::StatusCode statusCode(PandoraApi::RegisterAlgorithmToolFactory(pandora, a, new lar_dl_content::b##DL_FACTORY));     \
+        if (pandora::STATUS_CODE_SUCCESS != statusCode)                                                                                    \
+            return statusCode;                                                                                                             \
+    }
 
 pandora::StatusCode LArDLContent::RegisterAlgorithms(const pandora::Pandora &pandora)
 {
@@ -78,4 +82,3 @@ pandora::StatusCode LArDLContent::RegisterAlgorithms(const pandora::Pandora &pan
     LAR_DL_ALGORITHM_TOOL_LIST(LAR_DL_CONTENT_REGISTER_ALGORITHM_TOOL);
     return pandora::STATUS_CODE_SUCCESS;
 }
-

--- a/larpandoradlcontent/LArDLContent.h
+++ b/larpandoradlcontent/LArDLContent.h
@@ -8,7 +8,10 @@
 #ifndef LAR_DL_CONTENT_H
 #define LAR_DL_CONTENT_H 1
 
-namespace pandora { class Pandora; }
+namespace pandora
+{
+class Pandora;
+}
 
 /**
  *  @brief  LArDLContent class
@@ -25,4 +28,3 @@ public:
 };
 
 #endif // #ifndef LAR_DL_CONTENT_H
-

--- a/larpandoradlcontent/LArHelpers/LArDLHelper.cc
+++ b/larpandoradlcontent/LArHelpers/LArDLHelper.cc
@@ -44,4 +44,3 @@ void LArDLHelper::Forward(TorchModel &model, const TorchInputVector &input, Torc
 }
 
 } // namespace lar_dl_content
-

--- a/larpandoradlcontent/LArHelpers/LArDLHelper.h
+++ b/larpandoradlcontent/LArHelpers/LArDLHelper.h
@@ -58,4 +58,3 @@ public:
 } // namespace lar_dl_content
 
 #endif // #ifndef LAR_DL_HELPER_H
-

--- a/larpandoradlcontent/LArMonitoring/DlHitValidationAlgorithm.cc
+++ b/larpandoradlcontent/LArMonitoring/DlHitValidationAlgorithm.cc
@@ -21,10 +21,7 @@ using namespace lar_content;
 namespace lar_dl_content
 {
 
-DlHitValidationAlgorithm::DlHitValidationAlgorithm() :
-    m_confusionU(),
-    m_confusionV(),
-    m_confusionW()
+DlHitValidationAlgorithm::DlHitValidationAlgorithm() : m_confusionU(), m_confusionV(), m_confusionW()
 {
 }
 
@@ -49,7 +46,7 @@ DlHitValidationAlgorithm::~DlHitValidationAlgorithm()
     {
         PANDORA_MONITORING_API(SaveTree(this->GetPandora(), "confusion_tree", "confusion.root", "UPDATE"));
     }
-    catch(const StatusCodeException&)
+    catch (const StatusCodeException &)
     {
         std::cout << "DlHitValidationAlgorithm: Unable to write confusion_tree to file" << std::endl;
     }
@@ -78,8 +75,8 @@ StatusCode DlHitValidationAlgorithm::Run()
         // Turn off max photo propagation for now, only care about killing off daughters of neutrons
         parameters.m_maxPhotonPropagation = std::numeric_limits<float>::max();
         LArMCParticleHelper::MCContributionMap targetMCParticleToHitsMap;
-        LArMCParticleHelper::SelectReconstructableMCParticles(pMCParticleList, pCaloHitList, parameters,
-            LArMCParticleHelper::IsBeamNeutrinoFinalState, targetMCParticleToHitsMap);
+        LArMCParticleHelper::SelectReconstructableMCParticles(
+            pMCParticleList, pCaloHitList, parameters, LArMCParticleHelper::IsBeamNeutrinoFinalState, targetMCParticleToHitsMap);
 
         for (const CaloHit *pCaloHit : *pCaloHitList)
         {
@@ -99,7 +96,7 @@ StatusCode DlHitValidationAlgorithm::Run()
                 else
                     ++m_confusionW[truth][cls];
             }
-            catch (const StatusCodeException&)
+            catch (const StatusCodeException &)
             {
                 continue;
             }
@@ -113,8 +110,8 @@ StatusCode DlHitValidationAlgorithm::Run()
 
 StatusCode DlHitValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle,
-        "CaloHitListNames", m_caloHitListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "CaloHitListNames", m_caloHitListNames));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoradlcontent/LArMonitoring/DlHitValidationAlgorithm.h
+++ b/larpandoradlcontent/LArMonitoring/DlHitValidationAlgorithm.h
@@ -16,7 +16,7 @@ namespace lar_dl_content
 /**
  *  @brief  DlHitValidationlgorithm class
  */
-class DlHitValidationAlgorithm: public pandora::Algorithm
+class DlHitValidationAlgorithm : public pandora::Algorithm
 {
 public:
     /**
@@ -30,10 +30,10 @@ private:
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    pandora::StringVector     m_caloHitListNames;    ///< Name of input calo hit list
-    int                       m_confusionU[2][2];    ///< Confusion matrix for the U view
-    int                       m_confusionV[2][2];    ///< Confusion matrix for the V view
-    int                       m_confusionW[2][2];    ///< Confusion matrix for the W view
+    pandora::StringVector m_caloHitListNames; ///< Name of input calo hit list
+    int m_confusionU[2][2];                   ///< Confusion matrix for the U view
+    int m_confusionV[2][2];                   ///< Confusion matrix for the V view
+    int m_confusionW[2][2];                   ///< Confusion matrix for the W view
 };
 
 } // namespace lar_dl_content

--- a/larpandoradlcontent/LArTrackShowerId/DlHitTrackShowerIdAlgorithm.h
+++ b/larpandoradlcontent/LArTrackShowerId/DlHitTrackShowerIdAlgorithm.h
@@ -18,7 +18,7 @@ namespace lar_dl_content
 /**
  *  @brief  DlHitTrackShowerIdAlgorithm class
  */
-class DlHitTrackShowerIdAlgorithm: public pandora::Algorithm
+class DlHitTrackShowerIdAlgorithm : public pandora::Algorithm
 {
 public:
     /**
@@ -29,7 +29,7 @@ public:
     virtual ~DlHitTrackShowerIdAlgorithm();
 
 private:
-    typedef std::map<const pandora::CaloHit*, std::tuple<int, int, int, int>> CaloHitToPixelMap;
+    typedef std::map<const pandora::CaloHit *, std::tuple<int, int, int, int>> CaloHitToPixelMap;
     typedef std::map<int, int> PixelToTileMap;
 
     pandora::StatusCode Run();
@@ -67,19 +67,19 @@ private:
      */
     void GetSparseTileMap(const pandora::CaloHitList &caloHitList, const float xMin, const float zMin, const int nTilesX, PixelToTileMap &sparseMap);
 
-    pandora::StringVector     m_caloHitListNames;    ///< Name of input calo hit list
-    std::string               m_modelFileNameU;      ///< Model file name for U view
-    std::string               m_modelFileNameV;      ///< Model file name for V view
-    std::string               m_modelFileNameW;      ///< Model file name for W view
-    LArDLHelper::TorchModel   m_modelU;              ///< Model for the U view
-    LArDLHelper::TorchModel   m_modelV;              ///< Model for the V view
-    LArDLHelper::TorchModel   m_modelW;              ///< Model for the W view
-    int                       m_imageHeight;         ///< Height of images in pixels
-    int                       m_imageWidth;          ///< Width of images in pixels
-    float                     m_tileSize;            ///< Size of tile in cm
-    bool                      m_visualize;           ///< Whether to visualize the track shower ID scores
-    bool                      m_useTrainingMode;     ///< Training mode
-    std::string               m_trainingOutputFile;  ///< Output file name for training examples
+    pandora::StringVector m_caloHitListNames; ///< Name of input calo hit list
+    std::string m_modelFileNameU;             ///< Model file name for U view
+    std::string m_modelFileNameV;             ///< Model file name for V view
+    std::string m_modelFileNameW;             ///< Model file name for W view
+    LArDLHelper::TorchModel m_modelU;         ///< Model for the U view
+    LArDLHelper::TorchModel m_modelV;         ///< Model for the V view
+    LArDLHelper::TorchModel m_modelW;         ///< Model for the W view
+    int m_imageHeight;                        ///< Height of images in pixels
+    int m_imageWidth;                         ///< Width of images in pixels
+    float m_tileSize;                         ///< Size of tile in cm
+    bool m_visualize;                         ///< Whether to visualize the track shower ID scores
+    bool m_useTrainingMode;                   ///< Training mode
+    std::string m_trainingOutputFile;         ///< Output file name for training examples
 };
 
 } // namespace lar_dl_content


### PR DESCRIPTION
Apply the .clang-format [file](https://github.com/PandoraPFA/PandoraPFA/blob/master/.clang-format), maintained in the PandoraPFA repository, using clang 7.0.0.

To apply to all files in LArContent, can e.g. copy to top-level of repository, then, from that location:
`find ./ -iname *.h -o -iname *.cpp -o -iname *.cxx -o -iname *.cc | xargs clang-format -i -style=file`