### PR TITLE
Make default 'NuScore' configurable

### DIFF
--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc
@@ -33,6 +33,7 @@ NeutrinoIdTool<T>::NeutrinoIdTool() :
     m_minPurity(0.9f),
     m_minCompleteness(0.9f),
     m_minProbability(0.0f),
+    m_defaultProbability(0.0f),
     m_maxNeutrinos(1),
     m_persistFeatures(false),
     m_filePathEnvironmentVariable("FW_SEARCH_PATH")
@@ -250,7 +251,7 @@ void NeutrinoIdTool<T>::SelectPfosByProbability(const pandora::Algorithm *const 
     std::vector<UintFloatPair> sliceIndexProbabilityPairs;
     for (unsigned int sliceIndex = 0, nSlices = nuSliceHypotheses.size(); sliceIndex < nSlices; ++sliceIndex)
     {
-        const float nuProbability(sliceFeaturesVector.at(sliceIndex).GetNeutrinoProbability(m_mva));
+        const float nuProbability(sliceFeaturesVector.at(sliceIndex).GetNeutrinoProbability(m_mva, m_defaultProbability));
 
         for (const ParticleFlowObject *const pPfo : crSliceHypotheses.at(sliceIndex))
         {
@@ -477,11 +478,11 @@ void NeutrinoIdTool<T>::SliceFeatures::GetFeatureMap(LArMvaHelper::DoubleMap &fe
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-float NeutrinoIdTool<T>::SliceFeatures::GetNeutrinoProbability(const T &t) const
+float NeutrinoIdTool<T>::SliceFeatures::GetNeutrinoProbability(const T &t, const float defaultProbability) const
 {
-    // ATTN if one or more of the features can not be calculated, then default to calling the slice a cosmic ray
+    // ATTN if one or more of the features can not be calculated, then give the slice a default score
     if (!this->IsFeatureVectorAvailable())
-        return 0.f;
+        return defaultProbability;
 
     LArMvaHelper::MvaFeatureVector featureVector;
     this->GetFeatureVector(featureVector);
@@ -614,6 +615,9 @@ StatusCode NeutrinoIdTool<T>::ReadSettings(const TiXmlHandle xmlHandle)
 
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumNeutrinoProbability", m_minProbability));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "DefaultProbability", m_defaultProbability));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumNeutrinos", m_maxNeutrinos));
 

--- a/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
+++ b/larpandoracontent/LArControlFlow/NeutrinoIdTool.h
@@ -84,7 +84,7 @@ private:
          *
          *  @return the probability that the slice contains a neutrino interaction
          */
-        float GetNeutrinoProbability(const T &t) const;
+        float GetNeutrinoProbability(const T &t, const float defaultProbability) const;
 
     private:
         /**
@@ -265,6 +265,7 @@ private:
 
     // Classification
     float m_minProbability;      ///< Minimum probability required to classify a slice as the neutrino
+    float m_defaultProbability;  ///< Default probability set if score could not be calculated
     unsigned int m_maxNeutrinos; ///< The maximum number of neutrinos to select in any one event
 
     bool m_persistFeatures; ///< If true, the mva features will be persisted in the metadata


### PR DESCRIPTION
Original message in slack

> I've been digging into an issue in SBND where we were missing persisted slice ID variables for "neutrino" labelled slices. I've traced it down to [these](https://github.com/LArSoft/larpandoracontent/blob/develop/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc#L482-L484) lines in the NeutrinoID tool which gives slices for which not all MVA variables could be calculated a default value of 0. Because SBND runs with the default minimum probability of 0 [this](https://github.com/LArSoft/larpandoracontent/blob/develop/larpandoracontent/LArControlFlow/NeutrinoIdTool.cc#L289) line still fails and the slice is still persisted as a "neutrino slice", however, unlike all other neutrino slices we don't get any persisted input variables.
>
>Clearly there are catches I can add for this in our use cases. But I wondered whether there was any particular reason we wanted it to be 0.f ? Would a value of -1.f work in this scenario? It would nicely indicate to analysers that something went wrong with the calculation of the score, and would simultaneously ensure that it wasn't saved as a neutrino slice? (edited)

This PR aims to introduce the ability to set a different default score for the "neutrino probability" or nuscore created in the slice identification stage. Standard behaviour will not change for any experiment. SBND will introduce an xml change to activate this.