### PR TITLE
Add algorithm to clean up 3D hits

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -198,6 +198,7 @@
 #include "larpandoracontent/LArUtility/ListDeletionAlgorithm.h"
 #include "larpandoracontent/LArUtility/ListMergingAlgorithm.h"
 #include "larpandoracontent/LArUtility/ListPruningAlgorithm.h"
+#include "larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h"
 
 #include "larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.h"
 #include "larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.h"
@@ -304,6 +305,7 @@
     d("LArListChanging",                        ListChangingAlgorithm)                                                          \
     d("LArListDeletion",                        ListDeletionAlgorithm)                                                          \
     d("LArListMerging",                         ListMergingAlgorithm)                                                           \
+    d("LArPfoHitCleaning",                      PfoHitCleaningAlgorithm)                                                        \
     d("LArListPruning",                         ListPruningAlgorithm)                                                           \
     d("LArCandidateVertexCreation",             CandidateVertexCreationAlgorithm)                                               \
     d("LArEnergyKickVertexSelection",           EnergyKickVertexSelectionAlgorithm)                                             \

--- a/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.cc
+++ b/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.cc
@@ -9,6 +9,7 @@
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 #include "larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h"
 
 using namespace pandora;
@@ -20,6 +21,7 @@ StatusCode PfoHitCleaningAlgorithm::Run()
 {
     for (unsigned int i = 0; i < m_pfoListNames.size(); ++i)
     {
+        // ATTN - one-to-one correspondance required between PFO and cluster lists
         const std::string &pfoListName{m_pfoListNames.at(i)};
         const std::string &clusterListName{m_clusterListNames.at(i)};
         const PfoList *pList(nullptr);
@@ -30,10 +32,7 @@ StatusCode PfoHitCleaningAlgorithm::Run()
             for (const ParticleFlowObject *pPfo : *pList)
             {
                 ClusterList clustersToRemove;
-                const ClusterList &clusterList{pPfo->GetClusterList()};
-                for (const Cluster *pCluster : clusterList)
-                    if (LArClusterHelper::GetClusterHitType(pCluster) == TPC_3D)
-                        clustersToRemove.emplace_back(pCluster);
+                LArPfoHelper::GetClusters(pPfo, TPC_3D, clustersToRemove);
 
                 for (const Cluster *pCluster : clustersToRemove)
                 {

--- a/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.cc
+++ b/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.cc
@@ -1,0 +1,69 @@
+/**
+ *  @file   larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.cc
+ *
+ *  @brief  Implementation of the pfo hit cleaning algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+StatusCode PfoHitCleaningAlgorithm::Run()
+{
+    for (unsigned int i = 0; i < m_pfoListNames.size(); ++i)
+    {
+        const std::string &pfoListName{m_pfoListNames.at(i)};
+        const std::string &clusterListName{m_clusterListNames.at(i)};
+        const PfoList *pList(nullptr);
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, pfoListName, pList));
+
+        if (pList && !pList->empty())
+        {
+            for (const ParticleFlowObject *pPfo : *pList)
+            {
+                ClusterList clustersToRemove;
+                const ClusterList &clusterList{pPfo->GetClusterList()};
+                for (const Cluster *pCluster : clusterList)
+                    if (LArClusterHelper::GetClusterHitType(pCluster) == TPC_3D)
+                        clustersToRemove.emplace_back(pCluster);
+
+                for (const Cluster *pCluster : clustersToRemove)
+                {
+                    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RemoveFromPfo(*this, pPfo, pCluster));
+                    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+                        PandoraContentApi::Delete<Cluster>(*this, pCluster, clusterListName));
+                }
+            }
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PfoHitCleaningAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "PfoListNames", m_pfoListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
+
+    if (m_pfoListNames.size() != m_clusterListNames.size())
+    {
+        std::cout << "PfoHitCleaningAlgorithm: Mismatch between PFO and Cluster list sizes" << std::endl;
+        return STATUS_CODE_INVALID_PARAMETER;
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h
+++ b/larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h
@@ -1,0 +1,31 @@
+/**
+ *  @file   larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h
+ *
+ *  @brief  Header file for the pfo hit cleaning algorithm class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_PFO_HIT_CLEANING_ALGORITHM_H
+#define LAR_PFO_HIT_CLEANING_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  PfoHitCleaningAlgorithm class
+ */
+class PfoHitCleaningAlgorithm : public pandora::Algorithm
+{
+private:
+    pandora::StatusCode Run();
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    pandora::StringVector m_pfoListNames;     ///< The list of pfo list names
+    pandora::StringVector m_clusterListNames; ///< The list of cluster list names
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_PFO_HIT_CLEANING_ALGORITHM_H


### PR DESCRIPTION
This is a simple algorithm that removes all 3D hits from PFOs in specified lists and removes the corresponding 3D clusters from their specified lists.

Example XML snippet:

```
<algorithm type = "LArPfoHitCleaning">
    <PfoListNames>TrackParticles3D ShowerParticles3D</PfoListNames>
    <ClusterListNames>TrackClusters3D ShowerClusters3D</ClusterListNames>
</algorithm>
```