### PR TITLE
Feature/lhw_protodunehd_dev

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -41,6 +41,7 @@
 #include "larpandoracontent/LArControlFlow/SlicingAlgorithm.h"
 #include "larpandoracontent/LArControlFlow/StitchingCosmicRayMergingTool.h"
 #include "larpandoracontent/LArControlFlow/StreamingAlgorithm.h"
+#include "larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h"
 
 #include "larpandoracontent/LArCustomParticles/PcaShowerParticleBuildingAlgorithm.h"
 #include "larpandoracontent/LArCustomParticles/TrackParticleBuildingAlgorithm.h"
@@ -168,6 +169,7 @@
 #include "larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.h"
 #include "larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h"
 
+#include "larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h"
 #include "larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.h"
 #include "larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsExtensionAlgorithm.h"
 #include "larpandoracontent/LArTwoDReco/LArClusterAssociation/HitWidthClusterMergingAlgorithm.h"
@@ -289,6 +291,7 @@
     d("LArShowerGrowing",                       ShowerGrowingAlgorithm)                                                         \
     d("LArBdtPfoCharacterisation",              BdtPfoCharacterisationAlgorithm)                                                \
     d("LArSvmPfoCharacterisation",              SvmPfoCharacterisationAlgorithm)                                                \
+    d("LArBoundedRegionClusterMerging",         BoundedRegionClusterMergingAlgorithm)                                           \
     d("LArCrossGapsAssociation",                CrossGapsAssociationAlgorithm)                                                  \
     d("LArCrossGapsExtension",                  CrossGapsExtensionAlgorithm)                                                    \
     d("LArHitWidthClusterMerging",              HitWidthClusterMergingAlgorithm)                                                \
@@ -345,6 +348,7 @@
     d("LArBdtBeamParticleId",                   BdtBeamParticleIdTool)                                                          \
     d("LArBeamParticleId",                      BeamParticleIdTool)                                                             \
     d("LArCosmicRayTagging",                    CosmicRayTaggingTool)                                                           \
+    d("LArTestBeamCosmicRayTagging",            TestBeamCosmicRayTaggingTool)                                                   \
     d("LArBdtNeutrinoId",                       BdtNeutrinoIdTool)                                                              \
     d("LArSvmNeutrinoId",                       SvmNeutrinoIdTool)                                                              \
     d("LArSimpleNeutrinoId",                    SimpleNeutrinoIdTool)                                                           \

