### PR TITLE
ShowerHierarchyMopUp algorithm

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -95,6 +95,7 @@
 #include "larpandoracontent/LArThreeDReco/LArLongitudinalTrackMatching/ThreeViewLongitudinalTracksAlgorithm.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/RecursivePfoMopUpAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerPfoMopUpAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.h"
@@ -235,6 +236,7 @@
     d("LArThreeDLongitudinalTracks",            ThreeViewLongitudinalTracksAlgorithm)                                           \
     d("LArRecursivePfoMopUp",                   RecursivePfoMopUpAlgorithm)                                                     \
     d("LArSlidingConePfoMopUp",                 SlidingConePfoMopUpAlgorithm)                                                   \
+    d("LArShowerHierarchyMopUp",                ShowerHierarchyMopUpAlgorithm)                                                  \
     d("LArShowerPfoMopUp",                      ShowerPfoMopUpAlgorithm)                                                        \
     d("LArVertexBasedPfoMopUp",                 VertexBasedPfoMopUpAlgorithm)                                                   \
     d("LArParticleRecovery",                    ParticleRecoveryAlgorithm)                                                      \

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.cc
@@ -20,7 +20,8 @@ namespace lar_content
 StatusCode ShowerHierarchyMopUpAlgorithm::Run()
 {
     const PfoList *pLeadingPfoList(nullptr);
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_leadingPfoListName, pLeadingPfoList));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_leadingPfoListName, pLeadingPfoList));
 
     if (!pLeadingPfoList || pLeadingPfoList->empty())
     {
@@ -58,7 +59,7 @@ void ShowerHierarchyMopUpAlgorithm::FindParentShowerPfos(const Pfo *const pPfo, 
 
         if (parentShowerPfos.end() != std::find(parentShowerPfos.begin(), parentShowerPfos.end(), pPfo))
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
-        
+
         parentShowerPfos.push_back(pPfo);
     }
     else
@@ -89,8 +90,7 @@ void ShowerHierarchyMopUpAlgorithm::PerformPfoMerges(const PfoList &parentShower
 
 StatusCode ShowerHierarchyMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
-        "LeadingPfoListName", m_leadingPfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "LeadingPfoListName", m_leadingPfoListName));
 
     return PfoMopUpBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.cc
@@ -1,0 +1,111 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.cc
+ *
+ *  @brief  Implementation of the shower hierarchy mop up algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+
+#include "larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+StatusCode ShowerHierarchyMopUpAlgorithm::Run()
+{
+    const PfoList *pLeadingPfoList(nullptr);
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_leadingPfoListName, pLeadingPfoList));
+
+    if (!pLeadingPfoList || pLeadingPfoList->empty())
+    {
+        if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+            std::cout << "ShowerHierarchyMopUpAlgorithm: unable to find pfos in provided list, " << m_leadingPfoListName << std::endl;
+
+        return STATUS_CODE_SUCCESS;
+    }
+
+    PfoList parentShowerPfos;
+    this->FindParentShowerPfos(pLeadingPfoList, parentShowerPfos);
+if (!parentShowerPfos.empty())
+{
+    PandoraMonitoringApi::SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1., -1., 1.);
+    PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), &parentShowerPfos, "BeforeMerge", RED, true, false);
+    PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), pLeadingPfoList, "Leading", RED, true, true);
+    PandoraMonitoringApi::ViewEvent(this->GetPandora());
+}
+    this->PerformPfoMerges(parentShowerPfos);
+if (!parentShowerPfos.empty())
+{
+    PandoraMonitoringApi::SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1., -1., 1.);
+    PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), &parentShowerPfos, "AfterMerge", GREEN, true, false);
+    PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), pLeadingPfoList, "Leading", GREEN, true, true);
+    PandoraMonitoringApi::ViewEvent(this->GetPandora());
+}
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShowerHierarchyMopUpAlgorithm::FindParentShowerPfos(const PfoList *const pLeadingPfoList, PfoList &parentShowerPfos) const
+{
+    for (const Pfo *const pLeadingPfo : *pLeadingPfoList)
+    {
+        this->FindParentShowerPfos(pLeadingPfo, parentShowerPfos);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShowerHierarchyMopUpAlgorithm::FindParentShowerPfos(const Pfo *const pPfo, PfoList &parentShowerPfos) const
+{
+    if (LArPfoHelper::IsShower(pPfo))
+    {
+        if (pPfo->GetDaughterPfoList().empty())
+            return;
+
+        if (parentShowerPfos.end() != std::find(parentShowerPfos.begin(), parentShowerPfos.end(), pPfo))
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+        
+        parentShowerPfos.push_back(pPfo);
+    }
+    else
+    {
+        for (const Pfo *const pDaughterPfo : pPfo->GetDaughterPfoList())
+            this->FindParentShowerPfos(pDaughterPfo, parentShowerPfos);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShowerHierarchyMopUpAlgorithm::PerformPfoMerges(const PfoList &parentShowerPfos) const
+{
+    for (const Pfo *const pParentShowerPfo : parentShowerPfos)
+    {
+        PfoList downstreamPfos;
+        LArPfoHelper::GetAllDownstreamPfos(pParentShowerPfo, downstreamPfos);
+
+        for (const Pfo *const pDownstreamPfo : downstreamPfos)
+        {
+            if (pDownstreamPfo != pParentShowerPfo)
+                this->MergeAndDeletePfos(pParentShowerPfo, pDownstreamPfo);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ShowerHierarchyMopUpAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle,
+        "LeadingPfoListName", m_leadingPfoListName));
+
+    return PfoMopUpBaseAlgorithm::ReadSettings(xmlHandle);
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.cc
@@ -32,21 +32,8 @@ StatusCode ShowerHierarchyMopUpAlgorithm::Run()
 
     PfoList parentShowerPfos;
     this->FindParentShowerPfos(pLeadingPfoList, parentShowerPfos);
-if (!parentShowerPfos.empty())
-{
-    PandoraMonitoringApi::SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1., -1., 1.);
-    PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), &parentShowerPfos, "BeforeMerge", RED, true, false);
-    PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), pLeadingPfoList, "Leading", RED, true, true);
-    PandoraMonitoringApi::ViewEvent(this->GetPandora());
-}
     this->PerformPfoMerges(parentShowerPfos);
