### PR TITLE
Vertex Refinement Algorithm

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -204,6 +204,7 @@
 #include "larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.h"
 #include "larpandoracontent/LArVertex/HitAngleVertexSelectionAlgorithm.h"
 #include "larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.h"
+#include "larpandoracontent/LArVertex/VertexRefinementAlgorithm.h"
 
 #include "larpandoracontent/LArContent.h"
 
@@ -311,7 +312,8 @@
     d("LArEnergyKickVertexSelection",           EnergyKickVertexSelectionAlgorithm)                                             \
     d("LArHitAngleVertexSelection",             HitAngleVertexSelectionAlgorithm)                                               \
     d("LArBdtVertexSelection",                  BdtVertexSelectionAlgorithm)                                                    \
-    d("LArSvmVertexSelection",                  SvmVertexSelectionAlgorithm)
+    d("LArSvmVertexSelection",                  SvmVertexSelectionAlgorithm)                                                    \
+    d("LArVertexRefinement",                    VertexRefinementAlgorithm)
 
 #define LAR_ALGORITHM_TOOL_LIST(d)                                                                                              \
     d("LArBdtBeamParticleId",                   BdtBeamParticleIdTool)                                                          \

--- a/larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
@@ -215,9 +215,9 @@ void VertexRefinementAlgorithm::GetBestFitPoint(const CartesianPointVector &inte
         G(3 * i + 2, i + 3) = -directions[i].GetZ();
     }
 
