### PR TITLE
feature/hierarchy_tools

### DIFF
--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
@@ -583,18 +583,6 @@ const std::string LArHierarchyHelper::RecoHierarchy::ToString() const
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
-
-void LArHierarchyHelper::RecoHierarchy::GetAllRecoHits(const ParticleFlowObject *pPfo, CaloHitList &allHits) const
-{
-    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, allHits);
-    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, allHits);
-    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, allHits);
-    LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_U, allHits);
-    LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_V, allHits);
-    LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_W, allHits);
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 LArHierarchyHelper::RecoHierarchy::Node::Node(const RecoHierarchy &hierarchy, const ParticleFlowObject *pPfo) :

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
@@ -1,0 +1,967 @@
+/**
+ *  @file   larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+ *
+ *  @brief  Implementation of the lar hierarchy helper class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/PdgTable.h"
+#include "Pandora/StatusCodes.h"
+
+#include "larpandoracontent/LArHelpers/LArHierarchyHelper.h"
+
+namespace lar_content
+{
+
+using namespace pandora;
+
+LArHierarchyHelper::MCHierarchy::MCHierarchy(const ReconstructabilityCriteria &recoCriteria) :
+    m_recoCriteria(recoCriteria),
+    m_pNeutrino{nullptr}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::~MCHierarchy()
+{
+    for (const Node *pNode : m_rootNodes)
+        delete pNode;
+    m_rootNodes.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCHierarchy::FillHierarchy(const MCParticleList &mcParticleList, const CaloHitList &caloHitList,
+    const bool foldToPrimaries, const bool foldToLeadingShowers)
+{
+    auto predicate = [](const MCParticle *pMC) { return std::abs(pMC->GetParticleId() == NEUTRON); };
+    m_mcToHitsMap.clear();
+    for (const CaloHit *pCaloHit : caloHitList)
+    {
+        try
+        {
+            const MCParticle *pMC{MCParticleHelper::GetMainMCParticle(pCaloHit)};
+            m_mcToHitsMap[pMC].emplace_back(pCaloHit);
+        }
+        catch(const StatusCodeException&)
+        {
+            std::cout << "Found calo hit with no MC" << std::endl;
+        }
+    }
+
+    if (foldToPrimaries && !foldToLeadingShowers)
+    {
+        MCParticleSet primarySet;
+        m_pNeutrino = LArHierarchyHelper::GetMCPrimaries(mcParticleList, primarySet);
+        MCParticleList primaries(primarySet.begin(), primarySet.end());
+        if (m_recoCriteria.m_removeNeutrons)
+            primaries.erase(std::remove_if(primaries.begin(), primaries.end(), predicate), primaries.end());
+        for (const MCParticle *pPrimary : primaries)
+        {
+            MCParticleList allParticles{pPrimary};
+            if (!m_recoCriteria.m_removeNeutrons)
+            {
+                LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles);
+            }
+            else
+            {   // Collect track-like and shower-like particles together, but throw out neutrons and descendents
+                MCParticleList neutrons;
+                LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles, allParticles, neutrons);
+            }
+            CaloHitList allHits;
+            for (const MCParticle *pMC : allParticles)
+            {
+                // Not all MC particles will have hits
+                if (m_mcToHitsMap.find(pMC) != m_mcToHitsMap.end())
+                {
+                    const CaloHitList &caloHits(m_mcToHitsMap.at(pMC));
+                    allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+                }
+            }
+            m_rootNodes.emplace_back(new Node(*this, allParticles, allHits));
+        }
+    }
+    else if (foldToPrimaries && foldToLeadingShowers)
+    {
+        MCParticleSet primarySet;
+        m_pNeutrino = LArHierarchyHelper::GetMCPrimaries(mcParticleList, primarySet);
+        MCParticleList primaries(primarySet.begin(), primarySet.end());
+        if (m_recoCriteria.m_removeNeutrons)
+            primaries.erase(std::remove_if(primaries.begin(), primaries.end(), predicate), primaries.end());
+        for (const MCParticle *pPrimary : primaries)
+        {
+            MCParticleList allParticles{pPrimary}, showerParticles, neutrons;
+            int pdg{std::abs(pPrimary->GetParticleId())};
+            const bool isShower{pdg == E_MINUS || pdg == PHOTON};
+            const bool isNeutron{pdg == NEUTRON};
+            if (isShower || isNeutron)
+            {
+                if (!m_recoCriteria.m_removeNeutrons)
+                {
+                    LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles);
+                }
+                else
+                {   // Throw away neutrons
+                    MCParticleList dummy;
+                    LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles, allParticles, dummy);
+                }
+            }
+            else
+            {
+                LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles, showerParticles, neutrons);
+            }
+            CaloHitList allHits;
+            for (const MCParticle *pMC : allParticles)
+            {
+                // ATTN - Not all MC particles will have hits
+                if (m_mcToHitsMap.find(pMC) != m_mcToHitsMap.end())
+                {
+                    const CaloHitList &caloHits(m_mcToHitsMap.at(pMC));
+                    allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+                }
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            if (!showerParticles.empty())
+            {   // Collect up all descendent hits for each shower and add the nodes as a child of the root node
+                for (const MCParticle *pChild : showerParticles)
+                    pNode->FillFlat(pChild);
+            }
+            if (!m_recoCriteria.m_removeNeutrons && !neutrons.empty())
+            {   // Collect up all descendent hits for each neutron and add the nodes as a child of the root node
+                for (const MCParticle *pChild : neutrons)
+                    pNode->FillFlat(pChild);
+            }
+        }
+    }
+    else if (foldToLeadingShowers)
+    {
+        // Identify the primaries as the starting point for the hierarchy
+        // We have special handling for the neutrino, probably want something similar for testbeam particles
+        MCParticleSet primarySet;
+        m_pNeutrino = LArHierarchyHelper::GetMCPrimaries(mcParticleList, primarySet);
+        MCParticleList primaries(primarySet.begin(), primarySet.end());
+        if (m_recoCriteria.m_removeNeutrons)
+            primaries.erase(std::remove_if(primaries.begin(), primaries.end(), predicate), primaries.end());
+        for (const MCParticle *pPrimary : primaries)
+        {
+            MCParticleList allParticles{pPrimary};
+            int pdg{std::abs(pPrimary->GetParticleId())};
+            const bool isShower{pdg == E_MINUS || pdg == PHOTON};
+            const bool isNeutron{pdg == NEUTRON};
+            if (isShower || (isNeutron && !m_recoCriteria.m_removeNeutrons))
+                LArMCParticleHelper::GetAllDescendentMCParticles(pPrimary, allParticles);
+            CaloHitList allHits;
+            for (const MCParticle *pMC : allParticles)
+            {
+                // ATTN - Not all MC particles will have hits
+                if (m_mcToHitsMap.find(pMC) != m_mcToHitsMap.end())
+                {
+                    const CaloHitList &caloHits(m_mcToHitsMap.at(pMC));
+                    allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+                }
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            if (!(isShower || isNeutron))
+            {   // Find the children of this particle and recursively add them to the hierarchy
+                const MCParticleList &children{pPrimary->GetDaughterList()};
+                for (const MCParticle *pChild : children)
+                    pNode->FillHierarchy(pChild, foldToLeadingShowers);
+            }
+        }
+    }
+    else
+    {
+        MCParticleSet primarySet;
+        m_pNeutrino = LArHierarchyHelper::GetMCPrimaries(mcParticleList, primarySet);
+        MCParticleList primaries(primarySet.begin(), primarySet.end());
+        if (m_recoCriteria.m_removeNeutrons)
+            primaries.erase(std::remove_if(primaries.begin(), primaries.end(), predicate), primaries.end());
+        for (const MCParticle *pPrimary : primaries)
+        {
+            MCParticleList allParticles{pPrimary};
+            CaloHitList allHits;
+            for (const MCParticle *pMC : allParticles)
+            {
+                // ATTN - Not all MC particles will have hits
+                if (m_mcToHitsMap.find(pMC) != m_mcToHitsMap.end())
+                {
+                    const CaloHitList &caloHits(m_mcToHitsMap.at(pMC));
+                    allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+                }
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            // Find the children of this particle and recursively add them to the hierarchy
+            const MCParticleList &children{pPrimary->GetDaughterList()};
+            for (const MCParticle *pChild : children)
+                pNode->FillHierarchy(pChild, foldToLeadingShowers);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCHierarchy::GetFlattenedNodes(NodeVector &nodeVector) const
+{
+    NodeList queue;
+    for (const Node* pNode : m_rootNodes)
+    {
+        nodeVector.emplace_back(pNode);
+        queue.emplace_back(pNode);
+    }
+    while (!queue.empty())
+    {
+        const NodeVector &children{queue.front()->GetChildren()};
+        queue.pop_front();
+        for (const Node *pChild : children)
+        {
+            nodeVector.emplace_back(pChild);
+            queue.emplace_back(pChild);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string LArHierarchyHelper::MCHierarchy::ToString() const
+{
+    std::string str;
+    for (const Node *pNode : m_rootNodes)
+        str += pNode->ToString("") + "\n";
+
+    return str;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::Node::Node(const MCHierarchy &hierarchy, const MCParticle *pMC) :
+    m_hierarchy(hierarchy),
+    m_pdg{0}
+{
+    if (pMC)
+    {
+        m_pdg = pMC->GetParticleId();
+        m_mcParticles.emplace_back(pMC);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::Node::Node(const MCHierarchy &hierarchy, const MCParticleList &mcParticleList, const CaloHitList &caloHitList) :
+    m_hierarchy(hierarchy),
+    m_pdg{0}
+{
+    if (!mcParticleList.empty())
+        m_pdg = mcParticleList.front()->GetParticleId();
+    m_mcParticles = mcParticleList; m_mcParticles.sort();
+    m_caloHits = caloHitList; m_caloHits.sort();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::Node::~Node()
+{
+    m_mcParticles.clear();
+    m_caloHits.clear();
+    for (const Node *node : m_children)
+        delete node;
+    m_children.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCHierarchy::Node::FillHierarchy(const MCParticle *pRoot, const bool foldToLeadingShowers)
+{
+    MCParticleList allParticles{pRoot};
+    int pdg{std::abs(pRoot->GetParticleId())};
+    const bool isShower{pdg == E_MINUS || pdg == PHOTON};
+    const bool isNeutron{pdg == NEUTRON};
+    if (foldToLeadingShowers && (isShower || (isNeutron && !m_hierarchy.m_recoCriteria.m_removeNeutrons)))
+        LArMCParticleHelper::GetAllDescendentMCParticles(pRoot, allParticles);
+    else if (m_hierarchy.m_recoCriteria.m_removeNeutrons && isNeutron)
+        return;
+    CaloHitList allHits;
+    for (const MCParticle *pMC : allParticles)
+    {
+        // ATTN - Not all MC particles will have hits
+        if (m_hierarchy.m_mcToHitsMap.find(pMC) != m_hierarchy.m_mcToHitsMap.end())
+        {
+            const CaloHitList &caloHits(m_hierarchy.m_mcToHitsMap.at(pMC));
+            allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+        }
+    }
+    if (!allParticles.empty())
+    {
+        Node *pNode{new Node(m_hierarchy, allParticles, allHits)};
+        m_children.emplace_back(pNode);
+        if (!foldToLeadingShowers || (foldToLeadingShowers && !(isShower || isNeutron)))
+        {   // Find the children of this particle and recursively add them to the hierarchy
+            const MCParticleList &children{pRoot->GetDaughterList()};
+            for (const MCParticle *pChild : children)
+                pNode->FillHierarchy(pChild, foldToLeadingShowers);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCHierarchy::Node::FillFlat(const MCParticle *pRoot)
+{
+    MCParticleList allParticles{pRoot};
+    if (!m_hierarchy.m_recoCriteria.m_removeNeutrons)
+    {
+        LArMCParticleHelper::GetAllDescendentMCParticles(pRoot, allParticles);
+    }
+    else
+    {
+        MCParticleList neutrons;
+        LArMCParticleHelper::GetAllDescendentMCParticles(pRoot, allParticles, allParticles, neutrons);
+    }
+    CaloHitList allHits;
+    for (const MCParticle *pMC : allParticles)
+    {
+        // ATTN - Not all MC particles will have hits
+        if (m_hierarchy.m_mcToHitsMap.find(pMC) != m_hierarchy.m_mcToHitsMap.end())
+        {
+            const CaloHitList &caloHits(m_hierarchy.m_mcToHitsMap.at(pMC));
+            allHits.insert(allHits.begin(), caloHits.begin(), caloHits.end());
+        }
+    }
+    if (!allParticles.empty())
+    {
+        Node *pNode{new Node(m_hierarchy, allParticles, allHits)};
+        m_children.emplace_back(pNode);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool LArHierarchyHelper::MCHierarchy::Node::IsReconstructable() const
+{
+    const bool enoughHits{m_caloHits.size() >= m_hierarchy.m_recoCriteria.m_minHits};
+    bool enoughGoodViews{false};
+    int nHitsU{0}, nHitsV{0}, nHitsW{0};
+    for (const CaloHit *pCaloHit : m_caloHits)
+    {
+        switch (pCaloHit->GetHitType())
+        {
+            case TPC_VIEW_U:
+                ++nHitsU;
+                break;
+            case TPC_VIEW_V:
+                ++nHitsV;
+                break;
+            case TPC_VIEW_W:
+                ++nHitsW;
+                break;
+            default:
+                break;
+        }
+        int nGoodViews{0};
+        if (nHitsU >= m_hierarchy.m_recoCriteria.m_minHitsForGoodView)
+            ++nGoodViews;
+        if (nHitsV >= m_hierarchy.m_recoCriteria.m_minHitsForGoodView)
+            ++nGoodViews;
+        if (nHitsW >= m_hierarchy.m_recoCriteria.m_minHitsForGoodView)
+            ++nGoodViews;
+        if (nGoodViews >= m_hierarchy.m_recoCriteria.m_minGoodViews)
+        {
+            enoughGoodViews = true;
+            break;
+        }
+    }
+
+    return enoughHits && enoughGoodViews;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const MCParticleList &LArHierarchyHelper::MCHierarchy::Node::GetMCParticles() const
+{
+    return m_mcParticles;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const CaloHitList &LArHierarchyHelper::MCHierarchy::Node::GetCaloHits() const
+{
+    return m_caloHits;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+int LArHierarchyHelper::MCHierarchy::Node::GetParticleId() const
+{
+    return m_pdg;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string LArHierarchyHelper::MCHierarchy::Node::ToString(const std::string &prefix) const
+{
+    std::string str(prefix + "PDG: " + std::to_string(m_pdg) + " Energy: " + std::to_string(m_mcParticles.front()->GetEnergy()) +
+        " Hits: " + std::to_string(m_caloHits.size()) + "\n");
+    for (const Node *pChild : m_children)
+        str += pChild->ToString(prefix + "   ");
+
+    return str;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria() :
+    m_minHits{15},
+    m_minHitsForGoodView{5},
+    m_minGoodViews{2},
+    m_removeNeutrons{true}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria(const ReconstructabilityCriteria &obj) :
+    m_minHits{obj.m_minHits},
+    m_minHitsForGoodView{obj.m_minHitsForGoodView},
+    m_minGoodViews{obj.m_minGoodViews},
+    m_removeNeutrons{obj.m_removeNeutrons}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCHierarchy::ReconstructabilityCriteria::ReconstructabilityCriteria(const unsigned int minHits,
+    const unsigned int minHitsForGoodView, const unsigned int minGoodViews, const bool removeNeutrons) :
+    m_minHits{minHits},
+    m_minHitsForGoodView{minHitsForGoodView},
+    m_minGoodViews{minGoodViews},
+    m_removeNeutrons{removeNeutrons}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::RecoHierarchy() :
+    m_pNeutrino{nullptr}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::~RecoHierarchy()
+{
+    for (const Node *pNode : m_rootNodes)
+        delete pNode;
+    m_rootNodes.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::RecoHierarchy::FillHierarchy(const PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers)
+{
+    if (foldToPrimaries && !foldToLeadingShowers)
+    {
+        PfoSet primaries;
+        m_pNeutrino = LArHierarchyHelper::GetRecoPrimaries(pfoList, primaries);
+        for (const ParticleFlowObject *pPrimary : primaries)
+        {
+            PfoList allParticles;
+            // ATTN - pPrimary gets added to the list of downstream PFOs, not just the child PFOs
+            LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles);
+            CaloHitList allHits;
+            for (const ParticleFlowObject *pPfo : allParticles)
+            {
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, allHits);
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, allHits);
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_U, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_V, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_W, allHits);
+            }
+            m_rootNodes.emplace_back(new Node(*this, allParticles, allHits));
+        }
+    }
+    else if (foldToPrimaries && foldToLeadingShowers)
+    {
+        PfoSet primaries;
+        m_pNeutrino = LArHierarchyHelper::GetRecoPrimaries(pfoList, primaries);
+        for (const ParticleFlowObject *pPrimary : primaries)
+        {
+            PfoList allParticles, showerParticles;
+            int pdg{std::abs(pPrimary->GetParticleId())};
+            const bool isShower{pdg == E_MINUS};
+            // ATTN - pPrimary gets added to the list of downstream PFOs, not just the child PFOs
+            if (isShower)
+                LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles);
+            else
+                LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles, showerParticles);
+            CaloHitList allHits;
+            for (const ParticleFlowObject *pPfo : allParticles)
+            {
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, allHits);
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, allHits);
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_U, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_V, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_W, allHits);
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            if (!showerParticles.empty())
+            {   // Collect up all descendent hits for each shower and add the nodes as a child of the root node
+                for (const ParticleFlowObject *pChild : showerParticles)
+                    pNode->FillFlat(pChild);
+            }
+        }
+    }
+    else if (foldToLeadingShowers)
+    {
+        // Identify the primaries as the starting point for the hierarchy
+        // We have special handling for the neutrino, probably want something similar for testbeam particles
+        PfoSet primaries;
+        m_pNeutrino = LArHierarchyHelper::GetRecoPrimaries(pfoList, primaries);
+        for (const ParticleFlowObject *pPrimary : primaries)
+        {
+            PfoList allParticles;
+            int pdg{std::abs(pPrimary->GetParticleId())};
+            const bool isShower{pdg == E_MINUS};
+            // ATTN - pPrimary gets added to the list of downstream PFOs, not just the child PFOs
+            if (isShower)
+                LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles);
+            else
+                allParticles.emplace_back(pPrimary);
+
+            CaloHitList allHits;
+            for (const ParticleFlowObject *pPfo : allParticles)
+            {
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, allHits);
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, allHits);
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_U, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_V, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_W, allHits);
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            if (!isShower)
+            {   // Find the children of this particle and recursively add them to the hierarchy
+                const PfoList &children{pPrimary->GetDaughterPfoList()};
+                for (const ParticleFlowObject *pChild : children)
+                    pNode->FillHierarchy(pChild, foldToLeadingShowers);
+            }
+        }
+    }
+    else
+    {
+        PfoSet primaries;
+        m_pNeutrino = LArHierarchyHelper::GetRecoPrimaries(pfoList, primaries);
+        for (const ParticleFlowObject *pPrimary : primaries)
+        {
+            PfoList allParticles{pPrimary};
+            CaloHitList allHits;
+            for (const ParticleFlowObject *pPfo : allParticles)
+            {
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, allHits);
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, allHits);
+                LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_U, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_V, allHits);
+                LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_W, allHits);
+            }
+            Node *pNode{new Node(*this, allParticles, allHits)};
+            m_rootNodes.emplace_back(pNode);
+            // Find the children of this particle and recursively add them to the hierarchy
+            const PfoList &children{pPrimary->GetDaughterPfoList()};
+            for (const ParticleFlowObject *pChild : children)
+                pNode->FillHierarchy(pChild, foldToLeadingShowers);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::RecoHierarchy::GetFlattenedNodes(NodeVector &nodeVector) const
+{
+    NodeList queue;
+    for (const Node* pNode : m_rootNodes)
+    {
+        nodeVector.emplace_back(pNode);
+        queue.emplace_back(pNode);
+    }
+    while (!queue.empty())
+    {
+        const NodeVector &children{queue.front()->GetChildren()};
+        queue.pop_front();
+        for (const Node *pChild : children)
+        {
+            nodeVector.emplace_back(pChild);
+            queue.emplace_back(pChild);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string LArHierarchyHelper::RecoHierarchy::ToString() const
+{
+    std::string str;
+    for (const Node *pNode : m_rootNodes)
+        str += pNode->ToString("") + "\n";
+
+    return str;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::Node::Node(const RecoHierarchy &hierarchy, const ParticleFlowObject *pPfo) :
+    m_hierarchy(hierarchy),
+    m_pdg{0}
+{
+    if (pPfo)
+    {
+        m_pdg = pPfo->GetParticleId();
+        m_pfos.emplace_back(pPfo);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::Node::Node(const RecoHierarchy &hierarchy, const PfoList &pfoList, const CaloHitList &caloHitList) :
+    m_hierarchy(hierarchy),
+    m_pdg{0}
+{
+    if (!pfoList.empty())
+        m_pdg = pfoList.front()->GetParticleId();
+    m_pfos = pfoList; m_pfos.sort();
+    m_caloHits = caloHitList; m_caloHits.sort();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::RecoHierarchy::Node::~Node()
+{
+    m_pfos.clear();
+    m_caloHits.clear();
+    for (const Node *node : m_children)
+        delete node;
+    m_children.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::RecoHierarchy::Node::FillHierarchy(const ParticleFlowObject *pRoot, const bool foldToLeadingShowers)
+{
+    PfoList allParticles;
+    int pdg{std::abs(pRoot->GetParticleId())};
+    const bool isShower{pdg == E_MINUS};
+    if (foldToLeadingShowers && isShower)
+        LArPfoHelper::GetAllDownstreamPfos(pRoot, allParticles);
+    else
+        allParticles.emplace_back(pRoot);
+
+    CaloHitList allHits;
+    for (const ParticleFlowObject *pPfo : allParticles)
+    {
+        LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, allHits);
+        LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, allHits);
+        LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, allHits);
+        LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_U, allHits);
+        LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_V, allHits);
+        LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_W, allHits);
+    }
+    Node *pNode{new Node(m_hierarchy, allParticles, allHits)};
+    m_children.emplace_back(pNode);
+    if (!foldToLeadingShowers || (foldToLeadingShowers && !isShower))
+    {   // Find the children of this particle and recursively add them to the hierarchy
+        const PfoList &children{pRoot->GetDaughterPfoList()};
+        for (const ParticleFlowObject *pChild : children)
+            pNode->FillHierarchy(pChild, foldToLeadingShowers);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::RecoHierarchy::Node::FillFlat(const ParticleFlowObject *pRoot)
+{
+    PfoList allParticles;
+    LArPfoHelper::GetAllDownstreamPfos(pRoot, allParticles);
+    CaloHitList allHits;
+    for (const ParticleFlowObject *pPfo : allParticles)
+    {
+        LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, allHits);
+        LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, allHits);
+        LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, allHits);
+        LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_U, allHits);
+        LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_V, allHits);
+        LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_W, allHits);
+    }
+    Node *pNode{new Node(m_hierarchy, allParticles, allHits)};
+    m_children.emplace_back(pNode);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const PfoList &LArHierarchyHelper::RecoHierarchy::Node::GetRecoParticles() const
+{
+    return m_pfos;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const CaloHitList &LArHierarchyHelper::RecoHierarchy::Node::GetCaloHits() const
+{
+    return m_caloHits;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+int LArHierarchyHelper::RecoHierarchy::Node::GetParticleId() const
+{
+    return m_pdg;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const std::string LArHierarchyHelper::RecoHierarchy::Node::ToString(const std::string &prefix) const
+{
+    std::string str(prefix + "PDG: " + std::to_string(m_pdg) + " Hits: " + std::to_string(m_caloHits.size()) + "\n");
+    for (const Node *pChild : m_children)
+        str += pChild->ToString(prefix + "   ");
+
+    return str;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArHierarchyHelper::MCMatches::MCMatches(const MCHierarchy::Node *pMC) :
+    m_pMC{pMC}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MCMatches::AddRecoMatch(const RecoHierarchy::Node *pReco, const int nSharedHits)
+{
+    m_recoNodes.emplace_back(pReco);
+    m_sharedHits.emplace_back(nSharedHits);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+int LArHierarchyHelper::MCMatches::GetSharedHits(const RecoHierarchy::Node *pReco) const
+{
+    auto iter{std::find(m_recoNodes.begin(), m_recoNodes.end(), pReco)};
+    if (iter == m_recoNodes.end())
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+    int index = iter - m_recoNodes.begin();
+
+    return static_cast<int>(m_sharedHits[index]);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LArHierarchyHelper::MCMatches::GetPurity(const RecoHierarchy::Node *pReco) const
+{
+    auto iter{std::find(m_recoNodes.begin(), m_recoNodes.end(), pReco)};
+    if (iter == m_recoNodes.end())
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+    int index = iter - m_recoNodes.begin();
+
+    return m_sharedHits[index] / static_cast<float>(pReco->GetCaloHits().size());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LArHierarchyHelper::MCMatches::GetCompleteness(const RecoHierarchy::Node *pReco) const
+{
+    auto iter{std::find(m_recoNodes.begin(), m_recoNodes.end(), pReco)};
+    if (iter == m_recoNodes.end())
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+    int index = iter - m_recoNodes.begin();
+
+    return m_sharedHits[index] / static_cast<float>(m_pMC->GetCaloHits().size());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::FillMCHierarchy(const MCParticleList &mcParticleList, const CaloHitList &caloHitList, const bool foldToPrimaries,
+    const bool foldToLeadingShowers, MCHierarchy &hierarchy)
+{
+    hierarchy.FillHierarchy(mcParticleList, caloHitList, foldToPrimaries, foldToLeadingShowers);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::FillRecoHierarchy(const PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers,
+    RecoHierarchy &hierarchy)
+{
+    hierarchy.FillHierarchy(pfoList, foldToPrimaries, foldToLeadingShowers);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArHierarchyHelper::MatchHierarchies(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy, MCMatchesVector &matchVector)
+{
+    MCHierarchy::NodeVector mcNodes;
+    mcHierarchy.GetFlattenedNodes(mcNodes);
+    RecoHierarchy::NodeVector recoNodes;
+    recoHierarchy.GetFlattenedNodes(recoNodes);
+
+    std::sort(mcNodes.begin(), mcNodes.end(), [](const MCHierarchy::Node *lhs, const MCHierarchy::Node *rhs)
+        {
+            return lhs->GetCaloHits().size() > rhs->GetCaloHits().size();
+        });
+    std::sort(recoNodes.begin(), recoNodes.end(), [](const RecoHierarchy::Node *lhs, const RecoHierarchy::Node *rhs)
+        {
+            return lhs->GetCaloHits().size() > rhs->GetCaloHits().size();
+        });
+
+    std::map<const MCHierarchy::Node *, MCMatches> mcToMatchMap;
+    for (const RecoHierarchy::Node *pRecoNode : recoNodes)
+    {
+        const CaloHitList &recoHits{pRecoNode->GetCaloHits()};
+        const MCHierarchy::Node *pBestNode{nullptr};
+        size_t bestSharedHits{0};
+        for (const MCHierarchy::Node *pMCNode : mcNodes)
+        {
+            if (!pMCNode->IsReconstructable())
+                continue;
+            const CaloHitList &mcHits{pMCNode->GetCaloHits()};
+            CaloHitVector intersection;
+            std::set_intersection(mcHits.begin(), mcHits.end(), recoHits.begin(), recoHits.end(), std::back_inserter(intersection));
+
+            if (!intersection.empty())
+            {
+                const size_t sharedHits{intersection.size()};
+                if (sharedHits > bestSharedHits)
+                {
+                    bestSharedHits = sharedHits;
+                    pBestNode = pMCNode;
+                }
+            }
+        }
+        if (pBestNode)
+        {
+            auto iter{mcToMatchMap.find(pBestNode)};
+            if (iter != mcToMatchMap.end())
+            {
+                MCMatches &match(iter->second);
+                match.AddRecoMatch(pRecoNode, static_cast<int>(bestSharedHits));
+            }
+            else
+            {
+                MCMatches match(pBestNode);
+                match.AddRecoMatch(pRecoNode, static_cast<int>(bestSharedHits));
+                mcToMatchMap.insert(std::make_pair(pBestNode, match));
+            }
+        }
+    }
+
+    for (auto [ mc, matches ] : mcToMatchMap)
+    {   (void)mc;
+        matchVector.emplace_back(matches);
+    }
+
+    for (const MCHierarchy::Node *pMCNode : mcNodes)
+    {
+        if (mcToMatchMap.find(pMCNode) == mcToMatchMap.end())
+        {   // Unmatched MC
+            MCMatches match(pMCNode);
+            matchVector.emplace_back(match);
+        }
+    }
+
+    auto predicate = [](const MCMatches &lhs, const MCMatches &rhs)
+        {
+            return lhs.GetMC()->GetCaloHits().size() > rhs.GetMC()->GetCaloHits().size();
+        };
+    std::sort(matchVector.begin(), matchVector.end(), predicate);
+
+    for (const MCMatches &match : matchVector)
+    {
+        const MCHierarchy::Node *pMCNode{match.GetMC()};
+        const int pdg{pMCNode->GetParticleId()};
+        const size_t mcHits{pMCNode->GetCaloHits().size()};
+        std::cout << "MC " << pdg << " hits " << mcHits << std::endl;
+        const RecoHierarchy::NodeVector &nodeVector{match.GetRecoMatches()};
+        for (const RecoHierarchy::Node *pRecoNode : nodeVector)
+        {
+            const int recoHits{static_cast<int>(pRecoNode->GetCaloHits().size())};
+            const int sharedHits{match.GetSharedHits(pRecoNode)};
+            const float purity{match.GetPurity(pRecoNode)};
+            const float completeness{match.GetCompleteness(pRecoNode)};
+            std::cout << "   Matched " << sharedHits << " out of " << recoHits << " with purity " << purity << " and completeness " <<
+                completeness << std::endl;
+        }
+        if (nodeVector.empty())
+            std::cout << "   Unmatched" << std::endl;
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+// private
+
+const MCParticle *LArHierarchyHelper::GetMCPrimaries(const MCParticleList &mcParticleList, MCParticleSet &primaries)
+{
+    const MCParticle *pRoot{nullptr};
+    for (const MCParticle *pMC : mcParticleList)
+    {
+        try
+        {
+            const MCParticle *const pPrimary{LArMCParticleHelper::GetPrimaryMCParticle(pMC)};
+            primaries.insert(pPrimary);
+        }
+        catch (const StatusCodeException&)
+        {
+            if (LArMCParticleHelper::IsNeutrino(pMC))
+                pRoot = pMC;
+            else if (pMC->GetParticleId() != 111)
+                std::cout << "LArHierarchyHelper::MCHierarchy::FillHierarchy: MC particle with PDG code " << pMC->GetParticleId() <<
+                    " at address " << pMC << " has no associated primary particle" << std::endl;
+        }
+    }
+
+    return pRoot;
+}
+
+const ParticleFlowObject *LArHierarchyHelper::GetRecoPrimaries(const PfoList &pfoList, PfoSet &primaries)
+{
+    const ParticleFlowObject *pRoot{nullptr};
+    for (const ParticleFlowObject *pPfo : pfoList)
+    {
+        if (LArPfoHelper::IsNeutrino(pPfo))
+        {
+            pRoot = pPfo;
+            break;
+        }
+        else
+        {
+            const ParticleFlowObject *const pParent{LArPfoHelper::GetParentPfo(pPfo)};
+            if (LArPfoHelper::IsNeutrino(pParent))
+            {
+                pRoot = pParent;
+                break;
+            }
+            else
+            {
+                std::cout << "Still need to handle test beam, cosmics, ..." << std::endl;
+            }
+        }
+    }
+    const PfoList &children{pRoot->GetDaughterPfoList()};
+    for (const ParticleFlowObject *pPrimary : children)
+        primaries.insert(pPrimary); 
+
+    return pRoot;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.h
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.h
@@ -422,74 +422,150 @@ public:
 
     class MCMatches
     {
-        public:
-            /**
-             *  @brief  Constructor
-             *
-             *  @param  pMC The MCParticle being matched
-             */
-            MCMatches(const MCHierarchy::Node *pMC);
+    public:
+        /**
+         *  @brief  Constructor
+         *
+         *  @param  pMC The MCParticle being matched
+         */
+        MCMatches(const MCHierarchy::Node *pMC);
 
