### PR TITLE
Persist Slice BDT Inputs

### DIFF
--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -256,24 +256,12 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
 	    
-            LArMvaHelper::MvaFeatureVector featureVector;
-            sliceFeaturesVector.at(sliceIndex).GetFeatureVector(featureVector);
-            if(featureVector.size() != 10)
-              std::cout << "Feature Vector is not size 10 (" << featureVector.size() << ")" << std::endl;
-            else 
-              {
-                metadata.m_propertiesToAdd["NuNFinalStatePfos"] = featureVector[0].Get();
-                metadata.m_propertiesToAdd["NuNHitsTotal"] = featureVector[1].Get();
-                metadata.m_propertiesToAdd["NuVertexY"] = featureVector[2].Get();
-                metadata.m_propertiesToAdd["NuWeightedDirZ"] = featureVector[3].Get();
-                metadata.m_propertiesToAdd["NuNSpacePointsInSphere"] = featureVector[4].Get();
-                metadata.m_propertiesToAdd["NuEigenRatioInSphere"] = featureVector[5].Get();
-                metadata.m_propertiesToAdd["CRLongestTrackDirY"] = featureVector[6].Get();
-                metadata.m_propertiesToAdd["CRLongestTrackDeflection"] = featureVector[7].Get();
-                metadata.m_propertiesToAdd["CRFracHitsInLongestTrack"] = featureVector[8].Get();
-                metadata.m_propertiesToAdd["CRNHitsMax"] = featureVector[9].Get();
-              }
+	    std::map<std::string, double> featureMap;
+	    sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
 
+	    for(auto const& [ name, value ] : featureMap)
+	      metadata.m_propertiesToAdd[name] = value;
+	    
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
         }
 
@@ -282,23 +270,11 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
 
-            LArMvaHelper::MvaFeatureVector featureVector;
-            sliceFeaturesVector.at(sliceIndex).GetFeatureVector(featureVector);
-            if(featureVector.size() != 10)
-              std::cout << "Feature Vector is not size 10 (" << featureVector.size() << ")" << std::endl;
-            else 
-              {
-                metadata.m_propertiesToAdd["NuNFinalStatePfos"] = (float) featureVector[0].Get();
-                metadata.m_propertiesToAdd["NuNHitsTotal"] = featureVector[1].Get();
-                metadata.m_propertiesToAdd["NuVertexY"] = featureVector[2].Get();
-                metadata.m_propertiesToAdd["NuWeightedDirZ"] = featureVector[3].Get();
-                metadata.m_propertiesToAdd["NuNSpacePointsInSphere"] = featureVector[4].Get();
-                metadata.m_propertiesToAdd["NuEigenRatioInSphere"] = featureVector[5].Get();
-                metadata.m_propertiesToAdd["CRLongestTrackDirY"] = featureVector[6].Get();
-                metadata.m_propertiesToAdd["CRLongestTrackDeflection"] = featureVector[7].Get();
-                metadata.m_propertiesToAdd["CRFracHitsInLongestTrack"] = featureVector[8].Get();
-                metadata.m_propertiesToAdd["CRNHitsMax"] = featureVector[9].Get();
-              }
+	    std::map<std::string, double> featureMap;
+	    sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
+
+	    for(auto const& [ name, value ] : featureMap)
+	      metadata.m_propertiesToAdd[name] = value;
 
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
         }
@@ -442,6 +418,17 @@ NeutrinoIdTool<T>::SliceFeatures::SliceFeatures(const PfoList &nuPfos, const Pfo
         m_featureVector.push_back(crFracHitsInLongestTrack);
         m_featureVector.push_back(nCRHitsMax);
 
+        m_featureMap["NuNFinalStatePfos"] = nuNFinalStatePfos;
+        m_featureMap["NuNHitsTotal"] = nuNHitsTotal;
+        m_featureMap["NuVertexY"] = nuVertexY;
+        m_featureMap["NuWeightedDirZ"] = nuWeightedDirZ;
+        m_featureMap["NuNSpacePointsInSphere"] = nuNSpacePointsInSphere;
+        m_featureMap["NuEigenRatioInSphere"] = nuEigenRatioInSphere;
+        m_featureMap["CRLongestTrackDirY"] = crLongestTrackDirY;
+        m_featureMap["CRLongestTrackDeflection"] = crLongestTrackDeflection;
+        m_featureMap["CRFracHitsInLongestTrack"] = crFracHitsInLongestTrack;
+        m_featureMap["CRNHitsMax"] = nCRHitsMax;
+
         m_isAvailable = true;
     }
     catch (StatusCodeException &)
@@ -467,6 +454,17 @@ void NeutrinoIdTool<T>::SliceFeatures::GetFeatureVector(LArMvaHelper::MvaFeature
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);
 
     featureVector.insert(featureVector.end(), m_featureVector.begin(), m_featureVector.end());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+void NeutrinoIdTool<T>::SliceFeatures::GetFeatureMap(std::map<std::string, double> &featureMap) const
