### PR TITLE
HierarchyValidationAlgorithm: handle events with missing vertices & other updates

### DIFF
--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
@@ -1306,11 +1306,9 @@ void LArHierarchyHelper::MatchInfo::Match()
             RecoHierarchy::NodeVector recoNodes;
             m_recoHierarchy.GetFlattenedNodes(pRootPfo, recoNodes);
 
-            std::sort(mcNodes.begin(), mcNodes.end(),
-                [](const MCHierarchy::Node *lhs, const MCHierarchy::Node *rhs)
+            std::sort(mcNodes.begin(), mcNodes.end(), [](const MCHierarchy::Node *lhs, const MCHierarchy::Node *rhs)
                 { return lhs->GetCaloHits().size() > rhs->GetCaloHits().size(); });
-            std::sort(recoNodes.begin(), recoNodes.end(),
-                [](const RecoHierarchy::Node *lhs, const RecoHierarchy::Node *rhs)
+            std::sort(recoNodes.begin(), recoNodes.end(), [](const RecoHierarchy::Node *lhs, const RecoHierarchy::Node *rhs)
                 { return lhs->GetCaloHits().size() > rhs->GetCaloHits().size(); });
 
             for (const RecoHierarchy::Node *pRecoNode : recoNodes)
@@ -1463,7 +1461,6 @@ unsigned int LArHierarchyHelper::MatchInfo::GetNTestBeamMCNodes(const MCParticle
 
 void LArHierarchyHelper::MatchInfo::Print(const MCHierarchy &mcHierarchy) const
 {
-    (void)mcHierarchy;
     MCParticleList rootMCParticles;
     mcHierarchy.GetRootMCParticles(rootMCParticles);
 
@@ -1481,6 +1478,8 @@ void LArHierarchyHelper::MatchInfo::Print(const MCHierarchy &mcHierarchy) const
                 primaries.emplace_back(pLeadingMC);
             }
         }
+        if (primaries.size() == 0)
+            continue;
         primaries.sort(LArMCParticleHelper::SortByMomentum);
         const InteractionDescriptor descriptor{LArInteractionTypeHelper::GetInteractionDescriptor(primaries)};
 

--- a/larpandoracontent/LArMonitoring/HierarchyValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/HierarchyValidationAlgorithm.h
@@ -50,20 +50,27 @@ private:
 
 #endif
 
-    int m_event;                   ///< The current event
-    std::string m_caloHitListName; ///< Name of input calo hit list
-    std::string m_pfoListName;     ///< Name of input PFO list
-    std::string m_detector;        ///< Name of the detector
-    bool m_writeTree;              ///< Whether or not to output validation information to a ROOT file
-    std::string m_filename;        ///< The name of the ROOT file to write
-    std::string m_treename;        ///< The name of the ROOT tree to write
-    bool m_foldToPrimaries;        ///< Whether or not to fold the hierarchy back to primary particles
-    bool m_foldDynamic;            ///< Whether or not to fold the hierarchy dynamically
-    bool m_foldToLeadingShowers;   ///< Whether or not to fold the hierarchy back to leading shower particles
-    bool m_validateEvent;          ///< Whether to validate at the level of an event
-    bool m_validateMC;             ///< Whether to validate at the level of MC nodes
-    float m_minPurity;             ///< Minimum purity to tag a node as being of good quality
-    float m_minCompleteness;       ///< Minimum completeness to tag a node as being of good quality
+    int m_event;                       ///< The current event
+    std::string m_caloHitListName;     ///< Name of input calo hit list
+    std::string m_pfoListName;         ///< Name of input PFO list
+    std::string m_detector;            ///< Name of the detector
+    bool m_writeEventTree;             ///< Whether or not to output event validation information to a ROOT file
+    bool m_writeMCTree;                ///< Whether or not to output MC validation information to a ROOT file
+    std::string m_eventFileName;       ///< The name of the event ROOT file to write
+    std::string m_eventTreeName;       ///< The name of the event ROOT tree to write
+    std::string m_MCFileName;          ///< The name of the MC ROOT file to write
+    std::string m_MCTreeName;          ///< The name of the MC ROOT tree to write
+    bool m_foldToPrimaries;            ///< Whether or not to fold the hierarchy back to primary particles
+    bool m_foldDynamic;                ///< Whether or not to fold the hierarchy dynamically
+    bool m_foldToLeadingShowers;       ///< Whether or not to fold the hierarchy back to leading shower particles
+    bool m_validateEvent;              ///< Whether to validate at the level of an event
+    bool m_validateMC;                 ///< Whether to validate at the level of MC nodes
+    float m_minPurity;                 ///< Minimum purity to tag a node as being of good quality
+    float m_minCompleteness;           ///< Minimum completeness to tag a node as being of good quality
+    unsigned int m_minRecoHits;        ///< Minimum number of reconstructed primary good hits
+    unsigned int m_minRecoHitsPerView; ///< Minimum number of reconstructed hits for a good view
+    unsigned int m_minRecoGoodViews;   ///< Minimum number of reconstructed primary good views
+    bool m_removeRecoNeutrons;         ///< Whether to remove reconstructed neutrons and their downstream particles
 };
 
 } // namespace lar_content


### PR DESCRIPTION
Changes to the HierarchyValidationAlgorithm:

Do not skip events if there are problems accessing the PFO vertex or interaction code information (handles exceptions using try-catch).

Allow both the Event and MC hierarchy ROOT files to be created together if enabled, instead of only being either one or the other; they both use the same hierarchy matching info. Added the following xml parameters:

`ValidateEvent (false), WriteEventTree (false), EventFileName, EventTreeName`
`ValidateMC (false), WriteMCTree (false), MCFileName, MCTreeName`

Allow the reconstructability criteria to be modified by xml parameters:
`MinRecoHits (30), MinRecoHitsPerView (10), MinRecoGoodViews (2) & RemoveRecoNeutrons (true)`

Add reco and true MC vertex coordinates to the ROOT output.
