### PR TITLE
Fix vertex asymmetry tools when no shower clusters are present

### DIFF
--- a/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
+++ b/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc
@@ -33,13 +33,16 @@ void AsymmetryFeatureBaseTool::Run(LArMvaHelper::MvaFeatureVector &featureVector
     float asymmetry(0.f);
 
     asymmetry += this->GetAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U),
-        slidingFitDataListMap.at(TPC_VIEW_U), showerClusterListMap.at(TPC_VIEW_U));
+        slidingFitDataListMap.at(TPC_VIEW_U),
+        showerClusterListMap.empty() ? VertexSelectionBaseAlgorithm::ShowerClusterList() : showerClusterListMap.at(TPC_VIEW_U));
 
     asymmetry += this->GetAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V),
-        slidingFitDataListMap.at(TPC_VIEW_V), showerClusterListMap.at(TPC_VIEW_V));
+        slidingFitDataListMap.at(TPC_VIEW_V),
+        showerClusterListMap.empty() ? VertexSelectionBaseAlgorithm::ShowerClusterList() : showerClusterListMap.at(TPC_VIEW_V));
 
     asymmetry += this->GetAsymmetryForView(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W),
-        slidingFitDataListMap.at(TPC_VIEW_W), showerClusterListMap.at(TPC_VIEW_W));
+        slidingFitDataListMap.at(TPC_VIEW_W),
+        showerClusterListMap.empty() ? VertexSelectionBaseAlgorithm::ShowerClusterList() : showerClusterListMap.at(TPC_VIEW_W));
 
     featureVector.push_back(asymmetry);
 }


### PR DESCRIPTION
I recently ran into a bug where the standard (non-mva) vertexing would return a `Failure in algorithm` message. I found the issue was with the way the new `AsymmetryFeatureBaseTool` treats events where there are no shower clusters present, specifically in this case where an empty map is passed an exception would be thrown when `at` is called: https://github.com/PandoraPFA/LArContent/blob/603df26b1049c85ab0a7af746b5d279d2abecbb9/larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.cc#L57-L60
https://github.com/PandoraPFA/LArContent/blob/603df26b1049c85ab0a7af746b5d279d2abecbb9/larpandoracontent/LArVertex/AsymmetryFeatureBaseTool.cc#L35-L36
I added in some checks to avoid this exception being thrown. 

It seems like this issues slipped through the CI as no experiment uses this algorithm any more, but I think it would be good to have some checks somewhere to ensure `PandoraSettings_Master_Standard.xml` runs. 