-            virtual ~MCMatches() = default;
+        virtual ~MCMatches() = default;
 
-            // Might be better to pass in the shared hits themselves
-            /**
-             *  @brief  Add a reconstructed node as a match for this MC node
-             *
-             *  @param  pReco The reconstructed node that matches this MC node
-             */
-            void AddRecoMatch(const RecoHierarchy::Node *pReco, const int nSharedHits);
+        // Might be better to pass in the shared hits themselves
+        /**
+         *  @brief  Add a reconstructed node as a match for this MC node
+         *
+         *  @param  pReco The reconstructed node that matches this MC node
+         */
+        void AddRecoMatch(const RecoHierarchy::Node *pReco, const int nSharedHits);
 
-            /**
-             *  @brief  Retrieve the MC node
-             *
-             *  @return The MC node
-             */
-            const MCHierarchy::Node *GetMC() const { return m_pMC; };
+        /**
+         *  @brief  Retrieve the MC node
+         *
+         *  @return The MC node
+         */
+        const MCHierarchy::Node *GetMC() const { return m_pMC; };
 
-            /**
-             *  @brief  Retrieve the vector of matched reco nodes
-             *
-             *  @return The vector of matched reco nodes
-             */
-            const RecoHierarchy::NodeVector &GetRecoMatches() const { return m_recoNodes; };
+        /**
+         *  @brief  Retrieve the vector of matched reco nodes
+         *
+         *  @return The vector of matched reco nodes
+         */
+        const RecoHierarchy::NodeVector &GetRecoMatches() const { return m_recoNodes; };
 
