### PR TITLE
Update behavior of putting values into FeatureMap in TrackShowerIdFeatureTool

### DIFF
--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
@@ -66,7 +66,7 @@ void TwoDShowerFitFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap, Stri
     }
 
     featureOrder.push_back(featureToolName + "_WidthLenRatio");
-    featureMap[featureToolName + "_WidthLenRatio"] = toolFeatureVec[0].Get();
+    featureMap[featureToolName + "_WidthLenRatio"] = toolFeatureVec[0];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -144,12 +144,12 @@ void TwoDLinearFitFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap, Stri
     featureOrder.push_back(featureToolName + "_MaxFitGapLen");
     featureOrder.push_back(featureToolName + "_rmsSlidingLinFit");
 
-    featureMap[featureToolName + "_StLineLenLarge"] = toolFeatureVec[0].Get();
-    featureMap[featureToolName + "_DiffStLineMean"] = toolFeatureVec[1].Get();
-    featureMap[featureToolName + "_DiffStLineSigma"] = toolFeatureVec[2].Get();
-    featureMap[featureToolName + "_dTdLWidth"] = toolFeatureVec[3].Get();
-    featureMap[featureToolName + "_MaxFitGapLen"] = toolFeatureVec[4].Get();
-    featureMap[featureToolName + "_rmsSlidingLinFit"] = toolFeatureVec[5].Get();
+    featureMap[featureToolName + "_StLineLenLarge"] = toolFeatureVec[0];
+    featureMap[featureToolName + "_DiffStLineMean"] = toolFeatureVec[1];
+    featureMap[featureToolName + "_DiffStLineSigma"] = toolFeatureVec[2];
+    featureMap[featureToolName + "_dTdLWidth"] = toolFeatureVec[3];
+    featureMap[featureToolName + "_MaxFitGapLen"] = toolFeatureVec[4];
+    featureMap[featureToolName + "_rmsSlidingLinFit"] = toolFeatureVec[5];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -298,7 +298,7 @@ void TwoDVertexDistanceFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap,
     }
 
     featureOrder.push_back(featureToolName + "_DistLenRatio");
-    featureMap[featureToolName + "_DistLenRatio"] = toolFeatureVec[0].Get();
+    featureMap[featureToolName + "_DistLenRatio"] = toolFeatureVec[0];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -379,9 +379,9 @@ void PfoHierarchyFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap, Strin
     featureOrder.push_back(featureToolName + "_NDaughterHits3D");
     featureOrder.push_back(featureToolName + "_DaughterParentHitRatio");
 
-    featureMap[featureToolName + "_NDaughters"] = toolFeatureVec[0].Get();
-    featureMap[featureToolName + "_NDaughterHits3D"] = toolFeatureVec[1].Get();
-    featureMap[featureToolName + "_DaughterParentHitRatio"] = toolFeatureVec[2].Get();
+    featureMap[featureToolName + "_NDaughters"] = toolFeatureVec[0];
+    featureMap[featureToolName + "_NDaughterHits3D"] = toolFeatureVec[1];
+    featureMap[featureToolName + "_DaughterParentHitRatio"] = toolFeatureVec[2];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -462,9 +462,9 @@ void ConeChargeFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap, StringV
     featureOrder.push_back(featureToolName + "_Concentration");
     featureOrder.push_back(featureToolName + "_Conicalness");
 
-    featureMap[featureToolName + "_HaloTotalRatio"] = toolFeatureVec[0].Get();
-    featureMap[featureToolName + "_Concentration"] = toolFeatureVec[1].Get();
-    featureMap[featureToolName + "_Conicalness"] = toolFeatureVec[2].Get();
+    featureMap[featureToolName + "_HaloTotalRatio"] = toolFeatureVec[0];
+    featureMap[featureToolName + "_Concentration"] = toolFeatureVec[1];
+    featureMap[featureToolName + "_Conicalness"] = toolFeatureVec[2];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -616,10 +616,10 @@ void ThreeDLinearFitFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap, St
     featureOrder.push_back(featureToolName + "_MaxFitGapLength");
     featureOrder.push_back(featureToolName + "_SlidingLinearFitRMS");
 
