### PR TITLE
Remove circular dependency

### DIFF
--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingBaseTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingBaseTool.h
@@ -10,8 +10,6 @@
 
 #include "Pandora/AlgorithmTool.h"
 
-#include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
-
 namespace lar_content
 {
 


### PR DESCRIPTION
Remove an undesirable header include that causes a circular dependency during preprocessing.