+{
+    if (!m_isAvailable)
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+    featureMap.insert(m_featureMap.begin(), m_featureMap.end());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -34,6 +34,7 @@ NeutrinoIdTool<T>::NeutrinoIdTool() :
     m_minCompleteness(0.9f),
     m_minProbability(0.0f),
     m_maxNeutrinos(1),
+    m_persistFeatures(false),
     m_filePathEnvironmentVariable("FW_SEARCH_PATH")
 {
 }
@@ -256,12 +257,15 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
 	    
-	    std::map<std::string, double> featureMap;
-	    sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
+            if (m_persistFeatures)
+              {
+                std::map<std::string, double> featureMap;
+                sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
 
-	    for(auto const& [ name, value ] : featureMap)
-	      metadata.m_propertiesToAdd[name] = value;
-	    
+                for(auto const& [ name, value ] : featureMap)
+                  metadata.m_propertiesToAdd[name] = value;
+              }	    
+
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
         }
 
@@ -270,11 +274,14 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
 
-	    std::map<std::string, double> featureMap;
-	    sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
+            if (m_persistFeatures)
+              {
+                std::map<std::string, double> featureMap;
+                sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
 
-	    for(auto const& [ name, value ] : featureMap)
-	      metadata.m_propertiesToAdd[name] = value;
+                for(auto const& [ name, value ] : featureMap)
+                  metadata.m_propertiesToAdd[name] = value;
+              }
 
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
         }
@@ -609,6 +616,8 @@ StatusCode NeutrinoIdTool<T>::ReadSettings(const TiXmlHandle xmlHandle)
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumNeutrinoProbability", m_minProbability));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumNeutrinos", m_maxNeutrinos));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PersistFeatures", m_persistFeatures));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "FilePathEnvironmentVariable", m_filePathEnvironmentVariable));

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -255,6 +255,25 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
         {
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
+	    
+            LArMvaHelper::MvaFeatureVector featureVector;
+            sliceFeaturesVector.at(sliceIndex).GetFeatureVector(featureVector);
+            if(featureVector.size() != 10)
+              std::cout << "Feature Vector is not size 10 (" << featureVector.size() << ")" << std::endl;
+            else 
+              {
+                metadata.m_propertiesToAdd["NuNFinalStatePfos"] = featureVector[0].Get();
+                metadata.m_propertiesToAdd["NuNHitsTotal"] = featureVector[1].Get();
+                metadata.m_propertiesToAdd["NuVertexY"] = featureVector[2].Get();
+                metadata.m_propertiesToAdd["NuWeightedDirZ"] = featureVector[3].Get();
+                metadata.m_propertiesToAdd["NuNSpacePointsInSphere"] = featureVector[4].Get();
+                metadata.m_propertiesToAdd["NuEigenRatioInSphere"] = featureVector[5].Get();
+                metadata.m_propertiesToAdd["CRLongestTrackDirY"] = featureVector[6].Get();
+                metadata.m_propertiesToAdd["CRLongestTrackDeflection"] = featureVector[7].Get();
+                metadata.m_propertiesToAdd["CRFracHitsInLongestTrack"] = featureVector[8].Get();
+                metadata.m_propertiesToAdd["CRNHitsMax"] = featureVector[9].Get();
+              }
+
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
         }
 
@@ -262,6 +281,25 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
         {
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
+
+            LArMvaHelper::MvaFeatureVector featureVector;
+            sliceFeaturesVector.at(sliceIndex).GetFeatureVector(featureVector);
+            if(featureVector.size() != 10)
+              std::cout << "Feature Vector is not size 10 (" << featureVector.size() << ")" << std::endl;
+            else 
+              {
+                metadata.m_propertiesToAdd["NuNFinalStatePfos"] = (float) featureVector[0].Get();
+                metadata.m_propertiesToAdd["NuNHitsTotal"] = featureVector[1].Get();
+                metadata.m_propertiesToAdd["NuVertexY"] = featureVector[2].Get();
+                metadata.m_propertiesToAdd["NuWeightedDirZ"] = featureVector[3].Get();
+                metadata.m_propertiesToAdd["NuNSpacePointsInSphere"] = featureVector[4].Get();
+                metadata.m_propertiesToAdd["NuEigenRatioInSphere"] = featureVector[5].Get();
+                metadata.m_propertiesToAdd["CRLongestTrackDirY"] = featureVector[6].Get();
+                metadata.m_propertiesToAdd["CRLongestTrackDeflection"] = featureVector[7].Get();
+                metadata.m_propertiesToAdd["CRFracHitsInLongestTrack"] = featureVector[8].Get();
+                metadata.m_propertiesToAdd["CRNHitsMax"] = featureVector[9].Get();
+              }
+
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
         }
 

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -256,15 +256,15 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
         {
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
-	    
+
             if (m_persistFeatures)
-              {
+            {
                 std::map<std::string, double> featureMap;
                 sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
 
-                for(auto const& [ name, value ] : featureMap)
-                  metadata.m_propertiesToAdd[name] = value;
-              }	    
+                for (auto const &[name, value] : featureMap)
+                    metadata.m_propertiesToAdd[name] = value;
+            }
 
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
         }
@@ -275,13 +275,13 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
 
             if (m_persistFeatures)