-            /**
-             *  @brief  Retrieve the number of shared hits in the match
-             *
-             *  @param  pReco The reco node to consider
-             *
-             *  @return The number of shared hits
-             */
-            int GetSharedHits(const RecoHierarchy::Node *pReco) const;
+        /**
+         *  @brief  Retrieve the number of shared hits in the match
+         *
+         *  @param  pReco The reco node to consider
+         *
+         *  @return The number of shared hits
+         */
+        int GetSharedHits(const RecoHierarchy::Node *pReco) const;
 
-            /**
-             *  @brief  Retrieve the purity of the match
-             *
-             *  @param  pReco The reco node to consider
-             *
-             *  @return The purity of the match
-             */
-            float GetPurity(const RecoHierarchy::Node *pReco) const;
+        /**
+         *  @brief  Retrieve the purity of the match
+         *
+         *  @param  pReco The reco node to consider
+         *
+         *  @return The purity of the match
+         */
+        float GetPurity(const RecoHierarchy::Node *pReco) const;
 
-            /**
-             *  @brief  Retrieve the completeness of the match
-             *
-             *  @param  pReco The reco node to consider
-             *
-             *  @return The completeness of the match
-             */
-            float GetCompleteness(const RecoHierarchy::Node *pReco) const;
-
+        /**
+         *  @brief  Retrieve the completeness of the match
+         *
+         *  @param  pReco The reco node to consider
+         *
+         *  @return The completeness of the match
+         */
+        float GetCompleteness(const RecoHierarchy::Node *pReco) const;
 
         private:
             const MCHierarchy::Node *m_pMC; ///< MC node associated with any matches
             RecoHierarchy::NodeVector m_recoNodes; ///< Matched reco nodes
             pandora::IntVector m_sharedHits; ///< Number of shared hits for each match
