### PR TITLE
Decouple LAr object parameters from master algorithm

### DIFF
--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -653,29 +653,7 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *c
         return STATUS_CODE_INVALID_PARAMETER;
     }
     LArCaloHitParameters parameters;
-    parameters.m_positionVector = pCaloHit->GetPositionVector();
-    parameters.m_expectedDirection = pCaloHit->GetExpectedDirection();
-    parameters.m_cellNormalVector = pCaloHit->GetCellNormalVector();
-    parameters.m_cellGeometry = pCaloHit->GetCellGeometry();
-    parameters.m_cellSize0 = pCaloHit->GetCellSize0();
-    parameters.m_cellSize1 = pCaloHit->GetCellSize1();
-    parameters.m_cellThickness = pCaloHit->GetCellThickness();
-    parameters.m_nCellRadiationLengths = pCaloHit->GetNCellRadiationLengths();
-    parameters.m_nCellInteractionLengths = pCaloHit->GetNCellInteractionLengths();
-    parameters.m_time = pCaloHit->GetTime();
-    parameters.m_inputEnergy = pCaloHit->GetInputEnergy();
-    parameters.m_mipEquivalentEnergy = pCaloHit->GetMipEquivalentEnergy();
-    parameters.m_electromagneticEnergy = pCaloHit->GetElectromagneticEnergy();
-    parameters.m_hadronicEnergy = pCaloHit->GetHadronicEnergy();
-    parameters.m_isDigital = pCaloHit->IsDigital();
-    parameters.m_hitType = pCaloHit->GetHitType();
-    parameters.m_hitRegion = pCaloHit->GetHitRegion();
-    parameters.m_layer = pCaloHit->GetLayer();
-    parameters.m_isInOuterSamplingLayer = pCaloHit->IsInOuterSamplingLayer();
-    // ATTN Parent of calo hit in worker is corresponding calo hit in master
-    parameters.m_pParentAddress = static_cast<const void *>(pCaloHit);
-    parameters.m_larTPCVolumeId = pLArCaloHit->GetLArTPCVolumeId();
-    parameters.m_daughterVolumeId = (m_larCaloHitVersion > 1) ? pLArCaloHit->GetDaughterVolumeId() : 0;
+    pLArCaloHit->GetParameters(parameters);
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::CaloHit::Create(*pPandora, parameters, m_larCaloHitFactory));
 
@@ -700,7 +678,6 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *c
 
 StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const MCParticle *const pMCParticle, const LArMCParticleFactory *const pMCParticleFactory) const
 {
-    LArMCParticleParameters parameters;
     const LArMCParticle *const pLArMCParticle = dynamic_cast<const LArMCParticle *>(pMCParticle);
 
     if (!pLArMCParticle)
@@ -709,16 +686,8 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const MCParticle
         return STATUS_CODE_INVALID_PARAMETER;
     }
 
-    parameters.m_nuanceCode = pLArMCParticle->GetNuanceCode();
-    parameters.m_process = pLArMCParticle->GetProcess();
-    parameters.m_energy = pMCParticle->GetEnergy();
-    parameters.m_momentum = pMCParticle->GetMomentum();
-    parameters.m_vertex = pMCParticle->GetVertex();
-    parameters.m_endpoint = pMCParticle->GetEndpoint();
-    parameters.m_particleId = pMCParticle->GetParticleId();
-    parameters.m_mcParticleType = pMCParticle->GetMCParticleType();
-    // ATTN Parent of mc particle in worker is corresponding mc particle in master
-    parameters.m_pParentAddress = static_cast<const void *>(pMCParticle);
+    LArMCParticleParameters parameters;
+    pLArMCParticle->GetParameters(parameters);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::MCParticle::Create(*pPandora, parameters, *pMCParticleFactory));
 
     for (const MCParticle *const pDaughterMCParticle : pMCParticle->GetDaughterList())

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -653,8 +653,7 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *c
         return STATUS_CODE_INVALID_PARAMETER;
     }
     LArCaloHitParameters parameters;