-if (!parentShowerPfos.empty())
-{
-    PandoraMonitoringApi::SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1., -1., 1.);
-    PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), &parentShowerPfos, "AfterMerge", GREEN, true, false);
-    PandoraMonitoringApi::VisualizeParticleFlowObjects(this->GetPandora(), pLeadingPfoList, "Leading", GREEN, true, true);
-    PandoraMonitoringApi::ViewEvent(this->GetPandora());
-}
+
     return STATUS_CODE_SUCCESS;
 }
 

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.h
@@ -46,7 +46,7 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    std::string m_leadingPfoListName;  ///< The input leading pfo list name (e.g. list of neutrino or testbeam pfos)
+    std::string m_leadingPfoListName; ///< The input leading pfo list name (e.g. list of neutrino or testbeam pfos)
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.h
@@ -1,0 +1,54 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoMopUp/ShowerHierarchyMopUpAlgorithm.h
+ *
+ *  @brief  Header file for the shower hierarchy mop up algorithm class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_SHOWER_HIERARCHY_MOP_UP_ALGORITHM_H
+#define LAR_SHOWER_HIERARCHY_MOP_UP_ALGORITHM_H 1
+
+#include "larpandoracontent/LArUtility/PfoMopUpBaseAlgorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  ShowerHierarchyMopUpAlgorithm class
+ */
+class ShowerHierarchyMopUpAlgorithm : public PfoMopUpBaseAlgorithm
+{
+private:
+    pandora::StatusCode Run();
+
+    /**
+     *  @brief  Starting with provided leading pfos, find all shower pfos that themselves have daughter pfos
+     *
+     *  @param  pLeadingPfoList the list of leading pfos
+     *  @param  parentShowerPfos to receive the list of parent shower pfos
+     */
+    void FindParentShowerPfos(const pandora::PfoList *const pLeadingPfoList, pandora::PfoList &parentShowerPfos) const;
+
+    /**
+     *  @brief  Starting with provided pfo, find all downstream shower pfos that themselves have daughter pfos
+     *
+     *  @param  pPfo the address of a pfo
+     *  @param  parentShowerPfos to receive the list of parent shower pfos
+     */
+    void FindParentShowerPfos(const pandora::Pfo *const pLeadiPfo, pandora::PfoList &parentShowerPfos) const;
+
+    /**
+     *  @brief  For each parent shower pfo, merge all downstream pfos back into the parent shower
+     *
+     *  @param  parentShowerPfos the list of parent shower pfos
+     */
+    void PerformPfoMerges(const pandora::PfoList &parentShowerPfos) const;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    std::string m_leadingPfoListName;  ///< The input leading pfo list name (e.g. list of neutrino or testbeam pfos)
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_SHOWER_HIERARCHY_MOP_UP_ALGORITHM_H


### PR DESCRIPTION
A simple algorithm that grows any shower particles to include any particles marked as being downstream (of the shower) in the particle hierarchy. The particle growing proceeds automatically, decoupling this algorithm from the precise logic used to form the hierarchy itself.