-
     };
 
     typedef std::vector<MCMatches> MCMatchesVector;
+
+    class MatchInfo
+    {
+    public:
+        class QualityCuts
+        {
+        public:
+            /**
+             *  @brief Default constructor
+             */
+            QualityCuts();
+
+            /**
+             *  @brief Constructor
+             *
+             *  @param  minPurity The minimum purity for a cut to be considered good
+             *  @param  minCompleteness The minimum completeness for a cut to be considered good
+             */
+            QualityCuts(const float minPurity, const float minCompleteness);
+
+            const float m_minPurity;    ///< The minimum purity for a match to be considered good
+            const float m_minCompleteness;  ///< The minimum completeness for a match to be considered good
+        };
+
+
+        /**
+         *  @brief  Default constructor
+         */
+        MatchInfo();
+
+        /**
+         *  @brief  Constructor
+         *
+         *  @param  qualityCuts The quality cuts to be applied to matched nodes
+         */
+        MatchInfo(const QualityCuts &qualityCuts);
+
+        /**
+         *  @brief  Match the nodes in the MC and reco hierarchies.
+         *
+         *  @param  mcHierarchy The MC hierarchy
+         *  @param  recoHierarchy The reco hierarchy
+         */
+        void Match(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy);
+
+        /**
+         *  @brief  Retrieve the vector of good matches
+         *
+         *  @return The vector of good matches
+         */
+        const MCMatchesVector &GetGoodMatches() const { return m_goodMatches; }
+
+        /**
+         *  @brief  Retrieve the vector of matches that don't pass quality cuts
+         *
+         *  @return The vector of sub-threshold matches
+         */
+        const MCMatchesVector &GetSubThresholdMatches() const { return m_subThresholdMatches; }
+
+        /**
+         *  @brief  Retrieve the vector of unmatched MC nodes
+         *
+         *  @return The vector of unmatched MC
+         */
+        const MCHierarchy::NodeVector &GetUnmatchedMC() const { return m_unmatchedMC; };
+
+        /**
+         *  @brief  Retrieve the vector of unmatched reco nodes
+         */
+        const RecoHierarchy::NodeVector &GetUnmatchedReco() const { return m_unmatchedReco; }
+
+    private:
+        MCMatchesVector m_goodMatches;  ///< The vector of good matches
+        MCMatchesVector m_subThresholdMatches;  ///< The vector of matches MC nodes that don't pass quality cuts
+        MCHierarchy::NodeVector m_unmatchedMC;  ///< The vector of unmatched MC nodes
+        RecoHierarchy::NodeVector m_unmatchedReco;  ///< The vector of unmatched reco nodes
+        QualityCuts m_qualityCuts;  ///< The quality cuts to be applied to matches
+    };
 
     /**
      *  @brief  Fill an MC hierarchy based on the specified folding criteria (see MCHierarchy::Construct for details)
@@ -519,9 +595,9 @@ public:
      *
      *  @param  mcHierarchy The MC hiearchy
      *  @param  recoHierarchy The reconstructed hierarchy
-     *  @param  matchVector The output vector of matches
+     *  @param  matchInfo The output match information
      */
-    static void MatchHierarchies(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy, MCMatchesVector &matchVector);
+    static void MatchHierarchies(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy, MatchInfo &matchInfo);
 
 private:
     typedef std::set<const pandora::MCParticle*> MCParticleSet;

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.h
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.h
@@ -422,14 +422,6 @@ public:
         const std::string ToString() const;
 
     private:
-        /**
-         * @brief  GetAllRecoHits
-         *
-         * @param  pPfo The PFO from which hits should be retrieved
-         * @param  allHits The output list of hits
-         */
-        void GetAllRecoHits(const pandora::ParticleFlowObject *pPfo, pandora::CaloHitList &allHits) const;
-
         NodeVector m_rootNodes;                         ///< The leading nodes (e.g. primary particles, cosmic rays, ...)
         const pandora::ParticleFlowObject *m_pNeutrino; ///< The incident neutrino, if it exists
     };

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.h
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.h
@@ -145,6 +145,20 @@ public:
             int GetParticleId() const;
 
             /**
+             *  @brief  Check if this is a test beam particle
+             *
+             *  @return Whether or not this is a test beam particle
+             */
+            bool IsTestBeamParticle() const;
+
+            /**
+             *  @brief  Check if this is a cosmic ray particle
+             *
+             *  @return Whether or not this is a cosmic ray
+             */
+            bool IsCosmicRay() const;
+
+            /**
              *  @brief  Produce a string representation of the hierarchy
              *
              *  @return The string representation of the hierarchy
@@ -156,6 +170,7 @@ public:
             pandora::MCParticleList m_mcParticles;
             pandora::CaloHitList m_caloHits;
             NodeVector m_children;
+            const pandora::MCParticle *m_mainParticle;
             int m_pdg;
         };
 
@@ -224,6 +239,20 @@ public:
          *  @return The string representation of the hierarchy
          */
         const std::string ToString() const;
+
+        /**
+         *  @brief  Check if this is a neutrino hierarchy.
+         *
+         *  @return Whether or not this is a neutrino hierarchy.
+         */
+        bool IsNeutrinoHierarchy() const { return m_pNeutrino != nullptr; }
+
+        /**
+         *  @brief  Check if this is a test beam hierarchy.
+         *
+         *  @return Whether or not this is a test beam hierarchy.
+         */
+        bool IsTestBeamHierarchy() const { return m_pNeutrino == nullptr; };
 
     private:
         NodeVector m_rootNodes;

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.h
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.h
@@ -49,7 +49,7 @@ public:
             /**
              *  @brief  Constructor
              *
-             *  @param  minHits The total minimumm number of hits for a particle to be considered reconstructable
+             *  @param  minHits The total minimum number of hits for a particle to be considered reconstructable
              *  @param  minHitsForGoodView The number of hits within a view for a particle to be considered reconstructable
              *  @param  minGoodViews The minimum number of good views for a particle to be considered reconstructable
              *  @param removeNeutrons Whether to remove neutrons and downstream particles from consideration
@@ -57,15 +57,16 @@ public:
             ReconstructabilityCriteria(const unsigned int minHits, const unsigned int minHitsForGoodView, const unsigned int minGoodViews,
                 const bool removeNeutrons);
 
-            const unsigned int  m_minHits;              ///< the minimum number of primary good Hits
-            const unsigned int  m_minHitsForGoodView;   ///< the minimum number of Hits for a good view
-            const unsigned int  m_minGoodViews;         ///< the minimum number of primary good views
-            const bool m_removeNeutrons;                ///< whether to remove neutrons and their downstream particles
+            const unsigned int m_minHits;            ///< the minimum number of primary good Hits
+            const unsigned int m_minHitsForGoodView; ///< the minimum number of Hits for a good view
+            const unsigned int m_minGoodViews;       ///< the minimum number of primary good views
+            const bool m_removeNeutrons;             ///< whether to remove neutrons and their downstream particles
         };
 
         class Node;
-        typedef std::vector<const Node*> NodeVector;
-        typedef std::list<const Node*> NodeList;
+        typedef std::vector<const Node *> NodeVector;
+        typedef std::list<const Node *> NodeList;
+
         /**
          *  @brief  Node class
          */
@@ -76,9 +77,9 @@ public:
              *  @brief  Create a node with a primary MC particle
              *
              *  @param  hierarchy The parent hierarchy of this node
-             *  @param  pMC The primary MC particle with which this node should be created
+             *  @param  pMCParticle The primary MC particle with which this node should be created
              */