-    if ((G.transpose() * G).determinant() == 0)
+    if ((G.transpose() * G).determinant() < std::numeric_limits<float>::epsilon())
     {
-        bestFitPoint = CartesianVector(-999.f, -999.f, -999.f);
+        bestFitPoint = CartesianVector(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
         return;
     }
 

--- a/larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
@@ -1,0 +1,246 @@
+/**
+ *  @file   larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
+ *
+ *  @brief  Implementation of the vertex refinement algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
+
+#include "larpandoracontent/LArVertex/VertexRefinementAlgorithm.h"
+
+#include <Eigen/Dense>
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+VertexRefinementAlgorithm::VertexRefinementAlgorithm() :
+    m_chiSquaredCut(2.f),
+    m_distanceCut(5.f),
+    m_minimumHitsCut(5),
+    m_twoDDistanceCut(10.f)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode VertexRefinementAlgorithm::Run()
+{
+    const VertexList *pInputVertexList(NULL);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pInputVertexList));
+
+    if (!pInputVertexList || pInputVertexList->empty())
+    {
+        if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+            std::cout << "VertexRefinementAlgorithm: unable to find current vertex list " << std::endl;
+
+        return STATUS_CODE_SUCCESS;
+    }
+
+    const VertexList *pOutputVertexList(NULL);
+    std::string temporaryListName;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pOutputVertexList, temporaryListName));
+
+    ClusterList clusterListU, clusterListV, clusterListW;
+    this->GetClusterLists(m_inputClusterListNames, clusterListU, clusterListV, clusterListW);
+
+    this->RefineVertices(pInputVertexList, clusterListU, clusterListV, clusterListW);
+
+    if (!pOutputVertexList->empty())
+    {
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Vertex>(*this, m_outputVertexListName));
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Vertex>(*this, m_outputVertexListName));
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void VertexRefinementAlgorithm::GetClusterLists(
+    const StringVector &inputClusterListNames, ClusterList &clusterListU, ClusterList &clusterListV, ClusterList &clusterListW) const
+{
+    for (const std::string &clusterListName : inputClusterListNames)
+    {
+        const ClusterList *pClusterList(NULL);
+        PANDORA_THROW_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
+
+        if (!pClusterList || pClusterList->empty())
+        {
+            if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+                std::cout << "VertexRefinementAlgorithm: unable to find cluster list " << clusterListName << std::endl;
+
+            continue;
+        }
+
+        const HitType hitType(LArClusterHelper::GetClusterHitType(*(pClusterList->begin())));
+
+        if ((TPC_VIEW_U != hitType) && (TPC_VIEW_V != hitType) && (TPC_VIEW_W != hitType))
+            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+
+        ClusterList &clusterList((TPC_VIEW_U == hitType) ? clusterListU : (TPC_VIEW_V == hitType) ? clusterListV : clusterListW);
+        clusterList.insert(clusterList.end(), pClusterList->begin(), pClusterList->end());
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void VertexRefinementAlgorithm::RefineVertices(const VertexList *const pVertexList, const ClusterList &clusterListU,
+    const ClusterList &clusterListV, const ClusterList &clusterListW) const
+{
+    for (const Vertex *const pVertex : *pVertexList)
+    {
+        const CartesianVector originalPosition(pVertex->GetPosition());
+
+        const CartesianVector vtxU(
+            this->RefineVertexTwoD(clusterListU, LArGeometryHelper::ProjectPosition(this->GetPandora(), originalPosition, TPC_VIEW_U)));
+        const CartesianVector vtxV(
+            this->RefineVertexTwoD(clusterListV, LArGeometryHelper::ProjectPosition(this->GetPandora(), originalPosition, TPC_VIEW_V)));
+        const CartesianVector vtxW(
+            this->RefineVertexTwoD(clusterListW, LArGeometryHelper::ProjectPosition(this->GetPandora(), originalPosition, TPC_VIEW_W)));
+
+        CartesianVector vtxUV(-999, -999, -999), vtxUW(-999, -999, -999), vtxVW(-999, -999, -999), vtx3D(-999, -999, -999),
+            position3D(-999, -999, -999);
+        float chi2UV(-999.f), chi2UW(-999.f), chi2VW(-999.f), chi23D(-999.f), chi2(-999.f);
+
+        LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, vtxU, vtxV, vtxUV, chi2UV);
+        LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_W, vtxU, vtxW, vtxUW, chi2UW);
+        LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), TPC_VIEW_V, TPC_VIEW_W, vtxV, vtxW, vtxVW, chi2VW);
+        LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, vtxU, vtxV, vtxW, vtx3D, chi23D);
+
+        if (chi2UV < chi2UW && chi2UV < chi2VW && chi2UV < chi23D)
+        {
+            position3D = vtxUV;
+            chi2 = chi2UV;
+        }
+        else if (chi2UW < chi2VW && chi2UW < chi23D)
+        {
+            position3D = vtxUW;
+            chi2 = chi2UW;
+        }
+        else if (chi2VW < chi23D)
+        {
+            position3D = vtxVW;
+            chi2 = chi2VW;
+        }
+        else
+        {
+            position3D = vtx3D;
+            chi2 = chi23D;
+        }
+
+        if (chi2 > m_chiSquaredCut)
+            position3D = originalPosition;
+
+        if ((position3D - originalPosition).GetMagnitude() > m_distanceCut)
+            position3D = originalPosition;
+
+        PandoraContentApi::Vertex::Parameters parameters;
+        parameters.m_position = position3D;
+        parameters.m_vertexLabel = VERTEX_INTERACTION;
+        parameters.m_vertexType = VERTEX_3D;
+
+        const Vertex *pNewVertex(NULL);
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Vertex::Create(*this, parameters, pNewVertex));
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+CartesianVector VertexRefinementAlgorithm::RefineVertexTwoD(const ClusterList &clusterList, const CartesianVector &originalVtxPos) const
+{
+    CartesianPointVector intercepts, directions;
+    FloatVector weights;
+
+    for (const Cluster *const pCluster : clusterList)
+    {
+        if (LArClusterHelper::GetClosestDistance(originalVtxPos, pCluster) > 10)
+            continue;
+
+        if (pCluster->GetNCaloHits() < m_minimumHitsCut)
+            continue;
+
+        CartesianVector centroid(-999, -999, -999);
+        LArPcaHelper::EigenValues eigenValues(-999, -999, -999);
+        LArPcaHelper::EigenVectors eigenVectors;
+        CartesianPointVector pointVector;
+
+        LArClusterHelper::GetCoordinateVector(pCluster, pointVector);
+        LArPcaHelper::RunPca(pointVector, centroid, eigenValues, eigenVectors);
+
+        intercepts.push_back(LArClusterHelper::GetClosestPosition(originalVtxPos, pCluster));
+        directions.push_back(eigenVectors.at(0).GetUnitVector());
+        weights.push_back(1.f / ((LArClusterHelper::GetClosestPosition(originalVtxPos, pCluster) - originalVtxPos).GetMagnitudeSquared() + 1));
+    }
+
+    CartesianVector newVtxPos(originalVtxPos);
+    if (intercepts.size() > 1)
+        GetBestFitPoint(intercepts, directions, weights, newVtxPos);
+
+    if ((newVtxPos - originalVtxPos).GetMagnitude() > m_twoDDistanceCut)
+        return originalVtxPos;
+
+    return newVtxPos;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void VertexRefinementAlgorithm::GetBestFitPoint(const CartesianPointVector &intercepts, const CartesianPointVector &directions,
+    const FloatVector &weights, CartesianVector &bestFitPoint) const
+{
+    const int n(intercepts.size());
+
+    Eigen::VectorXd d = Eigen::VectorXd::Zero(3 * n);
+    Eigen::MatrixXd G = Eigen::MatrixXd::Zero(3 * n, n + 3);
+
+    for (int i = 0; i < n; ++i)
+    {
+        d(3 * i) = intercepts[i].GetX() * weights[i];
+        d(3 * i + 1) = intercepts[i].GetY() * weights[i];
+        d(3 * i + 2) = intercepts[i].GetZ() * weights[i];
+
+        G(3 * i, 0) = weights[i];
+        G(3 * i + 1, 1) = weights[i];
+        G(3 * i + 2, 2) = weights[i];
+
+        G(3 * i, i + 3) = -directions[i].GetX();
+        G(3 * i + 1, i + 3) = -directions[i].GetY();
+        G(3 * i + 2, i + 3) = -directions[i].GetZ();
+    }
+
+    Eigen::VectorXd m = (G.transpose() * G).inverse() * G.transpose() * d;
+
+    bestFitPoint = CartesianVector(m[0], m[1], m[2]);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode VertexRefinementAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
+
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputVertexListName", m_inputVertexListName));
+
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_outputVertexListName));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ChiSquaredCut", m_chiSquaredCut));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DistanceCut", m_distanceCut));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumHitsCut", m_minimumHitsCut));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TwoDDistanceCut", m_twoDDistanceCut));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArVertex/VertexRefinementAlgorithm.h
+++ b/larpandoracontent/LArVertex/VertexRefinementAlgorithm.h
@@ -1,0 +1,87 @@
+/**
+ *  @file   larpandoracontent/LArVertex/VertexRefinementAlgorithm.h
+ *
+ *  @brief  Header file for the vertex refinement algorithm class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_VERTEX_REFINEMENT_ALGORITHM_H
+#define LAR_VERTEX_REFINEMENT_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  VertexRefinementAlgorithm class
+ */
+class VertexRefinementAlgorithm : public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    VertexRefinementAlgorithm();
+
+private:
+    pandora::StatusCode Run();
+
+    /**
+     *  @brief  Get the input cluster lists
+     *
+     *  @param  inputClusterListNames the input cluster list names
+     *  @param  clusterListU the U-view cluster list to populate
+     *  @param  clusterListV the V-view cluster list to populate
+     *  @param  clusterListW the W-view cluster list to populate
+     */
+    void GetClusterLists(const pandora::StringVector &inputClusterListNames, pandora::ClusterList &clusterListU,
+        pandora::ClusterList &clusterListV, pandora::ClusterList &clusterListW) const;
+
+    /**
+     *  @brief  Perform the refinement proceduce on a list of vertices
+     *
+     *  @param  pVertexList address of the vertex list
+     *  @param  clusterListU the list of U-view clusters
+     *  @param  clusterListV the list of V-view clusters
+     *  @param  clusterListW the list of W-view clusters
+     */
+    void RefineVertices(const pandora::VertexList *const pVertexList, const pandora::ClusterList &clusterListU,
+        const pandora::ClusterList &clusterListV, const pandora::ClusterList &clusterListW) const;
+
+    /**
+     *  @brief  Refine the position of a two dimensional projection of a vertex using the clusters in that view
+     *
+     *  @param  clusterList the list of two dimensional clusters
+     *  @param  originalVtxPos the original vertex position projected into two dimensions
+     *
+     *  @return the new refined position
+     */
+    pandora::CartesianVector RefineVertexTwoD(const pandora::ClusterList &clusterList, const pandora::CartesianVector &originalVtxPos) const;
+
+    /**
+     *  @brief  Calculate the best fit point of a set of lines using a matrix equation
+     *
+     *  @param  intercepts the vector of the defining points of the lines
+     *  @param  directions the vector of line directions
+     *  @param  weights the vector of weights for each line
+     *  @param  bestFitPoint the resulting best fit point
+     */
+    void GetBestFitPoint(const pandora::CartesianPointVector &intercepts, const pandora::CartesianPointVector &directions,
+        const pandora::FloatVector &weights, pandora::CartesianVector &bestFitPoint) const;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    pandora::StringVector m_inputClusterListNames; ///< The list of input cluster list names
+    std::string m_inputVertexListName;             ///< The initial vertex list
+    std::string m_outputVertexListName;            ///< The refined vertex list to be outputted
+
+    float m_chiSquaredCut;         ///< The maximum chi2 value a refined vertex can have to be kept
+    float m_distanceCut;           ///< The maximum distance a refined vertex can be from the original position to be kept
+    unsigned int m_minimumHitsCut; ///< The minimum size of a cluster to be used in refinement
+    float m_twoDDistanceCut;       ///< The maximum distance a cluster can be from the original position to be used in refinement
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_VERTEX_REFINEMENT_ALGORITHM_H


### PR DESCRIPTION
This PR adds a new algorithm to the vertex reconstruction suite which performs a refinement procedure on a vertex / vertex candidate using the directions of nearby clusters. 

An example xml snippet for utilising this algorithm directly after the candidate creation algorithm would be:

```
<algorithm type = "LArVertexRefinement">
  <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
  <InputVertexListName>CandidateVertices3D</InputVertexListName>
  <OutputVertexListName>RefinedVertices3D</OutputVertexListName>
</algorithm>

```

I presented this algorithm and some results from testing it in SBND at the most recent meeting and the slides can be found [here](https://indico.fnal.gov/event/50252/contributions/221554/attachments/145990/186062/Vertex_Refinement_DUNE_UK.pdf).