### PR TITLE
Updates to MVA vertex selection algorithms.

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -145,6 +145,7 @@
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
 
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
+#include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/RPhiFeatureTool.h"
@@ -368,6 +369,7 @@
     d("LArTwoViewSimpleTracks",                 TwoViewSimpleTracksTool)                                                        \
     d("LArTwoViewThreeDKink",                   TwoViewThreeDKinkTool)                                                          \
     d("LArEnergyKickFeature",                   EnergyKickFeatureTool)                                                          \
+    d("LArEnergyDepositionAsymmetryFeature",    EnergyDepositionAsymmetryFeatureTool)                                           \
     d("LArGlobalAsymmetryFeature",              GlobalAsymmetryFeatureTool)                                                     \
     d("LArLocalAsymmetryFeature",               LocalAsymmetryFeatureTool)                                                      \
     d("LArRPhiFeature",                         RPhiFeatureTool)                                                                \

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -144,8 +144,8 @@
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewThreeDKinkTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
 
-#include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
 #include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
+#include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
 #include "larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/RPhiFeatureTool.h"

--- a/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
+++ b/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
@@ -63,9 +63,8 @@ void AsymmetryFeatureBaseTool::IncrementAsymmetryParameters(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-template <typename C, typename T = typename C::value_type>
 float AsymmetryFeatureBaseTool::CalculateAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
-    const C &asymmetryClusters, const CartesianVector &localWeightedDirectionSum) const
+    const ClusterVector &asymmetryClusters, const CartesianVector &localWeightedDirectionSum) const
 {
     // Project every hit onto local event axis direction and record side of the projected vtx position on which it falls
     float beforeVtxHitEnergy(0.f), afterVtxHitEnergy(0.f);
@@ -120,13 +119,5 @@ StatusCode AsymmetryFeatureBaseTool::ReadSettings(const TiXmlHandle xmlHandle)
 
     return STATUS_CODE_SUCCESS;
 }
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-template float AsymmetryFeatureBaseTool::CalculateAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
-    const ClusterVector &asymmetryClusters, const CartesianVector &localWeightedDirectionSum) const;
-
-template float AsymmetryFeatureBaseTool::CalculateAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
-    const ClusterList &asymmetryClusters, const CartesianVector &localWeightedDirectionSum) const;
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
+++ b/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
@@ -1,0 +1,132 @@
+/**
+ *  @file   larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
+ *
+ *  @brief  Implementation of the  asymmetry feature tool class.
+ *
+ *  $Log: $
+ */
+
+#include "larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h"
+#include "Pandora/AlgorithmHeaders.h"
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+AsymmetryFeatureBaseTool::AsymmetryFeatureBaseTool() : m_maxAsymmetryDistance(5.f)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void AsymmetryFeatureBaseTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+    const Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap,
+    const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
+    const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap, const float, float &)
+{
+    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    float asymmetry(0.f);
+
+    asymmetry += this->GetAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U), slidingFitDataListMap.at(TPC_VIEW_U), showerClusterListMap.at(TPC_VIEW_U));
+
+    asymmetry += this->GetAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V), slidingFitDataListMap.at(TPC_VIEW_V), showerClusterListMap.at(TPC_VIEW_V));
+
+    asymmetry += this->GetAsymmetryForView(
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W), slidingFitDataListMap.at(TPC_VIEW_W), showerClusterListMap.at(TPC_VIEW_W));
+
+    featureVector.push_back(asymmetry);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void AsymmetryFeatureBaseTool::IncrementAsymmetryParameters(
+    const float weight, const CartesianVector &clusterDirection, CartesianVector &localWeightedDirectionSum) const
+{
+    // If the new axis direction is at an angle of greater than 90 deg to the current axis direction, flip it 180 degs.
+    CartesianVector newDirection(clusterDirection);
+
+    if (localWeightedDirectionSum.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon())
+    {
+        if (localWeightedDirectionSum.GetCosOpeningAngle(clusterDirection) < 0.f)
+            newDirection *= -1.f;
+    }
+
+    localWeightedDirectionSum += newDirection * weight;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename C, typename T = typename C::value_type>
+float AsymmetryFeatureBaseTool::CalculateAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
+    const C &asymmetryClusters, const CartesianVector &localWeightedDirectionSum) const
+{
+    // Project every hit onto local event axis direction and record side of the projected vtx position on which it falls
+    float beforeVtxHitEnergy(0.f), afterVtxHitEnergy(0.f);
+    unsigned int beforeVtxHitCount(0), afterVtxHitCount(0);
+
+    const CartesianVector localWeightedDirection(localWeightedDirectionSum.GetUnitVector());
+    const float evtProjectedVtxPos(vertexPosition2D.GetDotProduct(localWeightedDirection));
+
+    for (const Cluster *const pCluster : asymmetryClusters)
+    {
+        CaloHitList caloHitList;
+        pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
+
+        CaloHitVector caloHitVector(caloHitList.begin(), caloHitList.end());
+        std::sort(caloHitVector.begin(), caloHitVector.end(), LArClusterHelper::SortHitsByPosition);
+
+        for (const CaloHit *const pCaloHit : caloHitVector)
+        {
+            if (pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection) < evtProjectedVtxPos)
+            {
+                beforeVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
+                ++beforeVtxHitCount;
+            }
+
+            else
+            {
+                afterVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
+                ++afterVtxHitCount;
+            }
+        }
+    }
+
+    // Use energy metrics if possible, otherwise fall back on hit counting.
+    const float totHitEnergy(beforeVtxHitEnergy + afterVtxHitEnergy);
+    const unsigned int totHitCount(beforeVtxHitCount + afterVtxHitCount);
+
+    if (useEnergyMetrics && (totHitEnergy > std::numeric_limits<float>::epsilon()))
+        return std::fabs((afterVtxHitEnergy - beforeVtxHitEnergy)) / totHitEnergy;
+
+    if (0 == totHitCount)
+        throw StatusCodeException(STATUS_CODE_FAILURE);
+
+    return std::fabs((static_cast<float>(afterVtxHitCount) - static_cast<float>(beforeVtxHitCount))) / static_cast<float>(totHitCount);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode AsymmetryFeatureBaseTool::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAsymmetryDistance", m_maxAsymmetryDistance));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template float AsymmetryFeatureBaseTool::CalculateAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
+    const ClusterVector &asymmetryClusters, const CartesianVector &localWeightedDirectionSum) const;
+
+template float AsymmetryFeatureBaseTool::CalculateAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
+    const ClusterList &asymmetryClusters, const CartesianVector &localWeightedDirectionSum) const;
+
+} // namespace lar_content

--- a/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
+++ b/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
@@ -32,14 +32,14 @@ void AsymmetryFeatureBaseTool::Run(LArMvaHelper::MvaFeatureVector &featureVector
 
     float asymmetry(0.f);
 
-    asymmetry += this->GetAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U), slidingFitDataListMap.at(TPC_VIEW_U), showerClusterListMap.at(TPC_VIEW_U));
+    asymmetry += this->GetAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U),
+        slidingFitDataListMap.at(TPC_VIEW_U), showerClusterListMap.at(TPC_VIEW_U));
 
-    asymmetry += this->GetAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V), slidingFitDataListMap.at(TPC_VIEW_V), showerClusterListMap.at(TPC_VIEW_V));
+    asymmetry += this->GetAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V),
+        slidingFitDataListMap.at(TPC_VIEW_V), showerClusterListMap.at(TPC_VIEW_V));
 
-    asymmetry += this->GetAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W), slidingFitDataListMap.at(TPC_VIEW_W), showerClusterListMap.at(TPC_VIEW_W));
+    asymmetry += this->GetAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W),
+        slidingFitDataListMap.at(TPC_VIEW_W), showerClusterListMap.at(TPC_VIEW_W));
 
     featureVector.push_back(asymmetry);
 }
@@ -88,7 +88,6 @@ float AsymmetryFeatureBaseTool::CalculateAsymmetry(const bool useEnergyMetrics, 
                 beforeVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
                 ++beforeVtxHitCount;
             }
-
             else
             {
                 afterVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();

--- a/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h
+++ b/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h
@@ -1,0 +1,84 @@
+/**
+ *  @file   larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h
+ *
+ *  @brief  Header file for the global asymmetry feature tool class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_ASYMMETRY_FEATURE_BASE_TOOL_H
+#define LAR_ASYMMETRY_FEATURE_BASE_TOOL_H 1
+
+#include "larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  AsymmetryFeatureBaseTool class
+ */
+class AsymmetryFeatureBaseTool : public VertexSelectionBaseAlgorithm::VertexFeatureTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    AsymmetryFeatureBaseTool();
+
+    /**
+     *  @brief  Run the tool
+     *
+     *  @param  pAlgorithm address of the calling algorithm
+     *  @param  pVertex address of the vertex
+     *  @param  slidingFitDataListMap map of the sliding fit data lists
+     *
+     *  @return the asymmetry feature
+     */
+    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const pandora::Vertex *const pVertex,
+        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
+        const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap, const float, float &);
+
+protected:
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief  Get the asymmetry feature for a given view
+     *
+     *  @param  vertexPosition2D the vertex position projected into this view
+     *  @param  slidingFitDataList the list of sliding fit data objects for this view
+     *
+     *  @return the asymmetry feature
+     */
+    virtual float GetAsymmetryForView(
+        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, 
+	const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const = 0;
+
+    /**
+     *  @brief  Increment the asymmetry parameters
+     *
+     *  @param  weight the weight to assign to this vector
+     *  @param  clusterDirection the direction of the cluster
+     *  @param  localWeightedDirectionSum the current energy-weighted local cluster direction vector
+     */
+    void IncrementAsymmetryParameters(
+        const float weight, const pandora::CartesianVector &clusterDirection, pandora::CartesianVector &localWeightedDirectionSum) const;
+
+    /**
+     *  @brief  Calculate the asymmetry feature
+     *
+     *  @param  useEnergyMetrics whether to use energy-based metrics instead of hit-counting-based metrics
+     *  @param  vertexPosition2D the vertex position in this view
+     *  @param  slidingFitDataList the list of sliding fit data objects
+     *  @param  localWeightedDirectionSum the local event axis
+     *
+     *  @return the asymmetry feature
+     */
+    template <typename C, typename T = typename C::value_type>
+    float CalculateAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
+        const C &asymmetryClusters, const pandora::CartesianVector &localWeightedDirectionSum) const;
+
+    float m_maxAsymmetryDistance; ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_ASYMMETRY_FEATURE_BASE_TOOL_H

--- a/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h
+++ b/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h
@@ -72,9 +72,8 @@ protected:
      *
      *  @return the asymmetry feature
      */
-    template <typename C, typename T = typename C::value_type>
-    float CalculateAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
-        const C &asymmetryClusters, const pandora::CartesianVector &localWeightedDirectionSum) const;
+    virtual float CalculateAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
+        const pandora::ClusterVector &asymmetryClusters, const pandora::CartesianVector &localWeightedDirectionSum) const;
 
     float m_maxAsymmetryDistance; ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
 };

--- a/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h
+++ b/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h
@@ -30,12 +30,14 @@ public:
      *  @param  pAlgorithm address of the calling algorithm
      *  @param  pVertex address of the vertex
      *  @param  slidingFitDataListMap map of the sliding fit data lists
+     *  @param  showerClusterListMap map of the shower cluster lists
      *
      *  @return the asymmetry feature
      */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const pandora::Vertex *const pVertex,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-        const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap, const float, float &);
+    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
+        const pandora::Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap,
+        const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
+        const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap, const float, float &);
 
 protected:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -45,12 +47,13 @@ protected:
      *
      *  @param  vertexPosition2D the vertex position projected into this view
      *  @param  slidingFitDataList the list of sliding fit data objects for this view
+     *  @param  showerClusterList the list of shower cluster objects for this view
      *
      *  @return the asymmetry feature
      */