-            Node(const MCHierarchy &hierarchy, const pandora::MCParticle *pMC);
+            Node(const MCHierarchy &hierarchy, const pandora::MCParticle *pMCParticle);
 
             /**
              *  @brief  Create a node from a list of MC particles
@@ -121,7 +122,7 @@ public:
              *
              *  @return The vector of children
              */
-            const NodeVector &GetChildren() const { return m_children; }
+            const NodeVector &GetChildren() const;
 
             /**
              *  @brief  Retrieve the MC particles associated with this node
@@ -145,6 +146,13 @@ public:
             int GetParticleId() const;
 
             /**
+             *  @brief  Check if this is a particle induced by a neutrino interaction
+             *
+             *  @return Whether or not this is neutrino induced
+             */
+            bool IsNeutrinoInduced() const;
+
+            /**
              *  @brief  Check if this is a test beam particle
              *
              *  @return Whether or not this is a test beam particle
@@ -166,12 +174,12 @@ public:
             const std::string ToString(const std::string &prefix) const;
 
         private:
-            const MCHierarchy &m_hierarchy;
-            pandora::MCParticleList m_mcParticles;
-            pandora::CaloHitList m_caloHits;
-            NodeVector m_children;
-            const pandora::MCParticle *m_mainParticle;
-            int m_pdg;
+            const MCHierarchy &m_hierarchy;            ///< The parent MC hierarchy
+            pandora::MCParticleList m_mcParticles;     ///< The list of MC particles of which this node is composed
+            pandora::CaloHitList m_caloHits;           ///< The list of calo hits of which this node is composed
+            NodeVector m_children;                     ///< The child nodes of this node
+            const pandora::MCParticle *m_mainParticle; ///< The leading MC particle for this node
+            int m_pdg;                                 ///< The PDG code of the leading MC particle for this node
         };
 
         /**
@@ -218,13 +226,12 @@ public:
         void FillHierarchy(const pandora::MCParticleList &mcParticleList, const pandora::CaloHitList &caloHitList,
             const bool foldToPrimaries, const bool foldToLeadingShowers);
 
-        // Note - likely want to change this to retrieve the neutrino, the test beam particle, all primaries, all cosmics etc
         /**
          *  @brief  Retrieve the root nodes in this hierarchy
          *
          *  @return The root nodes in this hierarchy
          */
-        const NodeVector& GetRootNodes() const { return m_rootNodes; }
+        const NodeVector &GetRootNodes() const;
 
         /**
          *  @brief  Retrieve a flat vector of the ndoes in the hierarchy
@@ -245,32 +252,32 @@ public:
          *
          *  @return Whether or not this is a neutrino hierarchy.
          */
-        bool IsNeutrinoHierarchy() const { return m_pNeutrino != nullptr; }
+        bool IsNeutrinoHierarchy() const;
 
         /**
          *  @brief  Check if this is a test beam hierarchy.
          *
          *  @return Whether or not this is a test beam hierarchy.
          */
-        bool IsTestBeamHierarchy() const { return m_pNeutrino == nullptr; };
+        bool IsTestBeamHierarchy() const;
 
     private:
-        NodeVector m_rootNodes;
-        ReconstructabilityCriteria m_recoCriteria;
-        const pandora::MCParticle *m_pNeutrino;
-        std::map<const pandora::MCParticle*, pandora::CaloHitList> m_mcToHitsMap;
+        NodeVector m_rootNodes;                    ///< The leading nodes (e.g. primary particles, cosmic rays, ...)
+        ReconstructabilityCriteria m_recoCriteria; ///< The criteria used to determine if the node is reconstructable
+        const pandora::MCParticle *m_pNeutrino;    ///< The incident neutrino, if it exists
+        std::map<const pandora::MCParticle *, pandora::CaloHitList> m_mcToHitsMap; ///< The map between MC particles and calo hits
     };
 
     /**
-     *  @brief   RecoHiearchy class
+     *  @brief   RecoHierarchy class
      */
     class RecoHierarchy
     {
     public:
-
         class Node;
-        typedef std::vector<const Node*> NodeVector;
-        typedef std::list<const Node*> NodeList;
+        typedef std::vector<const Node *> NodeVector;
+        typedef std::list<const Node *> NodeList;
+
         /**
          *  @brief  Node class
          */
@@ -319,7 +326,7 @@ public:
              *
              *  @return The vector of children
              */
-            const NodeVector &GetChildren() const { return m_children; }
+            const NodeVector &GetChildren() const;
 
             /**
              *  @brief  Retrieve the PFOs associated with this node
@@ -351,11 +358,11 @@ public:
             const std::string ToString(const std::string &prefix) const;
 
         private:
-            const RecoHierarchy &m_hierarchy;
-            pandora::PfoList m_pfos;
-            pandora::CaloHitList m_caloHits;
-            NodeVector m_children;
-            int m_pdg;
+            const RecoHierarchy &m_hierarchy; ///< The parent reco hierarchy
+            pandora::PfoList m_pfos;          ///< The list of PFOs of which this node is composed
+            pandora::CaloHitList m_caloHits;  ///< The list of calo hits of which this node is composed
+            NodeVector m_children;            ///< The child nodes of this node
+            int m_pdg;                        ///< The particle ID (track = muon, shower = electron)
         };
 
         /**
@@ -393,16 +400,15 @@ public:
          */
         void FillHierarchy(const pandora::PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers);
 
-        // Note - likely want to change this to retrieve the neutrino, the test beam particle, all primaries, all cosmics etc
         /**
          *  @brief  Retrieve the root nodes in this hierarchy
          *
          *  @return The root nodes in this hierarchy
          */
-        const NodeVector& GetRootNodes() const { return m_rootNodes; }
+        const NodeVector &GetRootNodes() const;
 
         /**
-         *  @brief  Retrieve a flat vector of the ndoes in the hierarchy
+         *  @brief  Retrieve a flat vector of the nodes in the hierarchy
          *
          *  @param  nodeVector The output vector for the nodes in the hierarchy in breadth first order
          */
@@ -416,27 +422,36 @@ public:
         const std::string ToString() const;
 
     private:
-        NodeVector m_rootNodes;
-        const pandora::ParticleFlowObject *m_pNeutrino;
+        /**
+         * @brief  GetAllRecoHits
+         *
+         * @param  pPfo The PFO from which hits should be retrieved
+         * @param  allHits The output list of hits
+         */
+        void GetAllRecoHits(const pandora::ParticleFlowObject *pPfo, pandora::CaloHitList &allHits) const;
+
+        NodeVector m_rootNodes;                         ///< The leading nodes (e.g. primary particles, cosmic rays, ...)
+        const pandora::ParticleFlowObject *m_pNeutrino; ///< The incident neutrino, if it exists
     };
 
+    /**
+     *  @brief  MCMatches class
+     */
     class MCMatches
     {
     public:
         /**
          *  @brief  Constructor
          *
-         *  @param  pMC The MCParticle being matched
+         *  @param  pMCParticle The MCParticle being matched
          */
-        MCMatches(const MCHierarchy::Node *pMC);
+        MCMatches(const MCHierarchy::Node *pMCParticle);
 
-        virtual ~MCMatches() = default;
-
-        // Might be better to pass in the shared hits themselves
         /**
          *  @brief  Add a reconstructed node as a match for this MC node
          *
          *  @param  pReco The reconstructed node that matches this MC node
+         *  @param  nSharedHits The number of hits shared betweeb reco and MC nodes
          */
         void AddRecoMatch(const RecoHierarchy::Node *pReco, const int nSharedHits);
 
@@ -445,14 +460,14 @@ public:
          *
          *  @return The MC node
          */
-        const MCHierarchy::Node *GetMC() const { return m_pMC; };
+        const MCHierarchy::Node *GetMC() const;
 
         /**
          *  @brief  Retrieve the vector of matched reco nodes
          *
          *  @return The vector of matched reco nodes
          */
-        const RecoHierarchy::NodeVector &GetRecoMatches() const { return m_recoNodes; };
+        const RecoHierarchy::NodeVector &GetRecoMatches() const;
 
         /**
          *  @brief  Retrieve the number of shared hits in the match
@@ -461,7 +476,7 @@ public:
          *
          *  @return The number of shared hits
          */
-        int GetSharedHits(const RecoHierarchy::Node *pReco) const;
+        unsigned int GetSharedHits(const RecoHierarchy::Node *pReco) const;
 
         /**
          *  @brief  Retrieve the purity of the match
@@ -481,17 +496,23 @@ public:
          */
         float GetCompleteness(const RecoHierarchy::Node *pReco) const;
 
-        private:
-            const MCHierarchy::Node *m_pMC; ///< MC node associated with any matches
-            RecoHierarchy::NodeVector m_recoNodes; ///< Matched reco nodes
-            pandora::IntVector m_sharedHits; ///< Number of shared hits for each match
+    private:
+        const MCHierarchy::Node *m_pMCParticle; ///< MC node associated with any matches
+        RecoHierarchy::NodeVector m_recoNodes;  ///< Matched reco nodes
+        pandora::IntVector m_sharedHits;        ///< Number of shared hits for each match
     };
 
     typedef std::vector<MCMatches> MCMatchesVector;
 
