### PR TITLE
Allow DLVertexing to use different driftStep & volumeType for the ND

### DIFF
--- a/larpandoracontent/LArHelpers/LArVertexHelper.cc
+++ b/larpandoracontent/LArHelpers/LArVertexHelper.cc
@@ -100,6 +100,13 @@ bool LArVertexHelper::IsInFiducialVolume(const Pandora &pandora, const Cartesian
         return (tpcMinX + 50.f) < x && x < (tpcMaxX - 50.f) && (tpcMinY + 50.f) < y && y < (tpcMaxY - 50.f) && (tpcMinZ + 50.f) < z &&
                z < (tpcMaxZ - 150.f);
     }
+    else if (detector == "dune_nd")
+    {
+        const float x{vertex.GetX()};
+        const float y{vertex.GetY()};
+        const float z{vertex.GetZ()};
+	return tpcMinX < x && x < tpcMaxX && tpcMinY < y && y < tpcMaxY && tpcMinZ < z && z < tpcMaxZ;
+    }
     else
     {
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.h
+++ b/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.h
@@ -236,6 +236,7 @@ private:
     std::string m_rootFileName;               ///< The ROOT file name
     std::mt19937 m_rng;                       ///< The random number generator
     std::vector<double> m_thresholds;         ///< Distance class thresholds
+    std::string m_volumeType;                 ///< The name of the fiducial volume type for the monitoring output
 };
 
 } // namespace lar_dl_content


### PR DESCRIPTION
The default values for the driftStep and volumeType for the Far Detector are 5 mm & "dune_fd_hd", respectively. These can be changed using the "DriftStep" & "VolumeType" LArDLVertexing xml settings.

Modified LArVertexHelper::IsInFiducialVolume to expect "dune_nd" for the Near Detector, which just checks that the vertex point is inside the TPC.