### PR TITLE
Updates required for the Range Loop Optimisation warnings from modern compilers

### DIFF
--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
@@ -998,7 +998,7 @@ unsigned int LArHierarchyHelper::MatchInfo::GetNMCNodes() const
         mcNodeSet.insert(match.GetMC());
     for (const MCMatches &match : this->GetSubThresholdMatches())
         mcNodeSet.insert(match.GetMC());
-    for (const MCMatches &match : this->GetUnmatchedMC())
+    for (const MCMatches match : this->GetUnmatchedMC())
         mcNodeSet.insert(match.GetMC());
 
     return static_cast<unsigned int>(mcNodeSet.size());
@@ -1027,7 +1027,7 @@ unsigned int LArHierarchyHelper::MatchInfo::GetNNeutrinoMCNodes() const
         if (!(pNode->IsCosmicRay() || pNode->IsTestBeamParticle()))
             mcNodeSet.insert(match.GetMC());
     }
-    for (const MCMatches &match : this->GetUnmatchedMC())
+    for (const MCMatches match : this->GetUnmatchedMC())
     {
         const MCHierarchy::Node *pNode{match.GetMC()};
         if (!(pNode->IsCosmicRay() || pNode->IsTestBeamParticle()))
@@ -1060,7 +1060,7 @@ unsigned int LArHierarchyHelper::MatchInfo::GetNCosmicRayMCNodes() const
         if (pNode->IsCosmicRay())
             mcNodeSet.insert(match.GetMC());
     }
-    for (const MCMatches &match : this->GetUnmatchedMC())
+    for (const MCMatches match : this->GetUnmatchedMC())
     {
         const MCHierarchy::Node *pNode{match.GetMC()};
         if (pNode->IsCosmicRay())
@@ -1093,7 +1093,7 @@ unsigned int LArHierarchyHelper::MatchInfo::GetNTestBeamMCNodes() const
         if (pNode->IsTestBeamParticle())
             mcNodeSet.insert(match.GetMC());
     }
-    for (const MCMatches &match : this->GetUnmatchedMC())
+    for (const MCMatches match : this->GetUnmatchedMC())
     {
         const MCHierarchy::Node *pNode{match.GetMC()};
         if (pNode->IsCosmicRay())

--- a/larpandoracontent/LArMonitoring/HierarchyValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/HierarchyValidationAlgorithm.cc
@@ -138,7 +138,7 @@ void HierarchyValidationAlgorithm::EventValidation(const LArHierarchyHelper::Mat
                 trackNodeSet.insert(pNode);
         }
 
-        for (const LArHierarchyHelper::MCMatches &mcMatch : matchInfo.GetUnmatchedMC())
+        for (const LArHierarchyHelper::MCMatches mcMatch : matchInfo.GetUnmatchedMC())
         {
             const LArHierarchyHelper::MCHierarchy::Node *pNode{mcMatch.GetMC()};
             if (pNode->IsLeadingLepton())

--- a/larpandoracontent/LArMonitoring/VisualParticleMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualParticleMonitoringAlgorithm.cc
@@ -149,7 +149,7 @@ void VisualParticleMonitoringAlgorithm::VisualizeMCByPdgCode(const LArMCParticle
         {"mu", MAGENTA}, {"e", RED}, {"gamma", ORANGE}, {"kaon", BLACK}, {"pi", GREEN}, {"p", BLUE}, {"other", GRAY}};
 
     std::map<std::string, CaloHitList> uHits, vHits, wHits;
-    for (const auto [key, value] : keys)
+    for (const auto & [key, value] : keys)
     {
         (void)key; // GCC 7 support, 8+ doesn't need this
         uHits[value] = CaloHitList();
@@ -160,7 +160,7 @@ void VisualParticleMonitoringAlgorithm::VisualizeMCByPdgCode(const LArMCParticle
     vHits["other"] = CaloHitList();
     wHits["other"] = CaloHitList();
 
-    for (const auto [pMC, pCaloHits] : mcMap)
+    for (const auto & [pMC, pCaloHits] : mcMap)
     {
         for (const CaloHit *pCaloHit : pCaloHits)
         {
@@ -190,7 +190,7 @@ void VisualParticleMonitoringAlgorithm::VisualizeMCByPdgCode(const LArMCParticle
     PANDORA_MONITORING_API(
         SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, m_transparencyThresholdE, m_energyScaleThresholdE, m_scalingFactor));
 
-    for (const auto [key, value] : keys)
+    for (const auto & [key, value] : keys)
     {
         (void)key; // GCC 7 support, 8+ doesn't need this
         if (!uHits[value].empty())
@@ -199,7 +199,7 @@ void VisualParticleMonitoringAlgorithm::VisualizeMCByPdgCode(const LArMCParticle
     if (!uHits["other"].empty())
         PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &uHits["other"], "u_other", colors.at("other")));
 
-    for (const auto [key, value] : keys)
+    for (const auto & [key, value] : keys)
     {
         (void)key; // GCC 7 support, 8+ doesn't need this
         if (!vHits[value].empty())
@@ -208,7 +208,7 @@ void VisualParticleMonitoringAlgorithm::VisualizeMCByPdgCode(const LArMCParticle
     if (!vHits["other"].empty())
         PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &uHits["other"], "v_other", colors.at("other")));
 
-    for (const auto [key, value] : keys)
+    for (const auto & [key, value] : keys)
     {
         (void)key; // GCC 7 support, 8+ doesn't need this
         if (!wHits[value].empty())


### PR DESCRIPTION
Natsumi Taniuchi reported being unable to build with Clang 13 because of it adds a number of warnings when using range-based for.

I've fixed this on both clang 12 and gcc 11.2, but because I don't have a Mac I'm unable to test with the same version as her.