+    /**
+     *  @brief  MatcheInfo class
+     */
     class MatchInfo
     {
     public:
+        /**
+         *  @brief  QualityCuts class
+         */
         class QualityCuts
         {
         public:
@@ -508,10 +529,9 @@ public:
              */
             QualityCuts(const float minPurity, const float minCompleteness);
 
-            const float m_minPurity;    ///< The minimum purity for a match to be considered good
-            const float m_minCompleteness;  ///< The minimum completeness for a match to be considered good
+            const float m_minPurity;       ///< The minimum purity for a match to be considered good
+            const float m_minCompleteness; ///< The minimum completeness for a match to be considered good
         };
-
 
         /**
          *  @brief  Default constructor
@@ -538,37 +558,37 @@ public:
          *
          *  @return The vector of good matches
          */
-        const MCMatchesVector &GetGoodMatches() const { return m_goodMatches; }
+        const MCMatchesVector &GetGoodMatches() const;
 
         /**
          *  @brief  Retrieve the vector of matches that don't pass quality cuts
          *
          *  @return The vector of sub-threshold matches
          */
-        const MCMatchesVector &GetSubThresholdMatches() const { return m_subThresholdMatches; }
+        const MCMatchesVector &GetSubThresholdMatches() const;
 
         /**
          *  @brief  Retrieve the vector of unmatched MC nodes
          *
          *  @return The vector of unmatched MC
          */
-        const MCHierarchy::NodeVector &GetUnmatchedMC() const { return m_unmatchedMC; };
+        const MCHierarchy::NodeVector &GetUnmatchedMC() const;
 
         /**
          *  @brief  Retrieve the vector of unmatched reco nodes
          */
-        const RecoHierarchy::NodeVector &GetUnmatchedReco() const { return m_unmatchedReco; }
+        const RecoHierarchy::NodeVector &GetUnmatchedReco() const;
 
     private:
-        MCMatchesVector m_goodMatches;  ///< The vector of good matches
-        MCMatchesVector m_subThresholdMatches;  ///< The vector of matches MC nodes that don't pass quality cuts
-        MCHierarchy::NodeVector m_unmatchedMC;  ///< The vector of unmatched MC nodes
-        RecoHierarchy::NodeVector m_unmatchedReco;  ///< The vector of unmatched reco nodes
-        QualityCuts m_qualityCuts;  ///< The quality cuts to be applied to matches
+        MCMatchesVector m_goodMatches;             ///< The vector of good matches
+        MCMatchesVector m_subThresholdMatches;     ///< The vector of matches MC nodes that don't pass quality cuts
+        MCHierarchy::NodeVector m_unmatchedMC;     ///< The vector of unmatched MC nodes
+        RecoHierarchy::NodeVector m_unmatchedReco; ///< The vector of unmatched reco nodes
+        QualityCuts m_qualityCuts;                 ///< The quality cuts to be applied to matches
     };
 
     /**
-     *  @brief  Fill an MC hierarchy based on the specified folding criteria (see MCHierarchy::Construct for details)
+     *  @brief  Fill an MC hierarchy based on the specified folding criteria (see MCHierarchy::FillHierarchy for details)
      *
      *  @param  mcParticleList The MCParticle list to use to fill this hierarchy
      *  @param  caloHitList The list of CaloHits to use to fill this hierarchy
@@ -580,15 +600,14 @@ public:
         const bool foldToPrimaries, const bool foldToLeadingShowers, MCHierarchy &hierarchy);
 
     /**
-     *  @brief  Fill a reconstructed hierarchy based on the specified folding criteria (see RecoHierarchy::Construct for details)
+     *  @brief  Fill a reconstructed hierarchy based on the specified folding criteria (see RecoHierarchy::FillHierarchy for details)
      *
      *  @param  pfoList The ParticleFlowObject list to use to fill this hierarchy
      *  @param  foldToPrimaries Whether or not to fold to primary particles
      *  @param  foldToLeadingShowers Whether or not to fold to leading shower particles
      *  @param  hierarchy The output reconstructed hierarchy
      */