-    virtual float GetAsymmetryForView(
-        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, 
-	const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const = 0;
+    virtual float GetAsymmetryForView(const pandora::CartesianVector &vertexPosition2D,
+        const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
+        const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const = 0;
 
     /**
      *  @brief  Increment the asymmetry parameters
@@ -67,7 +70,7 @@ protected:
      *
      *  @param  useEnergyMetrics whether to use energy-based metrics instead of hit-counting-based metrics
      *  @param  vertexPosition2D the vertex position in this view
-     *  @param  slidingFitDataList the list of sliding fit data objects
+     *  @param  asymmetryCluster the vector of cluster objects to be used in the asymmetry calculation
      *  @param  localWeightedDirectionSum the local event axis
      *
      *  @return the asymmetry feature

--- a/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.cc
@@ -1,0 +1,192 @@
+/**
+ *  @file   larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.cc
+ *
+ *  @brief  Implementation of the energy deposition asymmetry feature tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+EnergyDepositionAsymmetryFeatureTool::EnergyDepositionAsymmetryFeatureTool() :
+    m_maxAsymmetryDistance(5.f)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void EnergyDepositionAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const Vertex * const pVertex,
+    const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
+    const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
+{
+    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
+       std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    float dEdxAsymmetry(0.f);
+
+    dEdxAsymmetry += this->GetEnergyDepositionAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U),
+        slidingFitDataListMap.at(TPC_VIEW_U));
+
+    dEdxAsymmetry += this->GetEnergyDepositionAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V),
+        slidingFitDataListMap.at(TPC_VIEW_V));
+
+    dEdxAsymmetry += this->GetEnergyDepositionAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W),
+        slidingFitDataListMap.at(TPC_VIEW_W));
+
+    featureVector.push_back(dEdxAsymmetry);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float EnergyDepositionAsymmetryFeatureTool::GetEnergyDepositionAsymmetryForView(const CartesianVector &vertexPosition2D,
+    const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
+{
+    bool useEnergy(true);
+    CartesianVector energyWeightedDirectionSum(0.f, 0.f, 0.f), hitWeightedDirectionSum(0.f, 0.f, 0.f);
+
+    for (const VertexSelectionBaseAlgorithm::SlidingFitData &slidingFitData : slidingFitDataList)
+    {
+        const Cluster *const pCluster(slidingFitData.GetCluster());
+
+        if (pCluster->GetElectromagneticEnergy() < std::numeric_limits<float>::epsilon())
+            useEnergy = false;
+
+        const CartesianVector vertexToMinLayer(slidingFitData.GetMinLayerPosition() - vertexPosition2D);
+        const CartesianVector vertexToMaxLayer(slidingFitData.GetMaxLayerPosition() - vertexPosition2D);
+
+        const bool minLayerClosest(vertexToMinLayer.GetMagnitudeSquared() < vertexToMaxLayer.GetMagnitudeSquared());
+        const CartesianVector &clusterDirection((minLayerClosest) ? slidingFitData.GetMinLayerDirection() : slidingFitData.GetMaxLayerDirection());
+
+        if ((LArClusterHelper::GetClosestDistance(vertexPosition2D, pCluster) < m_maxAsymmetryDistance))
+        {
+            this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
+            this->IncrementAsymmetryParameters(static_cast<float>(pCluster->GetNCaloHits()), clusterDirection, hitWeightedDirectionSum);
+        }
+    }
+
+    const CartesianVector &localWeightedDirectionSum(useEnergy ? energyWeightedDirectionSum : hitWeightedDirectionSum);
+
+    if (localWeightedDirectionSum.GetMagnitudeSquared() < std::numeric_limits<float>::epsilon()){
+      return 0.f;
+    }
+
+    return this->CalculateEnergyDepositionAsymmetry(useEnergy, vertexPosition2D, slidingFitDataList, localWeightedDirectionSum);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void EnergyDepositionAsymmetryFeatureTool::IncrementAsymmetryParameters(const float weight, const CartesianVector &clusterDirection,
+    CartesianVector &localWeightedDirectionSum) const
+{
+    // If the new axis direction is at an angle of greater than 90 deg to the current axis direction, flip it 180 degs.
+    CartesianVector newDirection(clusterDirection);
+
+    if (localWeightedDirectionSum.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon())
+    {
+        if (localWeightedDirectionSum.GetCosOpeningAngle(clusterDirection) < 0.f)
+            newDirection *= -1.f;
+    }
+
+    localWeightedDirectionSum += newDirection * weight;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float EnergyDepositionAsymmetryFeatureTool::CalculateEnergyDepositionAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
+    const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, const CartesianVector &localWeightedDirectionSum) const
+{
+    // Project every hit onto local event axis direction and record side of the projected vtx position on which it falls
+    float beforeVtxHitEnergy(0.f), afterVtxHitEnergy(0.f);
+    unsigned int beforeVtxHitCount(0), afterVtxHitCount(0);
+
+    const CartesianVector localWeightedDirection(localWeightedDirectionSum.GetUnitVector());
+    const float evtProjectedVtxPos(vertexPosition2D.GetDotProduct(localWeightedDirection));
+
+    float minBeforeProjectedPos(std::numeric_limits<float>::max());
+    float maxBeforeProjectedPos(-std::numeric_limits<float>::max());
+
+    float minAfterProjectedPos(std::numeric_limits<float>::max());
+    float maxAfterProjectedPos(-std::numeric_limits<float>::max());
+
+    for (const VertexSelectionBaseAlgorithm::SlidingFitData &slidingFitData : slidingFitDataList)
+    {
+        const Cluster * const pCluster(slidingFitData.GetCluster());
+
+        CaloHitList caloHitList;
+        pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
+
+        CaloHitVector caloHitVector(caloHitList.begin(), caloHitList.end());
+        std::sort(caloHitVector.begin(), caloHitVector.end(), LArClusterHelper::SortHitsByPosition);
+
+        for (const CaloHit *const pCaloHit : caloHitVector)
+        {
+            if (pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection) < evtProjectedVtxPos)
+            {
+	      minBeforeProjectedPos = std::min(minBeforeProjectedPos, pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection));
+	      maxBeforeProjectedPos = std::max(maxBeforeProjectedPos, pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection));
+
+	      beforeVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
+	      ++beforeVtxHitCount;
+            }
+
+            else
+            {
+	      minAfterProjectedPos = std::min(minAfterProjectedPos, pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection));
+	      maxAfterProjectedPos = std::max(maxAfterProjectedPos, pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection));
+	      
+	      afterVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
+	      ++afterVtxHitCount;
+            }
+        }
+    }
+
+    // Use energy metrics if possible, otherwise fall back on hit counting.
+    const unsigned int totHitCount(beforeVtxHitCount + afterVtxHitCount);
+
+    const float beforeVtxEnergyDeposition(!std::fabs(maxBeforeProjectedPos - minBeforeProjectedPos) ? 0 : 
+					  beforeVtxHitEnergy / std::fabs(maxBeforeProjectedPos - minBeforeProjectedPos));
+
+    const float afterVtxEnergyDeposition(!std::fabs(maxAfterProjectedPos - minAfterProjectedPos) ? 0 : 
+					 afterVtxHitEnergy / std::fabs(maxAfterProjectedPos - minAfterProjectedPos));
+
+    const float totalEnergyDeposition(beforeVtxEnergyDeposition + afterVtxEnergyDeposition);
+
+    if (useEnergyMetrics && totalEnergyDeposition)
+        return std::fabs((afterVtxEnergyDeposition - beforeVtxEnergyDeposition)) / totalEnergyDeposition;
+
+    if (0 == totHitCount)
+        throw StatusCodeException(STATUS_CODE_FAILURE);
+
+    const float beforeVtxHitDeposition(!std::fabs(maxBeforeProjectedPos - minBeforeProjectedPos) ? 0 :
+				       beforeVtxHitCount / std::fabs(maxBeforeProjectedPos - minBeforeProjectedPos));
+
+    const float afterVtxHitDeposition(!std::fabs(maxAfterProjectedPos - minAfterProjectedPos) ? 0 : 
+				      afterVtxHitCount / std::fabs(maxAfterProjectedPos - minAfterProjectedPos));
+
+    const float totalHitDeposition(beforeVtxHitDeposition + afterVtxHitDeposition);
+
+    if(totalHitDeposition)
+      return std::fabs((afterVtxHitDeposition - beforeVtxHitDeposition)) / totalHitDeposition;
+
+    return 0.f;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode EnergyDepositionAsymmetryFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MaxAsymmetryDistance", m_maxAsymmetryDistance));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.cc
@@ -24,11 +24,11 @@ EnergyDepositionAsymmetryFeatureTool::EnergyDepositionAsymmetryFeatureTool() :
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 float EnergyDepositionAsymmetryFeatureTool::CalculateAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
-    const ClusterList &clusterList, const CartesianVector &localWeightedDirectionSum) const
+    const ClusterVector &clusterVector, const CartesianVector &localWeightedDirectionSum) const
 {
     // Project every hit onto local event axis direction and record side of the projected vtx position on which it falls
-    float beforeVtxHitEnergy(0.f), afterVtxHitEnergy(0.f);
-    unsigned int beforeVtxHitCount(0), afterVtxHitCount(0);
+    float beforeVtxEnergy(0.f), afterVtxEnergy(0.f);
+    unsigned int beforeVtxHits(0), afterVtxHits(0);
 
     const CartesianVector localWeightedDirection(localWeightedDirectionSum.GetUnitVector());
     const float evtProjectedVtxPos(vertexPosition2D.GetDotProduct(localWeightedDirection));
@@ -39,7 +39,7 @@ float EnergyDepositionAsymmetryFeatureTool::CalculateAsymmetry(const bool useEne
     float minAfterProjectedPos(std::numeric_limits<float>::max());
     float maxAfterProjectedPos(-std::numeric_limits<float>::max());
 
-    for (const Cluster *const pCluster : clusterList)
+    for (const Cluster *const pCluster : clusterVector)
     {
         CaloHitList caloHitList;
         pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
@@ -70,7 +70,7 @@ float EnergyDepositionAsymmetryFeatureTool::CalculateAsymmetry(const bool useEne
     }
 
     // Use energy metrics if possible, otherwise fall back on hit counting.
-    const unsigned int totHitCount(beforeVtxHitCount + afterVtxHitCount);
+    const unsigned int totalHits(beforeVtxHits + afterVtxHits);
 
     const float beforeVtxEnergyDeposition(!std::fabs(maxBeforeProjectedPos - minBeforeProjectedPos) ? 0 : 
 					  beforeVtxHitEnergy / std::fabs(maxBeforeProjectedPos - minBeforeProjectedPos));
@@ -83,7 +83,7 @@ float EnergyDepositionAsymmetryFeatureTool::CalculateAsymmetry(const bool useEne
     if (useEnergyMetrics && totalEnergyDeposition)
         return std::fabs((afterVtxEnergyDeposition - beforeVtxEnergyDeposition)) / totalEnergyDeposition;
 
-    if (0 == totHitCount)
+    if (0 == totalHits)
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
     const float beforeVtxHitDeposition(!std::fabs(maxBeforeProjectedPos - minBeforeProjectedPos) ? 0 :

--- a/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h
@@ -25,7 +25,7 @@ public:
     EnergyDepositionAsymmetryFeatureTool();
 
 private:
-    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
     /**
      *  @brief  Calculate the energy deposition asymmetry feature
@@ -38,7 +38,7 @@ private:
      *  @return the energy deposition asymmetry feature
      */
     float CalculateAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
-        const pandora::ClusterList &clusterList, const pandora::CartesianVector &localWeightedDirectionSum) const;
+        const pandora::ClusterVector &clusterVector, const pandora::CartesianVector &localWeightedDirectionSum) const override;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h
@@ -1,0 +1,80 @@
+/**
+ *  @file   larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h
+ *
+ *  @brief  Header file for the energy deposition asymmetry feature tool class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_ENERGY_DEPOSITION_ASYMMETRY_FEATURE_TOOL_H
+#define LAR_ENERGY_DEPOSITION_ASYMMETRY_FEATURE_TOOL_H 1
+
+#include "larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  EnergyDepositionAsymmetryFeatureTool class
+ */
+class EnergyDepositionAsymmetryFeatureTool : public VertexSelectionBaseAlgorithm::VertexFeatureTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    EnergyDepositionAsymmetryFeatureTool();
+
+    /**
+     *  @brief  Run the tool
+     *
+     *  @param  pAlgorithm address of the calling algorithm
+     *  @param  pVertex address of the vertex
+     *  @param  slidingFitDataListMap map of the sliding fit data lists
+     *
+     *  @return the energy deposition asymmetry feature
+     */
+    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm * const pAlgorithm, const pandora::Vertex * const pVertex,
+        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
+        const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &);
+
+private:
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief  Get the energy deposition asymmetry feature for a given view
+     *
+     *  @param  vertexPosition2D the vertex position projected into this view
+     *  @param  slidingFitDataList the list of sliding fit data objects for this view
+     *
+     *  @return the energy deposition asymmetry feature
+     */
+    float GetEnergyDepositionAsymmetryForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
+
+    /**
+     *  @brief  Increment the asymmetry parameters
+     *
+     *  @param  weight the weight to assign to this vector
+     *  @param  clusterDirection the direction of the cluster
+     *  @param  localWeightedDirectionSum the current energy-weighted local cluster direction vector
+     */
+    void IncrementAsymmetryParameters(const float weight, const pandora::CartesianVector &clusterDirection, pandora::CartesianVector &localWeightedDirectionSum) const;
+
+    /**
+     *  @brief  Calculate the energy deposition asymmetry feature
+     *
+     *  @param  useEnergyMetrics whether to use energy-based metrics instead of hit-counting-based metrics
+     *  @param  vertexPosition2D the vertex position in this view
+     *  @param  slidingFitDataList the list of sliding fit data objects
+     *  @param  localWeightedDirectionSum the local event axis
+     *
+     *  @return the energy deposition asymmetry feature
+     */
+    float CalculateEnergyDepositionAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
+        const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, const pandora::CartesianVector &localWeightedDirectionSum) const;
+
+    float     m_maxAsymmetryDistance;    ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_ENERGY_DEPOSITION_ASYMMETRY_FEATURE_TOOL_H

--- a/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h
@@ -8,7 +8,7 @@
 #ifndef LAR_ENERGY_DEPOSITION_ASYMMETRY_FEATURE_TOOL_H
 #define LAR_ENERGY_DEPOSITION_ASYMMETRY_FEATURE_TOOL_H 1
 