-    pLArCaloHit->GetParameters(parameters);
-
+    pLArCaloHit->FillParameters(parameters);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::CaloHit::Create(*pPandora, parameters, m_larCaloHitFactory));
 
     if (m_passMCParticlesToWorkerInstances)
@@ -687,7 +686,7 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const MCParticle
     }
 
     LArMCParticleParameters parameters;
-    pLArMCParticle->GetParameters(parameters);
+    pLArMCParticle->FillParameters(parameters);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::MCParticle::Create(*pPandora, parameters, *pMCParticleFactory));
 
     for (const MCParticle *const pDaughterMCParticle : pMCParticle->GetDaughterList())

--- a/larpandoracontent/LArObjects/LArCaloHit.h
+++ b/larpandoracontent/LArObjects/LArCaloHit.h
@@ -61,6 +61,13 @@ public:
     unsigned int GetDaughterVolumeId() const;
 
     /**
+     *  @brief  Get the parameters associated with this calo hit
+     *
+     *  @return the output parameters
+     */
+    void GetParameters(LArCaloHitParameters &parameters) const;
+
+    /**
      *  @brief  Get the probability that the hit is track-like
      *
      *  @return the probability the hit is track-like
@@ -167,6 +174,35 @@ inline unsigned int LArCaloHit::GetLArTPCVolumeId() const
 inline unsigned int LArCaloHit::GetDaughterVolumeId() const
 {
     return m_daughterVolumeId;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline void LArCaloHit::GetParameters(LArCaloHitParameters &parameters) const
+{
+    parameters.m_positionVector = this->GetPositionVector();
+    parameters.m_expectedDirection = this->GetExpectedDirection();
+    parameters.m_cellNormalVector = this->GetCellNormalVector();
+    parameters.m_cellGeometry = this->GetCellGeometry();
+    parameters.m_cellSize0 = this->GetCellSize0();
+    parameters.m_cellSize1 = this->GetCellSize1();
+    parameters.m_cellThickness = this->GetCellThickness();
+    parameters.m_nCellRadiationLengths = this->GetNCellRadiationLengths();
+    parameters.m_nCellInteractionLengths = this->GetNCellInteractionLengths();
+    parameters.m_time = this->GetTime();
+    parameters.m_inputEnergy = this->GetInputEnergy();
+    parameters.m_mipEquivalentEnergy = this->GetMipEquivalentEnergy();
+    parameters.m_electromagneticEnergy = this->GetElectromagneticEnergy();
+    parameters.m_hadronicEnergy = this->GetHadronicEnergy();
+    parameters.m_isDigital = this->IsDigital();
+    parameters.m_hitType = this->GetHitType();
+    parameters.m_hitRegion = this->GetHitRegion();
+    parameters.m_layer = this->GetLayer();
+    parameters.m_isInOuterSamplingLayer = this->IsInOuterSamplingLayer();
+    // ATTN Parent of calo hit in worker is corresponding calo hit in master
+    parameters.m_pParentAddress = static_cast<const void *>(this);
+    parameters.m_larTPCVolumeId = this->GetLArTPCVolumeId();
+    parameters.m_daughterVolumeId = this->GetDaughterVolumeId();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArObjects/LArCaloHit.h
+++ b/larpandoracontent/LArObjects/LArCaloHit.h
@@ -61,11 +61,11 @@ public:
     unsigned int GetDaughterVolumeId() const;
 
     /**
-     *  @brief  Get the parameters associated with this calo hit
+     *  @brief  Fill the parameters associated with this calo hit
      *
-     *  @return the output parameters
+     *  @param  parameters the output parameters
      */
