### PR TITLE
Vertex Refinement Bug

### DIFF
--- a/larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexRefinementAlgorithm.cc
@@ -210,9 +210,9 @@ void VertexRefinementAlgorithm::GetBestFitPoint(const CartesianPointVector &inte
         G(3 * i + 1, 1) = weights[i];
         G(3 * i + 2, 2) = weights[i];
 
-        G(3 * i, i + 3) = -directions[i].GetX();
-        G(3 * i + 1, i + 3) = -directions[i].GetY();
-        G(3 * i + 2, i + 3) = -directions[i].GetZ();
+        G(3 * i, i + 3) = - directions[i].GetX() * weights[i];
+        G(3 * i + 1, i + 3) = - directions[i].GetY() * weights[i];
+        G(3 * i + 2, i + 3) = - directions[i].GetZ() * weights[i];
     }
 
     if ((G.transpose() * G).determinant() < std::numeric_limits<float>::epsilon())


### PR DESCRIPTION
Issue #220 highlights a bug we discovered last week. This PR fixes the application of weighting to each line equation in the creation of the matrix equation. Validation was performed over the weekend which shows no impact to numu performance and a small degradation in nue performance. Suspicion is that this may come from the need to retrain the BDT selection tool on the output of this fixed algorithm.

Discussed on slack with @absolution1 and @AndyChappell. 