-#include "larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h"
+#include "larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h"
 
 namespace lar_content
 {
@@ -16,7 +16,7 @@ namespace lar_content
 /**
  *  @brief  EnergyDepositionAsymmetryFeatureTool class
  */
-class EnergyDepositionAsymmetryFeatureTool : public VertexSelectionBaseAlgorithm::VertexFeatureTool
+class EnergyDepositionAsymmetryFeatureTool : public GlobalAsymmetryFeatureTool
 {
 public:
     /**
@@ -24,40 +24,8 @@ public:
      */
     EnergyDepositionAsymmetryFeatureTool();
 
-    /**
-     *  @brief  Run the tool
-     *
-     *  @param  pAlgorithm address of the calling algorithm
-     *  @param  pVertex address of the vertex
-     *  @param  slidingFitDataListMap map of the sliding fit data lists
-     *
-     *  @return the energy deposition asymmetry feature
-     */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm * const pAlgorithm, const pandora::Vertex * const pVertex,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-        const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &);
-
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
-
-    /**
-     *  @brief  Get the energy deposition asymmetry feature for a given view
-     *
-     *  @param  vertexPosition2D the vertex position projected into this view
-     *  @param  slidingFitDataList the list of sliding fit data objects for this view
-     *
-     *  @return the energy deposition asymmetry feature
-     */
-    float GetEnergyDepositionAsymmetryForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
-
-    /**
-     *  @brief  Increment the asymmetry parameters
-     *
-     *  @param  weight the weight to assign to this vector
-     *  @param  clusterDirection the direction of the cluster
-     *  @param  localWeightedDirectionSum the current energy-weighted local cluster direction vector
-     */
-    void IncrementAsymmetryParameters(const float weight, const pandora::CartesianVector &clusterDirection, pandora::CartesianVector &localWeightedDirectionSum) const;
 
     /**
      *  @brief  Calculate the energy deposition asymmetry feature
@@ -69,10 +37,8 @@ private:
      *
      *  @return the energy deposition asymmetry feature
      */
-    float CalculateEnergyDepositionAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, const pandora::CartesianVector &localWeightedDirectionSum) const;
-
-    float     m_maxAsymmetryDistance;    ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
+    float CalculateAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
+        const pandora::ClusterList &clusterList, const pandora::CartesianVector &localWeightedDirectionSum) const;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
@@ -16,45 +16,25 @@ using namespace pandora;
 namespace lar_content
 {
 
-GlobalAsymmetryFeatureTool::GlobalAsymmetryFeatureTool() : m_maxAsymmetryDistance(5.f)
+GlobalAsymmetryFeatureTool::GlobalAsymmetryFeatureTool() :   AsymmetryFeatureBaseTool()
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void GlobalAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
-    const Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap,
-    const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
-    const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
-{
-    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
-
-    float globalAsymmetry(0.f);
-
-    globalAsymmetry += this->GetGlobalAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U), slidingFitDataListMap.at(TPC_VIEW_U));
-
-    globalAsymmetry += this->GetGlobalAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V), slidingFitDataListMap.at(TPC_VIEW_V));
-
-    globalAsymmetry += this->GetGlobalAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W), slidingFitDataListMap.at(TPC_VIEW_W));
-
-    featureVector.push_back(globalAsymmetry);
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-float GlobalAsymmetryFeatureTool::GetGlobalAsymmetryForView(
-    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
+float GlobalAsymmetryFeatureTool::GetAsymmetryForView(
+    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, 
+    const VertexSelectionBaseAlgorithm::ShowerClusterList &) const
 {
     bool useEnergy(true);
     CartesianVector energyWeightedDirectionSum(0.f, 0.f, 0.f), hitWeightedDirectionSum(0.f, 0.f, 0.f);
+    ClusterVector asymmetryClusters;
 
     for (const VertexSelectionBaseAlgorithm::SlidingFitData &slidingFitData : slidingFitDataList)
     {
         const Cluster *const pCluster(slidingFitData.GetCluster());
+
+	asymmetryClusters.push_back(pCluster);
 
         if (pCluster->GetElectromagneticEnergy() < std::numeric_limits<float>::epsilon())
             useEnergy = false;
@@ -69,7 +49,7 @@ float GlobalAsymmetryFeatureTool::GetGlobalAsymmetryForView(
         {
             this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
             this->IncrementAsymmetryParameters(static_cast<float>(pCluster->GetNCaloHits()), clusterDirection, hitWeightedDirectionSum);
-        }
+	}
     }
 
     const CartesianVector &localWeightedDirectionSum(useEnergy ? energyWeightedDirectionSum : hitWeightedDirectionSum);
@@ -77,85 +57,12 @@ float GlobalAsymmetryFeatureTool::GetGlobalAsymmetryForView(
     if (localWeightedDirectionSum.GetMagnitudeSquared() < std::numeric_limits<float>::epsilon())
         return 0.f;
 
-    return this->CalculateGlobalAsymmetry(useEnergy, vertexPosition2D, slidingFitDataList, localWeightedDirectionSum);
+    return this->CalculateAsymmetry(useEnergy, vertexPosition2D, asymmetryClusters, localWeightedDirectionSum);
 }
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-void GlobalAsymmetryFeatureTool::IncrementAsymmetryParameters(
-    const float weight, const CartesianVector &clusterDirection, CartesianVector &localWeightedDirectionSum) const
-{
-    // If the new axis direction is at an angle of greater than 90 deg to the current axis direction, flip it 180 degs.
-    CartesianVector newDirection(clusterDirection);
-
-    if (localWeightedDirectionSum.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon())
-    {
-        if (localWeightedDirectionSum.GetCosOpeningAngle(clusterDirection) < 0.f)
-            newDirection *= -1.f;
-    }
-
-    localWeightedDirectionSum += newDirection * weight;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-float GlobalAsymmetryFeatureTool::CalculateGlobalAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
-    const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, const CartesianVector &localWeightedDirectionSum) const
-{
-    // Project every hit onto local event axis direction and record side of the projected vtx position on which it falls
-    float beforeVtxHitEnergy(0.f), afterVtxHitEnergy(0.f);
-    unsigned int beforeVtxHitCount(0), afterVtxHitCount(0);
-
-    const CartesianVector localWeightedDirection(localWeightedDirectionSum.GetUnitVector());
-    const float evtProjectedVtxPos(vertexPosition2D.GetDotProduct(localWeightedDirection));
-
-    for (const VertexSelectionBaseAlgorithm::SlidingFitData &slidingFitData : slidingFitDataList)
-    {
-        const Cluster *const pCluster(slidingFitData.GetCluster());
-
-        CaloHitList caloHitList;
-        pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
-
-        CaloHitVector caloHitVector(caloHitList.begin(), caloHitList.end());
-        std::sort(caloHitVector.begin(), caloHitVector.end(), LArClusterHelper::SortHitsByPosition);
-
-        for (const CaloHit *const pCaloHit : caloHitVector)
-        {
-            if (pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection) < evtProjectedVtxPos)
-            {
-                beforeVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
-                ++beforeVtxHitCount;
-            }
-
-            else
-            {
-                afterVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
-                ++afterVtxHitCount;
-            }
-        }
-    }
-
-    // Use energy metrics if possible, otherwise fall back on hit counting.
-    const float totHitEnergy(beforeVtxHitEnergy + afterVtxHitEnergy);
-    const unsigned int totHitCount(beforeVtxHitCount + afterVtxHitCount);
-
-    if (useEnergyMetrics)
-        return std::fabs((afterVtxHitEnergy - beforeVtxHitEnergy)) / totHitEnergy;
-
-    if (0 == totHitCount)
-        throw StatusCodeException(STATUS_CODE_FAILURE);
-
-    return std::fabs((static_cast<float>(afterVtxHitCount) - static_cast<float>(beforeVtxHitCount))) / static_cast<float>(totHitCount);
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode GlobalAsymmetryFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAsymmetryDistance", m_maxAsymmetryDistance));
-
-    return STATUS_CODE_SUCCESS;
+  return AsymmetryFeatureBaseTool::ReadSettings(xmlHandle);
 }
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.cc
@@ -16,15 +16,14 @@ using namespace pandora;
 namespace lar_content
 {
 
-GlobalAsymmetryFeatureTool::GlobalAsymmetryFeatureTool() :   AsymmetryFeatureBaseTool()
+GlobalAsymmetryFeatureTool::GlobalAsymmetryFeatureTool() : AsymmetryFeatureBaseTool()
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float GlobalAsymmetryFeatureTool::GetAsymmetryForView(
-    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, 
-    const VertexSelectionBaseAlgorithm::ShowerClusterList &) const
+float GlobalAsymmetryFeatureTool::GetAsymmetryForView(const CartesianVector &vertexPosition2D,
+    const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, const VertexSelectionBaseAlgorithm::ShowerClusterList &) const
 {
     bool useEnergy(true);
     CartesianVector energyWeightedDirectionSum(0.f, 0.f, 0.f), hitWeightedDirectionSum(0.f, 0.f, 0.f);
@@ -34,7 +33,7 @@ float GlobalAsymmetryFeatureTool::GetAsymmetryForView(
     {
         const Cluster *const pCluster(slidingFitData.GetCluster());
 
-	asymmetryClusters.push_back(pCluster);
+        asymmetryClusters.push_back(pCluster);
 
         if (pCluster->GetElectromagneticEnergy() < std::numeric_limits<float>::epsilon())
             useEnergy = false;
@@ -49,7 +48,7 @@ float GlobalAsymmetryFeatureTool::GetAsymmetryForView(
         {
             this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
             this->IncrementAsymmetryParameters(static_cast<float>(pCluster->GetNCaloHits()), clusterDirection, hitWeightedDirectionSum);
-	}
+        }
     }
 
     const CartesianVector &localWeightedDirectionSum(useEnergy ? energyWeightedDirectionSum : hitWeightedDirectionSum);
@@ -62,7 +61,7 @@ float GlobalAsymmetryFeatureTool::GetAsymmetryForView(
 
 StatusCode GlobalAsymmetryFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
-  return AsymmetryFeatureBaseTool::ReadSettings(xmlHandle);
+    return AsymmetryFeatureBaseTool::ReadSettings(xmlHandle);
 }
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h
@@ -36,9 +36,8 @@ private:
      *
      *  @return the global asymmetry feature
      */
-    float GetAsymmetryForView(
-	const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
-	const VertexSelectionBaseAlgorithm::ShowerClusterList &) const override;
+    float GetAsymmetryForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
+        const VertexSelectionBaseAlgorithm::ShowerClusterList &) const override;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h
@@ -8,7 +8,7 @@
 #ifndef LAR_GLOBAL_ASYMMETRY_FEATURE_TOOL_H
 #define LAR_GLOBAL_ASYMMETRY_FEATURE_TOOL_H 1
 
-#include "larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h"
+#include "larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h"
 
 namespace lar_content
 {
@@ -16,7 +16,7 @@ namespace lar_content
 /**
  *  @brief  GlobalAsymmetryFeatureTool class
  */
-class GlobalAsymmetryFeatureTool : public VertexSelectionBaseAlgorithm::VertexFeatureTool
+class GlobalAsymmetryFeatureTool : public AsymmetryFeatureBaseTool
 {
 public:
     /**
@@ -24,22 +24,10 @@ public:
      */
     GlobalAsymmetryFeatureTool();
 
-    /**
-     *  @brief  Run the tool
-     *
-     *  @param  pAlgorithm address of the calling algorithm
-     *  @param  pVertex address of the vertex
-     *  @param  slidingFitDataListMap map of the sliding fit data lists
-     *
-     *  @return the global asymmetry feature
-     */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const pandora::Vertex *const pVertex,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-        const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &);
-
-private:
+protected:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
+private:
     /**
      *  @brief  Get the global asymmetry feature for a given view
      *
@@ -48,33 +36,9 @@ private:
      *
      *  @return the global asymmetry feature
      */
-    float GetGlobalAsymmetryForView(
-        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
-
-    /**
-     *  @brief  Increment the asymmetry parameters
-     *
-     *  @param  weight the weight to assign to this vector
-     *  @param  clusterDirection the direction of the cluster
-     *  @param  localWeightedDirectionSum the current energy-weighted local cluster direction vector
-     */
-    void IncrementAsymmetryParameters(
-        const float weight, const pandora::CartesianVector &clusterDirection, pandora::CartesianVector &localWeightedDirectionSum) const;
-
-    /**
-     *  @brief  Calculate the global asymmetry feature
-     *
-     *  @param  useEnergyMetrics whether to use energy-based metrics instead of hit-counting-based metrics
-     *  @param  vertexPosition2D the vertex position in this view
-     *  @param  slidingFitDataList the list of sliding fit data objects
-     *  @param  localWeightedDirectionSum the local event axis
-     *
-     *  @return the global asymmetry feature
-     */
-    float CalculateGlobalAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, const pandora::CartesianVector &localWeightedDirectionSum) const;
-
-    float m_maxAsymmetryDistance; ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
+    float GetAsymmetryForView(
+        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
+	const VertexSelectionBaseAlgorithm::ShowerClusterList &) const;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h
@@ -25,7 +25,7 @@ public:
     GlobalAsymmetryFeatureTool();
 
 protected:
-    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
 private:
     /**
@@ -37,8 +37,8 @@ private:
      *  @return the global asymmetry feature
      */
     float GetAsymmetryForView(
-        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
-	const VertexSelectionBaseAlgorithm::ShowerClusterList &) const;
+	const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
+	const VertexSelectionBaseAlgorithm::ShowerClusterList &) const override;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
@@ -26,9 +26,8 @@ LocalAsymmetryFeatureTool::LocalAsymmetryFeatureTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float LocalAsymmetryFeatureTool::GetAsymmetryForView(
-    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, 
-    const VertexSelectionBaseAlgorithm::ShowerClusterList &) const
+float LocalAsymmetryFeatureTool::GetAsymmetryForView(const CartesianVector &vertexPosition2D,
+    const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, const VertexSelectionBaseAlgorithm::ShowerClusterList &) const
 {
     bool useEnergy(true), useAsymmetry(true);
     CartesianVector energyWeightedDirectionSum(0.f, 0.f, 0.f), hitWeightedDirectionSum(0.f, 0.f, 0.f);
@@ -49,10 +48,10 @@ float LocalAsymmetryFeatureTool::GetAsymmetryForView(
 
         if (useAsymmetry && (LArClusterHelper::GetClosestDistance(vertexPosition2D, pCluster) < m_maxAsymmetryDistance))
         {
-  	    useAsymmetry &= this->CheckAngle(energyWeightedDirectionSum,clusterDirection);
-	    this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
-	  
-	    useAsymmetry &= this->CheckAngle(hitWeightedDirectionSum,clusterDirection);
+            useAsymmetry &= this->CheckAngle(energyWeightedDirectionSum, clusterDirection);
+            this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
+
+            useAsymmetry &= this->CheckAngle(hitWeightedDirectionSum, clusterDirection);
             this->IncrementAsymmetryParameters(static_cast<float>(pCluster->GetNCaloHits()), clusterDirection, hitWeightedDirectionSum);
 
             asymmetryClusters.push_back(pCluster);
@@ -78,11 +77,11 @@ float LocalAsymmetryFeatureTool::GetAsymmetryForView(
 
 bool LocalAsymmetryFeatureTool::CheckAngle(const CartesianVector &weightedDirectionSum, const CartesianVector &clusterDirection) const
 {
-  if (!(weightedDirectionSum.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()))
-    return true;
+    if (!(weightedDirectionSum.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()))
+        return true;
 
-  const float cosOpeningAngle(weightedDirectionSum.GetCosOpeningAngle(clusterDirection));
-  return std::fabs(cosOpeningAngle) > m_minAsymmetryCosAngle;
+    const float cosOpeningAngle(weightedDirectionSum.GetCosOpeningAngle(clusterDirection));
+    return std::fabs(cosOpeningAngle) > m_minAsymmetryCosAngle;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.cc
@@ -9,7 +9,6 @@
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
-#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 #include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 
@@ -19,7 +18,7 @@ namespace lar_content
 {
 
 LocalAsymmetryFeatureTool::LocalAsymmetryFeatureTool() :
-    m_maxAsymmetryDistance(5.f),
+    AsymmetryFeatureBaseTool(),
     m_minAsymmetryCosAngle(0.9962),
     m_maxAsymmetryNClusters(2)
 {
@@ -27,32 +26,9 @@ LocalAsymmetryFeatureTool::LocalAsymmetryFeatureTool() :
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LocalAsymmetryFeatureTool::Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
-    const Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap,
-    const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
-    const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &)
-{
-    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
-        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
-
-    float localAsymmetry(0.f);
-
-    localAsymmetry += this->GetLocalAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U), slidingFitDataListMap.at(TPC_VIEW_U));
-
-    localAsymmetry += this->GetLocalAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V), slidingFitDataListMap.at(TPC_VIEW_V));
-
-    localAsymmetry += this->GetLocalAsymmetryForView(
-        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W), slidingFitDataListMap.at(TPC_VIEW_W));
-
-    featureVector.push_back(localAsymmetry);
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(
-    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const
+float LocalAsymmetryFeatureTool::GetAsymmetryForView(
+    const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList, 
+    const VertexSelectionBaseAlgorithm::ShowerClusterList &) const
 {
     bool useEnergy(true), useAsymmetry(true);
     CartesianVector energyWeightedDirectionSum(0.f, 0.f, 0.f), hitWeightedDirectionSum(0.f, 0.f, 0.f);
@@ -73,8 +49,12 @@ float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(
 
         if (useAsymmetry && (LArClusterHelper::GetClosestDistance(vertexPosition2D, pCluster) < m_maxAsymmetryDistance))
         {
-            useAsymmetry &= this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
-            useAsymmetry &= this->IncrementAsymmetryParameters(static_cast<float>(pCluster->GetNCaloHits()), clusterDirection, hitWeightedDirectionSum);
+  	    useAsymmetry &= this->CheckAngle(energyWeightedDirectionSum,clusterDirection);
+	    this->IncrementAsymmetryParameters(pCluster->GetElectromagneticEnergy(), clusterDirection, energyWeightedDirectionSum);
+	  
+	    useAsymmetry &= this->CheckAngle(hitWeightedDirectionSum,clusterDirection);
+            this->IncrementAsymmetryParameters(static_cast<float>(pCluster->GetNCaloHits()), clusterDirection, hitWeightedDirectionSum);
+
             asymmetryClusters.push_back(pCluster);
         }
 
@@ -87,86 +67,22 @@ float LocalAsymmetryFeatureTool::GetLocalAsymmetryForView(
         (!useEnergy && hitWeightedDirectionSum == CartesianVector(0.f, 0.f, 0.f)))
         return 1.f;
 
-    const CartesianVector &localWeightedDirectionSum(useEnergy ? energyWeightedDirectionSum : hitWeightedDirectionSum);
-    return this->CalculateLocalAsymmetry(useEnergy, vertexPosition2D, asymmetryClusters, localWeightedDirectionSum);
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-bool LocalAsymmetryFeatureTool::IncrementAsymmetryParameters(
-    const float weight, const CartesianVector &clusterDirection, CartesianVector &localWeightedDirectionSum) const
-{
-    // If the new axis direction is at an angle of greater than 90 deg to the current axis direction, flip it 180 degs.
-    CartesianVector newDirection(clusterDirection);
-
-    if (localWeightedDirectionSum.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon())
-    {
-        const float cosOpeningAngle(localWeightedDirectionSum.GetCosOpeningAngle(clusterDirection));
-
-        if (std::fabs(cosOpeningAngle) > m_minAsymmetryCosAngle)
-        {
-            if (cosOpeningAngle < 0.f)
-                newDirection *= -1.f;
-        }
-
-        else
-            return false;
-    }
-
-    localWeightedDirectionSum += newDirection * weight;
-    return true;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-float LocalAsymmetryFeatureTool::CalculateLocalAsymmetry(const bool useEnergyMetrics, const CartesianVector &vertexPosition2D,
-    const ClusterVector &asymmetryClusters, const CartesianVector &localWeightedDirectionSum) const
-{
     if (asymmetryClusters.empty() || (asymmetryClusters.size() > m_maxAsymmetryNClusters))
         return 1.f;
 
-    // Project every hit onto local event axis direction and record side of the projected vtx position on which it falls
-    float beforeVtxHitEnergy(0.f), afterVtxHitEnergy(0.f);
-    unsigned int beforeVtxHitCount(0), afterVtxHitCount(0);
+    const CartesianVector &localWeightedDirectionSum(useEnergy ? energyWeightedDirectionSum : hitWeightedDirectionSum);
+    return this->CalculateAsymmetry(useEnergy, vertexPosition2D, asymmetryClusters, localWeightedDirectionSum);
+}
 
-    const CartesianVector localWeightedDirection(localWeightedDirectionSum.GetUnitVector());
-    const float evtProjectedVtxPos(vertexPosition2D.GetDotProduct(localWeightedDirection));
+//------------------------------------------------------------------------------------------------------------------------------------------
 
-    for (const Cluster *const pCluster : asymmetryClusters)
-    {
-        CaloHitList caloHitList;
-        pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
+bool LocalAsymmetryFeatureTool::CheckAngle(const CartesianVector &weightedDirectionSum, const CartesianVector &clusterDirection) const
+{
+  if (!(weightedDirectionSum.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()))
+    return true;
 
-        CaloHitVector caloHitVector(caloHitList.begin(), caloHitList.end());
-        std::sort(caloHitVector.begin(), caloHitVector.end(), LArClusterHelper::SortHitsByPosition);
-
-        for (const CaloHit *const pCaloHit : caloHitVector)
-        {
-            if (pCaloHit->GetPositionVector().GetDotProduct(localWeightedDirection) < evtProjectedVtxPos)
-            {
-                beforeVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
-                ++beforeVtxHitCount;
-            }
-
-            else
-            {
-                afterVtxHitEnergy += pCaloHit->GetElectromagneticEnergy();
-                ++afterVtxHitCount;
-            }
-        }
-    }
-
-    // Use energy metrics if possible, otherwise fall back on hit counting.
-    const float totHitEnergy(afterVtxHitEnergy + beforeVtxHitEnergy);
-    const unsigned int totHitCount(beforeVtxHitCount + afterVtxHitCount);
-
-    if (useEnergyMetrics && (totHitEnergy > std::numeric_limits<float>::epsilon()))
-        return std::fabs((afterVtxHitEnergy - beforeVtxHitEnergy)) / totHitEnergy;
-
-    if (0 == totHitCount)
-        throw StatusCodeException(STATUS_CODE_FAILURE);
-
-    return std::fabs((static_cast<float>(afterVtxHitCount) - static_cast<float>(beforeVtxHitCount))) / static_cast<float>(totHitCount);
+  const float cosOpeningAngle(weightedDirectionSum.GetCosOpeningAngle(clusterDirection));
+  return std::fabs(cosOpeningAngle) > m_minAsymmetryCosAngle;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -174,15 +90,12 @@ float LocalAsymmetryFeatureTool::CalculateLocalAsymmetry(const bool useEnergyMet
 StatusCode LocalAsymmetryFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAsymmetryDistance", m_maxAsymmetryDistance));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinAsymmetryCosAngle", m_minAsymmetryCosAngle));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAsymmetryNClusters", m_maxAsymmetryNClusters));
 
-    return STATUS_CODE_SUCCESS;
+    return AsymmetryFeatureBaseTool::ReadSettings(xmlHandle);
 }
 
 } // namespace lar_content

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h
@@ -25,7 +25,7 @@ public:
     LocalAsymmetryFeatureTool();
 
 private:
-    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
     /**
      *  @brief  Get the local asymmetry feature in a given view
@@ -36,9 +36,17 @@ private:
      *  @return the local asymmetry feature
      */
     float GetAsymmetryForView(
-        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
-	const VertexSelectionBaseAlgorithm::ShowerClusterList &) const;
+	const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
+	const VertexSelectionBaseAlgorithm::ShowerClusterList &) const override;
 
+    /**
+     *  @brief  Check whether a cluster's direction agrees with the current weighted direction
+     *
+     *  @param  weightedDirectionSum the current weighted direction
+     *  @param  clusterDirection the cluster's direction
+     *
+     *  @return boolean
+     */
     bool CheckAngle(const pandora::CartesianVector &weightedDirectionSum, const pandora::CartesianVector &clusterDirection) const;
 
     float m_minAsymmetryCosAngle;         ///< The min opening angle cosine used to determine viability of asymmetry score

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h
@@ -35,9 +35,8 @@ private:
      *
      *  @return the local asymmetry feature
      */
-    float GetAsymmetryForView(
-	const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
-	const VertexSelectionBaseAlgorithm::ShowerClusterList &) const override;
+    float GetAsymmetryForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
+        const VertexSelectionBaseAlgorithm::ShowerClusterList &) const override;
 
     /**
      *  @brief  Check whether a cluster's direction agrees with the current weighted direction

--- a/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h
@@ -8,7 +8,7 @@
 #ifndef LAR_LOCAL_ASYMMETRY_FEATURE_TOOL_H
 #define LAR_LOCAL_ASYMMETRY_FEATURE_TOOL_H 1
 
-#include "larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h"
+#include "larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h"
 
 namespace lar_content
 {
@@ -16,26 +16,13 @@ namespace lar_content
 /**
  *  @brief  LocalAsymmetryFeatureTool class
  */
-class LocalAsymmetryFeatureTool : public VertexSelectionBaseAlgorithm::VertexFeatureTool
+class LocalAsymmetryFeatureTool : public AsymmetryFeatureBaseTool
 {
 public:
     /**
      *  @brief  Default constructor
      */
     LocalAsymmetryFeatureTool();
-
-    /**
-     *  @brief  Run the tool
-     *
-     *  @param  pAlgorithm address of the calling algorithm
-     *  @param  pVertex address of the vertex
-     *  @param  slidingFitDataListMap map of the sliding fit data lists
-     *
-     *  @return the energy kick feature
-     */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm, const pandora::Vertex *const pVertex,
-        const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &slidingFitDataListMap, const VertexSelectionBaseAlgorithm::ClusterListMap &,
-        const VertexSelectionBaseAlgorithm::KDTreeMap &, const VertexSelectionBaseAlgorithm::ShowerClusterListMap &, const float, float &);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -48,35 +35,12 @@ private:
      *
      *  @return the local asymmetry feature
      */
-    float GetLocalAsymmetryForView(
-        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList) const;
+    float GetAsymmetryForView(
+        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &slidingFitDataList,
+	const VertexSelectionBaseAlgorithm::ShowerClusterList &) const;
 
-    /**
-     *  @brief  Increment the asymmetry parameters
-     *
-     *  @param  weight the weight for the increment
-     *  @param  clusterDirection the cluster direction
-     *  @param  localWeightedDirectionSum the current value of the vector
-     *
-     *  @return whether the energy asymmetry score is still viable
-     */
-    bool IncrementAsymmetryParameters(
-        const float weight, const pandora::CartesianVector &clusterDirection, pandora::CartesianVector &localWeightedDirectionSum) const;
+    bool CheckAngle(const pandora::CartesianVector &weightedDirectionSum, const pandora::CartesianVector &clusterDirection) const;
 
-    /**
-     *  @brief  Calculate the local asymmetry feature
-     *
-     *  @param  useEnergyMetrics whether to use energy-based rather than hit-counting-based metrics
-     *  @param  vertexPosition2D the vertex position
-     *  @param  asymmetryClusters the clusters to use to calculate the asymmetry
-     *  @param  localWeightedDirectionSum the local event axis
-     *
-     *  @return the local asymmetry feature
-     */
-    float CalculateLocalAsymmetry(const bool useEnergyMetrics, const pandora::CartesianVector &vertexPosition2D,
-        const pandora::ClusterVector &asymmetryClusters, const pandora::CartesianVector &localWeightedDirectionSum) const;
-
-    float m_maxAsymmetryDistance;         ///< The max distance between cluster (any hit) and vertex to calculate asymmetry score
     float m_minAsymmetryCosAngle;         ///< The min opening angle cosine used to determine viability of asymmetry score
     unsigned int m_maxAsymmetryNClusters; ///< The max number of associated clusters to calculate the asymmetry
 };

--- a/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.cc
@@ -114,7 +114,8 @@ void MvaVertexSelectionAlgorithm<T>::GetVertexScoreList(const VertexVector &vert
         if (!regionalVertices.empty())
         {
             // Use mva to choose the vertex and then fine-tune using the RPhi score.
-	    const Vertex *const pBestVertex(this->CompareVertices(regionalVertices, vertexFeatureInfoMap, eventFeatureList, kdTreeMap, m_mvaVertex, true));
+            const Vertex *const pBestVertex(
+                this->CompareVertices(regionalVertices, vertexFeatureInfoMap, eventFeatureList, kdTreeMap, m_mvaVertex, true));
             this->PopulateFinalVertexScoreList(vertexFeatureInfoMap, pBestVertex, vertexVector, vertexScoreList);
         }
     }
@@ -123,8 +124,8 @@ void MvaVertexSelectionAlgorithm<T>::GetVertexScoreList(const VertexVector &vert
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-const pandora::Vertex *MvaVertexSelectionAlgorithm<T>::CompareVertices(const VertexVector &vertexVector,
-    const VertexFeatureInfoMap &vertexFeatureInfoMap, const LArMvaHelper::MvaFeatureVector &eventFeatureList, const KDTreeMap &kdTreeMap, const T &t, const bool useRPhi) const
+const pandora::Vertex *MvaVertexSelectionAlgorithm<T>::CompareVertices(const VertexVector &vertexVector, const VertexFeatureInfoMap &vertexFeatureInfoMap,
+    const LArMvaHelper::MvaFeatureVector &eventFeatureList, const KDTreeMap &kdTreeMap, const T &t, const bool useRPhi) const
 {
     const Vertex *pBestVertex(vertexVector.front());
     LArMvaHelper::MvaFeatureVector chosenFeatureList;
@@ -141,28 +142,28 @@ const pandora::Vertex *MvaVertexSelectionAlgorithm<T>::CompareVertices(const Ver
         VertexFeatureInfo vertexFeatureInfo(vertexFeatureInfoMap.at(pVertex));
         this->AddVertexFeaturesToVector(vertexFeatureInfo, featureList, useRPhi);
 
-	if(!m_legacyVariables)
-	  {
-	    LArMvaHelper::MvaFeatureVector sharedFeatureList;
-	    float separation(0.f), axisHits(0.f);
-	    this->GetSharedFeatures(pVertex,pBestVertex,kdTreeMap,separation,axisHits);
-	    VertexSharedFeatureInfo sharedFeatureInfo(separation,axisHits);
-	    this->AddSharedFeaturesToVector(sharedFeatureInfo,sharedFeatureList);
-	  
-	    if (LArMvaHelper::Classify(t, eventFeatureList, featureList, chosenFeatureList, sharedFeatureList))
-	      {
-		pBestVertex = pVertex;
-		chosenFeatureList = featureList;
-	      }
-	  }
-	else
-	  {
-	    if (LArMvaHelper::Classify(t, eventFeatureList, featureList, chosenFeatureList))
-	      {
-		pBestVertex = pVertex;
-		chosenFeatureList = featureList;
-	      }
-	  }
+        if (!m_legacyVariables)
+        {
+            LArMvaHelper::MvaFeatureVector sharedFeatureList;
+            float separation(0.f), axisHits(0.f);
+            this->GetSharedFeatures(pVertex, pBestVertex, kdTreeMap, separation, axisHits);
+            VertexSharedFeatureInfo sharedFeatureInfo(separation, axisHits);
+            this->AddSharedFeaturesToVector(sharedFeatureInfo, sharedFeatureList);
+
+            if (LArMvaHelper::Classify(t, eventFeatureList, featureList, chosenFeatureList, sharedFeatureList))
+            {
+                pBestVertex = pVertex;
+                chosenFeatureList = featureList;
+            }
+        }
+        else
+        {
+            if (LArMvaHelper::Classify(t, eventFeatureList, featureList, chosenFeatureList))
+            {
+                pBestVertex = pVertex;
+                chosenFeatureList = featureList;
+            }
+        }
     }
 
     return pBestVertex;

--- a/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.h
@@ -65,13 +65,14 @@ private:
      *  @param  vertexVector the vector of vertices
      *  @param  vertexFeatureInfoMap the vertex feature info map
      *  @param  eventFeatureList the event feature list
+     *  @param  kdTreeMap the map of 2D hit kd trees
      *  @param  t the mva
      *  @param  useRPhi whether to include the r/phi feature
      *
      *  @return address of the best vertex
      */
     const pandora::Vertex *CompareVertices(const pandora::VertexVector &vertexVector, const VertexFeatureInfoMap &vertexFeatureInfoMap,
-        const LArMvaHelper::MvaFeatureVector &eventFeatureList, const T &t, const bool useRPhi) const;
+        const LArMvaHelper::MvaFeatureVector &eventFeatureList, const KDTreeMap &kdTreeMap, const T &t, const bool useRPhi) const;
 
     std::string m_filePathEnvironmentVariable; ///< The environment variable providing a list of paths to mva files
     std::string m_mvaFileName;                 ///< The mva file name

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
@@ -16,17 +16,14 @@ using namespace pandora;
 namespace lar_content
 {
 
-ShowerAsymmetryFeatureTool::ShowerAsymmetryFeatureTool() : 
-  AsymmetryFeatureBaseTool(),
-  m_vertexClusterDistance(4.f)
+ShowerAsymmetryFeatureTool::ShowerAsymmetryFeatureTool() : AsymmetryFeatureBaseTool(), m_vertexClusterDistance(4.f)
 {
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ShowerAsymmetryFeatureTool::GetAsymmetryForView(
-     const CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &, 
-     const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const
+float ShowerAsymmetryFeatureTool::GetAsymmetryForView(const CartesianVector &vertexPosition2D,
+    const VertexSelectionBaseAlgorithm::SlidingFitDataList &, const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const
 {
     float showerAsymmetry(1.f);
 
@@ -43,10 +40,10 @@ float ShowerAsymmetryFeatureTool::GetAsymmetryForView(
             if (STATUS_CODE_SUCCESS != showerFit.GetGlobalFitDirection(rL, showerDirection))
                 continue;
 
-	    ClusterVector asymmetryClusters;
-	    std::copy(showerCluster.GetClusters().begin(), showerCluster.GetClusters().end(), std::back_inserter(asymmetryClusters));
+            ClusterVector asymmetryClusters;
+            std::copy(showerCluster.GetClusters().begin(), showerCluster.GetClusters().end(), std::back_inserter(asymmetryClusters));
 
-	    showerAsymmetry = this->CalculateAsymmetry(true, vertexPosition2D, asymmetryClusters, showerDirection);
+            showerAsymmetry = this->CalculateAsymmetry(true, vertexPosition2D, asymmetryClusters, showerDirection);
 
             break;
         }

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.cc
@@ -43,7 +43,10 @@ float ShowerAsymmetryFeatureTool::GetAsymmetryForView(
             if (STATUS_CODE_SUCCESS != showerFit.GetGlobalFitDirection(rL, showerDirection))
                 continue;
 
-	    showerAsymmetry = this->CalculateAsymmetry(true, vertexPosition2D, showerCluster.GetClusters(), showerDirection);
+	    ClusterVector asymmetryClusters;
+	    std::copy(showerCluster.GetClusters().begin(), showerCluster.GetClusters().end(), std::back_inserter(asymmetryClusters));
+
+	    showerAsymmetry = this->CalculateAsymmetry(true, vertexPosition2D, asymmetryClusters, showerDirection);
 
             break;
         }
@@ -64,33 +67,6 @@ bool ShowerAsymmetryFeatureTool::ShouldUseShowerCluster(
     }
 
     return false;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-void ShowerAsymmetryFeatureTool::CalculateAsymmetryParameters(const VertexSelectionBaseAlgorithm::ShowerCluster &showerCluster,
-    const float projectedVtxPosition, const CartesianVector &showerDirection, float &beforeVtxEnergy, float &afterVtxEnergy) const
-{
-    beforeVtxEnergy = 0.f;
-    afterVtxEnergy = 0.f;
-
-    for (const Cluster *const pCluster : showerCluster.GetClusters())
-    {
-        CaloHitList caloHitList;
-        pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHitList);
-
-        CaloHitVector caloHitVector(caloHitList.begin(), caloHitList.end());
-        std::sort(caloHitVector.begin(), caloHitVector.end(), LArClusterHelper::SortHitsByPosition);
-
-        for (const CaloHit *const pCaloHit : caloHitVector)
-        {
-            if (pCaloHit->GetPositionVector().GetDotProduct(showerDirection) < projectedVtxPosition)
-                beforeVtxEnergy += pCaloHit->GetElectromagneticEnergy();
-
-            else if (pCaloHit->GetPositionVector().GetDotProduct(showerDirection) > projectedVtxPosition)
-                afterVtxEnergy += pCaloHit->GetElectromagneticEnergy();
-        }
-    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h
@@ -27,7 +27,7 @@ public:
     ShowerAsymmetryFeatureTool();
 
 private:
-    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle) override;
 
     /**
      *  @brief  Get the shower asymmetry feature for a given view
@@ -38,8 +38,8 @@ private:
      *  @return the shower asymmetry feature
      */
     float GetAsymmetryForView(
-         const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &, 
-	 const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const;
+	 const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &, 
+	 const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const override;
 
     /**
      *  @brief  Get whether we should use a given shower cluster for asymmetry calculation
@@ -50,18 +50,6 @@ private:
      *  @return whether the shower cluster should be considered
      */
     bool ShouldUseShowerCluster(const pandora::CartesianVector &vertexPosition, const VertexSelectionBaseAlgorithm::ShowerCluster &showerCluster) const;
-
-    /**
-     *  @brief  Calculate the parameters for the asymmetry calculation
-     *
-     *  @param  showerCluster the shower cluster
-     *  @param  projectedVtxPosition the projected vertex position
-     *  @param  showerDirection the direction of the shower axis
-     *  @param  beforeVtxEnergy the shower energy before the vertex position
-     *  @param  afterVtxEnergy the shower energy after the vertex position
-     */
-    void CalculateAsymmetryParameters(const VertexSelectionBaseAlgorithm::ShowerCluster &showerCluster, const float projectedVtxPosition,
-        const pandora::CartesianVector &showerDirection, float &beforeVtxEnergy, float &afterVtxEnergy) const;
 
     float m_vertexClusterDistance; ///< The distance around the vertex to look for shower clusters
 };

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h
@@ -8,7 +8,7 @@
 #ifndef LAR_SHOWER_ASYMMETRY_FEATURE_TOOL_H
 #define LAR_SHOWER_ASYMMETRY_FEATURE_TOOL_H 1
 
-#include "larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h"
+#include "larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.h"
 
 #include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
 
@@ -18,27 +18,13 @@ namespace lar_content
 /**
  *  @brief  ShowerAsymmetryFeatureTool class
  */
-class ShowerAsymmetryFeatureTool : public VertexSelectionBaseAlgorithm::VertexFeatureTool
+class ShowerAsymmetryFeatureTool : public AsymmetryFeatureBaseTool
 {
 public:
     /**
      *  @brief  Default constructor
      */
     ShowerAsymmetryFeatureTool();
-
-    /**
-     *  @brief  Run the tool
-     *
-     *  @param  pAlgorithm address of the calling algorithm
-     *  @param  pVertex address of the vertex
-     *  @param  showerClusterListMap map of the shower cluster lists
-     *
-     *  @return the shower asymmetry feature
-     */
-    void Run(LArMvaHelper::MvaFeatureVector &featureVector, const VertexSelectionBaseAlgorithm *const pAlgorithm,
-        const pandora::Vertex *const pVertex, const VertexSelectionBaseAlgorithm::SlidingFitDataListMap &,
-        const VertexSelectionBaseAlgorithm::ClusterListMap &, const VertexSelectionBaseAlgorithm::KDTreeMap &,
-        const VertexSelectionBaseAlgorithm::ShowerClusterListMap &showerClusterListMap, const float, float &);
 
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -51,8 +37,9 @@ private:
      *
      *  @return the shower asymmetry feature
      */
-    float GetShowerAsymmetryForView(
-        const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const;
+    float GetAsymmetryForView(
+         const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &, 
+	 const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const;
 
     /**
      *  @brief  Get whether we should use a given shower cluster for asymmetry calculation

--- a/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h
+++ b/larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h
@@ -37,9 +37,8 @@ private:
      *
      *  @return the shower asymmetry feature
      */
-    float GetAsymmetryForView(
-	 const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &, 
-	 const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const override;
+    float GetAsymmetryForView(const pandora::CartesianVector &vertexPosition2D, const VertexSelectionBaseAlgorithm::SlidingFitDataList &,
+        const VertexSelectionBaseAlgorithm::ShowerClusterList &showerClusterList) const override;
 
     /**
      *  @brief  Get whether we should use a given shower cluster for asymmetry calculation

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
@@ -15,12 +15,12 @@
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 #include "larpandoracontent/LArHelpers/LArMvaHelper.h"
 
+#include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
 #include "larpandoracontent/LArVertex/GlobalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/LocalAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/RPhiFeatureTool.h"
 #include "larpandoracontent/LArVertex/ShowerAsymmetryFeatureTool.h"
-#include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
 
 #include "larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h"
 
@@ -257,10 +257,10 @@ typename TrainedVertexSelectionAlgorithm::EventFeatureInfo TrainedVertexSelectio
     const ClusterListMap clusterListMap{{TPC_VIEW_U, clusterListU}, {TPC_VIEW_V, clusterListV}, {TPC_VIEW_W, clusterListW}};
 
     float eventArea(0.f), longitudinality(0.f);
-    if(m_legacyEventShapes)
-      this->GetLegacyEventShapeFeatures(allClusters, eventArea, longitudinality);
+    if (m_legacyEventShapes)
+        this->GetLegacyEventShapeFeatures(allClusters, eventArea, longitudinality);
     else
-      this->GetEventShapeFeatures(clusterListMap, eventArea, longitudinality);
+        this->GetEventShapeFeatures(clusterListMap, eventArea, longitudinality);
 
     return EventFeatureInfo(eventShoweryness, eventEnergy, eventArea, longitudinality, nHits, nClusters, vertexVector.size());
 }
@@ -291,39 +291,39 @@ inline bool TrainedVertexSelectionAlgorithm::IsClusterShowerLike(const Cluster *
 
 void TrainedVertexSelectionAlgorithm::GetLegacyEventShapeFeatures(const ClusterList &clusterList, float &eventVolume, float &longitudinality) const
 {
-  InputFloat xMin, yMin, zMin, xMax, yMax, zMax;
+    InputFloat xMin, yMin, zMin, xMax, yMax, zMax;
 
-  for (const Cluster *const pCluster : clusterList)
+    for (const Cluster *const pCluster : clusterList)
     {
-      CartesianVector minPosition(0.f, 0.f, 0.f), maxPosition(0.f, 0.f, 0.f);
-      LArClusterHelper::GetClusterBoundingBox(pCluster, minPosition, maxPosition);
+        CartesianVector minPosition(0.f, 0.f, 0.f), maxPosition(0.f, 0.f, 0.f);
+        LArClusterHelper::GetClusterBoundingBox(pCluster, minPosition, maxPosition);
 
-      this->UpdateSpanCoordinate(minPosition.GetX(), maxPosition.GetX(), xMin, xMax);
-      this->UpdateSpanCoordinate(minPosition.GetY(), maxPosition.GetY(), yMin, yMax);
-      this->UpdateSpanCoordinate(minPosition.GetZ(), maxPosition.GetZ(), zMin, zMax);
+        this->UpdateSpanCoordinate(minPosition.GetX(), maxPosition.GetX(), xMin, xMax);
+        this->UpdateSpanCoordinate(minPosition.GetY(), maxPosition.GetY(), yMin, yMax);
+        this->UpdateSpanCoordinate(minPosition.GetZ(), maxPosition.GetZ(), zMin, zMax);
     }
 
-  const float xSpan(this->GetCoordinateSpan(xMax, xMin));
-  const float ySpan(this->GetCoordinateSpan(yMax, zMin));
-  const float zSpan(this->GetCoordinateSpan(yMax, zMin));
+    const float xSpan(this->GetCoordinateSpan(xMax, xMin));
+    const float ySpan(this->GetCoordinateSpan(yMax, zMin));
+    const float zSpan(this->GetCoordinateSpan(yMax, zMin));
 
-  // Calculate the volume and longitudinality of the event (ySpan often 0 - to be investigated).
-  if ((xSpan > std::numeric_limits<float>::epsilon()) && (ySpan > std::numeric_limits<float>::epsilon()))
+    // Calculate the volume and longitudinality of the event (ySpan often 0 - to be investigated).
+    if ((xSpan > std::numeric_limits<float>::epsilon()) && (ySpan > std::numeric_limits<float>::epsilon()))
     {
-      eventVolume = xSpan * ySpan * zSpan;
-      longitudinality = zSpan / (xSpan + ySpan);
+        eventVolume = xSpan * ySpan * zSpan;
+        longitudinality = zSpan / (xSpan + ySpan);
     }
 
-  else if (ySpan > std::numeric_limits<float>::epsilon())
+    else if (ySpan > std::numeric_limits<float>::epsilon())
     {
-      eventVolume = ySpan * ySpan * zSpan;
-      longitudinality = zSpan / (ySpan + ySpan);
+        eventVolume = ySpan * ySpan * zSpan;
+        longitudinality = zSpan / (ySpan + ySpan);
     }
 
-  else if (xSpan > std::numeric_limits<float>::epsilon())
+    else if (xSpan > std::numeric_limits<float>::epsilon())
     {
-      eventVolume = xSpan * xSpan * zSpan;
-      longitudinality = zSpan / (xSpan + xSpan);
+        eventVolume = xSpan * xSpan * zSpan;
+        longitudinality = zSpan / (xSpan + xSpan);
     }
 }
 
@@ -331,7 +331,7 @@ void TrainedVertexSelectionAlgorithm::GetLegacyEventShapeFeatures(const ClusterL
 
 void TrainedVertexSelectionAlgorithm::GetEventShapeFeatures(const ClusterListMap &clusterListMap, float &eventArea, float &longitudinality) const
 {
-  float xSpanU(0.f), zSpanU(0.f), xSpanV(0.f), zSpanV(0.f), xSpanW(0.f), zSpanW(0.f);
+    float xSpanU(0.f), zSpanU(0.f), xSpanV(0.f), zSpanV(0.f), xSpanW(0.f), zSpanW(0.f);
 
     this->Get2DSpan(clusterListMap.at(TPC_VIEW_U), xSpanU, zSpanU);
     this->Get2DSpan(clusterListMap.at(TPC_VIEW_V), xSpanV, zSpanV);
@@ -351,37 +351,37 @@ void TrainedVertexSelectionAlgorithm::GetEventShapeFeatures(const ClusterListMap
 
 void TrainedVertexSelectionAlgorithm::Get2DSpan(const ClusterList &clusterList, float &xSpan, float &zSpan) const
 {
-  FloatVector xPositions, zPositions;
+    FloatVector xPositions, zPositions;
 
-  for (const Cluster *const pCluster : clusterList)
+    for (const Cluster *const pCluster : clusterList)
     {
-      const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
+        const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
 
-      for (OrderedCaloHitList::const_iterator iter = orderedCaloHitList.begin(), iterEnd = orderedCaloHitList.end(); iter != iterEnd; ++iter)
-	{
-	  for (CaloHitList::const_iterator hitIter = iter->second->begin(), hitIterEnd = iter->second->end(); hitIter != hitIterEnd; ++hitIter)
-	    {
-	      xPositions.push_back((*hitIter)->GetPositionVector().GetX());
-	      zPositions.push_back((*hitIter)->GetPositionVector().GetZ());
-	    }
-	}
+        for (OrderedCaloHitList::const_iterator iter = orderedCaloHitList.begin(), iterEnd = orderedCaloHitList.end(); iter != iterEnd; ++iter)
+        {
+            for (CaloHitList::const_iterator hitIter = iter->second->begin(), hitIterEnd = iter->second->end(); hitIter != hitIterEnd; ++hitIter)
+            {
+                xPositions.push_back((*hitIter)->GetPositionVector().GetX());
+                zPositions.push_back((*hitIter)->GetPositionVector().GetZ());
+            }
+        }
     }
 
-  std::sort(xPositions.begin(),xPositions.end());
-  std::sort(zPositions.begin(),zPositions.end());
+    std::sort(xPositions.begin(), xPositions.end());
+    std::sort(zPositions.begin(), zPositions.end());
 
-  if(xPositions.empty())
+    if (xPositions.empty())
     {
-      xSpan = 0;
-      zSpan = 0;
+        xSpan = 0;
+        zSpan = 0;
     }
-  else
+    else
     {
-      const int low = std::round(0.05*xPositions.size());
-      const int high = std::round(0.95*xPositions.size()) - 1;
-      
-      xSpan = xPositions[high] - xPositions[low];
-      zSpan = zPositions[high] - zPositions[low];
+        const int low = std::round(0.05 * xPositions.size());
+        const int high = std::round(0.95 * xPositions.size()) - 1;
+
+        xSpan = xPositions[high] - xPositions[low];
+        zSpan = zPositions[high] - zPositions[low];
     }
 }
 
@@ -455,15 +455,15 @@ void TrainedVertexSelectionAlgorithm::PopulateVertexFeatureInfoMap(const BeamCon
 
     double dEdxAsymmetry(0.f), vertexEnergy(0.f);
 
-    if(!m_legacyVariables)
-      {
-	dEdxAsymmetry = LArMvaHelper::CalculateFeaturesOfType<EnergyDepositionAsymmetryFeatureTool>(m_featureToolVector, this, pVertex,
-	    slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore)
-                                         .at(0)
-                                         .Get();
-	
-	vertexEnergy = this->GetVertexEnergy(pVertex, kdTreeMap);
-      }
+    if (!m_legacyVariables)
+    {
+        dEdxAsymmetry = LArMvaHelper::CalculateFeaturesOfType<EnergyDepositionAsymmetryFeatureTool>(m_featureToolVector, this, pVertex,
+            slidingFitDataListMap, clusterListMap, kdTreeMap, showerClusterListMap, beamDeweighting, bestFastScore)
+                            .at(0)
+                            .Get();
+
+        vertexEnergy = this->GetVertexEnergy(pVertex, kdTreeMap);
+    }
 
     VertexFeatureInfo vertexFeatureInfo(beamDeweighting, 0.f, energyKick, localAsymmetry, globalAsymmetry, showerAsymmetry, dEdxAsymmetry, vertexEnergy);
     vertexFeatureInfoMap.emplace(pVertex, vertexFeatureInfo);
@@ -535,7 +535,7 @@ void TrainedVertexSelectionAlgorithm::ProduceTrainingSets(const VertexVector &ve
 
     // Produce training examples for the vertices representing regions.
     const Vertex *const pBestRegionVertex(this->ProduceTrainingExamples(bestRegionVertices, vertexFeatureInfoMap, coinFlip, generator,
-	interactionType, m_trainingOutputFileRegion, eventFeatureList, kdTreeMap, m_regionRadius, m_useRPhiFeatureForRegion));
+        interactionType, m_trainingOutputFileRegion, eventFeatureList, kdTreeMap, m_regionRadius, m_useRPhiFeatureForRegion));
 
     // Get all the vertices in the best region.
     VertexVector regionalVertices{pBestRegionVertex};
@@ -618,8 +618,9 @@ std::string TrainedVertexSelectionAlgorithm::GetInteractionType() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 const pandora::Vertex *TrainedVertexSelectionAlgorithm::ProduceTrainingExamples(const VertexVector &vertexVector,
-    const VertexFeatureInfoMap &vertexFeatureInfoMap, std::bernoulli_distribution &coinFlip, std::mt19937 &generator, const std::string &interactionType,
-    const std::string &trainingOutputFile, const LArMvaHelper::MvaFeatureVector &eventFeatureList, const KDTreeMap &kdTreeMap, const float maxRadius, const bool useRPhi) const
+    const VertexFeatureInfoMap &vertexFeatureInfoMap, std::bernoulli_distribution &coinFlip, std::mt19937 &generator,
+    const std::string &interactionType, const std::string &trainingOutputFile, const LArMvaHelper::MvaFeatureVector &eventFeatureList,
+    const KDTreeMap &kdTreeMap, const float maxRadius, const bool useRPhi) const
 {
     const Vertex *pBestVertex(nullptr);
     float bestVertexDr(std::numeric_limits<float>::max());
@@ -639,32 +640,36 @@ const pandora::Vertex *TrainedVertexSelectionAlgorithm::ProduceTrainingExamples(
         VertexFeatureInfo vertexFeatureInfo(vertexFeatureInfoMap.at(pVertex));
         this->AddVertexFeaturesToVector(vertexFeatureInfo, featureList, useRPhi);
 
-	if(!m_legacyVariables)
-	  {
-	    LArMvaHelper::MvaFeatureVector sharedFeatureList;
-	    float separation(0.f), axisHits(0.f);
-	    this->GetSharedFeatures(pVertex,pBestVertex,kdTreeMap,separation,axisHits);
-	    VertexSharedFeatureInfo sharedFeatureInfo(separation,axisHits);
-	    this->AddSharedFeaturesToVector(sharedFeatureInfo,sharedFeatureList);
+        if (!m_legacyVariables)
+        {
+            LArMvaHelper::MvaFeatureVector sharedFeatureList;
+            float separation(0.f), axisHits(0.f);
+            this->GetSharedFeatures(pVertex, pBestVertex, kdTreeMap, separation, axisHits);
+            VertexSharedFeatureInfo sharedFeatureInfo(separation, axisHits);
+            this->AddSharedFeaturesToVector(sharedFeatureInfo, sharedFeatureList);
 
-	    if (pBestVertex && (bestVertexDr < maxRadius))
-	      {
-		if (coinFlip(generator)) LArMvaHelper::ProduceTrainingExample(
-		        trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList, bestVertexFeatureList, featureList, sharedFeatureList);
-		else LArMvaHelper::ProduceTrainingExample(
-		        trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList, featureList, bestVertexFeatureList, sharedFeatureList);
-	      }
-	  }
-	else
-	  {
-	    if (pBestVertex && (bestVertexDr < maxRadius))
-	      {
-		if (coinFlip(generator)) LArMvaHelper::ProduceTrainingExample(
-			trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList, bestVertexFeatureList, featureList);
-		else LArMvaHelper::ProduceTrainingExample(
-			trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList, featureList, bestVertexFeatureList);
-	      }
-	  }
+            if (pBestVertex && (bestVertexDr < maxRadius))
+            {
+                if (coinFlip(generator))
+                    LArMvaHelper::ProduceTrainingExample(trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList,
+                        bestVertexFeatureList, featureList, sharedFeatureList);
+                else
+                    LArMvaHelper::ProduceTrainingExample(trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList,
+                        featureList, bestVertexFeatureList, sharedFeatureList);
+            }
+        }
+        else
+        {
+            if (pBestVertex && (bestVertexDr < maxRadius))
+            {
+                if (coinFlip(generator))
+                    LArMvaHelper::ProduceTrainingExample(
+                        trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList, bestVertexFeatureList, featureList);
+                else
+                    LArMvaHelper::ProduceTrainingExample(
+                        trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList, featureList, bestVertexFeatureList);
+            }
+        }
     }
 
     return pBestVertex;
@@ -672,81 +677,80 @@ const pandora::Vertex *TrainedVertexSelectionAlgorithm::ProduceTrainingExamples(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::GetSharedFeatures(const Vertex *const pVertex1, const Vertex *const pVertex2, const KDTreeMap &kdTreeMap,
-							  float &separation, float &axisHits) const
+void TrainedVertexSelectionAlgorithm::GetSharedFeatures(
+    const Vertex *const pVertex1, const Vertex *const pVertex2, const KDTreeMap &kdTreeMap, float &separation, float &axisHits) const
 {
-  separation = (pVertex1->GetPosition() - pVertex2->GetPosition()).GetMagnitude();
+    separation = (pVertex1->GetPosition() - pVertex2->GetPosition()).GetMagnitude();
 
-  this->IncrementSharedAxisValues(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex1->GetPosition(), TPC_VIEW_U),
-				  LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex2->GetPosition(), TPC_VIEW_U),
-				  kdTreeMap.at(TPC_VIEW_U), axisHits);
-  
-  this->IncrementSharedAxisValues(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex1->GetPosition(), TPC_VIEW_V),
-				  LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex2->GetPosition(), TPC_VIEW_V),
-				  kdTreeMap.at(TPC_VIEW_V), axisHits);
-  
-  this->IncrementSharedAxisValues(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex1->GetPosition(), TPC_VIEW_W),
-				  LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex2->GetPosition(), TPC_VIEW_W),
-				  kdTreeMap.at(TPC_VIEW_W), axisHits);
+    this->IncrementSharedAxisValues(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex1->GetPosition(), TPC_VIEW_U),
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex2->GetPosition(), TPC_VIEW_U), kdTreeMap.at(TPC_VIEW_U), axisHits);
 
-  axisHits = separation > std::numeric_limits<float>::epsilon() ? axisHits / separation : 0.f;
+    this->IncrementSharedAxisValues(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex1->GetPosition(), TPC_VIEW_V),
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex2->GetPosition(), TPC_VIEW_V), kdTreeMap.at(TPC_VIEW_V), axisHits);
+
+    this->IncrementSharedAxisValues(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex1->GetPosition(), TPC_VIEW_W),
+        LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex2->GetPosition(), TPC_VIEW_W), kdTreeMap.at(TPC_VIEW_W), axisHits);
+
+    axisHits = separation > std::numeric_limits<float>::epsilon() ? axisHits / separation : 0.f;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::IncrementSharedAxisValues(const CartesianVector pos1, const CartesianVector pos2, HitKDTree2D &kdTree,
-								    float &axisHits) const
+void TrainedVertexSelectionAlgorithm::IncrementSharedAxisValues(
+    const CartesianVector pos1, const CartesianVector pos2, HitKDTree2D &kdTree, float &axisHits) const
 {
-  if(pos1 == pos2) return;
+    if (pos1 == pos2)
+        return;
 
-  // Define the axis and perpendicular directions
-  const CartesianVector unitAxis = (pos1 - pos2).GetUnitVector();
-  const CartesianVector unitPerp(unitAxis.GetZ(),0,-unitAxis.GetX());
+    // Define the axis and perpendicular directions
+    const CartesianVector unitAxis = (pos1 - pos2).GetUnitVector();
+    const CartesianVector unitPerp(unitAxis.GetZ(), 0, -unitAxis.GetX());
 
-  // Define the corners of the search box
-  const CartesianVector point1 = pos1 + unitPerp;
-  const CartesianVector point2 = pos1 - unitPerp;
-  const CartesianVector point3 = pos2 + unitPerp;
-  const CartesianVector point4 = pos2 - unitPerp;
+    // Define the corners of the search box
+    const CartesianVector point1 = pos1 + unitPerp;
+    const CartesianVector point2 = pos1 - unitPerp;
+    const CartesianVector point3 = pos2 + unitPerp;
+    const CartesianVector point4 = pos2 - unitPerp;
 
-  // Find the total coordinate span these points cover
-  const float xMin{std::min({point1.GetX(), point2.GetX(), point3.GetX(), point4.GetX()})};
-  const float xMax{std::max({point1.GetX(), point2.GetX(), point3.GetX(), point4.GetX()})};
-  const float zMin{std::min({point1.GetZ(), point2.GetZ(), point3.GetZ(), point4.GetZ()})};
-  const float zMax{std::max({point1.GetZ(), point2.GetZ(), point3.GetZ(), point4.GetZ()})};
+    // Find the total coordinate span these points cover
+    const float xMin{std::min({point1.GetX(), point2.GetX(), point3.GetX(), point4.GetX()})};
+    const float xMax{std::max({point1.GetX(), point2.GetX(), point3.GetX(), point4.GetX()})};
+    const float zMin{std::min({point1.GetZ(), point2.GetZ(), point3.GetZ(), point4.GetZ()})};
+    const float zMax{std::max({point1.GetZ(), point2.GetZ(), point3.GetZ(), point4.GetZ()})};
 
-  // Use a kd search to find the hits in the 'wide' area
-  KDTreeBox searchBox(xMin,zMin,xMax,zMax);
-  HitKDNode2DList found;
-  kdTree.search(searchBox, found);
+    // Use a kd search to find the hits in the 'wide' area
+    KDTreeBox searchBox(xMin, zMin, xMax, zMax);
+    HitKDNode2DList found;
+    kdTree.search(searchBox, found);
 
-  // Use IsHitInBox method to check the 'wide' area hits for those in the search box
-  for(auto f : found)
+    // Use IsHitInBox method to check the 'wide' area hits for those in the search box
+    for (auto f : found)
     {
-      const CartesianVector &hitPos = f.data->GetPositionVector();
-      bool inBox = this->IsHitInBox(hitPos,point1,point2,point3,point4);
+        const CartesianVector &hitPos = f.data->GetPositionVector();
+        bool inBox = this->IsHitInBox(hitPos, point1, point2, point3, point4);
 
-      if(inBox) ++axisHits;
+        if (inBox)
+            ++axisHits;
     }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool TrainedVertexSelectionAlgorithm::IsHitInBox(const CartesianVector &hitPos, const CartesianVector &point1, const CartesianVector &point2,
-						     const CartesianVector &point3, const CartesianVector &point4) const
+bool TrainedVertexSelectionAlgorithm::IsHitInBox(const CartesianVector &hitPos, const CartesianVector &point1,
+    const CartesianVector &point2, const CartesianVector &point3, const CartesianVector &point4) const
 {
-  bool b1 = std::signbit(((point2 - point1).GetCrossProduct(point2-hitPos)).GetY());
-  bool b2 = std::signbit(((point4 - point3).GetCrossProduct(point4-hitPos)).GetY());
+    bool b1 = std::signbit(((point2 - point1).GetCrossProduct(point2 - hitPos)).GetY());
+    bool b2 = std::signbit(((point4 - point3).GetCrossProduct(point4 - hitPos)).GetY());
 
-  if (!(b1 xor b2)) 
-    return false;
+    if (!(b1 xor b2))
+        return false;
 
-  bool b3 = std::signbit(((point3 - point1).GetCrossProduct(point3-hitPos)).GetY());
-  bool b4 = std::signbit(((point4 - point2).GetCrossProduct(point4-hitPos)).GetY());
-  
-  return (b3 xor b4);
+    bool b3 = std::signbit(((point3 - point1).GetCrossProduct(point3 - hitPos)).GetY());
+    bool b4 = std::signbit(((point4 - point2).GetCrossProduct(point4 - hitPos)).GetY());
+
+    return (b3 xor b4);
 }
-  
+
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void TrainedVertexSelectionAlgorithm::GetBestVertex(const VertexVector &vertexVector, const Vertex *&pBestVertex, float &bestVertexDr) const
@@ -801,11 +805,11 @@ void TrainedVertexSelectionAlgorithm::AddVertexFeaturesToVector(
     featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_localAsymmetry));
     featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_showerAsymmetry));
 
-    if(!m_legacyVariables)
-      {
-	featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_dEdxAsymmetry));
-	featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_vertexEnergy));
-      }
+    if (!m_legacyVariables)
+    {
+        featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_dEdxAsymmetry));
+        featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_vertexEnergy));
+    }
 
     if (useRPhi)
         featureVector.push_back(static_cast<double>(vertexFeatureInfo.m_rPhiFeature));
@@ -813,11 +817,11 @@ void TrainedVertexSelectionAlgorithm::AddVertexFeaturesToVector(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrainedVertexSelectionAlgorithm::AddSharedFeaturesToVector(const VertexSharedFeatureInfo &vertexSharedFeatureInfo,
-								LArMvaHelper::MvaFeatureVector &featureVector) const
+void TrainedVertexSelectionAlgorithm::AddSharedFeaturesToVector(
+    const VertexSharedFeatureInfo &vertexSharedFeatureInfo, LArMvaHelper::MvaFeatureVector &featureVector) const
 {
-  featureVector.push_back(static_cast<double>(vertexSharedFeatureInfo.m_separation));
-  featureVector.push_back(static_cast<double>(vertexSharedFeatureInfo.m_axisHits));
+    featureVector.push_back(static_cast<double>(vertexSharedFeatureInfo.m_separation));
+    featureVector.push_back(static_cast<double>(vertexSharedFeatureInfo.m_axisHits));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -934,12 +938,14 @@ StatusCode TrainedVertexSelectionAlgorithm::ReadSettings(const TiXmlHandle xmlHa
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TestBeamMode", m_testBeamMode));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LegacyEventShapes", m_legacyEventShapes));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LegacyEventShapes", m_legacyEventShapes));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LegacyVariables", m_legacyVariables));
 
-    if(m_trainingSetMode && m_legacyEventShapes)
-      std::cout << "TrainedVertexSelectionAlgorithm: WARNING -- Producing training sample using incorrect legacy event shapes, consider turning LegacyEventShapes off" << std::endl;
+    if (m_trainingSetMode && m_legacyEventShapes)
+        std::cout << "TrainedVertexSelectionAlgorithm: WARNING -- Producing training sample using incorrect legacy event shapes, consider turning LegacyEventShapes off"
+                  << std::endl;
 
     return VertexSelectionBaseAlgorithm::ReadSettings(xmlHandle);
 }

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
@@ -796,6 +796,15 @@ void TrainedVertexSelectionAlgorithm::AddVertexFeaturesToVector(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void TrainedVertexSelectionAlgorithm::AddSharedFeaturesToVector(const VertexSharedFeatureInfo &vertexSharedFeatureInfo,
+								LArMvaHelper::MvaFeatureVector &featureVector) const
+{
+  featureVector.push_back(static_cast<double>(vertexSharedFeatureInfo.m_separation));
+  featureVector.push_back(static_cast<double>(vertexSharedFeatureInfo.m_axisHits));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void TrainedVertexSelectionAlgorithm::PopulateFinalVertexScoreList(const VertexFeatureInfoMap &vertexFeatureInfoMap,
     const Vertex *const pFavouriteVertex, const VertexVector &vertexVector, VertexScoreList &finalVertexScoreList) const
 {

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
@@ -464,7 +464,7 @@ void TrainedVertexSelectionAlgorithm::PopulateVertexFeatureInfoMap(const BeamCon
 	
 	vertexEnergy = this->GetVertexEnergy(pVertex, kdTreeMap);
       }
-    
+
     VertexFeatureInfo vertexFeatureInfo(beamDeweighting, 0.f, energyKick, localAsymmetry, globalAsymmetry, showerAsymmetry, dEdxAsymmetry, vertexEnergy);
     vertexFeatureInfoMap.emplace(pVertex, vertexFeatureInfo);
 }

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
@@ -331,7 +331,7 @@ void TrainedVertexSelectionAlgorithm::GetLegacyEventShapeFeatures(const ClusterL
 
 void TrainedVertexSelectionAlgorithm::GetEventShapeFeatures(const ClusterListMap &clusterListMap, float &eventArea, float &longitudinality) const
 {
-    float xSpanU, zSpanU, xSpanV, zSpanV, xSpanW, zSpanW;
+  float xSpanU(0.f), zSpanU(0.f), xSpanV(0.f), zSpanV(0.f), xSpanW(0.f), zSpanW(0.f);
 
     this->Get2DSpan(clusterListMap.at(TPC_VIEW_U), xSpanU, zSpanU);
     this->Get2DSpan(clusterListMap.at(TPC_VIEW_V), xSpanV, zSpanV);
@@ -351,7 +351,7 @@ void TrainedVertexSelectionAlgorithm::GetEventShapeFeatures(const ClusterListMap
 
 void TrainedVertexSelectionAlgorithm::Get2DSpan(const ClusterList &clusterList, float &xSpan, float &zSpan) const
 {
-  std::vector<float> xPositions, zPositions;
+  FloatVector xPositions, zPositions;
 
   for (const Cluster *const pCluster : clusterList)
     {
@@ -370,7 +370,7 @@ void TrainedVertexSelectionAlgorithm::Get2DSpan(const ClusterList &clusterList, 
   std::sort(xPositions.begin(),xPositions.end());
   std::sort(zPositions.begin(),zPositions.end());
 
-  if(xPositions.size() == 0)
+  if(xPositions.empty())
     {
       xSpan = 0;
       zSpan = 0;
@@ -639,7 +639,7 @@ const pandora::Vertex *TrainedVertexSelectionAlgorithm::ProduceTrainingExamples(
         VertexFeatureInfo vertexFeatureInfo(vertexFeatureInfoMap.at(pVertex));
         this->AddVertexFeaturesToVector(vertexFeatureInfo, featureList, useRPhi);
 
-	if(m_legacyVariables)
+	if(!m_legacyVariables)
 	  {
 	    LArMvaHelper::MvaFeatureVector sharedFeatureList;
 	    float separation(0.f), axisHits(0.f);
@@ -649,34 +649,22 @@ const pandora::Vertex *TrainedVertexSelectionAlgorithm::ProduceTrainingExamples(
 
 	    if (pBestVertex && (bestVertexDr < maxRadius))
 	      {
-		if (coinFlip(generator))
-		  {
-		    LArMvaHelper::ProduceTrainingExample(
+		if (coinFlip(generator)) LArMvaHelper::ProduceTrainingExample(
 		        trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList, bestVertexFeatureList, featureList, sharedFeatureList);
-		  }
-
-		else
-		  {
-		    LArMvaHelper::ProduceTrainingExample(
+		else LArMvaHelper::ProduceTrainingExample(
 		        trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList, featureList, bestVertexFeatureList, sharedFeatureList);
-		  }
 	      }
 	  }
-
-        if (pBestVertex && (bestVertexDr < maxRadius))
-        {
-            if (coinFlip(generator))
-            {
-                LArMvaHelper::ProduceTrainingExample(
-		    trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList, bestVertexFeatureList, featureList);
-            }
-
-            else
-            {
-                LArMvaHelper::ProduceTrainingExample(
-		    trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList, featureList, bestVertexFeatureList);
-            }
-        }
+	else
+	  {
+	    if (pBestVertex && (bestVertexDr < maxRadius))
+	      {
+		if (coinFlip(generator)) LArMvaHelper::ProduceTrainingExample(
+			trainingOutputFile + "_" + interactionType + ".txt", true, eventFeatureList, bestVertexFeatureList, featureList);
+		else LArMvaHelper::ProduceTrainingExample(
+			trainingOutputFile + "_" + interactionType + ".txt", false, eventFeatureList, featureList, bestVertexFeatureList);
+	      }
+	  }
     }
 
     return pBestVertex;
@@ -701,10 +689,7 @@ void TrainedVertexSelectionAlgorithm::GetSharedFeatures(const Vertex *const pVer
 				  LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex2->GetPosition(), TPC_VIEW_W),
 				  kdTreeMap.at(TPC_VIEW_W), axisHits);
 
-  if(!separation)
-    axisHits = 0;
-
-  axisHits /= separation;
+  axisHits = separation > std::numeric_limits<float>::epsilon() ? axisHits / separation : 0.f;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -725,16 +710,10 @@ void TrainedVertexSelectionAlgorithm::IncrementSharedAxisValues(const CartesianV
   const CartesianVector point4 = pos2 - unitPerp;
 
   // Find the total coordinate span these points cover
-  float xMin(std::numeric_limits<float>::max());
-  float xMax(-std::numeric_limits<float>::max());
-  float zMin(std::numeric_limits<float>::max());
-  float zMax(-std::numeric_limits<float>::max());
-
-  this->UpdateBoxEdges(point1,xMin,xMax,zMin,zMax);
-  this->UpdateBoxEdges(point2,xMin,xMax,zMin,zMax);
-  this->UpdateBoxEdges(point3,xMin,xMax,zMin,zMax);
-  this->UpdateBoxEdges(point4,xMin,xMax,zMin,zMax);
-
+  const float xMin{std::min({point1.GetX(), point2.GetX(), point3.GetX(), point4.GetX()})};
+  const float xMax{std::max({point1.GetX(), point2.GetX(), point3.GetX(), point4.GetX()})};
+  const float zMin{std::min({point1.GetZ(), point2.GetZ(), point3.GetZ(), point4.GetZ()})};
+  const float zMax{std::max({point1.GetZ(), point2.GetZ(), point3.GetZ(), point4.GetZ()})};
 
   // Use a kd search to find the hits in the 'wide' area
   KDTreeBox searchBox(xMin,zMin,xMax,zMax);
@@ -744,21 +723,11 @@ void TrainedVertexSelectionAlgorithm::IncrementSharedAxisValues(const CartesianV
   // Use IsHitInBox method to check the 'wide' area hits for those in the search box
   for(auto f : found)
     {
-      const CartesianVector hitPos = f.data->GetPositionVector();
+      const CartesianVector &hitPos = f.data->GetPositionVector();
       bool inBox = this->IsHitInBox(hitPos,point1,point2,point3,point4);
 
       if(inBox) ++axisHits;
     }
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-void TrainedVertexSelectionAlgorithm::UpdateBoxEdges(const CartesianVector &point, float &xMin, float &xMax, float &zMin, float &zMax) const
-{
-  xMin = std::min(xMin,point.GetX());
-  xMax = std::max(xMax,point.GetX());
-  zMin = std::min(zMin,point.GetZ());
-  zMax = std::max(zMax,point.GetZ());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -768,10 +737,14 @@ bool TrainedVertexSelectionAlgorithm::IsHitInBox(const CartesianVector &hitPos, 
 {
   bool b1 = std::signbit(((point2 - point1).GetCrossProduct(point2-hitPos)).GetY());
   bool b2 = std::signbit(((point4 - point3).GetCrossProduct(point4-hitPos)).GetY());
+
+  if (!(b1 xor b2)) 
+    return false;
+
   bool b3 = std::signbit(((point3 - point1).GetCrossProduct(point3-hitPos)).GetY());
   bool b4 = std::signbit(((point4 - point2).GetCrossProduct(point4-hitPos)).GetY());
   
-  return (b1 xor b2) && (b3 xor b4);
+  return (b3 xor b4);
 }
   
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.cc
@@ -965,6 +965,9 @@ StatusCode TrainedVertexSelectionAlgorithm::ReadSettings(const TiXmlHandle xmlHa
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LegacyVariables", m_legacyVariables));
 
+    if(m_trainingSetMode && m_legacyEventShapes)
+      std::cout << "TrainedVertexSelectionAlgorithm: WARNING -- Producing training sample using incorrect legacy event shapes, consider turning LegacyEventShapes off" << std::endl;
+
     return VertexSelectionBaseAlgorithm::ReadSettings(xmlHandle);
 }
 

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
@@ -68,6 +68,26 @@ public:
     //--------------------------------------------------------------------------------------------------------------------------------------
 
     /**
+     *  @brief Shared vertex feature info class
+     */
+    class VertexSharedFeatureInfo
+    {
+    public:
+      /**
+       *  @brief  Constructor
+       *
+       *  @param  m_separation the distance between the two vertices
+       *  @param  m_axisHits the hit density along the axis between the two vertices
+       */
+      VertexSharedFeatureInfo(const float separation, const float axisHits);
+
+      float    m_separation;        ///< The distance between the two vertices
+      float    m_axisHits;          ///< The hit density along the axis between the two vertices
+    };
+
+    //--------------------------------------------------------------------------------------------------------------------------------------
+
+    /**
      *  @brief Event feature info class
      */
     class EventFeatureInfo
@@ -417,6 +437,14 @@ protected:
     void AddVertexFeaturesToVector(const VertexFeatureInfo &vertexFeatureInfo, LArMvaHelper::MvaFeatureVector &featureVector, const bool useRPhi) const;
 
     /**
+     *  @brief  Add the shared features to a vector in the correct order
+     *
+     *  @param  vertexSharedFeatureInfo the shared vertex feature info
+     *  @param  featureVector the vector of floats to append
+     */
+    void AddSharedFeaturesToVector(const VertexSharedFeatureInfo &vertexSharedFeatureInfo, LArMvaHelper::MvaFeatureVector &featureVector) const;
+
+    /**
      *  @brief  Populate the final vertex score list using the r/phi score to find the best vertex in the vicinity
      *
      *  @param  vertexFeatureInfoMap the vertex feature info map
@@ -485,6 +513,14 @@ inline TrainedVertexSelectionAlgorithm::EventFeatureInfo::EventFeatureInfo(const
     m_nHits(nHits),
     m_nClusters(nClusters),
     m_nCandidates(nCandidates)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline TrainedVertexSelectionAlgorithm::VertexSharedFeatureInfo::VertexSharedFeatureInfo(const float separation, const float axisHits) :
+    m_separation(separation),
+    m_axisHits(axisHits)
 {
 }
 

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
@@ -55,7 +55,7 @@ public:
          *  @param  vertexEnergy the vertex energy feature
          */
         VertexFeatureInfo(const float beamDeweighting, const float rPhiFeature, const float energyKick, const float localAsymmetry,
-	    const float globalAsymmetry, const float showerAsymmetry, const float dEdxAsymmetry, const float vertexEnergy);
+            const float globalAsymmetry, const float showerAsymmetry, const float dEdxAsymmetry, const float vertexEnergy);
 
         float m_beamDeweighting; ///< The beam deweighting feature
         float m_rPhiFeature;     ///< The r/phi feature
@@ -64,7 +64,7 @@ public:
         float m_globalAsymmetry; ///< The global asymmetry feature
         float m_showerAsymmetry; ///< The shower asymmetry feature
         float m_dEdxAsymmetry;   ///< The dE/dx asymmetry feature
-	float m_vertexEnergy;    ///< The vertex energy feature
+        float m_vertexEnergy;    ///< The vertex energy feature
     };
 
     typedef std::map<const pandora::Vertex *const, VertexFeatureInfo> VertexFeatureInfoMap;
@@ -77,16 +77,16 @@ public:
     class VertexSharedFeatureInfo
     {
     public:
-      /**
+        /**
        *  @brief  Constructor
        *
        *  @param  m_separation the distance between the two vertices
        *  @param  m_axisHits the hit density along the axis between the two vertices
        */
-      VertexSharedFeatureInfo(const float separation, const float axisHits);
+        VertexSharedFeatureInfo(const float separation, const float axisHits);
 
-      float    m_separation;        ///< The distance between the two vertices
-      float    m_axisHits;          ///< The hit density along the axis between the two vertices
+        float m_separation; ///< The distance between the two vertices
+        float m_axisHits;   ///< The hit density along the axis between the two vertices
     };
 
     //--------------------------------------------------------------------------------------------------------------------------------------
@@ -392,8 +392,8 @@ protected:
      *  @param  separation the 3D distance between the two vertex candidates
      *  @param  axisHits the number of hits between the two candidates normalised to the distance between them
      */
-    void GetSharedFeatures(const pandora::Vertex *const pVertex1, const pandora::Vertex *const pVertex2, const KDTreeMap &kdTreeMap, 
-			   float &separation, float &axisHits) const;
+    void GetSharedFeatures(const pandora::Vertex *const pVertex1, const pandora::Vertex *const pVertex2, const KDTreeMap &kdTreeMap,
+        float &separation, float &axisHits) const;
 
     /**
      *  @brief  Increments the axis hits information for one view
@@ -403,8 +403,7 @@ protected:
      *  @param  kdTree the kd tree of 2D hits
      *  @param  axisHits the number of hits between the two candidates
      */
-    void IncrementSharedAxisValues(const pandora::CartesianVector pos1, const pandora::CartesianVector pos2, HitKDTree2D &kdTree,
-				   float &axisHits) const;
+    void IncrementSharedAxisValues(const pandora::CartesianVector pos1, const pandora::CartesianVector pos2, HitKDTree2D &kdTree, float &axisHits) const;
 
     /**
      *  @brief  Determines whether a hit lies within the box defined by four other positions
@@ -417,8 +416,8 @@ protected:
      *
      *  @return boolean
      */
-    bool IsHitInBox(const pandora::CartesianVector &hitPos, const pandora::CartesianVector &point1, const pandora::CartesianVector &point2, 
-		    const pandora::CartesianVector &point3, const pandora::CartesianVector &point4) const;
+    bool IsHitInBox(const pandora::CartesianVector &hitPos, const pandora::CartesianVector &point1, const pandora::CartesianVector &point2,
+        const pandora::CartesianVector &point3, const pandora::CartesianVector &point4) const;
 
     /**
      *  @brief  Add the vertex features to a vector in the correct order
@@ -485,8 +484,8 @@ protected:
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline TrainedVertexSelectionAlgorithm::VertexFeatureInfo::VertexFeatureInfo(const float beamDeweighting, const float rPhiFeature,
-    const float energyKick, const float localAsymmetry, const float globalAsymmetry, const float showerAsymmetry, const float dEdxAsymmetry, const float vertexEnergy) :
+inline TrainedVertexSelectionAlgorithm::VertexFeatureInfo::VertexFeatureInfo(const float beamDeweighting, const float rPhiFeature, const float energyKick,
+    const float localAsymmetry, const float globalAsymmetry, const float showerAsymmetry, const float dEdxAsymmetry, const float vertexEnergy) :
     m_beamDeweighting(beamDeweighting),
     m_rPhiFeature(rPhiFeature),
     m_energyKick(energyKick),

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
@@ -51,9 +51,11 @@ public:
          *  @param  localAsymmetry the local asymmetry feature
          *  @param  globalAsymmetry the global asymmetry feature
          *  @param  showerAsymmetry the shower asymmetry feature
+         *  @param  dEdxAsymmetry the dE/dx asymmetry feature
+         *  @param  vertexEnergy the vertex energy feature
          */
         VertexFeatureInfo(const float beamDeweighting, const float rPhiFeature, const float energyKick, const float localAsymmetry,
-            const float globalAsymmetry, const float showerAsymmetry);
+	    const float globalAsymmetry, const float showerAsymmetry, const float dEdxAsymmetry, const float vertexEnergy);
 
         float m_beamDeweighting; ///< The beam deweighting feature
         float m_rPhiFeature;     ///< The r/phi feature
@@ -61,6 +63,8 @@ public:
         float m_localAsymmetry;  ///< The local asymmetry feature
         float m_globalAsymmetry; ///< The global asymmetry feature
         float m_showerAsymmetry; ///< The shower asymmetry feature
+        float m_dEdxAsymmetry;   ///< The dE/dx asymmetry feature
+	float m_vertexEnergy;    ///< The vertex energy feature
     };
 
     typedef std::map<const pandora::Vertex *const, VertexFeatureInfo> VertexFeatureInfoMap;
@@ -360,6 +364,7 @@ protected:
      *  @param  interactionType the interaction type string
      *  @param  trainingOutputFile the training set output file
      *  @param  eventFeatureList the event feature list
+     *  @param  kdTreeMap the map of 2D hit kd trees
      *  @param  maxRadius the maximum allowed radius for the 'best' vertex
      *  @param  useRPhi whether to include the r/phi feature
      *
@@ -367,7 +372,7 @@ protected:
      */
     const pandora::Vertex *ProduceTrainingExamples(const pandora::VertexVector &vertexVector, const VertexFeatureInfoMap &vertexFeatureInfoMap,
         std::bernoulli_distribution &coinFlip, std::mt19937 &generator, const std::string &interactionType, const std::string &trainingOutputFile,
-        const LArMvaHelper::MvaFeatureVector &eventFeatureList, const float maxRadius, const bool useRPhi) const;
+        const LArMvaHelper::MvaFeatureVector &eventFeatureList, const KDTreeMap &kdTreeMap, const float maxRadius, const bool useRPhi) const;
 
     /**
      *  @brief  Use the MC information to get the best vertex from a list
@@ -487,18 +492,21 @@ protected:
     bool m_dropFailedRPhiFastScoreCandidates; ///< Whether to drop candidates that fail the r/phi fast score test
     bool m_testBeamMode;                      ///< Test beam mode
     bool m_legacyEventShapes;                 ///< Whether to use the old event shapes calculation
+    bool m_legacyVariables;                   ///< Whether to only use the old variables
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline TrainedVertexSelectionAlgorithm::VertexFeatureInfo::VertexFeatureInfo(const float beamDeweighting, const float rPhiFeature,
-    const float energyKick, const float localAsymmetry, const float globalAsymmetry, const float showerAsymmetry) :
+    const float energyKick, const float localAsymmetry, const float globalAsymmetry, const float showerAsymmetry, const float dEdxAsymmetry, const float vertexEnergy) :
     m_beamDeweighting(beamDeweighting),
     m_rPhiFeature(rPhiFeature),
     m_energyKick(energyKick),
     m_localAsymmetry(localAsymmetry),
     m_globalAsymmetry(globalAsymmetry),
-    m_showerAsymmetry(showerAsymmetry)
+    m_showerAsymmetry(showerAsymmetry),
+    m_dEdxAsymmetry(dEdxAsymmetry),
+    m_vertexEnergy(vertexEnergy)
 {
 }
 

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
@@ -1,7 +1,7 @@
 /**
  *  @file   larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
  *
- *  @brief  Header file for the mva vertex selection algorithm class.
+ *  @brief  Header file for the trained vertex selection algorithm class.
  *
  *  $Log: $
  */
@@ -78,18 +78,18 @@ public:
          *
          *  @param  eventShoweryness the event showeryness feature
          *  @param  eventEnergy the energy of the event
-         *  @param  eventVolume the volume of the event
+         *  @param  eventArea the area of the event
          *  @param  longitudinality the longitudinality of the event
          *  @param  nHits the number of hits in the event
          *  @param  nClusters the number of clusters in the event
          *  @param  nCandidates the total number of vertex candidates
          */
-        EventFeatureInfo(const float eventShoweryness, const float eventEnergy, const float eventVolume, const float longitudinality,
+        EventFeatureInfo(const float eventShoweryness, const float eventEnergy, const float eventArea, const float longitudinality,
             const unsigned int nHits, const unsigned int nClusters, const unsigned int nCandidates);
 
         float m_eventShoweryness;   ///< The event showeryness feature
         float m_eventEnergy;        ///< The event energy
-        float m_eventVolume;        ///< The volume of the event
+        float m_eventArea;          ///< The area of the event
         float m_longitudinality;    ///< The longitudinality of the event
         unsigned int m_nHits;       ///< The number of hits in the event
         unsigned int m_nClusters;   ///< The number of clusters in the event
@@ -221,7 +221,25 @@ protected:
      *  @param  eventVolume the event volume
      *  @param  longitudinality the event longitudinality
      */
-    void GetEventShapeFeatures(const pandora::ClusterList &clusterList, float &eventVolume, float &longitudinality) const;
+    void GetLegacyEventShapeFeatures(const pandora::ClusterList &clusterList, float &eventVolume, float &longitudinality) const;
+
+    /**
+     *  @brief  Get the event shape features
+     *
+     *  @param  clusterList the map of cluster lists for each view
+     *  @param  eventArea the event area
+     *  @param  longitudinality the event longitudinality
+     */
+    void GetEventShapeFeatures(const ClusterListMap &clusterListMap, float &eventArea, float &longitudinality) const;
+
+    /**
+     *  @brief  Get the coordinate span in one view
+     *
+     *  @param  clusterList the cluster list in one view
+     *  @param  xSpan the coordinate span in the drift direction
+     *  @param  zSpan the coordinate span in the wire direction
+     */
+    void Get2DSpan(const pandora::ClusterList &clusterList, float &xSpan, float &zSpan) const;
 
     /**
      *  @brief  Update the min/max coordinate spans
@@ -348,7 +366,7 @@ protected:
      *  @param  kdTreeMap the map of 2D hit kd trees
      *  @param  separation the 3D distance between the two vertex candidates
      *  @param  axisHits the number of hits between the two candidates normalised to the distance between them
-     **/
+     */
 
     void GetSharedFeatures(const pandora::Vertex *const pVertex1, const pandora::Vertex *const pVertex2, const KDTreeMap &kdTreeMap, 
 			   float &separation, float &axisHits) const;
@@ -360,7 +378,7 @@ protected:
      *  @param  pos2 2D projected position of the second vertex
      *  @param  kdTree the kd tree of 2D hits
      *  @param  axisHits the number of hits between the two candidates
-     **/
+     */
     void IncrementSharedAxisValues(const pandora::CartesianVector pos1, const pandora::CartesianVector pos2, HitKDTree2D &kdTree,
 				   float &axisHits) const;
 
@@ -372,7 +390,7 @@ protected:
      *  @param  xMax the maximum position in the drift direction
      *  @param  zMin the minimum position in the wire direction
      *  @param  zMax the maximum position in the wire direction
-     **/
+     */
     void UpdateBoxEdges(const pandora::CartesianVector &point, float &xMin, float &xMax, float &zMin, float &zMax) const;
 
     /**
@@ -385,7 +403,7 @@ protected:
      *  @param  point4 the fourth corner of the box
      *
      *  @return boolean
-     **/
+     */
     bool IsHitInBox(const pandora::CartesianVector &hitPos, const pandora::CartesianVector &point1, const pandora::CartesianVector &point2, 
 		    const pandora::CartesianVector &point3, const pandora::CartesianVector &point4) const;
 
@@ -440,6 +458,7 @@ protected:
     bool m_useRPhiFeatureForRegion;           ///< Whether to use the r/phi feature for the region vertex
     bool m_dropFailedRPhiFastScoreCandidates; ///< Whether to drop candidates that fail the r/phi fast score test
     bool m_testBeamMode;                      ///< Test beam mode
+    bool m_legacyEventShapes;                 ///< Whether to use the old event shapes calculation
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -458,10 +477,10 @@ inline TrainedVertexSelectionAlgorithm::VertexFeatureInfo::VertexFeatureInfo(con
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline TrainedVertexSelectionAlgorithm::EventFeatureInfo::EventFeatureInfo(const float eventShoweryness, const float eventEnergy,
-    const float eventVolume, const float longitudinality, const unsigned int nHits, const unsigned int nClusters, const unsigned int nCandidates) :
+    const float eventArea, const float longitudinality, const unsigned int nHits, const unsigned int nClusters, const unsigned int nCandidates) :
     m_eventShoweryness(eventShoweryness),
     m_eventEnergy(eventEnergy),
-    m_eventVolume(eventVolume),
+    m_eventArea(eventArea),
     m_longitudinality(longitudinality),
     m_nHits(nHits),
     m_nClusters(nClusters),

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
@@ -392,7 +392,6 @@ protected:
      *  @param  separation the 3D distance between the two vertex candidates
      *  @param  axisHits the number of hits between the two candidates normalised to the distance between them
      */
-
     void GetSharedFeatures(const pandora::Vertex *const pVertex1, const pandora::Vertex *const pVertex2, const KDTreeMap &kdTreeMap, 
 			   float &separation, float &axisHits) const;
 
@@ -406,17 +405,6 @@ protected:
      */
     void IncrementSharedAxisValues(const pandora::CartesianVector pos1, const pandora::CartesianVector pos2, HitKDTree2D &kdTree,
 				   float &axisHits) const;
-
-
-    /**
-     *  @brief  Use a 2D vector point to update the minimum and maximum values in each direction
-     *
-     *  @param  xMin the minimum position in the drift direction
-     *  @param  xMax the maximum position in the drift direction
-     *  @param  zMin the minimum position in the wire direction
-     *  @param  zMax the maximum position in the wire direction
-     */
-    void UpdateBoxEdges(const pandora::CartesianVector &point, float &xMin, float &xMax, float &zMin, float &zMax) const;
 
     /**
      *  @brief  Determines whether a hit lies within the box defined by four other positions

--- a/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
+++ b/larpandoracontent/LArVertex/TrainedVertexSelectionAlgorithm.h
@@ -341,6 +341,55 @@ protected:
     void GetBestVertex(const pandora::VertexVector &vertexVector, const pandora::Vertex *&pBestVertex, float &bestVertexDr) const;
 
     /**
+     *  @brief  Calculates the shared features of a pair of vertex candidates
+     *
+     *  @param  pVertex1 the address of the first vertex
+     *  @param  pVertex2 the address of the second vertex
+     *  @param  kdTreeMap the map of 2D hit kd trees
+     *  @param  separation the 3D distance between the two vertex candidates
+     *  @param  axisHits the number of hits between the two candidates normalised to the distance between them
+     **/
+
+    void GetSharedFeatures(const pandora::Vertex *const pVertex1, const pandora::Vertex *const pVertex2, const KDTreeMap &kdTreeMap, 
+			   float &separation, float &axisHits) const;
+
+    /**
+     *  @brief  Increments the axis hits information for one view
+     *
+     *  @param  pos1 2D projected position of the first vertex
+     *  @param  pos2 2D projected position of the second vertex
+     *  @param  kdTree the kd tree of 2D hits
+     *  @param  axisHits the number of hits between the two candidates
+     **/
+    void IncrementSharedAxisValues(const pandora::CartesianVector pos1, const pandora::CartesianVector pos2, HitKDTree2D &kdTree,
+				   float &axisHits) const;
+
+
+    /**
+     *  @brief  Use a 2D vector point to update the minimum and maximum values in each direction
+     *
+     *  @param  xMin the minimum position in the drift direction
+     *  @param  xMax the maximum position in the drift direction
+     *  @param  zMin the minimum position in the wire direction
+     *  @param  zMax the maximum position in the wire direction
+     **/
+    void UpdateBoxEdges(const pandora::CartesianVector &point, float &xMin, float &xMax, float &zMin, float &zMax) const;
+
+    /**
+     *  @brief  Determines whether a hit lies within the box defined by four other positions
+     *
+     *  @param  hitPos the hit position
+     *  @param  point1 the first corner of the box
+     *  @param  point2 the second corner of the box
+     *  @param  point3 the third corner of the box
+     *  @param  point4 the fourth corner of the box
+     *
+     *  @return boolean
+     **/
+    bool IsHitInBox(const pandora::CartesianVector &hitPos, const pandora::CartesianVector &point1, const pandora::CartesianVector &point2, 
+		    const pandora::CartesianVector &point3, const pandora::CartesianVector &point4) const;
+
+    /**
      *  @brief  Add the vertex features to a vector in the correct order
      *
      *  @param  vertexFeatureInfo the vertex feature info

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
@@ -268,9 +268,10 @@ float VertexSelectionBaseAlgorithm::VertexHitEnergy(const Vertex *const pVertex,
   
   for(auto hit : foundHits)
     {
-      if((vertexPosition2D - hit.data->GetPositionVector()).GetMagnitude() < dr)
+      const float diff = (vertexPosition2D - hit.data->GetPositionVector()).GetMagnitude();
+      if(diff < dr)
 	{
-	  dr = (vertexPosition2D - hit.data->GetPositionVector()).GetMagnitude();
+	  dr = diff;
 	  energy = hit.data->GetElectromagneticEnergy();
 	}
     }

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
@@ -242,40 +242,43 @@ bool VertexSelectionBaseAlgorithm::IsVertexInGap(const Vertex *const pVertex, co
 
 float VertexSelectionBaseAlgorithm::GetVertexEnergy(const Vertex *const pVertex, const KDTreeMap &kdTreeMap) const
 {
-  float totalEnergy(0.f);
+    float totalEnergy(0.f);
 
-  if(!this->IsVertexInGap(pVertex, TPC_VIEW_U)) totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_U, kdTreeMap.at(TPC_VIEW_U));
+    if (!this->IsVertexInGap(pVertex, TPC_VIEW_U))
+        totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_U, kdTreeMap.at(TPC_VIEW_U));
 
-  if(!this->IsVertexInGap(pVertex, TPC_VIEW_V)) totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_V, kdTreeMap.at(TPC_VIEW_V));
+    if (!this->IsVertexInGap(pVertex, TPC_VIEW_V))
+        totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_V, kdTreeMap.at(TPC_VIEW_V));
 
-  if(!this->IsVertexInGap(pVertex, TPC_VIEW_W)) totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_W, kdTreeMap.at(TPC_VIEW_W));
+    if (!this->IsVertexInGap(pVertex, TPC_VIEW_W))
+        totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_W, kdTreeMap.at(TPC_VIEW_W));
 
-  return totalEnergy;
+    return totalEnergy;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 float VertexSelectionBaseAlgorithm::VertexHitEnergy(const Vertex *const pVertex, const HitType hitType, HitKDTree2D &kdTree) const
 {
-  const CartesianVector vertexPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
-  KDTreeBox searchRegionHits = build_2d_kd_search_region(vertexPosition2D, m_maxOnHitDisplacement, m_maxOnHitDisplacement);
-  
-  HitKDNode2DList foundHits;
-  kdTree.search(searchRegionHits, foundHits);
-  
-  float dr(std::numeric_limits<float>::max());
-  float energy(0);
-  
-  for(auto hit : foundHits)
+    const CartesianVector vertexPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
+    KDTreeBox searchRegionHits = build_2d_kd_search_region(vertexPosition2D, m_maxOnHitDisplacement, m_maxOnHitDisplacement);
+
+    HitKDNode2DList foundHits;
+    kdTree.search(searchRegionHits, foundHits);
+
+    float dr(std::numeric_limits<float>::max());
+    float energy(0);
+
+    for (auto hit : foundHits)
     {
-      const float diff = (vertexPosition2D - hit.data->GetPositionVector()).GetMagnitude();
-      if(diff < dr)
-	{
-	  dr = diff;
-	  energy = hit.data->GetElectromagneticEnergy();
-	}
+        const float diff = (vertexPosition2D - hit.data->GetPositionVector()).GetMagnitude();
+        if (diff < dr)
+        {
+            dr = diff;
+            energy = hit.data->GetElectromagneticEnergy();
+        }
     }
-  return energy;
+    return energy;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
@@ -240,6 +240,45 @@ bool VertexSelectionBaseAlgorithm::IsVertexInGap(const Vertex *const pVertex, co
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+float VertexSelectionBaseAlgorithm::GetVertexEnergy(const Vertex *const pVertex, const KDTreeMap &kdTreeMap) const
+{
+  float totalEnergy(0.f);
+
+  if(!this->IsVertexInGap(pVertex, TPC_VIEW_U)) totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_U, kdTreeMap.at(TPC_VIEW_U));
+
+  if(!this->IsVertexInGap(pVertex, TPC_VIEW_V)) totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_V, kdTreeMap.at(TPC_VIEW_V));
+
+  if(!this->IsVertexInGap(pVertex, TPC_VIEW_W)) totalEnergy += this->VertexHitEnergy(pVertex, TPC_VIEW_W, kdTreeMap.at(TPC_VIEW_W));
+
+  return totalEnergy;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float VertexSelectionBaseAlgorithm::VertexHitEnergy(const Vertex *const pVertex, const HitType hitType, HitKDTree2D &kdTree) const
+{
+  const CartesianVector vertexPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), hitType));
+  KDTreeBox searchRegionHits = build_2d_kd_search_region(vertexPosition2D, m_maxOnHitDisplacement, m_maxOnHitDisplacement);
+  
+  HitKDNode2DList foundHits;
+  kdTree.search(searchRegionHits, foundHits);
+  
+  float dr(std::numeric_limits<float>::max());
+  float energy(0);
+  
+  for(auto hit : foundHits)
+    {
+      if((vertexPosition2D - hit.data->GetPositionVector()).GetMagnitude() < dr)
+	{
+	  dr = (vertexPosition2D - hit.data->GetPositionVector()).GetMagnitude();
+	  energy = hit.data->GetElectromagneticEnergy();
+	}
+    }
+  return energy;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void VertexSelectionBaseAlgorithm::SelectTopScoreVertices(VertexScoreList &vertexScoreList, VertexList &selectedVertexList) const
 {
     float bestScore(0.f);

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
@@ -323,7 +323,7 @@ protected:
      *  @param  kdTreeMap the map of 2D hit kd trees
      *
      *  @return the summed vertex energy
-     **/
+     */
 
     float GetVertexEnergy(const pandora::Vertex *const pVertex, const KDTreeMap &kdTreeMap) const;
 
@@ -335,7 +335,7 @@ protected:
      *  @param  kdTree the kd tree of 2D hits
      *
      *  @return the energy of the nearest hit
-     **/
+     */
 
     float VertexHitEnergy(const pandora::Vertex *const pVertex, const pandora::HitType hitType, HitKDTree2D &kdTree) const;
 

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
@@ -307,16 +307,6 @@ protected:
     bool IsBeamModeOn() const;
 
     /**
-     *  @brief  Whether the vertex lies in a registered gap
-     *
-     *  @param  pVertex the address of the vertex
-     *  @param  hitType the relevant hit type
-     *
-     *  @return boolean
-     */
-    bool IsVertexInGap(const pandora::Vertex *const pVertex, const pandora::HitType hitType) const;
-
-    /**
      *  @brief  Calculate the energy of a vertex candidate by summing values from all three planes
      *
      *  @param  pVertex the address of the vertex
@@ -324,7 +314,6 @@ protected:
      *
      *  @return the summed vertex energy
      */
-
     float GetVertexEnergy(const pandora::Vertex *const pVertex, const KDTreeMap &kdTreeMap) const;
 
     /**
@@ -336,7 +325,6 @@ protected:
      *
      *  @return the energy of the nearest hit
      */
-
     float VertexHitEnergy(const pandora::Vertex *const pVertex, const pandora::HitType hitType, HitKDTree2D &kdTree) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -363,6 +351,16 @@ private:
      *  @return boolean
      */
     bool IsVertexOnHit(const pandora::Vertex *const pVertex, const pandora::HitType hitType, HitKDTree2D &kdTree) const;
+
+    /**
+     *  @brief  Whether the vertex lies in a registered gap
+     *
+     *  @param  pVertex the address of the vertex
+     *  @param  hitType the relevant hit type
+     *
+     *  @return boolean
+     */
+    bool IsVertexInGap(const pandora::Vertex *const pVertex, const pandora::HitType hitType) const;
 
     /**
      *  @brief  From the top-scoring candidate vertices, select a subset for further investigation

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
@@ -306,6 +306,39 @@ protected:
      */
     bool IsBeamModeOn() const;
 
+    /**
+     *  @brief  Whether the vertex lies in a registered gap
+     *
+     *  @param  pVertex the address of the vertex
+     *  @param  hitType the relevant hit type
+     *
+     *  @return boolean
+     */
+    bool IsVertexInGap(const pandora::Vertex *const pVertex, const pandora::HitType hitType) const;
+
+    /**
+     *  @brief  Calculate the energy of a vertex candidate by summing values from all three planes
+     *
+     *  @param  pVertex the address of the vertex
+     *  @param  kdTreeMap the map of 2D hit kd trees
+     *
+     *  @return the summed vertex energy
+     **/
+
+    float GetVertexEnergy(const pandora::Vertex *const pVertex, const KDTreeMap &kdTreeMap) const;
+
+    /**
+     *  @brief  Finds the energy of the nearest hit to the vertex candidate in this view
+     *
+     *  @param  pVertex the address of the vertex
+     *  @param  hitType the relevant hit type
+     *  @param  kdTree the kd tree of 2D hits
+     *
+     *  @return the energy of the nearest hit
+     **/
+
+    float VertexHitEnergy(const pandora::Vertex *const pVertex, const pandora::HitType hitType, HitKDTree2D &kdTree) const;
+
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
 private:
@@ -330,16 +363,6 @@ private:
      *  @return boolean
      */
     bool IsVertexOnHit(const pandora::Vertex *const pVertex, const pandora::HitType hitType, HitKDTree2D &kdTree) const;
-
-    /**
-     *  @brief  Whether the vertex lies in a registered gap
-     *
-     *  @param  pVertex the address of the vertex
-     *  @param  hitType the relevant hit type
-     *
-     *  @return boolean
-     */
-    bool IsVertexInGap(const pandora::Vertex *const pVertex, const pandora::HitType hitType) const;
 
     /**
      *  @brief  From the top-scoring candidate vertices, select a subset for further investigation


### PR DESCRIPTION
This PR includes a series of updates/improvements to the MVA vertex selection procedure. This includes the fix to issue #157, the addition of a new feature tool for calculating the `EnergyDepositionAsymmetry` and provides functionality to use features "shared" between the two vertex candidates. All operational changes are controlled by xml-parameters so the PR shouldn't have any affect without opting to move out of "legacy" mode.

There is a large amount of code here but the separate commits should represent distinct ideas, I hope this makes it easier for reviewing! 
- [b6d1cd](https://github.com/henrylay97/LArContent/commit/b6d1cd27ba0e46d83caf0969b6349980b1888760) adds the new `EnergyDepositionAsymmetryTool` 
- [9e3c99](https://github.com/henrylay97/LArContent/commit/9e3c99a4a087cd6d82206ae60021e989fe7b837c) adds the functionality that calculates the `VertexEnergy` variables
- [66f9c2](https://github.com/henrylay97/LArContent/commit/66f9c2cb4fc7c21e39238556fdff7276e205d9c9) adds the functionality for the shared variables and [93d5ec](https://github.com/henrylay97/LArContent/commit/93d5ec75e64939dae88e646c7e1bc20baa19f46a) adds the new object based on `VertexFeatureInfo` and `EventFeatureInfo` to store the shared variables.
- [d94d24](https://github.com/henrylay97/LArContent/commit/d94d2422a3774f7edd420ad2060114721706f4d9) fixes the event shape features, default is to use the old calculation still, [5b028c](https://github.com/henrylay97/LArContent/commit/5b028c0c561e63aac1fa73d70b605c85b7f8fb02) adds a warning message if using the old calculation whilst in training mode.
- [50008d](https://github.com/henrylay97/LArContent/commit/50008debb6856f01df45a7b1993ebbd88be712ea) actually uses all this in the configuration I presented last week. Again the default mode is to use the old configuration.
- [ddf431](https://github.com/henrylay97/LArContent/commit/ddf43161ad38b66fb5aca0da94ed9c98490a2ed9) and [9258e3](https://github.com/henrylay97/LArContent/commit/9258e35286b93246cc16dc63f084de8fd7333d53) tidy up the commenting and apply the clang format.