-    featureMap[featureToolName + "_Length"] = toolFeatureVec[0].Get();
-    featureMap[featureToolName + "_DiffStraightLineMean"] = toolFeatureVec[1].Get();
-    featureMap[featureToolName + "_MaxFitGapLength"] = toolFeatureVec[2].Get();
-    featureMap[featureToolName + "_SlidingLinearFitRMS"] = toolFeatureVec[3].Get();
+    featureMap[featureToolName + "_Length"] = toolFeatureVec[0];
+    featureMap[featureToolName + "_DiffStraightLineMean"] = toolFeatureVec[1];
+    featureMap[featureToolName + "_MaxFitGapLength"] = toolFeatureVec[2];
+    featureMap[featureToolName + "_SlidingLinearFitRMS"] = toolFeatureVec[3];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -788,7 +788,7 @@ void ThreeDVertexDistanceFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMa
 
     featureOrder.push_back(featureToolName + "_VertexDistance");
 
-    featureMap[featureToolName + "_VertexDistance"] = toolFeatureVec[0].Get();
+    featureMap[featureToolName + "_VertexDistance"] = toolFeatureVec[0];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -869,7 +869,7 @@ void ThreeDOpeningAngleFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap,
 
     featureOrder.push_back(featureToolName + "_AngleDiff");
 
-    featureMap[featureToolName + "_AngleDiff"] = toolFeatureVec[0].Get();
+    featureMap[featureToolName + "_AngleDiff"] = toolFeatureVec[0];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -1040,8 +1040,8 @@ void ThreeDPCAFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap, StringVe
     featureOrder.push_back(featureToolName + "_SecondaryPCARatio");
     featureOrder.push_back(featureToolName + "_TertiaryPCARatio");
 
-    featureMap[featureToolName + "_SecondaryPCARatio"] = toolFeatureVec[0].Get();
-    featureMap[featureToolName + "_TertiaryPCARatio"] = toolFeatureVec[1].Get();
+    featureMap[featureToolName + "_SecondaryPCARatio"] = toolFeatureVec[0];
+    featureMap[featureToolName + "_TertiaryPCARatio"] = toolFeatureVec[1];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -1103,8 +1103,8 @@ void ThreeDChargeFeatureTool::Run(LArMvaHelper::MvaFeatureMap &featureMap, Strin
     featureOrder.push_back(featureToolName + "_FractionalSpread");
     featureOrder.push_back(featureToolName + "_EndFraction");
 
-    featureMap[featureToolName + "_FractionalSpread"] = toolFeatureVec[0].Get();
-    featureMap[featureToolName + "_EndFraction"] = toolFeatureVec[1].Get();
+    featureMap[featureToolName + "_FractionalSpread"] = toolFeatureVec[0];
+    featureMap[featureToolName + "_EndFraction"] = toolFeatureVec[1];
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Already mentioned this in the Slack chat I had, but ICARUS is planning to make a production release soon (as in like late next week) and so if it is possible to review this and my (unrelated) LArPandora PR in that time frame I really appreciate that. That said, I obviously want changes to be vetted as necessary and validated. And - thanks as always for time spent looking at my PRs and related testing 😄 

_**Now, to explain this PR:**_

The way the algorithms currently put the features into the feature map is via a call to Get, e.g.

https://github.com/PandoraPFA/LArContent/blob/v04_01_00/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc#L791

In retrospect, I think this is a mistake that usually works out because I think `InitializedDouble` can be constructed with a `double`. But probably the better behavior would be to pass it along to the map directly as itself, which should work since the map is to be between strings and MvaFeatures (`InitializedDouble`) anyway. So then we could just do
```
featureMap[featureToolName + "_VertexDistance"] = toolFeatureVec[0]
```
and similar for the others.

I think then hopefully it should behave like the previous default in terms of checks? (links here are to either develop with the map updates or the version right before the map updates, v04_00_00)

* https://github.com/PandoraPFA/LArContent/blob/develop/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc#L791 if this line is changed then we'd get the string put into the featureOrder but the FeatureValue would be uninitialized

* https://github.com/PandoraPFA/LArContent/blob/develop/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc#L112 then this line should catch the uninitialized value and have it enter default behavior which seems to be setting score = -1 and then checking if the Pfo claims track-like (is this coming from the previous running of the `CutPfoCharacterisation`?)
In this case it should never even get to the point of trying to persist the features to the metadata

* From a quick look, I think the same can NOT be said for the 2d/cluster version, where it goes straight to `Classify`/`CalculateProbability`. However, again from a quick look, it seems like this was the behavior before too... it [made the feature vector and then fed it into `Classify`/`CalculateProbability`](https://github.com/PandoraPFA/LArContent/blob/v04_00_00/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc#L46)https://github.com/PandoraPFA/LArContent/blob/v04_00_00/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc#L46. Happy to add a check like there is in the Pfo case, however, here I have a question: is the default track state also `MU_MINUS` or is it something else for clusters?

Please let me know if someone here has a different understanding or finds an issue, and let me know about the clusters case. Thanks as always for your time and eyes on the code/validations/etc.!