-              {
+            {
                 std::map<std::string, double> featureMap;
                 sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
 
-                for(auto const& [ name, value ] : featureMap)
-                  metadata.m_propertiesToAdd[name] = value;
-              }
+                for (auto const &[name, value] : featureMap)
+                    metadata.m_propertiesToAdd[name] = value;
+            }
 
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*pAlgorithm, pPfo, metadata));
         }

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -259,7 +259,7 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
 
             if (m_persistFeatures)
             {
-                std::map<std::string, double> featureMap;
+                LArMvaHelper::MvaFeatureMap featureMap;
                 sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
 
                 for (auto const &[name, value] : featureMap)
@@ -276,7 +276,7 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
 
             if (m_persistFeatures)
             {
-                std::map<std::string, double> featureMap;
+                LArMvaHelper::MvaFeatureMap featureMap;
                 sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
 
                 for (auto const &[name, value] : featureMap)
@@ -466,7 +466,7 @@ void NeutrinoIdTool<T>::SliceFeatures::GetFeatureVector(LArMvaHelper::MvaFeature
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-void NeutrinoIdTool<T>::SliceFeatures::GetFeatureMap(std::map<std::string, double> &featureMap) const
+void NeutrinoIdTool<T>::SliceFeatures::GetFeatureMap(LArMvaHelper::MvaFeatureMap &featureMap) const
 {
     if (!m_isAvailable)
         throw StatusCodeException(STATUS_CODE_NOT_FOUND);

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -268,7 +268,7 @@ private:
     unsigned int m_maxNeutrinos; ///< The maximum number of neutrinos to select in any one event
 
     // Persistence
-    bool m_persistFeatures;      ///< If true, the mva features will be persisted in the metadata
+    bool m_persistFeatures; ///< If true, the mva features will be persisted in the metadata
 
     T m_mva;                                   ///< The mva
     std::string m_filePathEnvironmentVariable; ///< The environment variable providing a list of paths to mva files

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -71,6 +71,13 @@ private:
         void GetFeatureVector(LArMvaHelper::MvaFeatureVector &featureVector) const;
 
         /**
+         *  @brief  Get the feature map for the MVA
+         *
+         *  @param  featuresMap empty feature map to populate
+         */
+        void GetFeatureMap(std::map<std::string, double> &featureMap) const;
+
+        /**
          *  @brief  Get the probability that this slice contains a neutrino interaction
          *
          *  @param  t the MVA used to calculate the probability
@@ -147,6 +154,7 @@ private:
 
         bool m_isAvailable;                             ///< Is the feature vector available
         LArMvaHelper::MvaFeatureVector m_featureVector; ///< The MVA feature vector
+        std::map<std::string, double> m_featureMap;     ///< A map between MVA features and their names
         const NeutrinoIdTool *const m_pTool;            ///< The tool that owns this
     };
 

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -267,6 +267,9 @@ private:
     float m_minProbability;      ///< Minimum probability required to classify a slice as the neutrino
     unsigned int m_maxNeutrinos; ///< The maximum number of neutrinos to select in any one event
 
+    // Persistence
+    bool m_persistFeatures;      ///< If true, the mva features will be persisted in the metadata
+
     T m_mva;                                   ///< The mva
     std::string m_filePathEnvironmentVariable; ///< The environment variable providing a list of paths to mva files
 };

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -75,7 +75,7 @@ private:
          *
          *  @param  featuresMap empty feature map to populate
          */
-        void GetFeatureMap(std::map<std::string, double> &featureMap) const;
+        void GetFeatureMap(LArMvaHelper::MvaFeatureMap &featureMap) const;
 
         /**
          *  @brief  Get the probability that this slice contains a neutrino interaction
@@ -154,7 +154,7 @@ private:
 
         bool m_isAvailable;                             ///< Is the feature vector available
         LArMvaHelper::MvaFeatureVector m_featureVector; ///< The MVA feature vector
-        std::map<std::string, double> m_featureMap;     ///< A map between MVA features and their names
+        LArMvaHelper::MvaFeatureMap m_featureMap;       ///< A map between MVA features and their names
         const NeutrinoIdTool *const m_pTool;            ///< The tool that owns this
     };
 

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -267,7 +267,6 @@ private:
     float m_minProbability;      ///< Minimum probability required to classify a slice as the neutrino
     unsigned int m_maxNeutrinos; ///< The maximum number of neutrinos to select in any one event
 
-    // Persistence
     bool m_persistFeatures; ///< If true, the mva features will be persisted in the metadata
 
     T m_mva;                                   ///< The mva

--- a/larpandoracontent/LArHelpers/LArMvaHelper.h
+++ b/larpandoracontent/LArHelpers/LArMvaHelper.h
@@ -56,6 +56,7 @@ class LArMvaHelper
 public:
     typedef MvaTypes::MvaFeature MvaFeature;
     typedef MvaTypes::MvaFeatureVector MvaFeatureVector;
+    typedef std::map<std::string, double> MvaFeatureMap;
 
     /**
      *  @brief  Produce a training example with the given features and result


### PR DESCRIPTION
Add the functionality to persist the features used in the slice ID MVA but only with an opt-in xml parameter, should have no change to current functionality.