### PR TITLE
Fix for V-shaped events in ClusterAssociationAlgorithm

### DIFF
--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterAssociationAlgorithm.h
@@ -103,13 +103,10 @@ private:
     /**
      *  @brief  Update cluster association map to reflect an ambiguous cluster merge
      *
-     *  @param  pClusterToEnlarge address of the cluster to be enlarged
-     *  @param  pClusterToDelete address of the cluster to be deleted
-     *  @param  isForwardMerge whether merge is forward (pClusterToEnlarge is forward-associated with pClusterToDelete)
+     *  @param  pCluster address of the cluster to be cleared
      *  @param  clusterAssociationMap the cluster association map
      */
-    void UpdateForAmbiguousMerge(const pandora::Cluster *const pClusterToEnlarge, const pandora::Cluster *const pClusterToDelete,
-        const bool isForwardMerge, ClusterAssociationMap &clusterAssociationMap) const;
+    void UpdateForAmbiguousMerge(const pandora::Cluster *const pCluster, ClusterAssociationMap &clusterAssociationMap) const;
 
     /**
      *  @brief  Navigate along cluster associations, from specified cluster, in specified direction


### PR DESCRIPTION
This replicates [PR 161](https://github.com/PandoraPFA/LArContent/pull/161) while accommodating the recent clang format applied across this repository. The initial summary comment for that PR is replicated below.

---

I've simplified the ClusterAssociationAlgorithm::UpdateForAmbiguousMerge(...) method so that ambiguously-merged clusters are entirely removed from the cluster association map.

Previously, the UpdateForAmbiguousMerge(...) method was more elaborate and also called the UpdateForUnambiguousMerge(...) method. I think this last part was the cause of our V-shaped events.

Although the previous implementation was more elaborate, I think the net effect was to simply remove the clusters-to-be-merged from the cluster association map. So, I've coded this in a simpler way - but I worry that I've missed something!