### PR TITLE
Add a check on feature vector being available before trying to get th…

### DIFF
--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -257,7 +257,7 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
 
-            if (m_persistFeatures)
+            if (m_persistFeatures && sliceFeaturesVector.at(sliceIndex).IsFeatureVectorAvailable())
             {
                 LArMvaHelper::DoubleMap featureMap;
                 sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);
@@ -274,7 +274,7 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
             object_creation::ParticleFlowObject::Metadata metadata;
             metadata.m_propertiesToAdd["NuScore"] = nuProbability;
 
-            if (m_persistFeatures)
+            if (m_persistFeatures && sliceFeaturesVector.at(sliceIndex).IsFeatureVectorAvailable())
             {
                 LArMvaHelper::DoubleMap featureMap;
                 sliceFeaturesVector.at(sliceIndex).GetFeatureMap(featureMap);


### PR DESCRIPTION
…e map and persist.

Related to https://github.com/PandoraPFA/LArContent/issues/197. Continuing discussion here.

Perhaps we need defaults to fill the metadata instead?