-    void GetParameters(LArCaloHitParameters &parameters) const;
+    void FillParameters(LArCaloHitParameters &parameters) const;
 
     /**
      *  @brief  Get the probability that the hit is track-like
@@ -178,7 +178,7 @@ inline unsigned int LArCaloHit::GetDaughterVolumeId() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline void LArCaloHit::GetParameters(LArCaloHitParameters &parameters) const
+inline void LArCaloHit::FillParameters(LArCaloHitParameters &parameters) const
 {
     parameters.m_positionVector = this->GetPositionVector();
     parameters.m_expectedDirection = this->GetExpectedDirection();
@@ -199,7 +199,7 @@ inline void LArCaloHit::GetParameters(LArCaloHitParameters &parameters) const
     parameters.m_hitRegion = this->GetHitRegion();
     parameters.m_layer = this->GetLayer();
     parameters.m_isInOuterSamplingLayer = this->IsInOuterSamplingLayer();
-    // ATTN Parent of calo hit in worker is corresponding calo hit in master
+    // ATTN Set the parent address to the original owner of the calo hit
     parameters.m_pParentAddress = static_cast<const void *>(this);
     parameters.m_larTPCVolumeId = this->GetLArTPCVolumeId();
     parameters.m_daughterVolumeId = this->GetDaughterVolumeId();

--- a/larpandoracontent/LArObjects/LArMCParticle.h
+++ b/larpandoracontent/LArObjects/LArMCParticle.h
@@ -84,6 +84,13 @@ public:
     int GetNuanceCode() const;
 
     /**
+     *  @brief  Get the parameters associated with this MC particle
+     *
+     *  @param  parameters the output parameters
+     */
+    void GetParameters(LArMCParticleParameters &parameters) const;
+
+    /**
      *  @brief  Get the process
      *
      *  @return the process
@@ -160,6 +167,22 @@ inline LArMCParticle::LArMCParticle(const LArMCParticleParameters &parameters) :
 inline int LArMCParticle::GetNuanceCode() const
 {
     return m_nuanceCode;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline void LArMCParticle::GetParameters(LArMCParticleParameters &parameters) const
+{
+    parameters.m_nuanceCode = this->GetNuanceCode();
+    parameters.m_process = this->GetProcess();
+    parameters.m_energy = this->GetEnergy();
+    parameters.m_momentum = this->GetMomentum();
+    parameters.m_vertex = this->GetVertex();
+    parameters.m_endpoint = this->GetEndpoint();
+    parameters.m_particleId = this->GetParticleId();
+    parameters.m_mcParticleType = this->GetMCParticleType();
+    // ATTN Parent of mc particle in worker is corresponding mc particle in master
+    parameters.m_pParentAddress = static_cast<const void *>(this);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArObjects/LArMCParticle.h
+++ b/larpandoracontent/LArObjects/LArMCParticle.h
@@ -84,11 +84,11 @@ public:
     int GetNuanceCode() const;
 
     /**
-     *  @brief  Get the parameters associated with this MC particle
+     *  @brief  Fill the parameters associated with this MC particle
      *
      *  @param  parameters the output parameters
      */
-    void GetParameters(LArMCParticleParameters &parameters) const;
+    void FillParameters(LArMCParticleParameters &parameters) const;
 
     /**
      *  @brief  Get the process
@@ -171,7 +171,7 @@ inline int LArMCParticle::GetNuanceCode() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline void LArMCParticle::GetParameters(LArMCParticleParameters &parameters) const
+inline void LArMCParticle::FillParameters(LArMCParticleParameters &parameters) const
 {
     parameters.m_nuanceCode = this->GetNuanceCode();
     parameters.m_process = this->GetProcess();
@@ -181,7 +181,7 @@ inline void LArMCParticle::GetParameters(LArMCParticleParameters &parameters) co
     parameters.m_endpoint = this->GetEndpoint();
     parameters.m_particleId = this->GetParticleId();
     parameters.m_mcParticleType = this->GetMCParticleType();
-    // ATTN Parent of mc particle in worker is corresponding mc particle in master
+    // ATTN Set the parent address to the original owner of the mc particle
     parameters.m_pParentAddress = static_cast<const void *>(this);
 }
 


### PR DESCRIPTION
This PR decouples the MasterAlgorithm from the internal structure of the parameter classes for LArCaloHit and LArMCParticle.