-    static void FillRecoHierarchy(const pandora::PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers,
-        RecoHierarchy &hierarchy);
+    static void FillRecoHierarchy(const pandora::PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers, RecoHierarchy &hierarchy);
 
     /**
      *  @brief  Finds the matches between reconstructed and MC hierarchies.
@@ -600,8 +619,8 @@ public:
     static void MatchHierarchies(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy, MatchInfo &matchInfo);
 
 private:
-    typedef std::set<const pandora::MCParticle*> MCParticleSet;
-    typedef std::set<const pandora::ParticleFlowObject*> PfoSet;
+    typedef std::set<const pandora::MCParticle *> MCParticleSet;
+    typedef std::set<const pandora::ParticleFlowObject *> PfoSet;
 
     /**
      *  @brief  Retrieves the primary MC particles from a list and returns the root (neutrino) for hierarchy, if it exists.
@@ -623,6 +642,124 @@ private:
      */
     static const pandora::ParticleFlowObject *GetRecoPrimaries(const pandora::PfoList &pfoList, PfoSet &primaries);
 };
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCHierarchy::NodeVector &LArHierarchyHelper::MCHierarchy::Node::GetChildren() const
+{
+    return m_children;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const pandora::MCParticleList &LArHierarchyHelper::MCHierarchy::Node::GetMCParticles() const
+{
+    return m_mcParticles;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const pandora::CaloHitList &LArHierarchyHelper::MCHierarchy::Node::GetCaloHits() const
+{
+    return m_caloHits;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline int LArHierarchyHelper::MCHierarchy::Node::GetParticleId() const
+{
+    return m_pdg;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline bool LArHierarchyHelper::MCHierarchy::Node::IsNeutrinoInduced() const
+{
+    return !(LArHierarchyHelper::MCHierarchy::Node::IsTestBeamParticle() || LArHierarchyHelper::MCHierarchy::Node::IsCosmicRay());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCHierarchy::NodeVector &LArHierarchyHelper::MCHierarchy::GetRootNodes() const
+{
+    return m_rootNodes;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline bool LArHierarchyHelper::MCHierarchy::IsNeutrinoHierarchy() const
+{
+    return m_pNeutrino != nullptr;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline bool LArHierarchyHelper::MCHierarchy::IsTestBeamHierarchy() const
+{
+    return m_pNeutrino == nullptr;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::RecoHierarchy::NodeVector &LArHierarchyHelper::RecoHierarchy::Node::GetChildren() const
+{
+    return m_children;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::RecoHierarchy::NodeVector &LArHierarchyHelper::RecoHierarchy::GetRootNodes() const
+{
+    return m_rootNodes;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCHierarchy::Node *LArHierarchyHelper::MCMatches::GetMC() const
+{
+    return m_pMCParticle;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::RecoHierarchy::NodeVector &LArHierarchyHelper::MCMatches::GetRecoMatches() const
+{
+    return m_recoNodes;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCMatchesVector &LArHierarchyHelper::MatchInfo::GetGoodMatches() const
+{
+    return m_goodMatches;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCMatchesVector &LArHierarchyHelper::MatchInfo::GetSubThresholdMatches() const
+{
+    return m_subThresholdMatches;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::MCHierarchy::NodeVector &LArHierarchyHelper::MatchInfo::GetUnmatchedMC() const
+{
+    return m_unmatchedMC;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const LArHierarchyHelper::RecoHierarchy::NodeVector &LArHierarchyHelper::MatchInfo::GetUnmatchedReco() const
+{
+    return m_unmatchedReco;
+}
 
 } // namespace lar_content
 

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.h
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.h
@@ -1,0 +1,524 @@
+/**
+ *  @file   larpandoracontent/LArHelpers/LArHierarchyHelper.h
+ *
+ *  @brief  Header file for the lar hierarchy helper class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_HIERARCHY_HELPER_H
+#define LAR_HIERARCHY_HELPER_H 1
+
+#include "Pandora/PandoraInternal.h"
+
+#include "Helpers/MCParticleHelper.h"
+
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  LArHierarchyHelper class
+ */
+class LArHierarchyHelper
+{
+public:
+    /**
+     *  @brief   MCHierarchy class
+     */
+    class MCHierarchy
+    {
+    public:
+        /**
+         *  @brief   ReconstructabilityCriteria class
+         */
+        class ReconstructabilityCriteria
+        {
+        public:
+            /**
+             *  @brief  Default constructor
+             */
+            ReconstructabilityCriteria();
+
+            /**
+             *  @brief  Copy constructor
+             */
+            ReconstructabilityCriteria(const ReconstructabilityCriteria &obj);
+
+            /**
+             *  @brief  Constructor
+             *
+             *  @param  minHits The total minimumm number of hits for a particle to be considered reconstructable
+             *  @param  minHitsForGoodView The number of hits within a view for a particle to be considered reconstructable
+             *  @param  minGoodViews The minimum number of good views for a particle to be considered reconstructable
+             *  @param removeNeutrons Whether to remove neutrons and downstream particles from consideration
+             */
+            ReconstructabilityCriteria(const unsigned int minHits, const unsigned int minHitsForGoodView, const unsigned int minGoodViews,
+                const bool removeNeutrons);
+
+            const unsigned int  m_minHits;              ///< the minimum number of primary good Hits
+            const unsigned int  m_minHitsForGoodView;   ///< the minimum number of Hits for a good view
+            const unsigned int  m_minGoodViews;         ///< the minimum number of primary good views
+            const bool m_removeNeutrons;                ///< whether to remove neutrons and their downstream particles
+        };
+
+        class Node;
+        typedef std::vector<const Node*> NodeVector;
+        typedef std::list<const Node*> NodeList;
+        /**
+         *  @brief  Node class
+         */
+        class Node
+        {
+        public:
+            /**
+             *  @brief  Create a node with a primary MC particle
+             *
+             *  @param  hierarchy The parent hierarchy of this node
+             *  @param  pMC The primary MC particle with which this node should be created
+             */
+            Node(const MCHierarchy &hierarchy, const pandora::MCParticle *pMC);
+
+            /**
+             *  @brief  Create a node from a list of MC particles
+             *
+             *  @param  hierarchy The parent hierarchy of this node
+             *  @param  mcParticleList The MC particle list with which this node should be created
+             *  @parasm caloHitList The CaloHit list with which this node should be created
+             */
+            Node(const MCHierarchy &hierarchy, const pandora::MCParticleList &mcParticleList, const pandora::CaloHitList &caloHitList);
+
+            /**
+             *  @brief Destructor
+             */
+            virtual ~Node();
+
+            /**
+             *  @brief  Return whether or not this node should be considered reconstructable
+             *
+             *  @return true if reconstructable, false otherwise
+             */
+            bool IsReconstructable() const;
+
+            /**
+             *  @brief  Recursively fill the hierarchy based on the criteria established for this MCHierarchy
+             *
+             *  @param  pRoot The MC particle acting as the root of the current branch of the hierarchy
+             *  @param foldToLeadingShower Whether or not we're folding back to the leading shower particle
+             */
+            void FillHierarchy(const pandora::MCParticle *pRoot, const bool foldToLeadingShower);
+
+            /**
+             *  @brief  Fill this node by folding all descendent particles to this node
+             *
+             *  @param  pRoot The MC particle acting as the root of the current branch of the hierarchy
+             */
+            void FillFlat(const pandora::MCParticle *pRoot);
+
+            /**
+             *  @brief  Return the vector of children for this node
+             *
+             *  @return The vector of children
+             */
+            const NodeVector &GetChildren() const { return m_children; }
+
+            /**
+             *  @brief  Retrieve the MC particles associated with this node
+             *
+             *  @return The MC particles associated with this node
+             */
+            const pandora::MCParticleList &GetMCParticles() const;
+
+            /**
+             *  @brief  Retrieve the CaloHits associated with this node
+             *
+             *  @return The list of CaloHits associated with this node
+             */
+            const pandora::CaloHitList &GetCaloHits() const;
+
+            /**
+             *  @brief  Retrieve the PDG code for the leading particle in this node
+             *
+             *  @return The PDG code for the leading particle in this node
+             */
+            int GetParticleId() const;
+
+            /**
+             *  @brief  Produce a string representation of the hierarchy
+             *
+             *  @return The string representation of the hierarchy
+             */
+            const std::string ToString(const std::string &prefix) const;
+
+        private:
+            const MCHierarchy &m_hierarchy;
+            pandora::MCParticleList m_mcParticles;
+            pandora::CaloHitList m_caloHits;
+            NodeVector m_children;
+            int m_pdg;
+        };
+
+        /**
+         *  @brief  Default constructor
+         */
+        MCHierarchy() = default;
+
+        /**
+         *  @brief  Construct a new MCHierarchy object using specified reconstructability criteria
+         *
+         *  @param  recoCriteria The reconstructability criteria to be applied
+         */
+        MCHierarchy(const ReconstructabilityCriteria &recoCriteria);
+
+        /**
+         *  @brief Destructor
+         */
+        virtual ~MCHierarchy();
+
+        /**
+         *  @brief  Creates an MC hierarchy representation. Without folding this will be a mirror image of the standard MCParticle
+         *          relationships. However, with folding options selected the hierarchy structure will group together MC particles into
+         *          nodes based on the folding requirements.
+         *
+         *          If only folding back to primaries, the hierarchy will be relatively flat, with a top-level neutrino or test beam
+         *          particle, if appropriate, and then a set of leaf nodes, one for each primary particles also containing the MC particles
+         *          (and corresponding hits) from daughter particles.
+         *
+         *          If only folding back to leading shower particles, the hierarchy will largely mirror the standard MCParticle hierarchy,
+         *          but, when a shower particle is reached (for this purpose an electron or photon), this particle and all daughter
+         *          particles will be represented by a single leaf node.
+         *
+         *          If folding back to both primary and leading shower particles the hierarchy will again be rather flat, but in this case,
+         *          if a primary track-like particle (i.e. not an electron or photon) has a downstream shower particle then all downstream
+         *          particles above the shower-like particle will be folded into the primary node, but a new, daughter leaf node will be
+         *          created for the shower-like particle and all of its daughters, and a parent-child relationship will be formed between
+         *          the primary node and shower node.
+         *
+         *  @param  mcParticleList The list of MC particles with which to fill the hierarchy
+         *  @param  caloHitList The list of hits with which to fill the hierarchy
+         *  @param  foldToPrimaries Whether or not to fold daughter particles back to their primary particle
+         *  @param  foldToLeadingShowers Whether or not to fold daughter particles back to their leading shower particle
+         */
+        void FillHierarchy(const pandora::MCParticleList &mcParticleList, const pandora::CaloHitList &caloHitList,
+            const bool foldToPrimaries, const bool foldToLeadingShowers);
+
+        // Note - likely want to change this to retrieve the neutrino, the test beam particle, all primaries, all cosmics etc
+        /**
+         *  @brief  Retrieve the root nodes in this hierarchy
+         *
+         *  @return The root nodes in this hierarchy
+         */
+        const NodeVector& GetRootNodes() const { return m_rootNodes; }
+
+        /**
+         *  @brief  Retrieve a flat vector of the ndoes in the hierarchy
+         *
+         *  @param  nodeVector The output vector for the nodes in the hierarchy in breadth first order
+         */
+        void GetFlattenedNodes(NodeVector &nodeVector) const;
+
+        /**
+         *  @brief  Produce a string representation of the hierarchy
+         *
+         *  @return The string representation of the hierarchy
+         */
+        const std::string ToString() const;
+
+    private:
+        NodeVector m_rootNodes;
+        ReconstructabilityCriteria m_recoCriteria;
+        const pandora::MCParticle *m_pNeutrino;
+        std::map<const pandora::MCParticle*, pandora::CaloHitList> m_mcToHitsMap;
+    };
+
+    /**
+     *  @brief   RecoHiearchy class
+     */
+    class RecoHierarchy
+    {
+    public:
+
+        class Node;
+        typedef std::vector<const Node*> NodeVector;
+        typedef std::list<const Node*> NodeList;
+        /**
+         *  @brief  Node class
+         */
+        class Node
+        {
+        public:
+            /**
+             *  @brief  Create a node with a primary PFO
+             *
+             *  @param  hierarchy The parent hierarchy of this node
+             *  @param  pPfo The primary PFO with which this node should be created
+             */
+            Node(const RecoHierarchy &hierarchy, const pandora::ParticleFlowObject *pPfo);
+
+            /**
+             *  @brief  Create a node from a list of PFOs
+             *
+             *  @param  hierarchy The parent hierarchy of this node
+             *  @param  pfoList The PFO list with which this node should be created
+             *  @parasm caloHitList The CaloHit list with which this node should be created
+             */
+            Node(const RecoHierarchy &hierarchy, const pandora::PfoList &pfoList, const pandora::CaloHitList &caloHitList);
+
+            /**
+             *  @brief Destructor
+             */
+            virtual ~Node();
+
+            /**
+             *  @brief  Recursively fill the hierarchy based on the criteria established for this RecoHierarchy
+             *
+             *  @param  pRoot The PFO acting as the root of the current branch of the hierarchy
+             *  @param foldToLeadingShower Whether or not we're folding back to the leading shower particle
+             */
+            void FillHierarchy(const pandora::ParticleFlowObject *pRoot, const bool foldToLeadingShower);
+
+            /**
+             *  @brief  Fill this node by folding all descendent particles to this node
+             *
+             *  @param  pRoot The PFO acting as the root of the current branch of the hierarchy
+             */
+            void FillFlat(const pandora::ParticleFlowObject *pRoot);
+
+            /**
+             *  @brief  Return the vector of children for this node
+             *
+             *  @return The vector of children
+             */
+            const NodeVector &GetChildren() const { return m_children; }
+
+            /**
+             *  @brief  Retrieve the PFOs associated with this node
+             *
+             *  @return The PFOs associated with this node
+             */
+            const pandora::PfoList &GetRecoParticles() const;
+
+            /**
+             *  @brief  Retrieve the CaloHits associated with this node
+             *
+             *  @return The list of CaloHits associated with this node
+             */
+            const pandora::CaloHitList &GetCaloHits() const;
+
+            /**
+             *  @brief  Retrieve the PDG code for the leading particle in this node
+             *          Note, for reco objects the PDG codes represent tracks (muon PDG) and showers (electron PDG)
+             *
+             *  @return The PDG code for the leading particle in this node
+             */
+            int GetParticleId() const;
+
+            /**
+             *  @brief  Produce a string representation of the hierarchy
+             *
+             *  @return The string representation of the hierarchy
+             */
+            const std::string ToString(const std::string &prefix) const;
+
+        private:
+            const RecoHierarchy &m_hierarchy;
+            pandora::PfoList m_pfos;
+            pandora::CaloHitList m_caloHits;
+            NodeVector m_children;
+            int m_pdg;
+        };
+
+        /**
+         *  @brief  Default constructor
+         */
+        RecoHierarchy();
+
+        /**
+         *  @brief Destructor
+         */
+        virtual ~RecoHierarchy();
+
+        /**
+         *  @brief  Creates a reconstructed hierarchy representation. Without folding this will be a mirror image of the standard
+         *          ParticleFlowObject (PFO) relationships. However, with folding options selected the hierarchy structure will group
+         *          together PFOs into nodes based on the folding requirements.
+         *
+         *          If only folding back to primaries, the hierarchy will be relatively flat, with a top-level neutrino or test beam
+         *          particle, if appropriate, and then a set of leaf nodes, one for each primary particles also containing the PFOs (and
+         *          corresponding hits) from daughter particles.
+         *
+         *          If only folding back to leading shower particles, the hierarchy will largely mirror the standard PFO hierarchy, but,
+         *          when a shower particle is reached (based on the track/shower characterisation), this particle and all daughter particles
+         *          will be represented by a single leaf node.
+         *
+         *          If folding back to both primary and leading shower particles the hierarchy will again be rather flat, but in this case,
+         *          if a primary track-like particle has a downstream shower particle then all downstream particles above the shower-like
+         *          particle will be folded into the primary node, but a new, daughter leaf node will be created for the shower-like
+         *          particle and all of its daughters, and a parent-child relationship will be formed between the primary node and shower
+         *          node.
+         *
+         *  @param  pfoList The list of PFOs with which to fill the hierarchy
+         *  @param  foldToPrimaries Whether or not to fold daughter particles back to their primary particle
+         *  @param  foldToLeadingShowers Whether or not to fold daughter particles back to their leading shower particle
+         */
+        void FillHierarchy(const pandora::PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers);
+
+        // Note - likely want to change this to retrieve the neutrino, the test beam particle, all primaries, all cosmics etc
+        /**
+         *  @brief  Retrieve the root nodes in this hierarchy
+         *
+         *  @return The root nodes in this hierarchy
+         */
+        const NodeVector& GetRootNodes() const { return m_rootNodes; }
+
+        /**
+         *  @brief  Retrieve a flat vector of the ndoes in the hierarchy
+         *
+         *  @param  nodeVector The output vector for the nodes in the hierarchy in breadth first order
+         */
+        void GetFlattenedNodes(NodeVector &nodeVector) const;
+
+        /**
+         *  @brief  Produce a string representation of the hierarchy
+         *
+         *  @return The string representation of the hierarchy
+         */
+        const std::string ToString() const;
+
+    private:
+        NodeVector m_rootNodes;
+        const pandora::ParticleFlowObject *m_pNeutrino;
+    };
+
+    class MCMatches
+    {
+        public:
+            /**
+             *  @brief  Constructor
+             *
+             *  @param  pMC The MCParticle being matched
+             */
+            MCMatches(const MCHierarchy::Node *pMC);
+
+            virtual ~MCMatches() = default;
+
+            // Might be better to pass in the shared hits themselves
+            /**
+             *  @brief  Add a reconstructed node as a match for this MC node
+             *
+             *  @param  pReco The reconstructed node that matches this MC node
+             */
+            void AddRecoMatch(const RecoHierarchy::Node *pReco, const int nSharedHits);
+
+            /**
+             *  @brief  Retrieve the MC node
+             *
+             *  @return The MC node
+             */
+            const MCHierarchy::Node *GetMC() const { return m_pMC; };
+
+            /**
+             *  @brief  Retrieve the vector of matched reco nodes
+             *
+             *  @return The vector of matched reco nodes
+             */
+            const RecoHierarchy::NodeVector &GetRecoMatches() const { return m_recoNodes; };
+
+            /**
+             *  @brief  Retrieve the number of shared hits in the match
+             *
+             *  @param  pReco The reco node to consider
+             *
+             *  @return The number of shared hits
+             */
+            int GetSharedHits(const RecoHierarchy::Node *pReco) const;
+
+            /**
+             *  @brief  Retrieve the purity of the match
+             *
+             *  @param  pReco The reco node to consider
+             *
+             *  @return The purity of the match
+             */
+            float GetPurity(const RecoHierarchy::Node *pReco) const;
+
+            /**
+             *  @brief  Retrieve the completeness of the match
+             *
+             *  @param  pReco The reco node to consider
+             *
+             *  @return The completeness of the match
+             */
+            float GetCompleteness(const RecoHierarchy::Node *pReco) const;
+
+
+        private:
+            const MCHierarchy::Node *m_pMC; ///< MC node associated with any matches
+            RecoHierarchy::NodeVector m_recoNodes; ///< Matched reco nodes
+            pandora::IntVector m_sharedHits; ///< Number of shared hits for each match
+
+    };
+
+    typedef std::vector<MCMatches> MCMatchesVector;
+
+    /**
+     *  @brief  Fill an MC hierarchy based on the specified folding criteria (see MCHierarchy::Construct for details)
+     *
+     *  @param  mcParticleList The MCParticle list to use to fill this hierarchy
+     *  @param  caloHitList The list of CaloHits to use to fill this hierarchy
+     *  @param  foldToPrimaries Whether or not to fold to primary particles
+     *  @param  foldToLeadingShowers Whether or not to fold to leading shower particles
+     *  @param  hierarchy The output MC hierarchy
+     */
+    static void FillMCHierarchy(const pandora::MCParticleList &mcParticleList, const pandora::CaloHitList &caloHitList,
+        const bool foldToPrimaries, const bool foldToLeadingShowers, MCHierarchy &hierarchy);
+
+    /**
+     *  @brief  Fill a reconstructed hierarchy based on the specified folding criteria (see RecoHierarchy::Construct for details)
+     *
+     *  @param  pfoList The ParticleFlowObject list to use to fill this hierarchy
+     *  @param  foldToPrimaries Whether or not to fold to primary particles
+     *  @param  foldToLeadingShowers Whether or not to fold to leading shower particles
+     *  @param  hierarchy The output reconstructed hierarchy
+     */
+    static void FillRecoHierarchy(const pandora::PfoList &pfoList, const bool foldToPrimaries, const bool foldToLeadingShowers,
+        RecoHierarchy &hierarchy);
+
+    /**
+     *  @brief  Finds the matches between reconstructed and MC hierarchies.
+     *
+     *  @param  mcHierarchy The MC hiearchy
+     *  @param  recoHierarchy The reconstructed hierarchy
+     *  @param  matchVector The output vector of matches
+     */
+    static void MatchHierarchies(const MCHierarchy &mcHierarchy, const RecoHierarchy &recoHierarchy, MCMatchesVector &matchVector);
+
+private:
+    typedef std::set<const pandora::MCParticle*> MCParticleSet;
+    typedef std::set<const pandora::ParticleFlowObject*> PfoSet;
+
+    /**
+     *  @brief  Retrieves the primary MC particles from a list and returns the root (neutrino) for hierarchy, if it exists.
+     *
+     *  @param  mcParticleList The input list of MC particles
+     *  @param  primaries The output set of primary MC particles
+     *
+     *  @return The root neutrino, if it exists, or nullptr
+     */
+    static const pandora::MCParticle *GetMCPrimaries(const pandora::MCParticleList &mcParticleList, MCParticleSet &primaries);
+
+    /**
+     *  @brief  Retrieves the primary PFOs from a list and returns the root (neutrino) for hierarchy, if it exists.
+     *
+     *  @param  pfoList The input list of PFOs
+     *  @param  primaries The output set of primary PFOs
+     *
+     *  @return The root neutrino, if it exists, or nullptr
+     */
+    static const pandora::ParticleFlowObject *GetRecoPrimaries(const pandora::PfoList &pfoList, PfoSet &primaries);
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_HIERARCHY_HELPER_H

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -248,8 +248,7 @@ const MCParticle *LArMCParticleHelper::GetParentMCParticle(const MCParticle *con
 
 void LArMCParticleHelper::GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &descendentMCParticleList)
 {
-    const MCParticleList &daughterMCParticleList(pMCParticle->GetDaughterList());
-    for (const MCParticle *pDaughterMCParticle : daughterMCParticleList)
+    for (const MCParticle *pDaughterMCParticle : pMCParticle->GetDaughterList())
     {
         if (std::find(descendentMCParticleList.begin(), descendentMCParticleList.end(), pDaughterMCParticle) == descendentMCParticleList.end())
         {
@@ -264,8 +263,7 @@ void LArMCParticleHelper::GetAllDescendentMCParticles(const pandora::MCParticle 
 void LArMCParticleHelper::GetAllDescendentMCParticles(const MCParticle *const pMCParticle, MCParticleList &descendentTrackParticles,
     MCParticleList &leadingShowerParticles, MCParticleList &leadingNeutrons)
 {
-    const MCParticleList &daughterMCParticleList(pMCParticle->GetDaughterList());
-    for (const MCParticle *pDaughterMCParticle : daughterMCParticleList)
+    for (const MCParticle *pDaughterMCParticle : pMCParticle->GetDaughterList())
     {
         if (std::find(descendentTrackParticles.begin(), descendentTrackParticles.end(), pDaughterMCParticle) == descendentTrackParticles.end())
         {

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -226,6 +226,19 @@ public:
     static void GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &descendentMCParticleList);
 
     /**
+     *  @brief  Get all descendent mc particles, separated into track-like, shower-like and neutron branches.
+     *          This method collects together all track-like particles (i.e. not electron, photon or neutron) downstream of the root
+     *          particle, stopping at a leading shower or neutron and then storing that leading shower or neutron in a separate list.
+     *
+     *  @param  pMCParticle the input mc particle
+     *  @param  descendentTrackParticles the output list of descendent track-like particles
+     *  @param  leadingShowerParticles the output list of leading shower particles
+     *  @param  leadingNeutrons the output list of leading neutrons
+     */
+    static void GetAllDescendentMCParticles(const pandora::MCParticle *const pMCParticle, pandora::MCParticleList &descendentTrackParticles,
+        pandora::MCParticleList &leadingShowerParticles, pandora::MCParticleList &leadingNeutrons);
+
+    /**
      *  @brief  Get all ancestor mc particles
      *
      *  @param  pMCParticle the input mc particle

--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -173,6 +173,38 @@ void LArPfoHelper::GetAllDownstreamPfos(const ParticleFlowObject *const pPfo, Pf
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void LArPfoHelper::GetAllDownstreamPfos(
+    const pandora::ParticleFlowObject *const pPfo, pandora::PfoList &outputTrackPfoList, pandora::PfoList &outputLeadingShowerPfoList)
+{
+    if (LArPfoHelper::IsTrack(pPfo))
+    {
+        outputTrackPfoList.emplace_back(pPfo);
+        const PfoList &childPfoList(pPfo->GetDaughterPfoList());
+        for (const ParticleFlowObject *pChild : childPfoList)
+        {
+            if (std::find(outputTrackPfoList.begin(), outputTrackPfoList.end(), pChild) == outputTrackPfoList.end())
+            {
+                const int pdg{std::abs(pChild->GetParticleId())};
+                if (pdg == E_MINUS)
+                {
+                    outputLeadingShowerPfoList.emplace_back(pChild);
+                }
+                else
+                {
+                    outputTrackPfoList.emplace_back(pChild);
+                    LArPfoHelper::GetAllDownstreamPfos(pChild, outputTrackPfoList, outputLeadingShowerPfoList);
+                }
+            }
+        }
+    }
+    else
+    {
+        outputLeadingShowerPfoList.emplace_back(pPfo);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 int LArPfoHelper::GetHierarchyTier(const ParticleFlowObject *const pPfo)
 {
     const ParticleFlowObject *pParentPfo = pPfo;

--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -73,6 +73,18 @@ void LArPfoHelper::GetIsolatedCaloHits(const ParticleFlowObject *const pPfo, con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void LArPfoHelper::GetAllCaloHits(const ParticleFlowObject *const pPfo, CaloHitList &caloHitList)
+{
+    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, caloHitList);
+    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, caloHitList);
+    LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_W, caloHitList);
+    LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_U, caloHitList);
+    LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_V, caloHitList);
+    LArPfoHelper::GetIsolatedCaloHits(pPfo, TPC_VIEW_W, caloHitList);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void LArPfoHelper::GetClusters(const PfoList &pfoList, const HitType &hitType, ClusterList &clusterList)
 {
     for (const ParticleFlowObject *const pPfo : pfoList)
@@ -179,8 +191,7 @@ void LArPfoHelper::GetAllDownstreamPfos(
     if (LArPfoHelper::IsTrack(pPfo))
     {
         outputTrackPfoList.emplace_back(pPfo);
-        const PfoList &childPfoList(pPfo->GetDaughterPfoList());
-        for (const ParticleFlowObject *pChild : childPfoList)
+        for (const ParticleFlowObject *pChild : pPfo->GetDaughterPfoList())
         {
             if (std::find(outputTrackPfoList.begin(), outputTrackPfoList.end(), pChild) == outputTrackPfoList.end())
             {

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -144,6 +144,18 @@ public:
     static void GetAllDownstreamPfos(const pandora::ParticleFlowObject *const pPfo, pandora::PfoList &outputPfoList);
 
     /**
+     *  @brief  Get flat lists of all downstream track pfos and also shower-like pfos.
+     *          This method collects together all track-like particles downstream of the root particle, stopping at a leading shower and
+     *          then storing that leading shower in a separate list.
+     *
+     *  @param  pPfo the input pfo
+     *  @param  outputTrackPfoList the output list of descendent track-like particles
+     *  @param  outputLeadingShowerParticles the output list of leading shower particles
+     */
+    static void GetAllDownstreamPfos(
+        const pandora::ParticleFlowObject *const pPfo, pandora::PfoList &outputTrackPfoList, pandora::PfoList &outputLeadingShowerPfoList);
+
+    /**
      *  @brief  Determine the position in the hierarchy for the MCParticle
      *
      *  @param  pPfo the input Pfo

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -70,6 +70,14 @@ public:
     static void GetIsolatedCaloHits(const pandora::ParticleFlowObject *const pPfo, const pandora::HitType &hitType, pandora::CaloHitList &caloHitList);
 
     /**
+     *  @brief  Get a list of all calo hits (including isolated) of all types from a given pfo
+     *
+     *  @param  pPfo the input Pfo
+     *  @param  caloHitList the output list of calo hits
+     */
+    static void GetAllCaloHits(const pandora::ParticleFlowObject *pPfo, pandora::CaloHitList &caloHitList);
+
+    /**
      *  @brief  Get a list of clusters of a particular hit type from a list of pfos
      *
      *  @param  pfoList the input list of Pfos


### PR DESCRIPTION
This PR adds new reco/truth matching tools. These tools are designed to make it easier to determine the correspondence between reconstructed particles and MC particles, and assess the quality of the matches, with a view to increasing the sophistication of the analysis of reconstructed interaction hierarchies moving forward. Given lists of MC particles, CalHits and PFOs, matching can now be performed with the following short segment of code:

```
LArHierarchyHelper::MCHierarchy mcHierarchy;
LArHierarchyHelper::FillMCHierarchy(*pMCParticleList, *pCaloHitList, true, false, mcHierarchy);
LArHierarchyHelper::RecoHierarchy recoHierarchy;
LArHierarchyHelper::FillRecoHierarchy(*pPfoList, true, false, recoHierarchy);
LArHierarchyHelper::MatchInfo matchInfo;
LArHierarchyHelper::MatchHierarchies(mcHierarchy, recoHierarchy, matchInfo);
```

Different hierarchy folding options are available according to the booleans passed to the hierarchy filling functions. Matching information is made available to quickly establish links between reco and truth and the summary picture of the reconstruction. The MC and Reco hierarchies can also be queried in greater detail as needed.