--- a/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
@@ -1,0 +1,705 @@
+/**
+ *  @file   larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
+ *
+ *  @brief  Implementation of the cosmic-ray tagging tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+TestBeamCosmicRayTaggingTool::TestBeamCosmicRayTaggingTool() :
+    m_cutMode("nominal"),
+    m_angularUncertainty(5.f),
+    m_positionalUncertainty(3.f),
+    m_maxAssociationDist(3.f * 18.f),
+    m_minimumHits(15),
+    m_inTimeMargin(5.f),
+    m_inTimeMaxX0(1.f),
+    m_marginY(20.f),
+    m_marginZ(10.f),
+    m_maxNeutrinoCosTheta(0.2f),
+    m_minCosmicCosTheta(0.6f),
+    m_maxCosmicCurvature(0.04f),
+    m_tagTopEntering(true),
+    m_tagTopToBottom(true),
+    m_tagOutOfTime(true),
+    m_tagInVetoedTPCs(false),
+    m_face_Xa(0.f),
+    m_face_Xc(0.f),
+    m_face_Yb(0.f),
+    m_face_Yt(0.f),
+    m_face_Zu(0.f),
+    m_face_Zd(0.f)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TestBeamCosmicRayTaggingTool::Initialize()
+{
+    if ("nominal" == m_cutMode)
+    {
+        // Nominal values set in constructor
+    }
+    else if ("cautious" == m_cutMode)
+    {
+        m_minCosmicCosTheta = std::numeric_limits<double>::max();
+        m_maxCosmicCurvature = -std::numeric_limits<double>::max();
+    }
+    else if ("aggressive" == m_cutMode)
+    {
+        m_minCosmicCosTheta = 0.6f;
+        m_maxCosmicCurvature = 0.1f;
+    }
+    else
+    {
+        std::cout << "TestBeamCosmicRayTaggingTool - invalid cut mode " << m_cutMode << std::endl;
+        return STATUS_CODE_INVALID_PARAMETER;
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos, PfoList &ambiguousPfos, const MasterAlgorithm *const /*pAlgorithm*/)
+{
+    if (this->GetPandora().GetSettings()->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    // TODO First time only, TODO Refactor with master algorithm
+    const LArTPCMap &larTPCMap(this->GetPandora().GetGeometry()->GetLArTPCMap());
+    const LArTPC *const pFirstLArTPC(larTPCMap.begin()->second);
+
+    float parentMinX(pFirstLArTPC->GetCenterX() - 0.5f * pFirstLArTPC->GetWidthX());
+    float parentMaxX(pFirstLArTPC->GetCenterX() + 0.5f * pFirstLArTPC->GetWidthX());
+    float parentMinY(pFirstLArTPC->GetCenterY() - 0.5f * pFirstLArTPC->GetWidthY());
+    float parentMaxY(pFirstLArTPC->GetCenterY() + 0.5f * pFirstLArTPC->GetWidthY());
+    float parentMinZ(pFirstLArTPC->GetCenterZ() - 0.5f * pFirstLArTPC->GetWidthZ());
+    float parentMaxZ(pFirstLArTPC->GetCenterZ() + 0.5f * pFirstLArTPC->GetWidthZ());
+
+    for (const LArTPCMap::value_type &mapEntry : larTPCMap)
+    {
+        const LArTPC *const pLArTPC(mapEntry.second);
+        parentMinX = std::min(parentMinX, pLArTPC->GetCenterX() - 0.5f * pLArTPC->GetWidthX());
+        parentMaxX = std::max(parentMaxX, pLArTPC->GetCenterX() + 0.5f * pLArTPC->GetWidthX());
+        parentMinY = std::min(parentMinY, pLArTPC->GetCenterY() - 0.5f * pLArTPC->GetWidthY());
+        parentMaxY = std::max(parentMaxY, pLArTPC->GetCenterY() + 0.5f * pLArTPC->GetWidthY());
+        parentMinZ = std::min(parentMinZ, pLArTPC->GetCenterZ() - 0.5f * pLArTPC->GetWidthZ());
+        parentMaxZ = std::max(parentMaxZ, pLArTPC->GetCenterZ() + 0.5f * pLArTPC->GetWidthZ());
+    }
+
+    m_face_Xa = parentMinX;
+    m_face_Xc = parentMaxX;
+    m_face_Yb = parentMinY;
+    m_face_Yt = parentMaxY;
+    m_face_Zu = parentMinZ;
+    m_face_Zd = parentMaxZ;
+
+    PfoToPfoListMap pfoAssociationMap;
+    this->GetPfoAssociations(parentCosmicRayPfos, pfoAssociationMap);
+
+    PfoToSliceIdMap pfoToSliceIdMap;
+    this->SliceEvent(parentCosmicRayPfos, pfoAssociationMap, pfoToSliceIdMap);
+
+    CRCandidateList candidates;
+    this->GetCRCandidates(parentCosmicRayPfos, pfoToSliceIdMap, candidates);
+
+    // Create a map that will be used to find all cosmic ray pfos
+    PfoToBoolMap pfoToIsCosmicRayMap;
+    for (const CRCandidate &candidate : candidates)
+    {
+        pfoToIsCosmicRayMap[candidate.m_pPfo] = false;
+    }
+
+    // Tag all particles appearing to enter from the top
+    std::cout << "Running Top Entering? " << m_tagTopEntering << std::endl;
+    if (m_tagTopEntering)
+        this->CheckIfTopEntering(candidates, pfoToIsCosmicRayMap);
+
+    // Tag particles going from top to bottom
+    std::cout << "Running Top To Bottom? " << m_tagTopToBottom << std::endl;
+    if (m_tagTopToBottom)
+        this->CheckIfTopToBottom(candidates, pfoToIsCosmicRayMap);
+
+    // Tag particles with t0 != 0 or appears outside the detector with t0 = 0
+    std::cout << "Running Out of Time? " << m_tagOutOfTime << std::endl;
+    if (m_tagOutOfTime)
+        this->CheckIfOutOfTime(candidates, pfoToIsCosmicRayMap);
+
+    // Tag particles with their highest point in a given list of TPCs
+    std::cout << "Running Veto TPC? " << m_tagInVetoedTPCs << std::endl;
+    if (m_tagInVetoedTPCs)
+        this->CheckIfInVetoedTPC(candidates, pfoToIsCosmicRayMap);
+
+//    PfoToBoolMap pfoToIsContainedMap;
+//    this->CheckIfContained(candidates, pfoToIsContainedMap);
+
+//    UIntSet neutrinoSliceSet;
+//    this->GetNeutrinoSlices(candidates, pfoToInTimeMap, pfoToIsContainedMap, neutrinoSliceSet);
+
+//    PfoToBoolMap pfoToIsLikelyCRMuonMap;
+//    this->TagCRMuons(candidates, pfoToInTimeMap, pfoToIsTopToBottomMap, neutrinoSliceSet, pfoToIsLikelyCRMuonMap);
+
+    for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
+    {
+        if (!pfoToIsCosmicRayMap.at(pPfo))
+            ambiguousPfos.push_back(pPfo);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool TestBeamCosmicRayTaggingTool::GetValid3DCluster(const ParticleFlowObject *const pPfo, const Cluster *&pCluster3D) const
+{
+    pCluster3D = nullptr;
+    ClusterList clusters3D;
+    LArPfoHelper::GetThreeDClusterList(pPfo, clusters3D);
+
+    // ATTN Only uses first cluster with hits of type TPC_3D
+    if (clusters3D.empty() || (clusters3D.front()->GetNCaloHits() < m_minimumHits))
+        return false;
+
+    pCluster3D = clusters3D.front();
+    return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::GetPfoAssociations(const PfoList &parentCosmicRayPfos, PfoToPfoListMap &pfoAssociationMap) const
+{
+    // ATTN If wire w pitches vary between TPCs, exception will be raised in initialisation of lar pseudolayer plugin
+    const LArTPC *const pFirstLArTPC(this->GetPandora().GetGeometry()->GetLArTPCMap().begin()->second);
+    const float layerPitch(pFirstLArTPC->GetWirePitchW());
+
+    PfoToSlidingFitsMap pfoToSlidingFitsMap;
+
+    for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
+    {
+        const pandora::Cluster *pCluster(nullptr);
+        if (!this->GetValid3DCluster(pPfo, pCluster) || !pCluster)
+            continue;
+
+        (void)pfoToSlidingFitsMap.insert(PfoToSlidingFitsMap::value_type(pPfo,
+            std::make_pair(ThreeDSlidingFitResult(pCluster, 5, layerPitch), ThreeDSlidingFitResult(pCluster, 100, layerPitch)))); // TODO Configurable
+    }
+
+    for (const ParticleFlowObject *const pPfo1 : parentCosmicRayPfos)
+    {
+        PfoToSlidingFitsMap::const_iterator iter1(pfoToSlidingFitsMap.find(pPfo1));
+        if (pfoToSlidingFitsMap.end() == iter1)
+            continue;
+
+        const ThreeDSlidingFitResult &fitPos1(iter1->second.first), &fitDir1(iter1->second.second);
+
+        for (const ParticleFlowObject *const pPfo2 : parentCosmicRayPfos)
+        {
+            if (pPfo1 == pPfo2)
+                continue;
+
+            PfoToSlidingFitsMap::const_iterator iter2(pfoToSlidingFitsMap.find(pPfo2));
+            if (pfoToSlidingFitsMap.end() == iter2)
+                continue;
+
+            const ThreeDSlidingFitResult &fitPos2(iter2->second.first), &fitDir2(iter2->second.second);
+
+            // TODO Use existing LArPointingClusters and IsEmission/IsNode logic, for consistency
+            if (!(this->CheckAssociation(fitPos1.GetGlobalMinLayerPosition(), fitDir1.GetGlobalMinLayerDirection() * -1.f,
+                      fitPos2.GetGlobalMinLayerPosition(), fitDir2.GetGlobalMinLayerDirection() * -1.f) ||
+                    this->CheckAssociation(fitPos1.GetGlobalMinLayerPosition(), fitDir1.GetGlobalMinLayerDirection() * -1.f,
+                        fitPos2.GetGlobalMaxLayerPosition(), fitDir2.GetGlobalMaxLayerDirection()) ||
+                    this->CheckAssociation(fitPos1.GetGlobalMaxLayerPosition(), fitDir1.GetGlobalMaxLayerDirection(),
+                        fitPos2.GetGlobalMinLayerPosition(), fitDir2.GetGlobalMinLayerDirection() * -1.f) ||
+                    this->CheckAssociation(fitPos1.GetGlobalMaxLayerPosition(), fitDir1.GetGlobalMaxLayerDirection(),
+                        fitPos2.GetGlobalMaxLayerPosition(), fitDir2.GetGlobalMaxLayerDirection())))
+            {
+                continue;
+            }
+
+            PfoList &pfoList1(pfoAssociationMap[pPfo1]), &pfoList2(pfoAssociationMap[pPfo2]);
+
+            if (pfoList1.end() == std::find(pfoList1.begin(), pfoList1.end(), pPfo2))
+                pfoList1.push_back(pPfo2);
+
+            if (pfoList2.end() == std::find(pfoList2.begin(), pfoList2.end(), pPfo1))
+                pfoList2.push_back(pPfo1);
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool TestBeamCosmicRayTaggingTool::CheckAssociation(
+    const CartesianVector &endPoint1, const CartesianVector &endDir1, const CartesianVector &endPoint2, const CartesianVector &endDir2) const
+{
+    // TODO This function needs significant tidying and checks (variable names must be self describing, check deltaTheta, etc.)
+    const CartesianVector n(endDir1.GetUnitVector());
+    const CartesianVector m(endDir2.GetUnitVector());
+    const CartesianVector a(endPoint2 - endPoint1);
+    const float b(n.GetDotProduct(m));
+
+    // Parallel lines never meet
+    if (std::fabs(b - 1.f) < std::numeric_limits<float>::epsilon())
+        return false;
+
+    // Distance from endPoint1 along endDir1 to the point of closest approach
+    const float lambda((n - m * b).GetDotProduct(a) / (1.f - b * b));
+
+    // Distance from endPoint2 along endDir2 to the point of closest approach
+    const float mu((n * b - m).GetDotProduct(a) / (1.f - b * b));
+
+    // Calculate the maximum "vertex uncertainty"
+    const float deltaTheta(m_angularUncertainty * M_PI / 180.f);
+    const float maxVertexUncertainty(m_maxAssociationDist * std::sin(deltaTheta) + m_positionalUncertainty);
+
+    // Ensure that the distances to the point of closest approch are within the limits
+    if ((lambda < -maxVertexUncertainty) || (mu < -maxVertexUncertainty) || (lambda > m_maxAssociationDist + maxVertexUncertainty) ||
+        (mu > m_maxAssociationDist + maxVertexUncertainty))
+    {
+        return false;
+    }
+
+    // Ensure point of closest approach is within detector
+    const CartesianVector impactPosition((endPoint1 + n * lambda + endPoint2 + m * mu) * 0.5f);
+
+    if ((impactPosition.GetX() < m_face_Xa - maxVertexUncertainty) || (impactPosition.GetX() > m_face_Xc + maxVertexUncertainty) ||
+        (impactPosition.GetY() < m_face_Yb - maxVertexUncertainty) || (impactPosition.GetY() > m_face_Yt + maxVertexUncertainty) ||
+        (impactPosition.GetZ() < m_face_Zu - maxVertexUncertainty) || (impactPosition.GetZ() > m_face_Zd + maxVertexUncertainty))
+    {
+        return false;
+    }
+
+    // Compare distance of closest approach and max uncertainty in impact parameter
+    const float maxImpactDist(std::sin(deltaTheta) * (std::fabs(mu) + std::fabs(lambda)) + m_positionalUncertainty);
+    const CartesianVector d(a - n * lambda + m * mu);
+
+    return (d.GetMagnitude() < maxImpactDist);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::SliceEvent(const PfoList &parentCosmicRayPfos, const PfoToPfoListMap &pfoAssociationMap, PfoToSliceIdMap &pfoToSliceIdMap) const
+{
+    SliceList sliceList;
+
+    for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
+    {
+        bool isAlreadyInSlice(false);
+
+        for (const PfoList &slice : sliceList)
+        {
+            if (std::find(slice.begin(), slice.end(), pPfo) != slice.end())
+            {
+                isAlreadyInSlice = true;
+                break;
+            }
+        }
+
+        if (!isAlreadyInSlice)
+        {
+            sliceList.push_back(PfoList());
+            this->FillSlice(pPfo, pfoAssociationMap, sliceList.back());
+        }
+    }
+
+    unsigned int sliceId(0);
+    for (const PfoList &slice : sliceList)
+    {
+        for (const ParticleFlowObject *const pPfo : slice)
+        {
+            if (!pfoToSliceIdMap.insert(PfoToSliceIdMap::value_type(pPfo, sliceId)).second)
+                throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+        }
+
+        ++sliceId;
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::FillSlice(const ParticleFlowObject *const pPfo, const PfoToPfoListMap &pfoAssociationMap, PfoList &slice) const
+{
+    if (std::find(slice.begin(), slice.end(), pPfo) != slice.end())
+        return;
+
+    slice.push_back(pPfo);
+
+    PfoToPfoListMap::const_iterator iter(pfoAssociationMap.find(pPfo));
+
+    if (pfoAssociationMap.end() != iter)
+    {
+        for (const ParticleFlowObject *const pAssociatedPfo : iter->second)
+            this->FillSlice(pAssociatedPfo, pfoAssociationMap, slice);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::GetCRCandidates(const PfoList &parentCosmicRayPfos, const PfoToSliceIdMap &pfoToSliceIdMap, CRCandidateList &candidates) const
+{
+    for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
+    {
+        if (!LArPfoHelper::IsFinalState(pPfo))
+            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+
+        candidates.push_back(CRCandidate(this->GetPandora(), pPfo, pfoToSliceIdMap.at(pPfo)));
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::CheckIfOutOfTime(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const
+{
+    const LArTPCMap &larTPCMap(this->GetPandora().GetGeometry()->GetLArTPCMap());
+
+    for (const CRCandidate &candidate : candidates)
+    {
+        // Move on if this candidate has already been tagged
+        if (pfoToIsCosmicRayMap.at(candidate.m_pPfo))
+            continue;
+        // Cosmic-ray muons extending outside of (single) physical volume if given t0 is that of the beam particle
+        float minX(std::numeric_limits<float>::max()), maxX(-std::numeric_limits<float>::max());
+
+        if (candidate.m_canFit)
+        {
+            minX = ((candidate.m_endPoint1.GetX() < candidate.m_endPoint2.GetX()) ? candidate.m_endPoint1.GetX() : candidate.m_endPoint2.GetX());
+            maxX = ((candidate.m_endPoint1.GetX() > candidate.m_endPoint2.GetX()) ? candidate.m_endPoint1.GetX() : candidate.m_endPoint2.GetX());
+        }
+        else
+        {
+            // Handle any particles with small numbers of 3D hits, for which no 3D sliding fit information is available
+            for (const Cluster *const pCluster : candidate.m_pPfo->GetClusterList())
+            {
+                float clusterMinX(std::numeric_limits<float>::max()), clusterMaxX(-std::numeric_limits<float>::max());
+                pCluster->GetClusterSpanX(clusterMinX, clusterMaxX);
+                minX = std::min(clusterMinX, minX);
+                maxX = std::max(clusterMaxX, maxX);
+            }
+        }
+
+        bool isInTime((minX > m_face_Xa - m_inTimeMargin) && (maxX < m_face_Xc + m_inTimeMargin));
+
+        // Cosmic-ray muons that have been shifted and stitched across mid plane between volumes
+        if (isInTime)
+        {
+            try
+            {
+                if (std::fabs(LArPfoHelper::GetVertex(candidate.m_pPfo)->GetX0()) > m_inTimeMaxX0)
+                    isInTime = false;
+            }
+            catch (const StatusCodeException &)
+            {
+            }
+        }
+
+        // Cosmic-ray muons extending outside of (any individual) physical volume if given t0 is that of the beam particle
+        if (isInTime)
+        {
+            CaloHitList caloHitList;
+            LArPfoHelper::GetCaloHits(candidate.m_pPfo, TPC_VIEW_U, caloHitList);
+            LArPfoHelper::GetCaloHits(candidate.m_pPfo, TPC_VIEW_V, caloHitList);
+            LArPfoHelper::GetCaloHits(candidate.m_pPfo, TPC_VIEW_W, caloHitList);
+
+            bool isFirstHit(true);
+            bool isInSingleVolume(true);
+            unsigned int volumeId(std::numeric_limits<unsigned int>::max());
+
+            for (const CaloHit *const pCaloHit : caloHitList)
+            {
+                const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
+
+                if (!pLArCaloHit)
+                    continue;
+
+                if (isFirstHit)
+                {
+                    isFirstHit = false;
+                    volumeId = pLArCaloHit->GetLArTPCVolumeId();
+                }
+                else if (volumeId != pLArCaloHit->GetLArTPCVolumeId())
+                {
+                    isInSingleVolume = false;
+                    break;
+                }
+            }
+
+            LArTPCMap::const_iterator tpcIter(larTPCMap.find(volumeId));
+
+            if (isInSingleVolume && (larTPCMap.end() != tpcIter))
+            {
+                const float thisFaceXLow(tpcIter->second->GetCenterX() - 0.5f * tpcIter->second->GetWidthX());
+                const float thisFaceXHigh(tpcIter->second->GetCenterX() + 0.5f * tpcIter->second->GetWidthX());
+
+                if (!((minX > thisFaceXLow - m_inTimeMargin) && (maxX < thisFaceXHigh + m_inTimeMargin)))
+                    isInTime = false;
+            }
+        }
+
+        pfoToIsCosmicRayMap[candidate.m_pPfo] = !isInTime;
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::CheckIfContained(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsContainedMap) const
+{
+    for (const CRCandidate &candidate : candidates)
+    {
+        const float upperY(
+            (candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+        const float lowerY(
+            (candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+
+        const float zAtUpperY(
+            (candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetZ() : candidate.m_endPoint2.GetZ());
+        const float zAtLowerY(
+            (candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetZ() : candidate.m_endPoint2.GetZ());
+
+        const bool isContained((upperY < m_face_Yt - m_marginY) && (upperY > m_face_Yb + m_marginY) && (lowerY < m_face_Yt - m_marginY) &&
+                               (lowerY > m_face_Yb + m_marginY) && (zAtUpperY < m_face_Zd - m_marginZ) && (zAtUpperY > m_face_Zu + m_marginZ) &&
+                               (zAtLowerY < m_face_Zd - m_marginZ) && (zAtLowerY > m_face_Zu + m_marginZ));
+
+        if (!pfoToIsContainedMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, isContained)).second)
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::CheckIfTopToBottom(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const
+{
+    for (const CRCandidate &candidate : candidates)
+    {
+        // Move on if this candidate has already been tagged
+        if (pfoToIsCosmicRayMap.at(candidate.m_pPfo))
+            continue;
+        const float upperY(
+            (candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+        const float lowerY(
+            (candidate.m_endPoint1.GetY() < candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+
+        pfoToIsCosmicRayMap[candidate.m_pPfo] = ((upperY > m_face_Yt - m_marginY) && (lowerY < m_face_Yb + m_marginY));
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::CheckIfTopEntering(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const
+{
+    for (const CRCandidate &candidate : candidates)
+    {
+        // Move on if this candidate has already been tagged
+        if (pfoToIsCosmicRayMap.at(candidate.m_pPfo))
+            continue;
+        const float upperY(
+            (candidate.m_endPoint1.GetY() > candidate.m_endPoint2.GetY()) ? candidate.m_endPoint1.GetY() : candidate.m_endPoint2.GetY());
+        pfoToIsCosmicRayMap[candidate.m_pPfo] = (upperY > m_face_Yt - m_marginY);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::CheckIfInVetoedTPC(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const
+{
+    if (m_vetoedTPCs.empty())
+        return;
+
+    for (const CRCandidate &candidate : candidates)
+    {
+        // Move on if this candidate has already been tagged
+        if (pfoToIsCosmicRayMap.at(candidate.m_pPfo))
+            continue;
+
+        // We have to go via the hit volume id to get the TPC
+        CaloHitList caloHitList3D;
+        LArPfoHelper::GetCaloHits(candidate.m_pPfo, TPC_3D, caloHitList3D);
+        
+        float maxYPosition{-1.f * std::numeric_limits<float>::max()};
+        float maxYXPosition{-1.f * std::numeric_limits<float>::max()};
+        unsigned int maxYTPCId{std::numeric_limits<unsigned int>::max()};
+        for (const CaloHit *const pCaloHit : caloHitList3D)
+        {
+            const float hitYPos(pCaloHit->GetPositionVector().GetY());
+            const float hitXPos(pCaloHit->GetPositionVector().GetX());
+            if (maxYPosition < hitYPos)
+            {
+                maxYPosition = hitYPos;
+                maxYXPosition = hitXPos;
+                const unsigned int maxYDriftVol = reinterpret_cast<LArCaloHit*>(const_cast<void*>(pCaloHit->GetParentAddress()))->GetLArTPCVolumeId();
+                const unsigned int maxYAPA = reinterpret_cast<LArCaloHit*>(const_cast<void*>(pCaloHit->GetParentAddress()))->GetDaughterVolumeId();
+                maxYTPCId = maxYDriftVol + maxYAPA * 4;
+            }
+        }
+        std::cout << "Pfo " << candidate.m_pPfo << " starts in TPC " << maxYTPCId << " X " << maxYXPosition << std::endl;
+        if (std::find(m_vetoedTPCs.begin(), m_vetoedTPCs.end(), maxYTPCId) != m_vetoedTPCs.end())
+            pfoToIsCosmicRayMap[candidate.m_pPfo] = true;
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+//void TestBeamCosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap,
+//    const PfoToBoolMap &pfoToIsContainedMap, UIntSet &neutrinoSliceSet) const
+//{
+//    IntBoolMap sliceIdToIsInTimeMap;
+//
+//    for (const CRCandidate &candidate : candidates)
+//    {
+//        if (sliceIdToIsInTimeMap.find(candidate.m_sliceId) == sliceIdToIsInTimeMap.end())
+//            sliceIdToIsInTimeMap.insert(std::make_pair(candidate.m_sliceId, true));
+//
+//        if (!pfoToInTimeMap.at(candidate.m_pPfo))
+//            sliceIdToIsInTimeMap.at(candidate.m_sliceId) = false;
+//    }
+//
+//    for (const CRCandidate &candidate : candidates)
+//    {
+//        if (neutrinoSliceSet.count(candidate.m_sliceId))
+//            continue;
+//
+//        const bool likelyNeutrino(candidate.m_canFit && sliceIdToIsInTimeMap.at(candidate.m_sliceId) &&
+//                                  (candidate.m_theta < m_maxNeutrinoCosTheta || pfoToIsContainedMap.at(candidate.m_pPfo)));
+//
+//        if (likelyNeutrino)
+//            (void)neutrinoSliceSet.insert(candidate.m_sliceId);
+//    }
+//}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+//void TestBeamCosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap,
+//    const PfoToBoolMap &pfoToIsTopToBottomMap, const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const
+//{
+//    for (const CRCandidate &candidate : candidates)
+//    {
+//        const bool likelyCRMuon(
+//            !neutrinoSliceSet.count(candidate.m_sliceId) &&
+//            (!pfoToInTimeMap.at(candidate.m_pPfo) ||
+//                (candidate.m_canFit && (pfoToIsTopToBottomMap.at(candidate.m_pPfo) ||
+//                                           ((candidate.m_theta > m_minCosmicCosTheta) && (candidate.m_curvature < m_maxCosmicCurvature))))));
+//
+//        if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyCRMuon)).second)
+//            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+//    }
+//}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+TestBeamCosmicRayTaggingTool::CRCandidate::CRCandidate(const Pandora &pandora, const ParticleFlowObject *const pPfo, const unsigned int sliceId) :
+    m_pPfo(pPfo),
+    m_sliceId(sliceId),
+    m_canFit(false),
+    m_endPoint1(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max()),
+    m_endPoint2(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max()),
+    m_length(std::numeric_limits<float>::max()),
+    m_curvature(std::numeric_limits<float>::max()),
+    m_theta(std::numeric_limits<float>::max())
+{
+    ClusterList clusters3D;
+    LArPfoHelper::GetThreeDClusterList(pPfo, clusters3D);
+
+    if (!clusters3D.empty() && (clusters3D.front()->GetNCaloHits() > 15)) // TODO Configurable
+    {
+        m_canFit = true;
+        const LArTPC *const pFirstLArTPC(pandora.GetGeometry()->GetLArTPCMap().begin()->second);
+        const ThreeDSlidingFitResult slidingFitResult(clusters3D.front(), 5, pFirstLArTPC->GetWirePitchW()); // TODO Configurable
+        this->CalculateFitVariables(slidingFitResult);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TestBeamCosmicRayTaggingTool::CRCandidate::CalculateFitVariables(const ThreeDSlidingFitResult &slidingFitResult)
+{
+    m_endPoint1 = slidingFitResult.GetGlobalMinLayerPosition();
+    m_endPoint2 = slidingFitResult.GetGlobalMaxLayerPosition();
+    m_length = (m_endPoint2 - m_endPoint1).GetMagnitude();
+
+    if (std::fabs(m_length) > std::numeric_limits<float>::epsilon())
+        m_theta = std::fabs(m_endPoint2.GetY() - m_endPoint1.GetY()) / m_length;
+
+    const float layerPitch(slidingFitResult.GetFirstFitResult().GetLayerPitch());
+
+    CartesianPointVector directionList;
+    for (int i = slidingFitResult.GetMinLayer(); i < slidingFitResult.GetMaxLayer(); ++i)
+    {
+        CartesianVector direction(0.f, 0.f, 0.f);
+        if (STATUS_CODE_SUCCESS == slidingFitResult.GetGlobalFitDirection(static_cast<float>(i) * layerPitch, direction))
+            directionList.push_back(direction);
+    }
+
+    CartesianVector meanDirection(0.f, 0.f, 0.f);
+    for (const CartesianVector &direction : directionList)
+        meanDirection += direction;
+
+    if (!directionList.empty() > 0)
+        meanDirection *= 1.f / static_cast<float>(directionList.size());
+
+    m_curvature = 0.f;
+    for (const CartesianVector &direction : directionList)
+        m_curvature += (direction - meanDirection).GetMagnitude();
+
+    if (!directionList.empty() > 0)
+        m_curvature *= 1.f / static_cast<float>(directionList.size());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TestBeamCosmicRayTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CutMode", m_cutMode));
+    std::transform(m_cutMode.begin(), m_cutMode.end(), m_cutMode.begin(), ::tolower);
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "AngularUncertainty", m_angularUncertainty));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PositionalUncertainty", m_positionalUncertainty));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxAssociationDist", m_maxAssociationDist));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HitThreshold", m_minimumHits));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMargin", m_inTimeMargin));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMaxX0", m_inTimeMaxX0));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginY", m_marginY));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginZ", m_marginZ));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxNeutrinoCosTheta", m_maxNeutrinoCosTheta));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCosmicCosTheta", m_minCosmicCosTheta));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxCosmicCurvature", m_maxCosmicCurvature));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagTopEntering", m_tagTopEntering));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagTopToBottom", m_tagTopToBottom));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagOutOfTime", m_tagOutOfTime));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagInVetoedTPCs", m_tagInVetoedTPCs));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "VetoedTPCs", m_vetoedTPCs));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
@@ -155,7 +155,7 @@ void TestBeamCosmicRayTaggingTool::GetPfoAssociations(const PfoList &parentCosmi
         if (!this->GetValid3DCluster(pPfo, pCluster) || !pCluster)
             continue;
 
-        (void)pfoToSlidingFitsMap.insert(PfoToSlidingFitsMap::value_type(pPfo,
+        pfoToSlidingFitsMap.insert(PfoToSlidingFitsMap::value_type(pPfo,
             std::make_pair(ThreeDSlidingFitResult(pCluster, 5, layerPitch), ThreeDSlidingFitResult(pCluster, 100, layerPitch)))); // TODO Configurable
     }
 
@@ -298,7 +298,7 @@ void TestBeamCosmicRayTaggingTool::FillSlice(const ParticleFlowObject *const pPf
     if (std::find(slice.begin(), slice.end(), pPfo) != slice.end())
         return;
 
-    slice.push_back(pPfo);
+    slice.emplace_back(pPfo);
 
     PfoToPfoListMap::const_iterator iter(pfoAssociationMap.find(pPfo));
 
@@ -319,7 +319,7 @@ void TestBeamCosmicRayTaggingTool::GetCRCandidates(
         if (!LArPfoHelper::IsFinalState(pPfo))
             throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-        candidates.push_back(CRCandidate(this->GetPandora(), pPfo, pfoToSliceIdMap.at(pPfo)));
+        candidates.emplace_back(CRCandidate(this->GetPandora(), pPfo, pfoToSliceIdMap.at(pPfo)));
     }
 }
 
@@ -474,9 +474,9 @@ void TestBeamCosmicRayTaggingTool::CheckIfInVetoedTPC(const CRCandidateList &can
             if (maxYPosition < hitYPos)
             {
                 maxYPosition = hitYPos;
-                const unsigned int maxYDriftVol =
-                    reinterpret_cast<LArCaloHit *>(const_cast<void *>(pCaloHit->GetParentAddress()))->GetLArTPCVolumeId();
-                const unsigned int maxYAPA = reinterpret_cast<LArCaloHit *>(const_cast<void *>(pCaloHit->GetParentAddress()))->GetDaughterVolumeId();
+                const LArCaloHit *const pLArCaloHit{reinterpret_cast<LArCaloHit *>(const_cast<void *>(pCaloHit->GetParentAddress()))};
+                const unsigned int maxYDriftVol = pLArCaloHit->GetLArTPCVolumeId();
+                const unsigned int maxYAPA = pLArCaloHit->GetDaughterVolumeId();
                 maxYTPCId = maxYDriftVol + maxYAPA * 4;
             }
         }

--- a/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
@@ -467,23 +467,19 @@ void TestBeamCosmicRayTaggingTool::CheckIfInVetoedTPC(const CRCandidateList &can
         LArPfoHelper::GetCaloHits(candidate.m_pPfo, TPC_3D, caloHitList3D);
 
         float maxYPosition{-1.f * std::numeric_limits<float>::max()};
-        float maxYXPosition{-1.f * std::numeric_limits<float>::max()};
         unsigned int maxYTPCId{std::numeric_limits<unsigned int>::max()};
         for (const CaloHit *const pCaloHit : caloHitList3D)
         {
             const float hitYPos(pCaloHit->GetPositionVector().GetY());
-            const float hitXPos(pCaloHit->GetPositionVector().GetX());
             if (maxYPosition < hitYPos)
             {
                 maxYPosition = hitYPos;
-                maxYXPosition = hitXPos;
                 const unsigned int maxYDriftVol =
                     reinterpret_cast<LArCaloHit *>(const_cast<void *>(pCaloHit->GetParentAddress()))->GetLArTPCVolumeId();
                 const unsigned int maxYAPA = reinterpret_cast<LArCaloHit *>(const_cast<void *>(pCaloHit->GetParentAddress()))->GetDaughterVolumeId();
                 maxYTPCId = maxYDriftVol + maxYAPA * 4;
             }
         }
-        std::cout << "Pfo " << candidate.m_pPfo << " starts in TPC " << maxYTPCId << " X " << maxYXPosition << std::endl;
         if (std::find(m_vetoedTPCs.begin(), m_vetoedTPCs.end(), maxYTPCId) != m_vetoedTPCs.end())
             pfoToIsCosmicRayMap[candidate.m_pPfo] = true;
     }

--- a/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.cc
@@ -253,7 +253,8 @@ bool TestBeamCosmicRayTaggingTool::CheckAssociation(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TestBeamCosmicRayTaggingTool::SliceEvent(const PfoList &parentCosmicRayPfos, const PfoToPfoListMap &pfoAssociationMap, PfoToSliceIdMap &pfoToSliceIdMap) const
+void TestBeamCosmicRayTaggingTool::SliceEvent(
+    const PfoList &parentCosmicRayPfos, const PfoToPfoListMap &pfoAssociationMap, PfoToSliceIdMap &pfoToSliceIdMap) const
 {
     SliceList sliceList;
 
@@ -310,7 +311,8 @@ void TestBeamCosmicRayTaggingTool::FillSlice(const ParticleFlowObject *const pPf
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TestBeamCosmicRayTaggingTool::GetCRCandidates(const PfoList &parentCosmicRayPfos, const PfoToSliceIdMap &pfoToSliceIdMap, CRCandidateList &candidates) const
+void TestBeamCosmicRayTaggingTool::GetCRCandidates(
+    const PfoList &parentCosmicRayPfos, const PfoToSliceIdMap &pfoToSliceIdMap, CRCandidateList &candidates) const
 {
     for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
     {
@@ -463,7 +465,7 @@ void TestBeamCosmicRayTaggingTool::CheckIfInVetoedTPC(const CRCandidateList &can
         // We have to go via the hit volume id to get the TPC
         CaloHitList caloHitList3D;
         LArPfoHelper::GetCaloHits(candidate.m_pPfo, TPC_3D, caloHitList3D);
-        
+
         float maxYPosition{-1.f * std::numeric_limits<float>::max()};
         float maxYXPosition{-1.f * std::numeric_limits<float>::max()};
         unsigned int maxYTPCId{std::numeric_limits<unsigned int>::max()};
@@ -475,8 +477,9 @@ void TestBeamCosmicRayTaggingTool::CheckIfInVetoedTPC(const CRCandidateList &can
             {
                 maxYPosition = hitYPos;
                 maxYXPosition = hitXPos;
-                const unsigned int maxYDriftVol = reinterpret_cast<LArCaloHit*>(const_cast<void*>(pCaloHit->GetParentAddress()))->GetLArTPCVolumeId();
-                const unsigned int maxYAPA = reinterpret_cast<LArCaloHit*>(const_cast<void*>(pCaloHit->GetParentAddress()))->GetDaughterVolumeId();
+                const unsigned int maxYDriftVol =
+                    reinterpret_cast<LArCaloHit *>(const_cast<void *>(pCaloHit->GetParentAddress()))->GetLArTPCVolumeId();
+                const unsigned int maxYAPA = reinterpret_cast<LArCaloHit *>(const_cast<void *>(pCaloHit->GetParentAddress()))->GetDaughterVolumeId();
                 maxYTPCId = maxYDriftVol + maxYAPA * 4;
             }
         }

--- a/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
@@ -141,61 +141,37 @@ private:
     void CheckIfOutOfTime(const CRCandidateList &candidates, PfoToBoolMap &pfoToInTimeMap) const;
 
     /**
-     *  @brief  Check if each candidate is "contained" (contained = no associations to Y or Z detector faces, but the Pfo could still enter or exit by and X-face)
-     *
-     *  @param  candidates input list of candidates
-     *  @param  pfoToIsContainedMap output mapping between candidates Pfos and if they are contained
-     */
-    void CheckIfContained(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsContainedMap) const;
-
-    /**
      *  @brief  Check if each candidate is "top to bottom"
      *
      *  @param  candidates input list of candidates
-     *  @param  pfoToIsTopToBottomMap output mapping between candidates Pfos and if they are top to bottom
+     *  @param  pfoToIsCosmicRayMap output mapping between candidates Pfos and if they are top to bottom
      */
     void CheckIfTopToBottom(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const;
+
+    /**
+     *  @brief  Check if each candidate enters from the top of the detector
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToIsCosmicRayMap output mapping between candidates Pfos and if they are top entering
+     */
     void CheckIfTopEntering(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const;
+
+    /**
+     *  @brief  Check if each candidate has its highest value in one of the vetoed TPC volumes
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToIsCosmicRayMap output mapping between candidates Pfos and if they are in the vetoed TPCs
+     */
     void CheckIfInVetoedTPC(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const;
 
     typedef std::set<unsigned int> UIntSet;
     typedef std::unordered_map<int, bool> IntBoolMap;
-
-    /**
-     *  @brief  Get the slice indices which contain a likely neutrino Pfo
-     *
-     *  @param  candidates input list of candidates
-     *  @param  pfoToInTimeMap input map between Pfo and if in time
-     *  @param  pfoToIsContainedMap input map between Pfo and if contained
-     *  @param  neutrinoSliceSet output set of slice indices containing a likely neutrino Pfo
-     */
-//    void GetNeutrinoSlices(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsContainedMap,
-//        UIntSet &neutrinoSliceSet) const;
-
-    /**
-     *  @brief  Tag Pfos which are likely to be a CR muon
-     *
-     *  @param  candidates input list of candidates
-     *  @param  pfoToInTimeMap input map between Pfo and if in time
-     *  @param  pfoToIsTopToBottomMap input mapping between candidate Pfos and if they are top to bottom
-     *  @param  neutrinoSliceSet input set of slice indices containing a likely neutrino Pfo
-     *  @param  pfoToIsLikelyCRMuonMap to receive the output mapping between Pfos and a boolean deciding if they are likely a CR muon
-     */
-//    void TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsTopToBottomMap,
-//        const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     typedef std::pair<const ThreeDSlidingFitResult, const ThreeDSlidingFitResult> SlidingFitPair;
     typedef std::unordered_map<const pandora::ParticleFlowObject *, SlidingFitPair> PfoToSlidingFitsMap;
     typedef std::vector<pandora::PfoList> SliceList;
-
-    /**
-     *  @brief  Choose a set of cuts using a keyword - "cautious" = remove as few neutrinos as possible
-     *          "nominal" = optimised to maximise CR removal whilst preserving neutrinos
-     *          "aggressive" = remove CR muons and allow more neutrinos to be tagged
-     */
-    std::string m_cutMode;
 
     float m_angularUncertainty;    ///< The uncertainty in degrees for the angle of a Pfo
     float m_positionalUncertainty; ///< The uncertainty in cm for the position of Pfo endpoint in 3D
@@ -206,17 +182,13 @@ private:
     float m_inTimeMargin; ///< The maximum distance outside of the physical detector volume that a Pfo may be to still be considered in time
     float m_inTimeMaxX0;  ///< The maximum pfo x0 (determined from shifted vertex) to allow pfo to still be considered in time
     float m_marginY;      ///< The minimum distance from a detector Y-face for a Pfo to be associated
-    float m_marginZ;      ///< The minimum distance from a detector Z-face for a Pfo to be associated
-    float m_maxNeutrinoCosTheta; ///< The maximum cos(theta) that a Pfo can have to be classified as a likely neutrino
-    float m_minCosmicCosTheta;   ///< The minimum cos(theta) that a Pfo can have to be classified as a likely CR muon
-    float m_maxCosmicCurvature;  ///< The maximum curvature that a Pfo can have to be classified as a likely CR muon
 
-    bool m_tagTopEntering;
-    bool m_tagTopToBottom;
-    bool m_tagOutOfTime;
-    bool m_tagInVetoedTPCs;
+    bool m_tagTopEntering;   ///< Whether to tag all top entering particles as cosmic rays
+    bool m_tagTopToBottom;   ///< Whether to tag all top-to-bottom particles as cosmic rays
+    bool m_tagOutOfTime;     ///< Whether to tag all out-of-time particles as cosmic rays
 
-    std::vector<unsigned int> m_vetoedTPCs;
+    bool m_tagInVetoedTPCs;  ///< Whether to tag all particles with their highest position in vetoed TPCs as cosmic rays
+    std::vector<unsigned int> m_vetoedTPCs; ///< List of vetoed TPCs for tagging cosmic rays
 
     float m_face_Xa; ///< Anode      X face
     float m_face_Xc; ///< Cathode    X face

--- a/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
@@ -1,0 +1,231 @@
+/**
+ *  @file   larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
+ *
+ *  @brief  Header file for the cosmic-ray tagging tool class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_TEST_BEAM_COSMIC_RAY_TAGGING_TOOL_H
+#define LAR_TEST_BEAM_COSMIC_RAY_TAGGING_TOOL_H 1
+
+#include "larpandoracontent/LArControlFlow/CosmicRayTaggingBaseTool.h"
+#include "larpandoracontent/LArControlFlow/MasterAlgorithm.h"
+
+#include "larpandoracontent/LArObjects/LArThreeDSlidingFitResult.h"
+
+#include <unordered_map>
+
+namespace lar_content
+{
+
+/**
+ *  @brief  TestBeamCosmicRayTaggingTool class
+ */
+class TestBeamCosmicRayTaggingTool : public CosmicRayTaggingBaseTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    TestBeamCosmicRayTaggingTool();
+
+    pandora::StatusCode Initialize();
+    void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm);
+
+private:
+    /**
+     *  @brief  Class to encapsulate the logic required determine if a Pfo should or shouldn't be tagged as a cosmic ray
+     */
+    class CRCandidate
+    {
+    public:
+        /**
+         *  @brief  Constructor
+         *
+         *  @param  pandora the relevant pandora instance
+         *  @param  pPfo the address of the candidate pfo
+         *  @param  slice the slice id
+         */
+        CRCandidate(const pandora::Pandora &pandora, const pandora::ParticleFlowObject *const pPfo, const unsigned int sliceId);
+
+        const pandora::ParticleFlowObject *const m_pPfo; ///< Address of the candidate Pfo
+        unsigned int m_sliceId;                          ///< Slice ID
+        bool m_canFit;                                   ///< If there are a sufficient number of 3D hits to perform a fitting
+        pandora::CartesianVector m_endPoint1;            ///< First fitted end point in 3D
+        pandora::CartesianVector m_endPoint2;            ///< Second fitted end point in 3D
+        double m_length;                                 ///< Straight line length of the linear fit
+        double m_curvature;                              ///< Measure of the curvature of the track
+        double m_theta;                                  ///< Direction made with vertical
+
+    private:
+        /**
+         *  @brief  Calculate all variables which require a fit
+         *
+         *  @param  slidingFitResult the three dimensional sliding fit result
+         */
+        void CalculateFitVariables(const ThreeDSlidingFitResult &slidingFitResult);
+    };
+
+    typedef std::list<CRCandidate> CRCandidateList;
+
+    /**
+     *  @brief  Get the 3D calo hit cluster associated with a given Pfo, and check if it has sufficient hits
+     *
+     *  @param  pPfo input Pfo
+     *  @param  pCluster3D to receive the address of the 3D cluster
+     *
+     *  @return whether the Pfo has sufficient hits?
+     */
+    bool GetValid3DCluster(const pandora::ParticleFlowObject *const pPfo, const pandora::Cluster *&pCluster3D) const;
+
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, pandora::PfoList> PfoToPfoListMap;
+
+    /**
+     *  @brief  Get mapping between Pfos that are associated with it other by pointing
+     *
+     *  @param  parentCosmicRayPfos input list of Pfos
+     *  @param  pfoAssociationsMap to receive the output mapping between associated Pfos
+     */
+    void GetPfoAssociations(const pandora::PfoList &parentCosmicRayPfos, PfoToPfoListMap &pfoAssociationMap) const;
+
+    /**
+     *  @brief  Check whethe two Pfo endpoints are associated by distance of closest approach
+     *
+     *  @param  endPoint1 position vector of an endpoint of Pfo 1
+     *  @param  endDir1 direction vector of an endpoint of Pfo 1
+     *  @param  endPoint2 position vector of an endpoint of Pfo 2
+     *  @param  endDir2 direction vector of an endpoint of Pfos
+     *
+     *  @return whether the Pfos are associated
+     */
+    bool CheckAssociation(const pandora::CartesianVector &endPoint1, const pandora::CartesianVector &endDir1,
+        const pandora::CartesianVector &endPoint2, const pandora::CartesianVector &endDir2) const;
+
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, unsigned int> PfoToSliceIdMap;
+
+    /**
+     *  @brief  Break the event up into slices of associated Pfos
+     *
+     *  @param  parentCosmicRayPfos input list of Pfos
+     *  @param  pfoAssociationMap mapping between Pfos and other associated Pfos
+     *  @param  pfoToSliceIdMap to receive the mapping between Pfos and their slice ID
+     */
+    void SliceEvent(const pandora::PfoList &parentCosmicRayPfos, const PfoToPfoListMap &pfoAssociationMap, PfoToSliceIdMap &pfoToSliceIdMap) const;
+
+    /**
+     *  @brief  Fill a slice iteratively using Pfo associations
+     *
+     *  @param  pPfo Pfo to add to the slice
+     *  @param  pfoAssociationMap mapping between Pfos and other associated Pfos
+     *  @param  slice the slice to add Pfos to
+     */
+    void FillSlice(const pandora::ParticleFlowObject *const pPfo, const PfoToPfoListMap &pfoAssociationMap, pandora::PfoList &slice) const;
+
+    /**
+     *  @brief  Make a list of CRCandidates
+     *
+     *  @param  parentCosmicRayPfos input list of Pfos
+     *  @param  pfoToSliceIdMap input mapping between Pfos and their slice id
+     *  @param  candidates to receive the output list of CRCandidates
+     */
+    void GetCRCandidates(const pandora::PfoList &parentCosmicRayPfos, const PfoToSliceIdMap &pfoToSliceIdMap, CRCandidateList &candidates) const;
+
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, bool> PfoToBoolMap;
+
+    /**
+     *  @brief  Check if each candidate is "in time"
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToInTimeMap output mapping between candidates Pfos and if they are in time
+     */
+    void CheckIfOutOfTime(const CRCandidateList &candidates, PfoToBoolMap &pfoToInTimeMap) const;
+
+    /**
+     *  @brief  Check if each candidate is "contained" (contained = no associations to Y or Z detector faces, but the Pfo could still enter or exit by and X-face)
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToIsContainedMap output mapping between candidates Pfos and if they are contained
+     */
+    void CheckIfContained(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsContainedMap) const;
+
+    /**
+     *  @brief  Check if each candidate is "top to bottom"
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToIsTopToBottomMap output mapping between candidates Pfos and if they are top to bottom
+     */
+    void CheckIfTopToBottom(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const;
+    void CheckIfTopEntering(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const;
+    void CheckIfInVetoedTPC(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const;
+
+    typedef std::set<unsigned int> UIntSet;
+    typedef std::unordered_map<int, bool> IntBoolMap;
+
+    /**
+     *  @brief  Get the slice indices which contain a likely neutrino Pfo
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToInTimeMap input map between Pfo and if in time
+     *  @param  pfoToIsContainedMap input map between Pfo and if contained
+     *  @param  neutrinoSliceSet output set of slice indices containing a likely neutrino Pfo
+     */
+//    void GetNeutrinoSlices(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsContainedMap,
+//        UIntSet &neutrinoSliceSet) const;
+
+    /**
+     *  @brief  Tag Pfos which are likely to be a CR muon
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToInTimeMap input map between Pfo and if in time
+     *  @param  pfoToIsTopToBottomMap input mapping between candidate Pfos and if they are top to bottom
+     *  @param  neutrinoSliceSet input set of slice indices containing a likely neutrino Pfo
+     *  @param  pfoToIsLikelyCRMuonMap to receive the output mapping between Pfos and a boolean deciding if they are likely a CR muon
+     */
+//    void TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsTopToBottomMap,
+//        const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    typedef std::pair<const ThreeDSlidingFitResult, const ThreeDSlidingFitResult> SlidingFitPair;
+    typedef std::unordered_map<const pandora::ParticleFlowObject *, SlidingFitPair> PfoToSlidingFitsMap;
+    typedef std::vector<pandora::PfoList> SliceList;
+
+    /**
+     *  @brief  Choose a set of cuts using a keyword - "cautious" = remove as few neutrinos as possible
+     *          "nominal" = optimised to maximise CR removal whilst preserving neutrinos
+     *          "aggressive" = remove CR muons and allow more neutrinos to be tagged
+     */
+    std::string m_cutMode;
+
+    float m_angularUncertainty;    ///< The uncertainty in degrees for the angle of a Pfo
+    float m_positionalUncertainty; ///< The uncertainty in cm for the position of Pfo endpoint in 3D
+    float m_maxAssociationDist; ///< The maximum distance from endpoint to point of closest approach, typically a multiple of LAr radiation length
+
+    unsigned int m_minimumHits; ///< The minimum number of hits for a Pfo to be considered
+
+    float m_inTimeMargin; ///< The maximum distance outside of the physical detector volume that a Pfo may be to still be considered in time
+    float m_inTimeMaxX0;  ///< The maximum pfo x0 (determined from shifted vertex) to allow pfo to still be considered in time
+    float m_marginY;      ///< The minimum distance from a detector Y-face for a Pfo to be associated
+    float m_marginZ;      ///< The minimum distance from a detector Z-face for a Pfo to be associated
+    float m_maxNeutrinoCosTheta; ///< The maximum cos(theta) that a Pfo can have to be classified as a likely neutrino
+    float m_minCosmicCosTheta;   ///< The minimum cos(theta) that a Pfo can have to be classified as a likely CR muon
+    float m_maxCosmicCurvature;  ///< The maximum curvature that a Pfo can have to be classified as a likely CR muon
+
+    bool m_tagTopEntering;
+    bool m_tagTopToBottom;
+    bool m_tagOutOfTime;
+    bool m_tagInVetoedTPCs;
+
+    std::vector<unsigned int> m_vetoedTPCs;
+
+    float m_face_Xa; ///< Anode      X face
+    float m_face_Xc; ///< Cathode    X face
+    float m_face_Yb; ///< Bottom     Y face
+    float m_face_Yt; ///< Top        Y face
+    float m_face_Zu; ///< Upstream   Z face
+    float m_face_Zd; ///< Downstream Z face
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_TETS_BEAM_COSMIC_RAY_TAGGING_TOOL_H

--- a/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
@@ -183,11 +183,11 @@ private:
     float m_inTimeMaxX0;  ///< The maximum pfo x0 (determined from shifted vertex) to allow pfo to still be considered in time
     float m_marginY;      ///< The minimum distance from a detector Y-face for a Pfo to be associated
 
-    bool m_tagTopEntering;   ///< Whether to tag all top entering particles as cosmic rays
-    bool m_tagTopToBottom;   ///< Whether to tag all top-to-bottom particles as cosmic rays
-    bool m_tagOutOfTime;     ///< Whether to tag all out-of-time particles as cosmic rays
+    bool m_tagTopEntering; ///< Whether to tag all top entering particles as cosmic rays
+    bool m_tagTopToBottom; ///< Whether to tag all top-to-bottom particles as cosmic rays
+    bool m_tagOutOfTime;   ///< Whether to tag all out-of-time particles as cosmic rays
 
-    bool m_tagInVetoedTPCs;  ///< Whether to tag all particles with their highest position in vetoed TPCs as cosmic rays
+    bool m_tagInVetoedTPCs;                 ///< Whether to tag all particles with their highest position in vetoed TPCs as cosmic rays
     std::vector<unsigned int> m_vetoedTPCs; ///< List of vetoed TPCs for tagging cosmic rays
 
     float m_face_Xa; ///< Anode      X face

--- a/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/TestBeamCosmicRayTaggingTool.h
@@ -30,6 +30,13 @@ public:
     TestBeamCosmicRayTaggingTool();
 
     pandora::StatusCode Initialize();
+    /**
+     *  @brief  Find the list of ambiguous pfos (could represent cosmic-ray muons or neutrinos)
+     *
+     *  @param  parentCosmicRayPfos the list of parent cosmic-ray pfos
+     *  @param  ambiguousPfos to receive the list of ambiguous pfos
+     *  @param  pAlgorithm the address of this master algorithm
+     */
     void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm);
 
 private:
@@ -81,7 +88,7 @@ private:
     typedef std::unordered_map<const pandora::ParticleFlowObject *, pandora::PfoList> PfoToPfoListMap;
 
     /**
-     *  @brief  Get mapping between Pfos that are associated with it other by pointing
+     *  @brief  Get mapping between Pfos that are associated with each other by pointing
      *
      *  @param  parentCosmicRayPfos input list of Pfos
      *  @param  pfoAssociationsMap to receive the output mapping between associated Pfos
@@ -136,9 +143,9 @@ private:
      *  @brief  Check if each candidate is "in time"
      *
      *  @param  candidates input list of candidates
-     *  @param  pfoToInTimeMap output mapping between candidates Pfos and if they are in time
+     *  @param  pfoToIsCosmicRayMap output mapping between candidates Pfos and if they are in time
      */
-    void CheckIfOutOfTime(const CRCandidateList &candidates, PfoToBoolMap &pfoToInTimeMap) const;
+    void CheckIfOutOfTime(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsCosmicRayMap) const;
 
     /**
      *  @brief  Check if each candidate is "top to bottom"

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.cc
@@ -242,8 +242,9 @@ void EventSlicingTool::CollectAssociatedClusters(const Cluster *const pClusterIn
 
         if ((m_usePointingAssociation && this->PassPointing(pClusterInSlice, pCandidateCluster, trackFitResults)) ||
             (m_useProximityAssociation && this->PassProximity(pClusterInSlice, pCandidateCluster)) ||
-            (m_useShowerConeAssociation && (this->PassShowerCone(pClusterInSlice, pCandidateCluster, showerConeFitResults) ||
-                                               this->PassShowerCone(pCandidateCluster, pClusterInSlice, showerConeFitResults))))
+            (m_useShowerConeAssociation &&
+                (this->PassShowerCone(pClusterInSlice, pCandidateCluster, showerConeFitResults) ||
+                    this->PassShowerCone(pCandidateCluster, pClusterInSlice, showerConeFitResults))))
         {
             addedClusters.push_back(pCandidateCluster);
             (void)usedClusters.insert(pCandidateCluster);
@@ -349,9 +350,9 @@ bool EventSlicingTool::PassShowerCone(
 bool EventSlicingTool::CheckClosestApproach(const LArPointingCluster &cluster1, const LArPointingCluster &cluster2) const
 {
     return (this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetInnerVertex()) ||
-            this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetInnerVertex()) ||
-            this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetOuterVertex()) ||
-            this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetOuterVertex()));
+        this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetInnerVertex()) ||
+        this->CheckClosestApproach(cluster1.GetInnerVertex(), cluster2.GetOuterVertex()) ||
+        this->CheckClosestApproach(cluster1.GetOuterVertex(), cluster2.GetOuterVertex()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -375,7 +376,7 @@ bool EventSlicingTool::CheckClosestApproach(const LArPointingCluster::Vertex &ve
     const float closestApproach((approach1 - approach2).GetMagnitude());
 
     return ((closestApproach < m_maxClosestApproach) && (std::fabs(displacement1) < m_maxInterceptDistance) &&
-            (std::fabs(displacement2) < m_maxInterceptDistance));
+        (std::fabs(displacement2) < m_maxInterceptDistance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -384,20 +385,20 @@ bool EventSlicingTool::IsNode(const LArPointingCluster &cluster1, const LArPoint
 {
     return (LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetInnerVertex(),
                 m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
-            LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
+        LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance) ||
+        LArPointingClusterHelper::IsNode(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexTransverseDistance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -406,20 +407,20 @@ bool EventSlicingTool::IsEmission(const LArPointingCluster &cluster1, const LArP
 {
     return (LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetInnerVertex(),
                 m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
-            LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
-                m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
+        LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster1.GetInnerVertex().GetPosition(), cluster2.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster1.GetOuterVertex().GetPosition(), cluster2.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetInnerVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster2.GetInnerVertex().GetPosition(), cluster1.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance) ||
+        LArPointingClusterHelper::IsEmission(cluster2.GetOuterVertex().GetPosition(), cluster1.GetOuterVertex(),
+            m_minVertexLongitudinalDistance, m_maxVertexLongitudinalDistance, m_maxVertexTransverseDistance, m_vertexAngularAllowance));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -471,7 +472,9 @@ void EventSlicingTool::CopyPfoHitsToSlices(const ClusterToSliceIndexMap &cluster
             if ((TPC_VIEW_U != hitType) && (TPC_VIEW_V != hitType) && (TPC_VIEW_W != hitType))
                 throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 
-            CaloHitList &targetList((TPC_VIEW_U == hitType) ? slice.m_caloHitListU : (TPC_VIEW_V == hitType) ? slice.m_caloHitListV : slice.m_caloHitListW);
+            CaloHitList &targetList((TPC_VIEW_U == hitType) ? slice.m_caloHitListU
+                    : (TPC_VIEW_V == hitType)               ? slice.m_caloHitListV
+                                                            : slice.m_caloHitListW);
 
             pCluster2D->GetOrderedCaloHitList().FillCaloHitList(targetList);
             targetList.insert(targetList.end(), pCluster2D->GetIsolatedCaloHitList().begin(), pCluster2D->GetIsolatedCaloHitList().end());
@@ -563,7 +566,7 @@ void EventSlicingTool::AssignRemainingHitsToSlices(
         for (const Cluster *const pCluster2D : sortedRemainingClusters)
         {
             const HitType hitType(LArClusterHelper::GetClusterHitType(pCluster2D));
-//            std::cout << " - Cluster in view " << hitType << " has " << pCluster2D->GetNCaloHits() << " hits" << std::endl;
+            //            std::cout << " - Cluster in view " << hitType << " has " << pCluster2D->GetNCaloHits() << " hits" << std::endl;
 
             if ((TPC_VIEW_U != hitType) && (TPC_VIEW_V != hitType) && (TPC_VIEW_W != hitType))
                 throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
@@ -575,7 +578,9 @@ void EventSlicingTool::AssignRemainingHitsToSlices(
                 continue;
 
             Slice &slice(sliceList.at(pointToSliceIndexMap.at(pBestResultPoint->data)));
-            CaloHitList &targetList((TPC_VIEW_U == hitType) ? slice.m_caloHitListU : (TPC_VIEW_V == hitType) ? slice.m_caloHitListV : slice.m_caloHitListW);
+            CaloHitList &targetList((TPC_VIEW_U == hitType) ? slice.m_caloHitListU
+                    : (TPC_VIEW_V == hitType)               ? slice.m_caloHitListV
+                                                            : slice.m_caloHitListW);
 
             pCluster2D->GetOrderedCaloHitList().FillCaloHitList(targetList);
             targetList.insert(targetList.end(), pCluster2D->GetIsolatedCaloHitList().begin(), pCluster2D->GetIsolatedCaloHitList().end());

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.cc
@@ -66,11 +66,9 @@ void EventSlicingTool::RunSlicing(const Algorithm *const pAlgorithm, const HitTy
 
     ClusterList trackClusters3D;
     this->GetThreeDClusters(pAlgorithm, m_trackPfoListName, trackClusters3D, clusterToPfoMap);
-    std::cout << "Read in " << trackClusters3D.size() << " 3D track clusters" << std::endl;
 
     ClusterList showerClusters3D;
     this->GetThreeDClusters(pAlgorithm, m_showerPfoListName, showerClusters3D, clusterToPfoMap);
-    std::cout << "Read in " << showerClusters3D.size() << " 3D shower clusters" << std::endl;
 
     ClusterSliceList clusterSliceList;
     this->GetClusterSliceList(trackClusters3D, showerClusters3D, clusterSliceList);
@@ -83,7 +81,6 @@ void EventSlicingTool::RunSlicing(const Algorithm *const pAlgorithm, const HitTy
     {
         ClusterToSliceIndexMap clusterToSliceIndexMap;
         this->CreateSlices(clusterSliceList, sliceList, clusterToSliceIndexMap);
-        std::cout << "We created " << sliceList.size() << " slices" << std::endl;
 
         ClusterSet assignedClusters;
         this->CopyPfoHitsToSlices(clusterToSliceIndexMap, clusterToPfoMap, sliceList, assignedClusters);
@@ -561,12 +558,9 @@ void EventSlicingTool::AssignRemainingHitsToSlices(
         ClusterVector sortedRemainingClusters(remainingClusters.begin(), remainingClusters.end());
         std::sort(sortedRemainingClusters.begin(), sortedRemainingClusters.end(), LArClusterHelper::SortByNHits);
 
-        std::cout << "How many left over 2D clusters do we have? " << sortedRemainingClusters.size() << std::endl;
-
         for (const Cluster *const pCluster2D : sortedRemainingClusters)
         {
             const HitType hitType(LArClusterHelper::GetClusterHitType(pCluster2D));
-            //            std::cout << " - Cluster in view " << hitType << " has " << pCluster2D->GetNCaloHits() << " hits" << std::endl;
 
             if ((TPC_VIEW_U != hitType) && (TPC_VIEW_V != hitType) && (TPC_VIEW_W != hitType))
                 throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);

--- a/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.h
+++ b/larpandoracontent/LArThreeDReco/LArEventBuilding/EventSlicingTool.h
@@ -301,6 +301,8 @@ private:
     float m_coneBoundedFraction2;    ///< The minimum cluster bounded fraction for association 2
 
     bool m_use3DProjectionsInHitPickUp; ///< Whether to include 3D cluster projections when assigning remaining clusters to slices
+
+    float m_unassoc2DClusterMaxDist; ///< Maximum distance to attach unassociated 2D Clusters to 3D slices
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
@@ -1,0 +1,228 @@
+/**
+ *  @file   larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
+ *
+ *  @brief  Implementation of the cluster merging algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+
+#include "larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+BoundedRegionClusterMergingAlgorithm::BoundedRegionClusterMergingAlgorithm() :
+m_xRegionMin(-100.f),
+m_xRegionMax(0.f),
+m_zRegionMin(235.f),
+m_zRegionMax(400.f),
+m_maxDistance(10.f),
+m_minClusterHits(2)
+{}
+
+StatusCode BoundedRegionClusterMergingAlgorithm::Run()
+{
+    const ClusterList *pClusterList = NULL;
+
+    if (m_inputClusterListName.empty())
+    {
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
+    }
+    else
+    {
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputClusterListName, pClusterList));
+    }
+
+    if (!pClusterList || pClusterList->empty())
+    {
+        if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+            std::cout << "BoundedRegionClusterMergingAlgorithm: unable to find cluster list " << m_inputClusterListName << std::endl;
+
+        return STATUS_CODE_SUCCESS;
+    }
+
+    std::cout << "Running Bounded Region Clustering for cluster list " << m_inputClusterListName << std::endl;
+    while (true)
+    {
+//        ClusterVector unsortedVector, clusterVector;
+//        this->GetListOfCleanClusters(pClusterList, unsortedVector);
+        ClusterVector clusterVector;
+        ClusterMergeMap clusterMergeMap;
+        this->GetListOfBoundedRegionClusters(pClusterList, clusterVector);
+//        std::cout << " - " << clusterVector.size() << " clusters to play with" << std::endl;
+        if (clusterVector.size() < 2)
+            break;
+
+        this->PopulateClusterMergeMap(clusterVector, clusterMergeMap);
+
+        if (clusterMergeMap.empty())
+            break;
+
+        this->MergeClusters(clusterVector, clusterMergeMap);
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void BoundedRegionClusterMergingAlgorithm::GetListOfBoundedRegionClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const
+{
+    for (const Cluster *const pCluster : *pClusterList)
+    {
+        if (!pCluster->IsAvailable())
+            continue;
+
+        if (pCluster->GetNCaloHits() < m_minClusterHits)
+            continue;
+
+        CartesianVector minimumPos(0.f, 0.f, 0.f), maximumPos(0.f, 0.f, 0.f);
+        LArClusterHelper::GetClusterBoundingBox(pCluster, minimumPos, maximumPos);
+        (void)maximumPos; // To get rid of an unused variable warning
+
+//        std::cout << "Cluster position = " << minimumPos.GetX() << ", " << minimumPos.GetY() << ", " << minimumPos.GetZ() << std::endl;
+        if ( minimumPos.GetX() > m_xRegionMin && minimumPos.GetX() < m_xRegionMax && minimumPos.GetZ() > m_zRegionMin && minimumPos.GetZ() < m_zRegionMax)
+            clusterVector.emplace_back(pCluster);
+    }
+
+    if (!clusterVector.empty())
+        std::sort(clusterVector.begin(), clusterVector.end(), LArClusterHelper::SortByNHits);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void BoundedRegionClusterMergingAlgorithm::PopulateClusterMergeMap(const ClusterVector &clusterVector, ClusterMergeMap &clusterMergeMap) const
+{
+    ClusterVector usedClusters;
+
+    for (unsigned int i = 0; i < clusterVector.size() - 1; ++i)
+    {
+        const Cluster *const pCluster1 = clusterVector.at(i);
+
+        for (unsigned int j = i + 1; j < clusterVector.size(); ++j)
+        {
+            const Cluster *const pCluster2 = clusterVector.at(j);
+            if (!pCluster2->IsAvailable())
+                continue;
+
+            if  (std::find(usedClusters.begin(), usedClusters.end(), pCluster2) != usedClusters.end())
+                continue;
+
+            if (this->AreClustersAssociated(pCluster1, pCluster2))
+            {
+                clusterMergeMap[pCluster1].push_back(pCluster2);
+                usedClusters.emplace_back(pCluster2);
+            }
+        }   
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool BoundedRegionClusterMergingAlgorithm::AreClustersAssociated(const Cluster *const pCluster1, const Cluster *const pCluster2) const
+{
+    const float distance = LArClusterHelper::GetClosestDistance(pCluster1, pCluster2);
+    if (distance < m_maxDistance)
+    {
+//        std::cout << "Clusters " << pCluster1 << " and " << pCluster2 << " are set to be merged" << std::endl;
+        return true;
+    }
+
+    return false;
+}
+
+/*
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void BoundedRegionClusterMergingAlgorithm::CollectAssociatedClusters(
+    const Cluster *const pSeedCluster, const ClusterMergeMap &clusterMergeMap, ClusterList &associatedClusterList) const
+{
+    ClusterSet clusterVetoList;
+    this->CollectAssociatedClusters(pSeedCluster, pSeedCluster, clusterMergeMap, clusterVetoList, associatedClusterList);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void BoundedRegionClusterMergingAlgorithm::CollectAssociatedClusters(const Cluster *const pSeedCluster, const Cluster *const pCurrentCluster,
+    const ClusterMergeMap &clusterMergeMap, const ClusterSet &clusterVetoList, ClusterList &associatedClusterList) const
+{
+    if (clusterVetoList.count(pCurrentCluster))
+        return;
+
+    ClusterMergeMap::const_iterator iter1 = clusterMergeMap.find(pCurrentCluster);
+
+    if (iter1 == clusterMergeMap.end())
+        return;
+
+    ClusterVector associatedClusters(iter1->second.begin(), iter1->second.end());
+    std::sort(associatedClusters.begin(), associatedClusters.end(), LArClusterHelper::SortByNHits);
+
+    for (const Cluster *const pAssociatedCluster : associatedClusters)
+    {
+        if (pAssociatedCluster == pSeedCluster)
+            continue;
+
+        if (associatedClusterList.end() != std::find(associatedClusterList.begin(), associatedClusterList.end(), pAssociatedCluster))
+            continue;
+
+        associatedClusterList.push_back(pAssociatedCluster);
+        this->CollectAssociatedClusters(pSeedCluster, pAssociatedCluster, clusterMergeMap, clusterVetoList, associatedClusterList);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void BoundedRegionClusterMergingAlgorithm::GetSortedListOfCleanClusters(const ClusterVector &inputClusters, ClusterVector &outputClusters) const
+{
+    ClusterVector pfoClusters, availableClusters;
+
+    for (ClusterVector::const_iterator iter = inputClusters.begin(), iterEnd = inputClusters.end(); iter != iterEnd; ++iter)
+    {
+        const Cluster *const pCluster = *iter;
+
+        if (!pCluster->IsAvailable())
+        {
+            pfoClusters.push_back(pCluster);
+        }
+        else
+        {
+            availableClusters.push_back(pCluster);
+        }
+    }
+
+    std::sort(pfoClusters.begin(), pfoClusters.end(), LArClusterHelper::SortByNHits);
+    std::sort(availableClusters.begin(), availableClusters.end(), LArClusterHelper::SortByNHits);
+
+    outputClusters.insert(outputClusters.end(), pfoClusters.begin(), pfoClusters.end());
+    outputClusters.insert(outputClusters.end(), availableClusters.begin(), availableClusters.end());
+}
+*/
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode BoundedRegionClusterMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumX", m_xRegionMin));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumX", m_xRegionMax));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumZ", m_zRegionMin));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumZ", m_zRegionMax));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxDistance", m_maxDistance));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterHits", m_minClusterHits));
+    return ClusterMergingAlgorithm::ReadSettings(xmlHandle);
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
@@ -133,6 +133,12 @@ bool BoundedRegionClusterMergingAlgorithm::AreClustersAssociated(const Cluster *
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void BoundedRegionClusterMergingAlgorithm::GetListOfCleanClusters(const ClusterList *const /*pClusterList*/, pandora::ClusterVector & /*clusterVector*/) const
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 StatusCode BoundedRegionClusterMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumX", m_xRegionMin));

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
@@ -18,12 +18,12 @@ namespace lar_content
 {
 
 BoundedRegionClusterMergingAlgorithm::BoundedRegionClusterMergingAlgorithm() :
-m_xRegionMin(-100.f),
-m_xRegionMax(0.f),
-m_zRegionMin(235.f),
-m_zRegionMax(400.f),
-m_maxDistance(10.f),
-m_minClusterHits(2)
+    m_xRegionMin(-100.f),
+    m_xRegionMax(0.f),
+    m_zRegionMin(235.f),
+    m_zRegionMax(400.f),
+    m_maxDistance(10.f),
+    m_minClusterHits(2)
 {}
 
 StatusCode BoundedRegionClusterMergingAlgorithm::Run()
@@ -51,17 +51,13 @@ StatusCode BoundedRegionClusterMergingAlgorithm::Run()
     std::cout << "Running Bounded Region Clustering for cluster list " << m_inputClusterListName << std::endl;
     while (true)
     {
-//        ClusterVector unsortedVector, clusterVector;
-//        this->GetListOfCleanClusters(pClusterList, unsortedVector);
         ClusterVector clusterVector;
         ClusterMergeMap clusterMergeMap;
         this->GetListOfBoundedRegionClusters(pClusterList, clusterVector);
-//        std::cout << " - " << clusterVector.size() << " clusters to play with" << std::endl;
         if (clusterVector.size() < 2)
             break;
 
         this->PopulateClusterMergeMap(clusterVector, clusterMergeMap);
-
         if (clusterMergeMap.empty())
             break;
 
@@ -87,8 +83,7 @@ void BoundedRegionClusterMergingAlgorithm::GetListOfBoundedRegionClusters(const 
         LArClusterHelper::GetClusterBoundingBox(pCluster, minimumPos, maximumPos);
         (void)maximumPos; // To get rid of an unused variable warning
 
-//        std::cout << "Cluster position = " << minimumPos.GetX() << ", " << minimumPos.GetY() << ", " << minimumPos.GetZ() << std::endl;
-        if ( minimumPos.GetX() > m_xRegionMin && minimumPos.GetX() < m_xRegionMax && minimumPos.GetZ() > m_zRegionMin && minimumPos.GetZ() < m_zRegionMax)
+        if (minimumPos.GetX() > m_xRegionMin && minimumPos.GetX() < m_xRegionMax && minimumPos.GetZ() > m_zRegionMin && minimumPos.GetZ() < m_zRegionMax)
             clusterVector.emplace_back(pCluster);
     }
 
@@ -130,80 +125,11 @@ bool BoundedRegionClusterMergingAlgorithm::AreClustersAssociated(const Cluster *
 {
     const float distance = LArClusterHelper::GetClosestDistance(pCluster1, pCluster2);
     if (distance < m_maxDistance)
-    {
-//        std::cout << "Clusters " << pCluster1 << " and " << pCluster2 << " are set to be merged" << std::endl;
         return true;
-    }
 
     return false;
 }
 
-/*
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-void BoundedRegionClusterMergingAlgorithm::CollectAssociatedClusters(
-    const Cluster *const pSeedCluster, const ClusterMergeMap &clusterMergeMap, ClusterList &associatedClusterList) const
-{
-    ClusterSet clusterVetoList;
-    this->CollectAssociatedClusters(pSeedCluster, pSeedCluster, clusterMergeMap, clusterVetoList, associatedClusterList);
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-void BoundedRegionClusterMergingAlgorithm::CollectAssociatedClusters(const Cluster *const pSeedCluster, const Cluster *const pCurrentCluster,
-    const ClusterMergeMap &clusterMergeMap, const ClusterSet &clusterVetoList, ClusterList &associatedClusterList) const
-{
-    if (clusterVetoList.count(pCurrentCluster))
-        return;
-
-    ClusterMergeMap::const_iterator iter1 = clusterMergeMap.find(pCurrentCluster);
-
-    if (iter1 == clusterMergeMap.end())
-        return;
-
-    ClusterVector associatedClusters(iter1->second.begin(), iter1->second.end());
-    std::sort(associatedClusters.begin(), associatedClusters.end(), LArClusterHelper::SortByNHits);
-
-    for (const Cluster *const pAssociatedCluster : associatedClusters)
-    {
-        if (pAssociatedCluster == pSeedCluster)
-            continue;
-
-        if (associatedClusterList.end() != std::find(associatedClusterList.begin(), associatedClusterList.end(), pAssociatedCluster))
-            continue;
-
-        associatedClusterList.push_back(pAssociatedCluster);
-        this->CollectAssociatedClusters(pSeedCluster, pAssociatedCluster, clusterMergeMap, clusterVetoList, associatedClusterList);
-    }
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-void BoundedRegionClusterMergingAlgorithm::GetSortedListOfCleanClusters(const ClusterVector &inputClusters, ClusterVector &outputClusters) const
-{
-    ClusterVector pfoClusters, availableClusters;
-
-    for (ClusterVector::const_iterator iter = inputClusters.begin(), iterEnd = inputClusters.end(); iter != iterEnd; ++iter)
-    {
-        const Cluster *const pCluster = *iter;
-
-        if (!pCluster->IsAvailable())
-        {
-            pfoClusters.push_back(pCluster);
-        }
-        else
-        {
-            availableClusters.push_back(pCluster);
-        }
-    }
-
-    std::sort(pfoClusters.begin(), pfoClusters.end(), LArClusterHelper::SortByNHits);
-    std::sort(availableClusters.begin(), availableClusters.end(), LArClusterHelper::SortByNHits);
-
-    outputClusters.insert(outputClusters.end(), pfoClusters.begin(), pfoClusters.end());
-    outputClusters.insert(outputClusters.end(), availableClusters.begin(), availableClusters.end());
-}
-*/
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode BoundedRegionClusterMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
@@ -24,7 +24,8 @@ BoundedRegionClusterMergingAlgorithm::BoundedRegionClusterMergingAlgorithm() :
     m_zRegionMax(400.f),
     m_maxDistance(10.f),
     m_minClusterHits(2)
-{}
+{
+}
 
 StatusCode BoundedRegionClusterMergingAlgorithm::Run()
 {
@@ -69,7 +70,8 @@ StatusCode BoundedRegionClusterMergingAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void BoundedRegionClusterMergingAlgorithm::GetListOfBoundedRegionClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const
+void BoundedRegionClusterMergingAlgorithm::GetListOfBoundedRegionClusters(
+    const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const
 {
     for (const Cluster *const pCluster : *pClusterList)
     {
@@ -107,7 +109,7 @@ void BoundedRegionClusterMergingAlgorithm::PopulateClusterMergeMap(const Cluster
             if (!pCluster2->IsAvailable())
                 continue;
 
-            if  (std::find(usedClusters.begin(), usedClusters.end(), pCluster2) != usedClusters.end())
+            if (std::find(usedClusters.begin(), usedClusters.end(), pCluster2) != usedClusters.end())
                 continue;
 
             if (this->AreClustersAssociated(pCluster1, pCluster2))
@@ -115,7 +117,7 @@ void BoundedRegionClusterMergingAlgorithm::PopulateClusterMergeMap(const Cluster
                 clusterMergeMap[pCluster1].push_back(pCluster2);
                 usedClusters.emplace_back(pCluster2);
             }
-        }   
+        }
     }
 }
 
@@ -134,20 +136,14 @@ bool BoundedRegionClusterMergingAlgorithm::AreClustersAssociated(const Cluster *
 
 StatusCode BoundedRegionClusterMergingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumX", m_xRegionMin));
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumX", m_xRegionMax));
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumZ", m_zRegionMin));
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumZ", m_zRegionMax));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumX", m_xRegionMin));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumX", m_xRegionMax));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinimumZ", m_zRegionMin));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaximumZ", m_zRegionMax));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxDistance", m_maxDistance));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxDistance", m_maxDistance));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterHits", m_minClusterHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinClusterHits", m_minClusterHits));
     return ClusterMergingAlgorithm::ReadSettings(xmlHandle);
 }
 

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
@@ -49,7 +49,6 @@ StatusCode BoundedRegionClusterMergingAlgorithm::Run()
         return STATUS_CODE_SUCCESS;
     }
 
-    std::cout << "Running Bounded Region Clustering for cluster list " << m_inputClusterListName << std::endl;
     while (true)
     {
         ClusterVector clusterVector;

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.cc
@@ -29,7 +29,7 @@ BoundedRegionClusterMergingAlgorithm::BoundedRegionClusterMergingAlgorithm() :
 
 StatusCode BoundedRegionClusterMergingAlgorithm::Run()
 {
-    const ClusterList *pClusterList = NULL;
+    const ClusterList *pClusterList{nullptr};
 
     if (m_inputClusterListName.empty())
     {
@@ -100,11 +100,11 @@ void BoundedRegionClusterMergingAlgorithm::PopulateClusterMergeMap(const Cluster
 
     for (unsigned int i = 0; i < clusterVector.size() - 1; ++i)
     {
-        const Cluster *const pCluster1 = clusterVector.at(i);
+        const Cluster *const pCluster1{clusterVector.at(i)};
 
         for (unsigned int j = i + 1; j < clusterVector.size(); ++j)
         {
-            const Cluster *const pCluster2 = clusterVector.at(j);
+            const Cluster *const pCluster2{clusterVector.at(j)};
             if (!pCluster2->IsAvailable())
                 continue;
 
@@ -113,7 +113,7 @@ void BoundedRegionClusterMergingAlgorithm::PopulateClusterMergeMap(const Cluster
 
             if (this->AreClustersAssociated(pCluster1, pCluster2))
             {
-                clusterMergeMap[pCluster1].push_back(pCluster2);
+                clusterMergeMap[pCluster1].emplace_back(pCluster2);
                 usedClusters.emplace_back(pCluster2);
             }
         }
@@ -124,11 +124,8 @@ void BoundedRegionClusterMergingAlgorithm::PopulateClusterMergeMap(const Cluster
 
 bool BoundedRegionClusterMergingAlgorithm::AreClustersAssociated(const Cluster *const pCluster1, const Cluster *const pCluster2) const
 {
-    const float distance = LArClusterHelper::GetClosestDistance(pCluster1, pCluster2);
-    if (distance < m_maxDistance)
-        return true;
-
-    return false;
+    const float distance{LArClusterHelper::GetClosestDistance(pCluster1, pCluster2)};
+    return distance < m_maxDistance;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
@@ -65,13 +65,12 @@ protected:
     void PopulateClusterMergeMap(const pandora::ClusterVector &clusterVector, ClusterMergeMap &clusterMergeMap) const;
 
 private:
-
-    float m_xRegionMin;               ///< Minimum x value of the bounded region box
-    float m_xRegionMax;               ///< Maximum x value of the bounded region box
-    float m_zRegionMin;               ///< Minimum z value (wire dimension) of the bounded region box
-    float m_zRegionMax;               ///< Maximum z value (wire dimension) of the bounded region box
-    float m_maxDistance;              ///< Maximum distance below which clusters can be associated
-    unsigned int m_minClusterHits;    ///< Threshold on the size of clusters to be considered for merging
+    float m_xRegionMin;            ///< Minimum x value of the bounded region box
+    float m_xRegionMax;            ///< Maximum x value of the bounded region box
+    float m_zRegionMin;            ///< Minimum z value (wire dimension) of the bounded region box
+    float m_zRegionMax;            ///< Maximum z value (wire dimension) of the bounded region box
+    float m_maxDistance;           ///< Maximum distance below which clusters can be associated
+    unsigned int m_minClusterHits; ///< Threshold on the size of clusters to be considered for merging
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
@@ -30,7 +30,22 @@ protected:
 
     typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterMergeMap;
 
+    /**
+     *  @brief Populate cluster vector with all clusters starting in the defined region
+     *
+     *  @param  pClusterList pointer to the list of all 2D clusters
+     *  @param  clusterVector to receive the clusters within the bounded region
+     */
     void GetListOfBoundedRegionClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const;
+
+    /**
+     *  @brief Compare two clusters and decide if they should be associated with eachother
+     *
+     *  @param pCluster1 pointer to the first cluster
+     *  @param pCluster2 pointer to the second cluster
+     *
+     *  @return whether the clusters should be associated or not
+     */
     bool AreClustersAssociated(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2) const;
 
     /**
@@ -49,52 +64,14 @@ protected:
      */
     void PopulateClusterMergeMap(const pandora::ClusterVector &clusterVector, ClusterMergeMap &clusterMergeMap) const;
 
-    /**
-     *  @brief  Merge associated clusters
-     *
-     *  @param  clusterVector the vector of clean clusters
-     *  @param  clusterMergeMap the matrix of cluster associations
-     */
-//    void MergeClusters(pandora::ClusterVector &clusterVector, ClusterMergeMap &clusterMergeMap) const;
-
-    /**
-     *  @brief  Collect up all clusters associations related to a given seed cluster
-     *
-     *  @param  pSeedCluster pointer to the initial cluster
-     *  @param  clusterMergeMap the map of cluster associations
-     *  @param  associatedClusterList the output list of associated clusters
-     */
-//    void CollectAssociatedClusters(const pandora::Cluster *const pSeedCluster, const ClusterMergeMap &clusterMergeMap,
-//        pandora::ClusterList &associatedClusterList) const;
-
-    /**
-     *  @brief  Collect up all clusters associations related to a given seed cluster
-     *
-     *  @param  pSeedCluster pointer to the initial cluster
-     *  @param  pCurrentCluster pointer to the current cluster
-     *  @param  clusterMergeMap the map of cluster associations
-     *  @param  clusterVetoList the list of clusters that have already been merged
-     *  @param  associatedClusterList the output list of associated clusters
-     */
-//    void CollectAssociatedClusters(const pandora::Cluster *const pSeedCluster, const pandora::Cluster *const pCurrentCluster,
-//        const ClusterMergeMap &clusterMergeMap, const pandora::ClusterSet &clusterVetoList, pandora::ClusterList &associatedClusterList) const;
-
-    /**
-     *  @brief  Sort the selected clusters, so that they have a well-defined ordering
-     *
-     *  @param  inputClusters the input vector of clusters
-     *  @param  outputClusters the output vector of clusters
-     */
-//    void GetSortedListOfCleanClusters(const pandora::ClusterVector &inputClusters, pandora::ClusterVector &outputClusters) const;
-
 private:
 
-    float m_xRegionMin;
-    float m_xRegionMax;
-    float m_zRegionMin;
-    float m_zRegionMax;
-    float m_maxDistance;
-    unsigned int m_minClusterHits;
+    float m_xRegionMin;               ///< Minimum x value of the bounded region box
+    float m_xRegionMax;               ///< Maximum x value of the bounded region box
+    float m_zRegionMin;               ///< Minimum z value (wire dimension) of the bounded region box
+    float m_zRegionMax;               ///< Maximum z value (wire dimension) of the bounded region box
+    float m_maxDistance;              ///< Maximum distance below which clusters can be associated
+    unsigned int m_minClusterHits;    ///< Threshold on the size of clusters to be considered for merging
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
@@ -1,0 +1,102 @@
+/**
+ *  @file   larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
+ *
+ *  @brief  Header file for the bounded region cluster merging algorithm class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_BOUNDED_REGION_CLUSTER_MERGING_ALGORITHM_H
+#define LAR_BOUNDED_REGION_CLUSTER_MERGING_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+#include "larpandoracontent/LArTwoDReco/LArClusterAssociation/ClusterMergingAlgorithm.h"
+
+#include <unordered_map>
+
+namespace lar_content
+{
+
+/**
+ *  @brief  BoundedRegionClusterMergingAlgorithm class
+ */
+class BoundedRegionClusterMergingAlgorithm : public ClusterMergingAlgorithm
+{
+public:
+    BoundedRegionClusterMergingAlgorithm();
+
+protected:
+    virtual pandora::StatusCode Run();
+    virtual pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    typedef std::unordered_map<const pandora::Cluster *, pandora::ClusterList> ClusterMergeMap;
+
+    void GetListOfBoundedRegionClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const;
+    bool AreClustersAssociated(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2) const;
+
+    /**
+     *  @brief  Populate cluster vector with subset of cluster list, containing clusters judged to be clean
+     *
+     *  @param  pClusterList address of the cluster list
+     *  @param  clusterVector to receive the populated cluster vector
+     */
+    void GetListOfCleanClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const {};
+
+    /**
+     *  @brief  Form associations between pointing clusters
+     *
+     *  @param  clusterVector the vector of clean clusters
+     *  @param  clusterMergeMap the matrix of cluster associations
+     */
+    void PopulateClusterMergeMap(const pandora::ClusterVector &clusterVector, ClusterMergeMap &clusterMergeMap) const;
+
+    /**
+     *  @brief  Merge associated clusters
+     *
+     *  @param  clusterVector the vector of clean clusters
+     *  @param  clusterMergeMap the matrix of cluster associations
+     */
+//    void MergeClusters(pandora::ClusterVector &clusterVector, ClusterMergeMap &clusterMergeMap) const;
+
+    /**
+     *  @brief  Collect up all clusters associations related to a given seed cluster
+     *
+     *  @param  pSeedCluster pointer to the initial cluster
+     *  @param  clusterMergeMap the map of cluster associations
+     *  @param  associatedClusterList the output list of associated clusters
+     */
+//    void CollectAssociatedClusters(const pandora::Cluster *const pSeedCluster, const ClusterMergeMap &clusterMergeMap,
+//        pandora::ClusterList &associatedClusterList) const;
+
+    /**
+     *  @brief  Collect up all clusters associations related to a given seed cluster
+     *
+     *  @param  pSeedCluster pointer to the initial cluster
+     *  @param  pCurrentCluster pointer to the current cluster
+     *  @param  clusterMergeMap the map of cluster associations
+     *  @param  clusterVetoList the list of clusters that have already been merged
+     *  @param  associatedClusterList the output list of associated clusters
+     */
+//    void CollectAssociatedClusters(const pandora::Cluster *const pSeedCluster, const pandora::Cluster *const pCurrentCluster,
+//        const ClusterMergeMap &clusterMergeMap, const pandora::ClusterSet &clusterVetoList, pandora::ClusterList &associatedClusterList) const;
+
+    /**
+     *  @brief  Sort the selected clusters, so that they have a well-defined ordering
+     *
+     *  @param  inputClusters the input vector of clusters
+     *  @param  outputClusters the output vector of clusters
+     */
+//    void GetSortedListOfCleanClusters(const pandora::ClusterVector &inputClusters, pandora::ClusterVector &outputClusters) const;
+
+private:
+
+    float m_xRegionMin;
+    float m_xRegionMax;
+    float m_zRegionMin;
+    float m_zRegionMax;
+    float m_maxDistance;
+    unsigned int m_minClusterHits;
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_BOUNDED_REGION_CLUSTER_MERGING_ALGORITHM_H

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
@@ -39,7 +39,7 @@ protected:
     void GetListOfBoundedRegionClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const;
 
     /**
-     *  @brief Compare two clusters and decide if they should be associated with eachother
+     *  @brief Compare two clusters and decide if they should be associated with each other
      *
      *  @param pCluster1 pointer to the first cluster
      *  @param pCluster2 pointer to the second cluster

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/BoundedRegionClusterMergingAlgorithm.h
@@ -54,7 +54,7 @@ protected:
      *  @param  pClusterList address of the cluster list
      *  @param  clusterVector to receive the populated cluster vector
      */
-    void GetListOfCleanClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const {};
+    void GetListOfCleanClusters(const pandora::ClusterList *const pClusterList, pandora::ClusterVector &clusterVector) const;
 
     /**
      *  @brief  Form associations between pointing clusters


### PR DESCRIPTION
Some changes to help with beam particle reconstruction for ProtoDUNE-HD given the issues in APA1. As a recap, the collection plane performance is badly compromised, so we need to be able to cope with only having two views. The main changes are:

TestBeamCosmicRayTaggingTool:
- Stricter cosmic ray tagging appropriate for test beam experiments where we don't expect any top-exiting particles

BoundedRegionClusterMergingAlgorithm:
- Performs basic 2D cluster merging within a defined 2D box in (x,z) space for a given 2D view. This helps to reclaim some beam particles missed in earlier steps.

A simple change to EventSlicingTool was required as a result of the new cosmic tagging significantly reducing the number of slices. A maximum distance has been added for associating the unassociated 2D clusters to the 3D slices, since adding them from the other side of the detector causes issues with the post-slicing test beam reconstruction. This distance has a default value of float-max, so should never have an effect unless set via xml.