### PR TITLE
Add functionality to run 3D clusters reclustering tools

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -68,6 +68,8 @@
 #include "larpandoracontent/LArPersistency/EventWritingAlgorithm.h"
 
 #include "larpandoracontent/LArPlugins/LArParticleIdPlugins.h"
+#include "larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h"
+#include "larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h"
 
 #include "larpandoracontent/LArShowerRefinement/ConnectionPathwayFeatureTool.h"
 #include "larpandoracontent/LArShowerRefinement/ElectronInitialRegionRefinementAlgorithm.h"
@@ -155,6 +157,7 @@
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewThreeDKinkTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
+#include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
 
 #include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
@@ -334,9 +337,13 @@
     d("LArHitAngleVertexSelection",             HitAngleVertexSelectionAlgorithm)                                               \
     d("LArBdtVertexSelection",                  BdtVertexSelectionAlgorithm)                                                    \
     d("LArSvmVertexSelection",                  SvmVertexSelectionAlgorithm)                                                    \
-    d("LArVertexRefinement",                    VertexRefinementAlgorithm)
+    d("LArVertexRefinement",                    VertexRefinementAlgorithm)                                                      \
+    d("LArThreeDReclustering",                  ThreeDReclusteringAlgorithm)                                                    \
+
 
 #define LAR_ALGORITHM_TOOL_LIST(d)                                                                                              \
+    d("LArCheatedThreeDClusteringTool",         CheatedThreeDClusteringTool)                                                    \
+    d("LArSimplePCAThreeDClusteringTool",                 SimplePCAThreeDClusteringTool)                                        \
     d("LArConnectionRegionFeatureTool",         ConnectionRegionFeatureTool)                                                    \
     d("LArShowerRegionFeatureTool",             ShowerRegionFeatureTool)                                                        \
     d("LArAmbiguousRegionFeatureTool",          AmbiguousRegionFeatureTool)                                                     \

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -216,12 +216,12 @@
 #include "larpandoracontent/LArUtility/ListPruningAlgorithm.h"
 #include "larpandoracontent/LArUtility/PfoHitCleaningAlgorithm.h"
 
+#include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
 #include "larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.h"
 #include "larpandoracontent/LArVertex/EnergyKickVertexSelectionAlgorithm.h"
 #include "larpandoracontent/LArVertex/HitAngleVertexSelectionAlgorithm.h"
 #include "larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.h"
 #include "larpandoracontent/LArVertex/VertexRefinementAlgorithm.h"
-#include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
 
 #include "larpandoracontent/LArContent.h"
 
@@ -332,13 +332,13 @@
     d("LArListMerging",                         ListMergingAlgorithm)                                                           \
     d("LArPfoHitCleaning",                      PfoHitCleaningAlgorithm)                                                        \
     d("LArListPruning",                         ListPruningAlgorithm)                                                           \
+    d("LArThreeDReclustering",                  ThreeDReclusteringAlgorithm)                                                    \
     d("LArCandidateVertexCreation",             CandidateVertexCreationAlgorithm)                                               \
     d("LArEnergyKickVertexSelection",           EnergyKickVertexSelectionAlgorithm)                                             \
     d("LArHitAngleVertexSelection",             HitAngleVertexSelectionAlgorithm)                                               \
     d("LArBdtVertexSelection",                  BdtVertexSelectionAlgorithm)                                                    \
     d("LArSvmVertexSelection",                  SvmVertexSelectionAlgorithm)                                                    \
     d("LArVertexRefinement",                    VertexRefinementAlgorithm)                                                      \
-    d("LArThreeDReclustering",                  ThreeDReclusteringAlgorithm)                                                    \
 
 
 #define LAR_ALGORITHM_TOOL_LIST(d)                                                                                              \

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -157,7 +157,6 @@
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewSimpleTracksTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewThreeDKinkTool.h"
 #include "larpandoracontent/LArThreeDReco/LArTwoViewMatching/TwoViewTransverseTracksAlgorithm.h"
-#include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
 
 #include "larpandoracontent/LArVertex/EnergyDepositionAsymmetryFeatureTool.h"
 #include "larpandoracontent/LArVertex/EnergyKickFeatureTool.h"
@@ -222,6 +221,7 @@
 #include "larpandoracontent/LArVertex/HitAngleVertexSelectionAlgorithm.h"
 #include "larpandoracontent/LArVertex/MvaVertexSelectionAlgorithm.h"
 #include "larpandoracontent/LArVertex/VertexRefinementAlgorithm.h"
+#include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
 
 #include "larpandoracontent/LArContent.h"
 
@@ -343,7 +343,7 @@
 
 #define LAR_ALGORITHM_TOOL_LIST(d)                                                                                              \
     d("LArCheatedThreeDClusteringTool",         CheatedThreeDClusteringTool)                                                    \
-    d("LArSimplePCAThreeDClusteringTool",                 SimplePCAThreeDClusteringTool)                                        \
+    d("LArSimplePCAThreeDClusteringTool",       SimplePCAThreeDClusteringTool)                                                  \
     d("LArConnectionRegionFeatureTool",         ConnectionRegionFeatureTool)                                                    \
     d("LArShowerRegionFeatureTool",             ShowerRegionFeatureTool)                                                        \
     d("LArAmbiguousRegionFeatureTool",          AmbiguousRegionFeatureTool)                                                     \

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -8,9 +8,7 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
-
 #include "larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h"
-
 
 using namespace pandora;
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -21,7 +21,7 @@ CheatedThreeDClusteringTool::CheatedThreeDClusteringTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector)
+bool CheatedThreeDClusteringTool::Run(const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector)
 {
     LArMCParticleHelper::MCContributionMap mcParticleCaloHitListMap;
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -6,9 +6,9 @@
  *  $Log: $
  */
 
+#include "larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h"
 #include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
-#include "larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h"
 
 using namespace pandora;
 
@@ -21,7 +21,7 @@ CheatedThreeDClusteringTool::CheatedThreeDClusteringTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool CheatedThreeDClusteringTool::Run(const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector)
+bool CheatedThreeDClusteringTool::Run(const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector)
 {
     LArMCParticleHelper::MCContributionMap mcParticleCaloHitListMap;
 
@@ -33,7 +33,7 @@ bool CheatedThreeDClusteringTool::Run(const pandora::CaloHitList &inputCaloHitLi
 
         auto it = mcParticleCaloHitListMap.find(pMainMCParticle);
 
-        if (it != mcParticleCaloHitListMap.end()) 
+        if (it != mcParticleCaloHitListMap.end())
         {
             it->second.push_back(pCaloHit3D);
         }
@@ -42,10 +42,9 @@ bool CheatedThreeDClusteringTool::Run(const pandora::CaloHitList &inputCaloHitLi
             CaloHitList newList;
             newList.push_back(pCaloHit3D);
             mcParticleCaloHitListMap.insert(std::make_pair(pMainMCParticle, newList));
-        } 
-
+        }
     }
-    for (auto& pair : mcParticleCaloHitListMap)
+    for (auto &pair : mcParticleCaloHitListMap)
         outputCaloHitListsVector.push_back(std::ref(pair.second));
 
     return true;

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -46,6 +46,7 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const pAlgorithm, std::ve
         else
         {
             CaloHitList* newList = new CaloHitList();
+            newList->push_back(pCaloHit);
             McIdCaloHitListMap.insert(std::make_pair(mainMcParticleIndex, newList));
         } 
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -23,11 +23,11 @@ CheatedThreeDClusteringTool::CheatedThreeDClusteringTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-std::vector<std::reference_wrapper<pandora::CaloHitList>> CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList)
+std::vector<std::reference_wrapper<CaloHitList>> CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::reference_wrapper<CaloHitList> &inputCaloHitList)
 {
-    std::vector<std::reference_wrapper<pandora::CaloHitList>> newCaloHitListsVector;
+    std::vector<std::reference_wrapper<CaloHitList>> newCaloHitListsVector;
 
-    std::map<const pandora::MCParticle *, CaloHitList> McParticleCaloHitListMap;
+    LArMCParticleHelper::MCContributionMap mcParticleCaloHitListMap;
 
     for (const CaloHit *const pCaloHit : inputCaloHitList.get())
     {
@@ -35,9 +35,9 @@ std::vector<std::reference_wrapper<pandora::CaloHitList>> CheatedThreeDClusterin
 
         const MCParticle *const pMainMCParticle(MCParticleHelper::GetMainMCParticle(pParentCaloHit));
 
-        auto it = McParticleCaloHitListMap.find(pMainMCParticle);
+        auto it = mcParticleCaloHitListMap.find(pMainMCParticle);
 
-        if (it != McParticleCaloHitListMap.end()) 
+        if (it != mcParticleCaloHitListMap.end()) 
         {
             it->second.push_back(pCaloHit);
         }
@@ -45,11 +45,11 @@ std::vector<std::reference_wrapper<pandora::CaloHitList>> CheatedThreeDClusterin
         {
             CaloHitList newList;
             newList.push_back(pCaloHit);
-            McParticleCaloHitListMap.insert(std::make_pair(pMainMCParticle, newList));
+            mcParticleCaloHitListMap.insert(std::make_pair(pMainMCParticle, newList));
         } 
 
     }
-    for (auto& pair : McParticleCaloHitListMap)
+    for (auto& pair : mcParticleCaloHitListMap)
         newCaloHitListsVector.push_back(std::ref(pair.second));
 
     return newCaloHitListsVector;

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -25,7 +25,7 @@ CheatedThreeDClusteringTool::CheatedThreeDClusteringTool()
 
 bool CheatedThreeDClusteringTool::Run(const Algorithm *const pAlgorithm, std::vector<pandora::CaloHitList*> &newCaloHitListsVector)
 {
-    if (newCaloHitListsVector.empty() || newCaloHitListsVector.size() != 1)
+    if (newCaloHitListsVector.size() != 1)
         return false;
 
     CaloHitList *initialCaloHitList = newCaloHitListsVector.at(0);
@@ -39,7 +39,7 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const pAlgorithm, std::ve
 
         int mainMcParticleIndex = this->GetMainMcParticleIndex(pAlgorithm, pParentCaloHit);
 
-        if (McIdCaloHitListMap.find(mainMcParticleIndex) != McIdCaloHitListMap.end()) 
+        if (McIdCaloHitListMap.count(mainMcParticleIndex)) 
         {
             McIdCaloHitListMap.at(mainMcParticleIndex)->push_back(pCaloHit);
         }
@@ -50,7 +50,9 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const pAlgorithm, std::ve
         } 
 
     }
-    for (const auto& pair : McIdCaloHitListMap) newCaloHitListsVector.push_back(pair.second);
+    for (const auto& pair : McIdCaloHitListMap)
+        newCaloHitListsVector.push_back(pair.second);
+
     return true;
 }
 
@@ -60,7 +62,7 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const pAlgorithm, std::ve
 int CheatedThreeDClusteringTool::GetMainMcParticleIndex(const Algorithm *const pAlgorithm, const pandora::CaloHit *const pCaloHit)
 {
     if (!pCaloHit) {
-        std::cerr << "pCaloHit is null!" << std::endl;
+        std::cerr << "ERROR in CheatedThreeDClusteringTool: pCaloHit is null!" << std::endl;
         return -1;
     }
     const MCParticleList *pMCParticleList(nullptr);
@@ -81,7 +83,7 @@ int CheatedThreeDClusteringTool::GetMainMcParticleIndex(const Algorithm *const p
         for(const MCParticle *const pMCParticle: mcParticleVector) 
         { 
             if(pMCParticle==weightMapEntry.first) { break;} 
-            iMcPart++; 
+            ++iMcPart; 
         }
       } 
     }

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -25,22 +25,22 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, con
 {
     LArMCParticleHelper::MCContributionMap mcParticleCaloHitListMap;
 
-    for (const CaloHit *const pCaloHit : inputCaloHitList)
+    for (const CaloHit *const pCaloHit3D : inputCaloHitList)
     {
-        const CaloHit *const pParentCaloHit = static_cast<const CaloHit *>(pCaloHit->GetParentAddress());
+        const CaloHit *const pParentCaloHit2D = static_cast<const CaloHit *>(pCaloHit3D->GetParentAddress());
 
-        const MCParticle *const pMainMCParticle(MCParticleHelper::GetMainMCParticle(pParentCaloHit));
+        const MCParticle *const pMainMCParticle(MCParticleHelper::GetMainMCParticle(pParentCaloHit2D));
 
         auto it = mcParticleCaloHitListMap.find(pMainMCParticle);
 
         if (it != mcParticleCaloHitListMap.end()) 
         {
-            it->second.push_back(pCaloHit);
+            it->second.push_back(pCaloHit3D);
         }
         else
         {
             CaloHitList newList;
-            newList.push_back(pCaloHit);
+            newList.push_back(pCaloHit3D);
             mcParticleCaloHitListMap.insert(std::make_pair(pMainMCParticle, newList));
         } 
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -6,9 +6,9 @@
  *  $Log: $
  */
 
-#include "larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h"
 #include "Pandora/AlgorithmHeaders.h"
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h"
 
 using namespace pandora;
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -27,7 +27,7 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, con
 
     for (const CaloHit *const pCaloHit3D : inputCaloHitList)
     {
-        const CaloHit *const pParentCaloHit2D = static_cast<const CaloHit *>(pCaloHit3D->GetParentAddress());
+        const CaloHit *const pParentCaloHit2D{static_cast<const CaloHit *>(pCaloHit3D->GetParentAddress())};
 
         const MCParticle *const pMainMCParticle(MCParticleHelper::GetMainMCParticle(pParentCaloHit2D));
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -53,9 +53,8 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode CheatedThreeDClusteringTool::ReadSettings(const TiXmlHandle xmlHandle)
+StatusCode CheatedThreeDClusteringTool::ReadSettings(const TiXmlHandle /*xmlHandle*/)
 {
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
     return STATUS_CODE_SUCCESS;
 }
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -49,30 +49,6 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const pAlgorithm, std::ve
             McIdCaloHitListMap.insert(std::make_pair(mainMcParticleIndex, newList));
         } 
 
-        // Flag to indicate if a matching list was found
-        //bool found = false;
-
-        // Search for an existing list with matching MC particle index
-        /*for (CaloHitList *caloHitList : newCaloHitListsVector)
-        {
-            const CaloHit *const pListParentCaloHit = static_cast<const CaloHit *>(caloHitList->front()->GetParentAddress());
-            int listMainMcParticleIndex = this->GetMainMcParticleIndex(pAlgorithm, pListParentCaloHit);
-            if (listMainMcParticleIndex == mainMcParticleIndex)
-            {
-                found = true;
-                caloHitList->push_back(pCaloHit);
-                break;
-            }
-        }
-		
-        // If a list with matching MC particle hits is not found, create one
-        if (!found)
-        {
-            CaloHitList* newList = new CaloHitList();
-            newList->push_back(pCaloHit);
-            newCaloHitListsVector.push_back(newList);
-        }
-        */
     }
     for (const auto& pair : McIdCaloHitListMap) newCaloHitListsVector.push_back(pair.second);
     return true;

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -1,0 +1,109 @@
+/**
+ *  @file   larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+ *
+ *  @brief  Implementation file for the reclustering algorithm that uses transverse calorimetric profiles.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+
+#include "larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h"
+
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+CheatedThreeDClusteringTool::CheatedThreeDClusteringTool()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool CheatedThreeDClusteringTool::Run(const Algorithm *const pAlgorithm, std::vector<pandora::CaloHitList*> &newCaloHitListsVector)
+{
+    if (newCaloHitListsVector.empty() || newCaloHitListsVector.size() != 1)
+        return false;
+
+    CaloHitList *initialCaloHitList = newCaloHitListsVector.at(0);
+    newCaloHitListsVector.clear();
+    for (const CaloHit *const pCaloHit : *initialCaloHitList)
+    {
+        const CaloHit *const pParentCaloHit = static_cast<const CaloHit *>(pCaloHit->GetParentAddress());
+
+        int mainMcParticleIndex = this->GetMainMcParticleIndex(pAlgorithm, pParentCaloHit);
+
+        // Flag to indicate if a matching list was found
+        bool found = false;
+
+        // Search for an existing list with matching MC particle index
+        for (CaloHitList *caloHitList : newCaloHitListsVector)
+        {
+            const CaloHit *const pListParentCaloHit = static_cast<const CaloHit *>(caloHitList->front()->GetParentAddress());
+            int listMainMcParticleIndex = this->GetMainMcParticleIndex(pAlgorithm, pListParentCaloHit);
+            if (listMainMcParticleIndex == mainMcParticleIndex)
+            {
+                found = true;
+                caloHitList->push_back(pCaloHit);
+                break;
+            }
+        }
+
+        // If a list with matching MC particle hits is not found, create one
+        if (!found)
+        {
+            CaloHitList* newList = new CaloHitList();
+            newList->push_back(pCaloHit);
+            newCaloHitListsVector.push_back(newList);
+        }
+    }
+
+    return true;
+}
+
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+int CheatedThreeDClusteringTool::GetMainMcParticleIndex(const Algorithm *const pAlgorithm, const pandora::CaloHit *const pCaloHit)
+{
+    if (!pCaloHit) {
+        std::cerr << "pCaloHit is null!" << std::endl;
+        return -1;
+    }
+    const MCParticleList *pMCParticleList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*pAlgorithm, m_mcParticleListName, pMCParticleList));
+    if (!pMCParticleList) {
+        std::cerr << "MCParticleList is null!" << std::endl;
+        return -1;
+    }
+    MCParticleVector mcParticleVector(pMCParticleList->begin(),pMCParticleList->end());
+    std::sort(mcParticleVector.begin(), mcParticleVector.end(), LArMCParticleHelper::SortByMomentum);
+
+    int iMcPart(0); 
+    for (const auto &weightMapEntry : pCaloHit->GetMCParticleWeightMap()) 
+    { 
+      if(weightMapEntry.second>0.5) 
+      { 
+        iMcPart=0;  
+        for(const MCParticle *const pMCParticle: mcParticleVector) 
+        { 
+            if(pMCParticle==weightMapEntry.first) { break;} 
+            iMcPart++; 
+        }
+      } 
+    }
+    return iMcPart;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode CheatedThreeDClusteringTool::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -23,17 +23,13 @@ CheatedThreeDClusteringTool::CheatedThreeDClusteringTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::vector<pandora::CaloHitList*> &newCaloHitListsVector)
+std::vector<std::reference_wrapper<pandora::CaloHitList>> CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList)
 {
-    if (newCaloHitListsVector.size() != 1)
-        return false;
+    std::vector<std::reference_wrapper<pandora::CaloHitList>> newCaloHitListsVector;
 
-    CaloHitList *initialCaloHitList = newCaloHitListsVector.at(0);
-    newCaloHitListsVector.clear();
+    std::map<const pandora::MCParticle *, CaloHitList> McParticleCaloHitListMap;
 
-    std::map<const pandora::MCParticle *, CaloHitList*> McParticleCaloHitListMap;
-
-    for (const CaloHit *const pCaloHit : *initialCaloHitList)
+    for (const CaloHit *const pCaloHit : inputCaloHitList.get())
     {
         const CaloHit *const pParentCaloHit = static_cast<const CaloHit *>(pCaloHit->GetParentAddress());
 
@@ -43,20 +39,20 @@ bool CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std
 
         if (it != McParticleCaloHitListMap.end()) 
         {
-            it->second->push_back(pCaloHit);
+            it->second.push_back(pCaloHit);
         }
         else
         {
-            CaloHitList* newList = new CaloHitList();
-            newList->push_back(pCaloHit);
+            CaloHitList newList;
+            newList.push_back(pCaloHit);
             McParticleCaloHitListMap.insert(std::make_pair(pMainMCParticle, newList));
         } 
 
     }
-    for (const auto& pair : McParticleCaloHitListMap)
-        newCaloHitListsVector.push_back(pair.second);
+    for (auto& pair : McParticleCaloHitListMap)
+        newCaloHitListsVector.push_back(std::ref(pair.second));
 
-    return true;
+    return newCaloHitListsVector;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
@@ -21,13 +21,11 @@ CheatedThreeDClusteringTool::CheatedThreeDClusteringTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-std::vector<std::reference_wrapper<CaloHitList>> CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::reference_wrapper<CaloHitList> &inputCaloHitList)
+bool CheatedThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector)
 {
-    std::vector<std::reference_wrapper<CaloHitList>> newCaloHitListsVector;
-
     LArMCParticleHelper::MCContributionMap mcParticleCaloHitListMap;
 
-    for (const CaloHit *const pCaloHit : inputCaloHitList.get())
+    for (const CaloHit *const pCaloHit : inputCaloHitList)
     {
         const CaloHit *const pParentCaloHit = static_cast<const CaloHit *>(pCaloHit->GetParentAddress());
 
@@ -48,9 +46,9 @@ std::vector<std::reference_wrapper<CaloHitList>> CheatedThreeDClusteringTool::Ru
 
     }
     for (auto& pair : mcParticleCaloHitListMap)
-        newCaloHitListsVector.push_back(std::ref(pair.second));
+        outputCaloHitListsVector.push_back(std::ref(pair.second));
 
-    return newCaloHitListsVector;
+    return true;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
@@ -1,0 +1,48 @@
+/**
+ *  @file   larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
+ *
+ *  @brief  Header file for cheated clustering tool class.
+ *
+ *  $Log: $
+ */
+
+#ifndef LAR_CHEATED_THREE_D_CLUSTERING_TOOL_H
+#define LAR_CHEATED_THREE_D_CLUSTERING_TOOL_H 1
+
+#include "Pandora/Algorithm.h"
+#include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
+
+namespace lar_content
+{
+
+class ClusteringTool;
+
+class CheatedThreeDClusteringTool : public ClusteringTool
+{
+public:
+
+    CheatedThreeDClusteringTool();
+
+private:
+
+    bool Run(const pandora::Algorithm *const pAlgorithm, std::vector<pandora::CaloHitList*> &newCaloHitListsVector) override;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief Get the MC index for the true particle that contributes most energy to the calo hit 
+     *
+     *  @param pAlgorithm the algorithm calling the tool 
+     *  @param pCaloHit address of the calo hit
+     *
+     *  @return MCParticle Index
+     */
+
+    int GetMainMcParticleIndex(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHit *const pCaloHit);
+
+    std::string m_mcParticleListName; ///< The mc particle list name 
+};
+
+} // namespace lar_content
+
+#endif // #endif LAR_CHEATED_THREE_D_CLUSTERING_TOOL_H

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
@@ -29,17 +29,6 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    /**
-     *  @brief Get the MC index for the true particle that contributes most energy to the calo hit 
-     *
-     *  @param pAlgorithm the algorithm calling the tool 
-     *  @param pCaloHit address of the calo hit
-     *
-     *  @return MCParticle Index
-     */
-
-    int GetMainMcParticleIndex(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHit *const pCaloHit);
-
     std::string m_mcParticleListName; ///< The mc particle list name 
 };
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
@@ -27,9 +27,7 @@ private:
 
     bool Run(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
 
-    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
-
-    std::string m_mcParticleListName; ///< The mc particle list name 
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/);
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
@@ -25,7 +25,7 @@ public:
 
 private:
 
-    std::vector<std::reference_wrapper<pandora::CaloHitList>> Run(const pandora::Algorithm *const pAlgorithm, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList);
+    bool Run(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
@@ -25,7 +25,7 @@ public:
 
 private:
 
-    bool Run(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
+    bool Run(const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/);
 };

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
@@ -25,7 +25,7 @@ public:
 
 private:
 
-    bool Run(const pandora::Algorithm *const pAlgorithm, std::vector<pandora::CaloHitList*> &newCaloHitListsVector) override;
+    std::vector<std::reference_wrapper<pandora::CaloHitList>> Run(const pandora::Algorithm *const pAlgorithm, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 

--- a/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h
@@ -20,11 +20,9 @@ class ClusteringTool;
 class CheatedThreeDClusteringTool : public ClusteringTool
 {
 public:
-
     CheatedThreeDClusteringTool();
 
 private:
-
     bool Run(const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/);

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -23,26 +23,22 @@ SimplePCAThreeDClusteringTool::SimplePCAThreeDClusteringTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::vector<pandora::CaloHitList*> &newCaloHitListsVector)
+std::vector<std::reference_wrapper<pandora::CaloHitList>> SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList)
 {
-    if (newCaloHitListsVector.size() != 1)
-        return false;
-
-    CaloHitList *pInitialCaloHitList = newCaloHitListsVector.at(0);
-    newCaloHitListsVector.clear();
+    std::vector<std::reference_wrapper<pandora::CaloHitList>> newCaloHitListsVector;
 
     // Begin with a PCA
     CartesianVector centroid(0.f, 0.f, 0.f);
     LArPcaHelper::EigenVectors eigenVecs;
     LArPcaHelper::EigenValues eigenValues(0.f, 0.f, 0.f);
-    LArPcaHelper::RunPca(*pInitialCaloHitList, centroid, eigenValues, eigenVecs);
+    LArPcaHelper::RunPca(inputCaloHitList.get(), centroid, eigenValues, eigenVecs);
 
     // By convention, the primary axis has a positive z-component.
     const CartesianVector axisDirection(eigenVecs.at(0).GetZ() > 0.f ? eigenVecs.at(0) : eigenVecs.at(0) * -1.f);
 
     // Place intercept at hit with minimum projection
     float minProjection(std::numeric_limits<float>::max());
-    for (const CaloHit *const pCaloHit3D : *pInitialCaloHitList)
+    for (const CaloHit *const pCaloHit3D : inputCaloHitList.get())
         minProjection = std::min(minProjection, axisDirection.GetDotProduct(pCaloHit3D->GetPositionVector() - centroid));
 
     const CartesianVector axisIntercept(centroid + (axisDirection * minProjection));
@@ -53,20 +49,19 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, s
     const CartesianVector orthoDirection1(seedDirection.GetCrossProduct(axisDirection).GetUnitVector());
 
     //Lists for hits that have a positive and negative projection on the secondary axis
-    CaloHitList *posCaloHitList = new CaloHitList;
-    CaloHitList *negCaloHitList = new CaloHitList;
+    CaloHitList posCaloHitList, negCaloHitList;
 
-    for (const CaloHit *const pCaloHit : *pInitialCaloHitList)
+    for (const CaloHit *const pCaloHit : inputCaloHitList.get())
     {
         const CartesianVector pCaloHitPosition = pCaloHit->GetPositionVector();
 
         if((pCaloHitPosition-centroid).GetDotProduct(centroid+orthoDirection1)<0)
         {
-            negCaloHitList->push_back(pCaloHit);
+            negCaloHitList.push_back(pCaloHit);
         }
 		else
 		{ 
-            posCaloHitList->push_back(pCaloHit);
+            posCaloHitList.push_back(pCaloHit);
 		}
     }
 
@@ -79,7 +74,7 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, s
     CartesianVector centroidPos(0.f, 0.f, 0.f);
     LArPcaHelper::EigenVectors eigenVecsPos;
     LArPcaHelper::EigenValues eigenValuesPos(0.f, 0.f, 0.f);
-    LArPcaHelper::RunPca(*posCaloHitList, centroidPos, eigenValuesPos, eigenVecsPos);
+    LArPcaHelper::RunPca(posCaloHitList, centroidPos, eigenValuesPos, eigenVecsPos);
 
     // By convention, the primary axis has a positive z-component.
     const CartesianVector axisDirectionPos(eigenVecsPos.at(0).GetZ() > 0.f ? eigenVecsPos.at(0) : eigenVecsPos.at(0) * -1.f);
@@ -88,7 +83,7 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, s
     CartesianVector centroidNeg(0.f, 0.f, 0.f);
     LArPcaHelper::EigenVectors eigenVecsNeg;
     LArPcaHelper::EigenValues eigenValuesNeg(0.f, 0.f, 0.f);
-    LArPcaHelper::RunPca(*negCaloHitList, centroidNeg, eigenValuesNeg, eigenVecsNeg);
+    LArPcaHelper::RunPca(negCaloHitList, centroidNeg, eigenValuesNeg, eigenVecsNeg);
 
     // By convention, the primary axis has a positive z-component.
     const CartesianVector axisDirectionNeg(eigenVecsNeg.at(0).GetZ() > 0.f ? eigenVecsNeg.at(0) : eigenVecsNeg.at(0) * -1.f);
@@ -99,20 +94,20 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, s
     LArPointingClusterHelper::GetIntersection(centroidPos,axisDirectionPos,centroidNeg,axisDirectionNeg,intersectionPoint,displacementPos,displacementNeg);
 
     //Clear pos and neg lists
-    posCaloHitList->clear();
-    negCaloHitList->clear();
+    posCaloHitList.clear();
+    negCaloHitList.clear();
 
     //Loop over original hit list, check whether it is within smaller cone of pos or neg axis, attach to relevant list
-    for (const CaloHit *const pCaloHit3D : *pInitialCaloHitList)
+    for (const CaloHit *const pCaloHit3D : inputCaloHitList.get())
     {
         const float cosConeAxisPos = axisDirectionPos.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
         const float cosConeAxisNeg = axisDirectionNeg.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
         if(cosConeAxisPos>cosConeAxisNeg)
-            posCaloHitList->push_back(pCaloHit3D);
-        else negCaloHitList->push_back(pCaloHit3D);
+            posCaloHitList.push_back(pCaloHit3D);
+        else negCaloHitList.push_back(pCaloHit3D);
     }
 
-    return true;
+    return newCaloHitListsVector;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -9,8 +9,8 @@
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "larpandoracontent/LArHelpers/LArPcaHelper.h"
-#include "larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h"
 #include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
+#include "larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h"
 
 using namespace pandora;
 

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -25,7 +25,7 @@ SimplePCAThreeDClusteringTool::SimplePCAThreeDClusteringTool()
 
 bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::vector<pandora::CaloHitList*> &newCaloHitListsVector)
 {
-    if (newCaloHitListsVector.empty() || newCaloHitListsVector.size() != 1)
+    if (newCaloHitListsVector.size() != 1)
         return false;
 
     CaloHitList *pInitialCaloHitList = newCaloHitListsVector.at(0);
@@ -61,7 +61,7 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, s
         const CartesianVector pCaloHitPosition = pCaloHit->GetPositionVector();
 
         if((pCaloHitPosition-centroid).GetDotProduct(centroid+orthoDirection1)<0)
-		{
+        {
             negCaloHitList->push_back(pCaloHit);
         }
 		else
@@ -103,12 +103,12 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, s
     negCaloHitList->clear();
 
     //Loop over original hit list, check whether it is within smaller cone of pos or neg axis, attach to relevant list
-    float cosConeAxisPos(0), cosConeAxisNeg(0);
     for (const CaloHit *const pCaloHit3D : *pInitialCaloHitList)
     {
-        cosConeAxisPos = axisDirectionPos.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
-        cosConeAxisNeg = axisDirectionNeg.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
-        if(cosConeAxisPos>cosConeAxisNeg) posCaloHitList->push_back(pCaloHit3D);
+        const float cosConeAxisPos = axisDirectionPos.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
+        const float cosConeAxisNeg = axisDirectionNeg.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
+        if(cosConeAxisPos>cosConeAxisNeg)
+            posCaloHitList->push_back(pCaloHit3D);
         else negCaloHitList->push_back(pCaloHit3D);
     }
 

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -34,17 +34,8 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, c
     // By convention, the primary axis has a positive z-component.
     const CartesianVector axisDirection(eigenVecs.at(0).GetZ() > 0.f ? eigenVecs.at(0) : eigenVecs.at(0) * -1.f);
 
-    // Place intercept at hit with minimum projection
-    float minProjection(std::numeric_limits<float>::max());
-    for (const CaloHit *const pCaloHit3D : inputCaloHitList)
-        minProjection = std::min(minProjection, axisDirection.GetDotProduct(pCaloHit3D->GetPositionVector() - centroid));
-
-    const CartesianVector axisIntercept(centroid + (axisDirection * minProjection));
-
     // Now define ortho directions
-    const CartesianVector seedDirection((axisDirection.GetX() < std::min(axisDirection.GetY(), axisDirection.GetZ())) ? CartesianVector(1.f, 0.f, 0.f) :
-        (axisDirection.GetY() < std::min(axisDirection.GetX(), axisDirection.GetZ())) ? CartesianVector(0.f, 1.f, 0.f) : CartesianVector(0.f, 0.f, 1.f));
-    const CartesianVector orthoDirection1(seedDirection.GetCrossProduct(axisDirection).GetUnitVector());
+    const CartesianVector orthoDirection1(eigenVecs.at(1).GetZ() > 0.f ? eigenVecs.at(1) : eigenVecs.at(1) * -1.f);
 
     //Lists for hits that have a positive and negative projection on the secondary axis
     CaloHitList posCaloHitList, negCaloHitList;
@@ -53,7 +44,7 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, c
     {
         const CartesianVector pCaloHit3DPosition = pCaloHit3D->GetPositionVector();
 
-        if((pCaloHit3DPosition-centroid).GetDotProduct(centroid+orthoDirection1)<0)
+        if((pCaloHit3DPosition-centroid).GetDotProduct(orthoDirection1)<0)
         {
             negCaloHitList.push_back(pCaloHit3D);
         }

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -42,7 +42,7 @@ bool SimplePCAThreeDClusteringTool::Run(const CaloHitList &inputCaloHitList, std
 
     for (const CaloHit *const pCaloHit3D : inputCaloHitList)
     {
-        const CartesianVector pCaloHit3DPosition = pCaloHit3D->GetPositionVector();
+        const CartesianVector pCaloHit3DPosition{pCaloHit3D->GetPositionVector()};
 
         if((pCaloHit3DPosition-centroid).GetDotProduct(orthoDirection1)<0)
         {

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -44,14 +44,14 @@ bool SimplePCAThreeDClusteringTool::Run(const CaloHitList &inputCaloHitList, std
     {
         const CartesianVector pCaloHit3DPosition{pCaloHit3D->GetPositionVector()};
 
-        if((pCaloHit3DPosition-centroid).GetDotProduct(orthoDirection1)<0)
+        if ((pCaloHit3DPosition - centroid).GetDotProduct(orthoDirection1) < 0)
         {
             negCaloHitList.push_back(pCaloHit3D);
         }
-		else
-		{ 
+        else
+        {
             posCaloHitList.push_back(pCaloHit3D);
-		}
+        }
     }
 
     outputCaloHitListsVector.push_back(posCaloHitList);
@@ -79,11 +79,15 @@ bool SimplePCAThreeDClusteringTool::Run(const CaloHitList &inputCaloHitList, std
 
     //Get intersection point of the two new principal axes
     CartesianVector intersectionPoint(0.f, 0.f, 0.f);
-    float displacementPos(0.f),displacementNeg(0.f);
+    float displacementPos(0.f), displacementNeg(0.f);
 
-    try {
-        LArPointingClusterHelper::GetIntersection(centroidPos,axisDirectionPos,centroidNeg,axisDirectionNeg,intersectionPoint,displacementPos,displacementNeg);
-    } catch (const StatusCodeException &){
+    try
+    {
+        LArPointingClusterHelper::GetIntersection(
+            centroidPos, axisDirectionPos, centroidNeg, axisDirectionNeg, intersectionPoint, displacementPos, displacementNeg);
+    }
+    catch (const StatusCodeException &)
+    {
         std::cout << "Exception caught! Cannot get intersection between positive and negative hit lists primary PCA axes!" << std::endl;
     }
 
@@ -94,11 +98,12 @@ bool SimplePCAThreeDClusteringTool::Run(const CaloHitList &inputCaloHitList, std
     //Loop over original hit list, check whether it is within smaller cone of pos or neg axis, attach to relevant list
     for (const CaloHit *const pCaloHit3D : inputCaloHitList)
     {
-        const float cosConeAxisPos = axisDirectionPos.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
-        const float cosConeAxisNeg = axisDirectionNeg.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
-        if(cosConeAxisPos>cosConeAxisNeg)
+        const float cosConeAxisPos = axisDirectionPos.GetCosOpeningAngle(pCaloHit3D->GetPositionVector() - intersectionPoint);
+        const float cosConeAxisNeg = axisDirectionNeg.GetCosOpeningAngle(pCaloHit3D->GetPositionVector() - intersectionPoint);
+        if (cosConeAxisPos > cosConeAxisNeg)
             posCaloHitList.push_back(pCaloHit3D);
-        else negCaloHitList.push_back(pCaloHit3D);
+        else
+            negCaloHitList.push_back(pCaloHit3D);
     }
 
     return true;

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -80,7 +80,12 @@ bool SimplePCAThreeDClusteringTool::Run(const CaloHitList &inputCaloHitList, std
     //Get intersection point of the two new principal axes
     CartesianVector intersectionPoint(0.f, 0.f, 0.f);
     float displacementPos(0.f),displacementNeg(0.f);
-    LArPointingClusterHelper::GetIntersection(centroidPos,axisDirectionPos,centroidNeg,axisDirectionNeg,intersectionPoint,displacementPos,displacementNeg);
+
+    try {
+        LArPointingClusterHelper::GetIntersection(centroidPos,axisDirectionPos,centroidNeg,axisDirectionNeg,intersectionPoint,displacementPos,displacementNeg);
+    } catch (const StatusCodeException &){
+        std::cout << "Exception caught! Cannot get intersection between positive and negative hit lists primary PCA axes!" << std::endl;
+    }
 
     //Clear pos and neg lists
     posCaloHitList.clear();

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -1,0 +1,125 @@
+/**
+ *  @file   larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+ *
+ *  @brief  Implementation file for the simple PCA-based clustering tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
+#include "larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h"
+#include "larpandoracontent/LArHelpers/LArPointingClusterHelper.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+SimplePCAThreeDClusteringTool::SimplePCAThreeDClusteringTool()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, std::vector<pandora::CaloHitList*> &newCaloHitListsVector)
+{
+    if (newCaloHitListsVector.empty() || newCaloHitListsVector.size() != 1)
+        return false;
+
+    CaloHitList *pInitialCaloHitList = newCaloHitListsVector.at(0);
+    newCaloHitListsVector.clear();
+
+    // Begin with a PCA
+    CartesianVector centroid(0.f, 0.f, 0.f);
+    LArPcaHelper::EigenVectors eigenVecs;
+    LArPcaHelper::EigenValues eigenValues(0.f, 0.f, 0.f);
+    LArPcaHelper::RunPca(*pInitialCaloHitList, centroid, eigenValues, eigenVecs);
+
+    // By convention, the primary axis has a positive z-component.
+    const CartesianVector axisDirection(eigenVecs.at(0).GetZ() > 0.f ? eigenVecs.at(0) : eigenVecs.at(0) * -1.f);
+
+    // Place intercept at hit with minimum projection
+    float minProjection(std::numeric_limits<float>::max());
+    for (const CaloHit *const pCaloHit3D : *pInitialCaloHitList)
+        minProjection = std::min(minProjection, axisDirection.GetDotProduct(pCaloHit3D->GetPositionVector() - centroid));
+
+    const CartesianVector axisIntercept(centroid + (axisDirection * minProjection));
+
+    // Now define ortho directions
+    const CartesianVector seedDirection((axisDirection.GetX() < std::min(axisDirection.GetY(), axisDirection.GetZ())) ? CartesianVector(1.f, 0.f, 0.f) :
+        (axisDirection.GetY() < std::min(axisDirection.GetX(), axisDirection.GetZ())) ? CartesianVector(0.f, 1.f, 0.f) : CartesianVector(0.f, 0.f, 1.f));
+    const CartesianVector orthoDirection1(seedDirection.GetCrossProduct(axisDirection).GetUnitVector());
+
+    //Lists for hits that have a positive and negative projection on the secondary axis
+    CaloHitList *posCaloHitList = new CaloHitList;
+    CaloHitList *negCaloHitList = new CaloHitList;
+
+    for (const CaloHit *const pCaloHit : *pInitialCaloHitList)
+    {
+        const CartesianVector pCaloHitPosition = pCaloHit->GetPositionVector();
+
+        if((pCaloHitPosition-centroid).GetDotProduct(centroid+orthoDirection1)<0)
+		{
+            negCaloHitList->push_back(pCaloHit);
+        }
+		else
+		{ 
+            posCaloHitList->push_back(pCaloHit);
+		}
+    }
+
+    newCaloHitListsVector.push_back(posCaloHitList);
+    newCaloHitListsVector.push_back(negCaloHitList);
+
+    //Now, run PCA independently on pos and neg hit lists, to refine split
+
+    //Get pos list PCA
+    CartesianVector centroidPos(0.f, 0.f, 0.f);
+    LArPcaHelper::EigenVectors eigenVecsPos;
+    LArPcaHelper::EigenValues eigenValuesPos(0.f, 0.f, 0.f);
+    LArPcaHelper::RunPca(*posCaloHitList, centroidPos, eigenValuesPos, eigenVecsPos);
+
+    // By convention, the primary axis has a positive z-component.
+    const CartesianVector axisDirectionPos(eigenVecsPos.at(0).GetZ() > 0.f ? eigenVecsPos.at(0) : eigenVecsPos.at(0) * -1.f);
+
+    //Get neg list PCA
+    CartesianVector centroidNeg(0.f, 0.f, 0.f);
+    LArPcaHelper::EigenVectors eigenVecsNeg;
+    LArPcaHelper::EigenValues eigenValuesNeg(0.f, 0.f, 0.f);
+    LArPcaHelper::RunPca(*negCaloHitList, centroidNeg, eigenValuesNeg, eigenVecsNeg);
+
+    // By convention, the primary axis has a positive z-component.
+    const CartesianVector axisDirectionNeg(eigenVecsNeg.at(0).GetZ() > 0.f ? eigenVecsNeg.at(0) : eigenVecsNeg.at(0) * -1.f);
+
+    //Get intersection point of the two new principal axes
+    CartesianVector intersectionPoint(0.f, 0.f, 0.f);
+    float displacementPos(0.f),displacementNeg(0.f);
+    LArPointingClusterHelper::GetIntersection(centroidPos,axisDirectionPos,centroidNeg,axisDirectionNeg,intersectionPoint,displacementPos,displacementNeg);
+
+    //Clear pos and neg lists
+    posCaloHitList->clear();
+    negCaloHitList->clear();
+
+    //Loop over original hit list, check whether it is within smaller cone of pos or neg axis, attach to relevant list
+    float cosConeAxisPos(0), cosConeAxisNeg(0);
+    for (const CaloHit *const pCaloHit3D : *pInitialCaloHitList)
+    {
+        cosConeAxisPos = axisDirectionPos.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
+        cosConeAxisNeg = axisDirectionNeg.GetCosOpeningAngle(pCaloHit3D->GetPositionVector()-intersectionPoint);
+        if(cosConeAxisPos>cosConeAxisNeg) posCaloHitList->push_back(pCaloHit3D);
+        else negCaloHitList->push_back(pCaloHit3D);
+    }
+
+    return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode SimplePCAThreeDClusteringTool::ReadSettings(const TiXmlHandle /*xmlHandle*/)
+{
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -49,17 +49,17 @@ bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, c
     //Lists for hits that have a positive and negative projection on the secondary axis
     CaloHitList posCaloHitList, negCaloHitList;
 
-    for (const CaloHit *const pCaloHit : inputCaloHitList)
+    for (const CaloHit *const pCaloHit3D : inputCaloHitList)
     {
-        const CartesianVector pCaloHitPosition = pCaloHit->GetPositionVector();
+        const CartesianVector pCaloHit3DPosition = pCaloHit3D->GetPositionVector();
 
-        if((pCaloHitPosition-centroid).GetDotProduct(centroid+orthoDirection1)<0)
+        if((pCaloHit3DPosition-centroid).GetDotProduct(centroid+orthoDirection1)<0)
         {
-            negCaloHitList.push_back(pCaloHit);
+            negCaloHitList.push_back(pCaloHit3D);
         }
 		else
 		{ 
-            posCaloHitList.push_back(pCaloHit);
+            posCaloHitList.push_back(pCaloHit3D);
 		}
     }
 

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
@@ -23,7 +23,7 @@ SimplePCAThreeDClusteringTool::SimplePCAThreeDClusteringTool()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool SimplePCAThreeDClusteringTool::Run(const Algorithm *const /*pAlgorithm*/, const CaloHitList &inputCaloHitList, std::vector<CaloHitList> &outputCaloHitListsVector)
+bool SimplePCAThreeDClusteringTool::Run(const CaloHitList &inputCaloHitList, std::vector<CaloHitList> &outputCaloHitListsVector)
 {
     // Begin with a PCA
     CartesianVector centroid(0.f, 0.f, 0.f);

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
@@ -23,7 +23,7 @@ public:
 
 private:
 
-    std::vector<std::reference_wrapper<pandora::CaloHitList>> Run(const pandora::Algorithm *const pAlgorithm, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList);
+    bool Run(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/);
 };

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
@@ -23,7 +23,7 @@ public:
 
 private:
 
-    bool Run(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
+    bool Run(const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/);
 };

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
@@ -23,7 +23,7 @@ public:
 
 private:
 
-    bool Run(const pandora::Algorithm *const /*pAlgorithm*/, std::vector<pandora::CaloHitList*> &newCaloHitListsVector) override;
+    std::vector<std::reference_wrapper<pandora::CaloHitList>> Run(const pandora::Algorithm *const pAlgorithm, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/);
 };

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
@@ -18,11 +18,9 @@ namespace lar_content
 class SimplePCAThreeDClusteringTool : public ClusteringTool
 {
 public:
-
     SimplePCAThreeDClusteringTool();
 
 private:
-
     bool Run(const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/);

--- a/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
+++ b/larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
@@ -1,0 +1,33 @@
+/**
+ *  @file   larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h
+ *
+ *  @brief  Header file for the simple PCA-based clustering tool class.
+ *
+ *  $Log: $
+ */
+
+#ifndef LAR_SIMPLE_PCA_THREE_D_CLUSTERING_TOOL_H
+#define LAR_SIMPLE_PCA_THREE_D_CLUSTERING_TOOL_H 1
+
+#include "Pandora/Algorithm.h"
+#include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
+
+namespace lar_content
+{
+
+class SimplePCAThreeDClusteringTool : public ClusteringTool
+{
+public:
+
+    SimplePCAThreeDClusteringTool();
+
+private:
+
+    bool Run(const pandora::Algorithm *const /*pAlgorithm*/, std::vector<pandora::CaloHitList*> &newCaloHitListsVector) override;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle /*xmlHandle*/);
+};
+
+} // namespace lar_content
+
+#endif // #endif LAR_SIMPLE_PCA_THREE_D_CLUSTERING_TOOL_H

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -23,7 +23,6 @@ namespace lar_content
 
 ThreeDReclusteringAlgorithm::ThreeDReclusteringAlgorithm():
     m_pfoListName("ShowerParticles3D"),
-    m_hitThresholdForNewPfo(0),
     m_fomThresholdForReclustering(0.3)
 {
 }
@@ -423,7 +422,6 @@ StatusCode ThreeDReclusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "FigureOfMeritNames", m_figureOfMeritNames));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "HitThresholdForNewPfo", m_hitThresholdForNewPfo));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "FOMThresholdForReclustering", m_fomThresholdForReclustering));
 
     AlgorithmToolVector algorithmToolVector;

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -89,15 +89,13 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Cluster>(*this, "ShowerClusters3D"));
 
 		//Split the calo hit list into a new set of calo hit lists, taking the best outcome out of different algorithms
-        std::vector<std::reference_wrapper<CaloHitList>> newCaloHitListsVector, minimumFigureOfMeritCaloHitListsVector;
+        std::vector<CaloHitList> newCaloHitListsVector, minimumFigureOfMeritCaloHitListsVector;
         minimumFigureOfMeritCaloHitListsVector.push_back(initialCaloHitList);
-
-        std::reference_wrapper<CaloHitList> initialCaloHitListWrapper(initialCaloHitList);
 
         for (auto toolIter = m_algorithmToolVector.begin(); toolIter != m_algorithmToolVector.end(); ++toolIter)
         {
             try {
-                newCaloHitListsVector = (*toolIter)->Run(this, initialCaloHitListWrapper);
+                (*toolIter)->Run(this, initialCaloHitList, newCaloHitListsVector);
             } catch (const StatusCodeException &){
                 std::cout << "Exception caught! Cannot run reclustering tool!" << std::endl;
             }
@@ -109,13 +107,13 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
             if(newFigureOfMerit <= minimumFigureOfMerit)
             {
                  minimumFigureOfMerit = newFigureOfMerit;
-                 PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyListVector(newCaloHitListsVector,minimumFigureOfMeritCaloHitListsVector));
+                 minimumFigureOfMeritCaloHitListsVector=newCaloHitListsVector;
             }
             newCaloHitListsVector.clear();
         }
         
         //If the new best calo hit lists outcome is equivalent to original, move pfo to unchanged pfo list. Else, create new vector of 3D clusters
-        if((minimumFigureOfMeritCaloHitListsVector.size()==1) && (minimumFigureOfMeritCaloHitListsVector.at(0).get()==initialCaloHitList))
+        if((minimumFigureOfMeritCaloHitListsVector.size()==1) && (minimumFigureOfMeritCaloHitListsVector.at(0)==initialCaloHitList))
         {
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToPfo(*this, pShowerPfo, clusterList3D.front()));
             unchangedPfoList.push_back(pShowerPfo);
@@ -133,7 +131,7 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
         {
             const Cluster *pCluster = nullptr;
             PandoraContentApi::Cluster::Parameters parameters;
-            parameters.m_caloHitList = list.get();
+            parameters.m_caloHitList = list;
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, parameters, pCluster));
             newClustersList.push_back(pCluster);
         }
@@ -382,7 +380,7 @@ float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::string &figureOfM
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<std::reference_wrapper<CaloHitList>> &newClustersCaloHitLists3D)
+float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<CaloHitList> &newClustersCaloHitLists3D)
 {
       std::vector<float> newClustersFigureOfMeritVector;
       for(auto clusterCaloHitLists3D: newClustersCaloHitLists3D)
@@ -395,7 +393,7 @@ float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::string &figureOfM
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::vector<std::reference_wrapper<CaloHitList>> &newClustersCaloHitLists3D)
+float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::vector<CaloHitList> &newClustersCaloHitLists3D)
 {
     std::vector<float> figureOfMeritVector;
     for (StringVector::const_iterator iter = m_figureOfMeritNames.begin(), iterEnd = m_figureOfMeritNames.end(); iter != iterEnd; ++iter)
@@ -419,22 +417,6 @@ float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const CaloHitList &mergedClu
     const float figureOfMerit=*(std::min_element(figureOfMeritVector.begin(), figureOfMeritVector.end()));
     return figureOfMerit;
 }
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-StatusCode ThreeDReclusteringAlgorithm::CopyListVector(std::vector<std::reference_wrapper<CaloHitList>> listVectorSource, std::vector<std::reference_wrapper<CaloHitList>> listVectorDestination)
-{
-    listVectorDestination.clear();
-
-    for (size_t i = 0; i < listVectorSource.size(); ++i)
-    {
-        listVectorDestination.push_back(listVectorSource[i].get());
-    }
-
-    return STATUS_CODE_SUCCESS;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode ThreeDReclusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -1,0 +1,470 @@
+/**
+ *  @file   larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+ *
+ *  @brief  Implementation file for the reclustering algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+#include "Managers/ClusterManager.h"
+
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+
+#include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+ThreeDReclusteringAlgorithm::ThreeDReclusteringAlgorithm():
+    m_hitThresholdForNewPfo(0),
+    m_fomThresholdForReclustering(0.3)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+ThreeDReclusteringAlgorithm::~ThreeDReclusteringAlgorithm()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ThreeDReclusteringAlgorithm::Run()
+{
+    //Only proceed if successfuly get shower pfo list, and it has at least one pfo
+    const PfoList *pShowerPfoList(nullptr);
+    if ((STATUS_CODE_SUCCESS == PandoraContentApi::GetList(*this, "ShowerParticles3D", pShowerPfoList)) && pShowerPfoList->size())
+    {
+        m_newPfosListNameAllAfterReclustering = "newShowerParticles3D";
+        std::string newPfosListNameUnchanged = "unchangedShowerParticles3D";
+        PfoList unchangedPfoList;   
+
+        //Save current pfo list name, so that this can be set as current again at the end of reclustering
+        std::string initialPfosListName;
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentListName<Pfo>(*this, initialPfosListName));
+
+        //Some pfos are shower-like and yet include track-like 3D clusters. For the moment I don't want to deal with these.
+        const ClusterList *pShowerClusters(nullptr);
+        PandoraContentApi::GetList(*this, "ShowerClusters3D", pShowerClusters);
+        if(!pShowerClusters) return STATUS_CODE_NOT_FOUND;
+
+        for (const Pfo *const pShowerPfo : *pShowerPfoList)
+        {
+            ClusterList clusterList3D;
+            LArPfoHelper::GetThreeDClusterList(pShowerPfo, clusterList3D);
+           
+            if(!this->PassesCutsForReclustering(pShowerPfo))
+            {
+                unchangedPfoList.push_back(pShowerPfo);
+                continue;
+            }
+            if (clusterList3D.empty())
+                continue;
+
+            //Some pfos are shower-like and yet include track-like 3D clusters. For the moment I don't want to deal with these.
+            if(pShowerClusters->end() == std::find(pShowerClusters->begin(), pShowerClusters->end(), clusterList3D.front())) continue;
+
+            CaloHitList caloHitList3D;
+            clusterList3D.front()->GetOrderedCaloHitList().FillCaloHitList(caloHitList3D);
+
+			//Calculate initial figure of merit 
+            float initialFigureOfMerit=this->GetFigureOfMerit(caloHitList3D);
+			
+			//Create a variable for the minimum figure of merit and initialize to initial FOM
+            float minimumFigureOfMerit(initialFigureOfMerit);
+
+            //Free the hits in this cluster, so that they are not owned by the original pfo, and are available for reclustering
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RemoveFromPfo(*this, pShowerPfo, clusterList3D.front()));
+
+            // Initialize reclustering with these local lists
+            std::string currentClustersListName;
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentListName<Cluster>(*this, currentClustersListName));
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Cluster>(*this, "ShowerClusters3D"));
+
+			//I want to split the calo hit list into a new set of calo hit lists, taking the best outcome out of different algorithms
+            std::vector<CaloHitList*> newCaloHitListsVector, minimumFigureOfMeritCaloHitListsVector, initialCaloHitListsVector;
+            initialCaloHitListsVector.emplace_back(&caloHitList3D);
+            minimumFigureOfMeritCaloHitListsVector = initialCaloHitListsVector;
+
+            for (auto toolIter = m_algorithmToolVector.begin(); toolIter != m_algorithmToolVector.end(); ++toolIter)
+            {
+                newCaloHitListsVector = initialCaloHitListsVector;
+
+                try {
+                    (*toolIter)->Run(this, newCaloHitListsVector);
+                } catch (const StatusCodeException &){
+                    std::cout << "Exception caught! Cannot run reclustering tool!" << std::endl;
+                }
+
+                //Calculate FOM for this vector of new CaloHitLists
+				float newFigureOfMerit = this->GetFigureOfMerit(newCaloHitListsVector);
+
+                //Is this FOM smaller?
+                if(newFigureOfMerit <= minimumFigureOfMerit)
+                {
+                     minimumFigureOfMerit = newFigureOfMerit;
+                     minimumFigureOfMeritCaloHitListsVector = newCaloHitListsVector;
+                }
+                else //If not, clear the lists and vector!!
+                {
+                    for (CaloHitList* caloHitList : newCaloHitListsVector) delete caloHitList;
+                }
+                newCaloHitListsVector.clear();
+            }
+            
+            //If the new best calo hit lists outcome is equivalent to original, move pfo to unchanged pfo list. Else, create new vector of 3D clusters
+            if(minimumFigureOfMeritCaloHitListsVector==newCaloHitListsVector)
+            {
+                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToPfo(*this, pShowerPfo, clusterList3D.front()));
+                unchangedPfoList.push_back(pShowerPfo);
+            }
+            else
+            {
+                const ClusterList reclusterClusterList(1, clusterList3D.front());
+                std::string clusterListToSaveName, clusterListToDeleteName;
+ 
+                PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
+                PandoraContentApi::InitializeFragmentation(*this, reclusterClusterList, clusterListToDeleteName, clusterListToSaveName));
+
+                ClusterList newClustersList;
+                for(auto list: minimumFigureOfMeritCaloHitListsVector)
+                {
+                    const Cluster *pCluster = nullptr;
+                    PandoraContentApi::Cluster::Parameters parameters;
+                    parameters.m_caloHitList = *list;
+                    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, parameters, pCluster));
+                    newClustersList.push_back(pCluster);
+                }
+
+                PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::EndFragmentation(*this, clusterListToSaveName, clusterListToDeleteName));
+                PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RebuildPfo(pShowerPfo, newClustersList));
+                newCaloHitListsVector.clear();
+            }
+        }
+        //If there are any pfos that did not change after reclustering procedure, move them from list called ShowerParticles3D into list of new pfos after reclustering
+        if(unchangedPfoList.size()>0) PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<PfoList>(*this, "ShowerParticles3D", m_newPfosListNameAllAfterReclustering,  unchangedPfoList));
+
+        //Save list of Pfos after reclustering into list called ShowerParticles3D
+        const PfoList *pNewPfosListAllAfterReclustering;
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList<PfoList>(*this, m_newPfosListNameAllAfterReclustering, pNewPfosListAllAfterReclustering));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, m_newPfosListNameAllAfterReclustering, "ShowerParticles3D"));
+
+        //Set current list to be the same as before reclustering
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Pfo>(*this, initialPfosListName));
+    }
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ThreeDReclusteringAlgorithm::BuildNewTwoDClusters(const Pfo *pPfoToRebuild, ClusterList &newClustersList)
+{
+    ClusterList clusterList2D;
+    LArPfoHelper::GetTwoDClusterList(pPfoToRebuild, clusterList2D);
+
+    for(const Cluster *const pTwoDCluster : clusterList2D)
+    {
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::RemoveFromPfo(*this, pPfoToRebuild, pTwoDCluster));
+        HitType hitType = LArClusterHelper::GetClusterHitType(pTwoDCluster);
+        std::string clusterListName(hitType == TPC_VIEW_U ? "ClustersU" : hitType == TPC_VIEW_V ? "ClustersV" : "ClustersW");
+
+        std::string initialListName="";
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentListName<Cluster>(*this, initialListName));
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Cluster>(*this, clusterListName));
+
+        std::string originalListName, fragmentListName;
+        ClusterList originalClusterList;
+        originalClusterList.push_back(pTwoDCluster);
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::InitializeFragmentation(*this, originalClusterList, originalListName, fragmentListName));
+    
+        const OrderedCaloHitList &twoDClusterOrderedCaloHitList(pTwoDCluster->GetOrderedCaloHitList());
+        OrderedCaloHitList leftoverCaloHitList = twoDClusterOrderedCaloHitList;
+    
+        int iCluster(0);
+        for(const Cluster *pNewCluster : newClustersList)
+        {
+     		if (!pNewCluster)
+    		{
+         		  std::cout << "Error: found null pointer in list of new clusters!" << std::endl;
+       			  continue;
+    		}
+            PandoraContentApi::Cluster::Parameters parameters;
+            CaloHitList newClusterCaloHitList3D;
+            pNewCluster->GetOrderedCaloHitList().FillCaloHitList(newClusterCaloHitList3D); 
+    
+            for(const CaloHit *const p3DCaloHit : newClusterCaloHitList3D)
+            {
+                for (const OrderedCaloHitList::value_type &mapEntry : twoDClusterOrderedCaloHitList)
+                {
+                    for (const CaloHit *const pCaloHit : *mapEntry.second)
+                    {
+                        if(pCaloHit==static_cast<const CaloHit *>(p3DCaloHit->GetParentAddress())) 
+                        {
+                          parameters.m_caloHitList.push_back(static_cast<const CaloHit *>(pCaloHit));
+                          leftoverCaloHitList.Remove(pCaloHit);
+                        }
+                    }
+                }
+            }
+            const Cluster *pNewTwoDCluster(nullptr);
+            if (!parameters.m_caloHitList.empty())
+            {
+                PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, parameters, pNewTwoDCluster));
+            }
+            if(pNewTwoDCluster!=nullptr && !parameters.m_caloHitList.empty() && hitType==TPC_VIEW_U) {m_newClustersUMap.insert(std::make_pair(iCluster,pNewTwoDCluster));}
+            else if(pNewTwoDCluster!=nullptr && !parameters.m_caloHitList.empty() && hitType==TPC_VIEW_V) {m_newClustersVMap.insert(std::make_pair(iCluster,pNewTwoDCluster));}
+            else if(pNewTwoDCluster!=nullptr && !parameters.m_caloHitList.empty() && hitType==TPC_VIEW_W) {m_newClustersWMap.insert(std::make_pair(iCluster,pNewTwoDCluster));}
+            
+            iCluster++;
+        }
+
+        //Check the leftover caloHits. Attach to the nearest cluster in the new cluster list.
+        std::map<int,const Cluster*> clustersForLeftoverHitsMap;
+        if(hitType==TPC_VIEW_U) clustersForLeftoverHitsMap = m_newClustersUMap;
+        else if(hitType==TPC_VIEW_V) clustersForLeftoverHitsMap = m_newClustersVMap;
+        else if(hitType==TPC_VIEW_W) clustersForLeftoverHitsMap = m_newClustersWMap;
+        if(clustersForLeftoverHitsMap.size())
+        {
+        for(const OrderedCaloHitList::value_type &mapEntry : leftoverCaloHitList)
+            {
+                for (const CaloHit *const pCaloHit : *mapEntry.second)
+                {
+                    const Cluster* pNearestCluster = nullptr;
+                    double minimumDistance(std::numeric_limits<float>::max());
+                    for(const auto & [clusterIndex, pNewTwoDCluster] : clustersForLeftoverHitsMap)
+                    {
+                        double dist = LArClusterHelper::GetClosestDistance(pCaloHit->GetPositionVector(), pNewTwoDCluster);  
+                        if (dist<minimumDistance)
+                        {
+                            minimumDistance=dist;
+                            pNearestCluster=pNewTwoDCluster;
+                        }
+                    }
+                    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AddToCluster(*this,pNearestCluster,pCaloHit));
+                }
+            }
+        }
+
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::EndFragmentation(*this, fragmentListName, originalListName));
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Cluster>(*this, initialListName));
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ThreeDReclusteringAlgorithm::BuildNewPfos(const Pfo *pPfoToRebuild, ClusterList &newClustersList)
+{
+    const PfoList *pNewPfoList(nullptr);
+    std::string newPfoListName = "changedShowerParticles3D";
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pNewPfoList, newPfoListName));
+         
+    std::string originalClusterListName="InitialCluster";
+    int iCluster(0);
+        
+    for(const Cluster *pNewThreeDCluster : newClustersList)
+    {
+        PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
+        const bool isAvailableU((m_newClustersUMap.count(iCluster)) && m_newClustersUMap.at(iCluster)->IsAvailable());
+        const bool isAvailableV((m_newClustersVMap.count(iCluster)) && m_newClustersVMap.at(iCluster)->IsAvailable());
+        const bool isAvailableW((m_newClustersWMap.count(iCluster)) && m_newClustersWMap.at(iCluster)->IsAvailable());
+        CaloHitList clusterUHits, clusterVHits, clusterWHits;
+        if(isAvailableU)m_newClustersUMap.at(iCluster)->GetOrderedCaloHitList().FillCaloHitList(clusterUHits);
+        if(isAvailableV)m_newClustersVMap.at(iCluster)->GetOrderedCaloHitList().FillCaloHitList(clusterVHits);
+        if(isAvailableW)m_newClustersWMap.at(iCluster)->GetOrderedCaloHitList().FillCaloHitList(clusterWHits);
+        if(isAvailableU) pfoParameters.m_clusterList.push_back(m_newClustersUMap.at(iCluster));
+        if(isAvailableV) pfoParameters.m_clusterList.push_back(m_newClustersVMap.at(iCluster));
+        if(isAvailableW) pfoParameters.m_clusterList.push_back(m_newClustersWMap.at(iCluster));
+
+        pfoParameters.m_clusterList.push_back(pNewThreeDCluster);
+        
+        pfoParameters.m_particleId = pPfoToRebuild->GetParticleId();
+        pfoParameters.m_charge = PdgTable::GetParticleCharge(pfoParameters.m_particleId.Get());
+        pfoParameters.m_mass = PdgTable::GetParticleMass(pfoParameters.m_particleId.Get());
+        pfoParameters.m_energy = 0.f;
+        pfoParameters.m_momentum = CartesianVector(0.f, 0.f, 0.f);
+        
+        const ParticleFlowObject *pNewPfo(nullptr);
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pNewPfo));
+        
+        iCluster++;
+    }
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, newPfoListName, m_newPfosListNameAllAfterReclustering));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ThreeDReclusteringAlgorithm::RebuildPfo(const Pfo *pPfoToRebuild, ClusterList &newClustersList)
+{
+    m_newClustersUMap.clear();
+	m_newClustersVMap.clear();
+	m_newClustersWMap.clear();
+
+    //For each of the new 3D clusters, build a new 2D cluster in each view, and a new Pfo
+	PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->BuildNewTwoDClusters(pPfoToRebuild, newClustersList));
+	PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->BuildNewPfos(pPfoToRebuild, newClustersList));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool ThreeDReclusteringAlgorithm::PassesCutsForReclustering(const pandora::ParticleFlowObject *const pShowerPfo)
+{
+    if (!LArPfoHelper::IsShower(pShowerPfo)) return false;
+    ClusterList clusterList3D;
+    LArPfoHelper::GetThreeDClusterList(pShowerPfo, clusterList3D);
+
+    if (clusterList3D.empty()) return false;
+    CaloHitList caloHitList3D;
+    clusterList3D.front()->GetOrderedCaloHitList().FillCaloHitList(caloHitList3D);
+
+    //Quality cuts
+    if (caloHitList3D.size() < 2) return false;
+
+    //Some pfos are shower-like and yet include track-like 3D clusters. For the moment I don't want to deal with these.
+    const ClusterList *pShowerClusters(nullptr);
+    PandoraContentApi::GetList(*this, "ShowerClusters3D", pShowerClusters);
+    if(!pShowerClusters) return false;
+
+    if(pShowerClusters->end() == std::find(pShowerClusters->begin(), pShowerClusters->end(), clusterList3D.front())) return false;
+    if(this->GetFigureOfMerit(caloHitList3D)<m_fomThresholdForReclustering) return false; 	
+    return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ThreeDReclusteringAlgorithm::GetCheatedFigureOfMerit(CaloHitList mergedClusterCaloHitList3D)
+{
+    std::map<int,int> mainMcParticleMap;
+    for (const CaloHit *const pCaloHit : mergedClusterCaloHitList3D)
+    {
+        const CaloHit *const pParentCaloHit = static_cast<const CaloHit *>(pCaloHit->GetParentAddress());
+        int mainMcParticleIndex = this->GetMainMcParticleIndex(pParentCaloHit);
+        std::map<int, int>::iterator it = mainMcParticleMap.find(mainMcParticleIndex);
+ 
+        if (it != mainMcParticleMap.end()) {
+            it->second++;
+        }
+        else {
+            mainMcParticleMap.insert(std::make_pair(mainMcParticleIndex, 1));
+        }
+    }
+    const MCParticleList *pMCParticleList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_mcParticleListName, pMCParticleList));
+    MCParticleVector mcParticleVector(pMCParticleList->begin(),pMCParticleList->end());
+    std::sort(mcParticleVector.begin(), mcParticleVector.end(), LArMCParticleHelper::SortByMomentum);
+    
+    auto maxSharedHits = std::max_element(mainMcParticleMap.begin(), mainMcParticleMap.end(), [](const auto &x, const auto &y) {return x.second < y.second;});
+    float mainMcParticleFraction = (float)maxSharedHits->second/mergedClusterCaloHitList3D.size();
+    return (1-mainMcParticleFraction);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+int ThreeDReclusteringAlgorithm::GetMainMcParticleIndex(const pandora::CaloHit *const pCaloHit)
+{
+    const MCParticleList *pMCParticleList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_mcParticleListName, pMCParticleList));
+    MCParticleVector mcParticleVector(pMCParticleList->begin(),pMCParticleList->end());
+    std::sort(mcParticleVector.begin(), mcParticleVector.end(), LArMCParticleHelper::SortByMomentum);
+    int iMcPart(0); 
+    for (const auto &weightMapEntry : pCaloHit->GetMCParticleWeightMap()) 
+    { 
+      if(weightMapEntry.second>0.5) 
+      { 
+        iMcPart=0;  
+        for(const MCParticle *const pMCParticle: mcParticleVector) 
+        { 
+            if(pMCParticle==weightMapEntry.first) { break;} 
+            iMcPart++; 
+        }
+      } 
+    }
+    return iMcPart;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ThreeDReclusteringAlgorithm::GetFigureOfMerit(std::string figureOfMeritName, CaloHitList mergedClusterCaloHitList3D)
+{
+    float figureOfMerit(-999);
+    if(figureOfMeritName=="cheated") figureOfMerit=this->GetCheatedFigureOfMerit(mergedClusterCaloHitList3D);
+    return figureOfMerit;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ThreeDReclusteringAlgorithm::GetFigureOfMerit(std::string figureOfMeritName, std::vector<CaloHitList*> newClustersCaloHitLists3D)
+{
+      std::vector<float> newClustersFigureOfMeritVector;
+      for(auto clusterCaloHitLists3D: newClustersCaloHitLists3D)
+      {
+        if(figureOfMeritName=="cheated")newClustersFigureOfMeritVector.push_back(this->GetCheatedFigureOfMerit(*clusterCaloHitLists3D));
+      }
+      float figureOfMerit=*(std::min_element(newClustersFigureOfMeritVector.begin(), newClustersFigureOfMeritVector.end()));
+      return figureOfMerit;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ThreeDReclusteringAlgorithm::GetFigureOfMerit(std::vector<CaloHitList*> newClustersCaloHitLists3D)
+{
+    std::vector<float> figureOfMeritVector;
+    for (StringVector::const_iterator iter = m_figureOfMeritNames.begin(), iterEnd = m_figureOfMeritNames.end(); iter != iterEnd; ++iter)
+    {
+        figureOfMeritVector.push_back(this->GetFigureOfMerit(*iter,newClustersCaloHitLists3D));
+    }
+    
+    float figureOfMerit=*(std::min_element(figureOfMeritVector.begin(), figureOfMeritVector.end()));
+    return figureOfMerit;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ThreeDReclusteringAlgorithm::GetFigureOfMerit(CaloHitList mergedClusterCaloHitList3D)
+{
+    std::vector<float> figureOfMeritVector;
+    for (StringVector::const_iterator iter = m_figureOfMeritNames.begin(), iterEnd = m_figureOfMeritNames.end(); iter != iterEnd; ++iter)
+    {
+        figureOfMeritVector.push_back(this->GetFigureOfMerit(*iter,mergedClusterCaloHitList3D)); 
+    }
+    float figureOfMerit=*(std::min_element(figureOfMeritVector.begin(), figureOfMeritVector.end()));
+    return figureOfMerit;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ThreeDReclusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "FigureOfMeritNames", m_figureOfMeritNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "HitThresholdForNewPfo", m_hitThresholdForNewPfo));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "FOMThresholdForReclustering", m_fomThresholdForReclustering));
+
+    AlgorithmToolVector algorithmToolVector;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "ClusteringTools", algorithmToolVector));
+
+    for (auto algorithmTool : algorithmToolVector)
+    {
+        ClusteringTool *const pClusteringTool(dynamic_cast<ClusteringTool *>(algorithmTool));
+
+        if (!pClusteringTool)
+            return STATUS_CODE_INVALID_PARAMETER;
+
+        m_algorithmToolVector.push_back(pClusteringTool);
+     }
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -9,10 +9,10 @@
 #include "Pandora/AlgorithmHeaders.h"
 #include "Managers/ClusterManager.h"
 
-#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
-#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArHelpers/LArPcaHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h"
 
@@ -421,8 +421,8 @@ StatusCode ThreeDReclusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "FigureOfMeritNames", m_figureOfMeritNames));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "MCParticleListName", m_mcParticleListName));
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "FOMThresholdForReclustering", m_fomThresholdForReclustering));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FOMThresholdForReclustering", m_fomThresholdForReclustering));
 
     AlgorithmToolVector algorithmToolVector;
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "ClusteringTools", algorithmToolVector));

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -95,7 +95,7 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
         for (auto toolIter = m_algorithmToolVector.begin(); toolIter != m_algorithmToolVector.end(); ++toolIter)
         {
             try {
-                (*toolIter)->Run(this, initialCaloHitList, newCaloHitListsVector);
+                (*toolIter)->Run(initialCaloHitList, newCaloHitListsVector);
             } catch (const StatusCodeException &){
                 std::cout << "Exception caught! Cannot run reclustering tool!" << std::endl;
             }

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -21,6 +21,11 @@ using namespace pandora;
 namespace lar_content
 {
 
+//Figure of merit type enum to string map
+const std::unordered_map<std::string, ThreeDReclusteringAlgorithm::FigureOfMeritType> ThreeDReclusteringAlgorithm::m_stringToEnumMap = {
+    {"cheated", ThreeDReclusteringAlgorithm::FigureOfMeritType::CHEATED}
+};
+
 ThreeDReclusteringAlgorithm::ThreeDReclusteringAlgorithm():
     m_pfoListName("ShowerParticles3D"),
     m_clusterListName("ShowerClusters3D"),
@@ -370,7 +375,14 @@ float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::string &figureOfM
 {
     float figureOfMerit(-999.f);
 
-    if(figureOfMeritName=="cheated")
+    FigureOfMeritType figureOfMeritType(FigureOfMeritType::CHEATED);
+    auto stringToEnumIt=m_stringToEnumMap.find(figureOfMeritName);
+    if (stringToEnumIt != m_stringToEnumMap.end())
+    {
+        figureOfMeritType = stringToEnumIt->second;
+    }
+
+    if(figureOfMeritType==FigureOfMeritType::CHEATED)
         figureOfMerit=this->GetCheatedFigureOfMerit(mergedClusterCaloHitList3D);
     else
         throw pandora::StatusCodeException(pandora::STATUS_CODE_INVALID_PARAMETER);
@@ -385,7 +397,7 @@ float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::string &figureOfM
       std::vector<float> newClustersFigureOfMeritVector;
       for(auto clusterCaloHitLists3D: newClustersCaloHitLists3D)
       {
-        if(figureOfMeritName=="cheated")newClustersFigureOfMeritVector.push_back(this->GetFigureOfMerit("cheated",clusterCaloHitLists3D));
+        newClustersFigureOfMeritVector.push_back(this->GetFigureOfMerit(figureOfMeritName,clusterCaloHitLists3D));
       }
       const float figureOfMerit(*std::min_element(newClustersFigureOfMeritVector.begin(), newClustersFigureOfMeritVector.end()));
       return figureOfMerit;
@@ -417,6 +429,8 @@ float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const CaloHitList &mergedClu
     const float figureOfMerit=*(std::min_element(figureOfMeritVector.begin(), figureOfMeritVector.end()));
     return figureOfMerit;
 }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode ThreeDReclusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -104,7 +104,7 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
             }
 
             //Calculate FOM for this vector of new CaloHitLists
-            float newFigureOfMerit = this->GetFigureOfMerit(newCaloHitListsVector);
+            float newFigureOfMerit(this->GetFigureOfMerit(newCaloHitListsVector));
 
             //Is this FOM smaller?
             if(newFigureOfMerit <= minimumFigureOfMerit)
@@ -193,11 +193,11 @@ StatusCode ThreeDReclusteringAlgorithm::BuildNewTwoDClusters(const Pfo *pPfoToRe
         int iCluster(0);
         for(const Cluster *pNewCluster : newClustersList)
         {
-     		if (!pNewCluster)
-    		{
-         		  std::cout << "Error: found null pointer in list of new clusters!" << std::endl;
-       			  continue;
-    		}
+            if (!pNewCluster)
+            {
+                std::cout << "Error: found null pointer in list of new clusters!" << std::endl;
+                continue;
+            }
             PandoraContentApi::Cluster::Parameters parameters;
             CaloHitList newClusterCaloHitList3D;
             pNewCluster->GetOrderedCaloHitList().FillCaloHitList(newClusterCaloHitList3D); 
@@ -239,7 +239,7 @@ StatusCode ThreeDReclusteringAlgorithm::BuildNewTwoDClusters(const Pfo *pPfoToRe
             {
                 for (const CaloHit *const pCaloHit : *mapEntry.second)
                 {
-                    const Cluster* pNearestCluster = nullptr;
+                    const Cluster* pNearestCluster(nullptr);
                     double minimumDistance(std::numeric_limits<float>::max());
                     for(const auto & [clusterIndex, pNewTwoDCluster] : clustersForLeftoverHitsMap)
                     {
@@ -374,7 +374,7 @@ float ThreeDReclusteringAlgorithm::GetCheatedFigureOfMerit(const CaloHitList &me
     
     const auto maxSharedHits = std::max_element(mainMcParticleMap.begin(), mainMcParticleMap.end(), [](const auto &x, const auto &y) {return x.second < y.second;});
     float mainMcParticleFraction = (float)maxSharedHits->second/mergedClusterCaloHitList3D.size();
-    return (1-mainMcParticleFraction);
+    return (1.f-mainMcParticleFraction);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -405,7 +405,7 @@ int ThreeDReclusteringAlgorithm::GetMainMcParticleIndex(const pandora::CaloHit *
 
 float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::string &figureOfMeritName, const CaloHitList &mergedClusterCaloHitList3D)
 {
-    float figureOfMerit(-999);
+    float figureOfMerit(-999.f);
 
     if(figureOfMeritName=="cheated")
         figureOfMerit=this->GetCheatedFigureOfMerit(mergedClusterCaloHitList3D);
@@ -424,7 +424,7 @@ float ThreeDReclusteringAlgorithm::GetFigureOfMerit(const std::string &figureOfM
       {
         if(figureOfMeritName=="cheated")newClustersFigureOfMeritVector.push_back(this->GetCheatedFigureOfMerit(*clusterCaloHitLists3D));
       }
-      const float figureOfMerit=*(std::min_element(newClustersFigureOfMeritVector.begin(), newClustersFigureOfMeritVector.end()));
+      const float figureOfMerit(*std::min_element(newClustersFigureOfMeritVector.begin(), newClustersFigureOfMeritVector.end()));
       return figureOfMerit;
 }
 

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -24,17 +24,26 @@ namespace lar_content
  class ThreeDReclusteringAlgorithm : public pandora::Algorithm
  {
  public:
-     /**
-      *  @brief  Default constructor
-      */
+
+    /**
+    *  @brief  FigureOfMerit type enumeration
+    */
+    enum FigureOfMeritType
+    {
+        CHEATED
+    };
+
+    /**
+     *  @brief  Default constructor
+     */
     ThreeDReclusteringAlgorithm();
 
-   /**
+    /**
     *  @brief  Destructor
     */
     ~ThreeDReclusteringAlgorithm();
 
-private:
+ private:
 
     typedef std::vector<ClusteringTool *> ClusteringToolVector;
 
@@ -111,7 +120,7 @@ private:
      * @return The figure of merit (purity)
      */
     float GetCheatedFigureOfMerit(const pandora::CaloHitList &mergedClusterCaloHitList3D);
-    
+
     /**
      *  @brief Select pfos to be reclustered if it passes reclustering criteria
      *
@@ -135,6 +144,8 @@ private:
     std::string m_vClustersListName;
     std::string m_wClustersListName; //Names of U,V and W cluster lists
     std::map<int,const pandora::Cluster*> m_newClustersUMap, m_newClustersVMap,m_newClustersWMap; ///< Per-view maps associating new 3D clusters with new 2D clusters 
+
+    static const std::unordered_map<std::string, ThreeDReclusteringAlgorithm::FigureOfMeritType> m_stringToEnumMap; //Figure of merit type enum to string map
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -142,9 +153,9 @@ private:
 /**
  *  @brief  ClusteringTool class
  */
-class ClusteringTool: public pandora::AlgorithmTool {
-
-public:
+class ClusteringTool: public pandora::AlgorithmTool
+{
+ public:
     ClusteringTool() = default;
     ~ClusteringTool() = default;
     virtual bool Run(const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector) = 0;

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -56,6 +56,7 @@ private:
      *  @param newClustersList a reference to the new list of clusters obtained via the reclustering process 
      */
     pandora::StatusCode BuildNewTwoDClusters(const pandora::Pfo *pPfoToRebuild, pandora::ClusterList &newClustersList);
+
     /**
      *  @brief Create new Pfos for each  new ThreeD cluster in newClustersList  
      *
@@ -126,11 +127,9 @@ private:
     std::string m_pfoListName; ///< Name of the list of pfos to consider for reclustering
     pandora::StringVector m_figureOfMeritNames; ///< The names of the figures of merit to use
     std::string m_PfosForReclusteringListName; ///< Name of the internal list to contain new Pfos before/after reclustering
-    int m_hitThresholdForNewPfo; ///< Minimum nr. of hits to form new 3Dclusters
     std::string m_mcParticleListName; ///< The mc particle list name 
     float m_fomThresholdForReclustering; ///< A threshold on the minimum figure of merit for reclustering
     std::map<int,const pandora::Cluster*> m_newClustersUMap, m_newClustersVMap,m_newClustersWMap; ///< Per-view maps associating new 3D clusters with new 2D clusters 
-
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -142,7 +141,7 @@ class ClusteringTool: public pandora::AlgorithmTool {
 
 public:
     ClusteringTool() = default;
-    virtual ~ClusteringTool() = default;
+    ~ClusteringTool() = default;
     virtual bool Run(const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector) = 0;
 };
 

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -1,0 +1,161 @@
+/**
+ *  @file   larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+ *
+ *  @brief  Header file for the reclustering algorithm class.
+ *
+ *  $Log: $
+ */
+
+#ifndef LAR_THREE_D_RECLUSTERING_ALGORITHM_H
+#define LAR_THREE_D_RECLUSTERING_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+ class ClusteringTool; 
+ 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+ /**
+  *  @brief  RecursivePfoMopUpAlgorithm class
+  */
+ class ThreeDReclusteringAlgorithm : public pandora::Algorithm
+ {
+ public:
+     /**
+      *  @brief  Default constructor
+      */
+    ThreeDReclusteringAlgorithm();
+
+   /**
+    *  @brief  Destructor
+    */
+    ~ThreeDReclusteringAlgorithm();
+
+private:
+
+    typedef std::vector<ClusteringTool *> ClusteringToolVector;
+
+    pandora::StatusCode Run();
+
+
+    /**
+     *  @brief Create new TwoD clusters and Pfos for each  new ThreeD cluster in newClustersList
+     *
+     *  @param pPfoToRebuild the address of the original pfo to rebuild 
+     *  @param newClustersList a reference to the new list of clusters obtained via the reclustering process 
+     */
+    pandora::StatusCode RebuildPfo(const pandora::Pfo *pPfoToRebuild, pandora::ClusterList &newClustersList);
+
+     /**
+     *  @brief Create new TwoD clusters for each  new ThreeD cluster in newClustersList 
+     *
+     *  @param pPfoToRebuild the address of the original pfo to rebuild 
+     *  @param newClustersList a reference to the new list of clusters obtained via the reclustering process 
+     */
+    pandora::StatusCode BuildNewTwoDClusters(const pandora::Pfo *pPfoToRebuild, pandora::ClusterList &newClustersList);
+    /**
+     *  @brief Create new Pfos for each  new ThreeD cluster in newClustersList  
+     *
+     *  @param pPfoToRebuild the address of the original pfo to rebuild 
+     *  @param newClustersList a reference to the new list of clusters obtained via the reclustering process 
+     */
+    pandora::StatusCode BuildNewPfos(const pandora::Pfo *pPfoToRebuild, pandora::ClusterList &newClustersList);
+
+    /**
+     *  @brief Loop over all specified figure of merit names, calculate figures of merit for the CaloHitList under consideration, and return the smallest FOM
+     *
+     *  @param mergedClusterCaloHitList3D the CaloHitList under consideration 
+     *
+     *  @return The figure of merit
+     */
+    float GetFigureOfMerit(pandora::CaloHitList mergedClusterCaloHitList3D);
+    
+    /**
+     *  @brief Calculate the specified figure of merit for the CaloHitList under consideration, under consideration, and return the smallest FOM
+     *
+     *  @param figureOfMeritName the name of the figure of merit
+     *  @param mergedClusterCaloHitList3D the CaloHitList under consideration 
+     *
+     *  @return The figure of merit
+     */
+    float GetFigureOfMerit(std::string figureOfMeritName, pandora::CaloHitList mergedClusterCaloHitList3D);
+
+    /**
+     *  @brief Loop over all specified figure of merit names, calculate figures of merit for each CaloHitList in the provided vector, under consideration, and return the smallest FOM
+     *
+     *  @param newClustersCaloHitLists3D the vector of CaloHitLists under consideration 
+     *
+     *  @return The figure of merit
+     */
+    float GetFigureOfMerit(std::vector<pandora::CaloHitList*> newClustersCaloHitList3D);
+
+    /**
+     *  @brief Calculate the specified figure of merit for each CaloHitList in the provided vector, under consideration, and return the smallest FOM
+     *
+     *  @param figureOfMeritName the name of the figure of merit
+     *  @param newClustersCaloHitLists3D the vector of CaloHitLists under consideration 
+     *
+     *  @return The figure of merit 
+     */
+   float GetFigureOfMerit(std::string figureOfMeritName, std::vector<pandora::CaloHitList*> newClustersCaloHitLists3D);
+
+    /** 
+     *  @brief Get cheated FOM as an impurity: the fraction of hits that are NOT contributed by the main MC particle. If clustering was perfect, cheated FOM would always be 0.
+     *
+     * @param List of calo hits for the pfo to recluster
+     *
+     * @return The figure of merit (purity)
+     */
+    float GetCheatedFigureOfMerit(pandora::CaloHitList mergedClusterCaloHitList3D);
+    
+    /**
+     *  @brief Select pfos to be reclustered if it passes reclustering criteria
+     *
+     *  @param pPfo the address of the pfo 
+     *
+     *  @return bool corresponding to decision: recluster (1), do not recluster (0)
+     */
+    bool PassesCutsForReclustering(const pandora::ParticleFlowObject *const pPfo);
+
+    /**
+     *  @brief Get the MC index for the true particle that contributes most energy to the calo hit 
+     *
+     *  @param pCaloHit address of the calo hit
+     *
+     *  @return MCParticle Index
+     */
+    int GetMainMcParticleIndex(const pandora::CaloHit *const pCaloHit);
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    ClusteringToolVector m_algorithmToolVector; ///< The reclustering algorithm tool vector
+    std::string m_pfoListName; ///< The input pfo list name
+    pandora::StringVector m_figureOfMeritNames; ///< The names of the figures of merit to use
+    std::string m_newPfosListNameAllAfterReclustering; ///< Name of the list that contains new Pfos after reclustering
+    int m_hitThresholdForNewPfo; ///< Minimum nr. of hits to form new 3Dclusters
+    std::string m_mcParticleListName; ///< The mc particle list name 
+    float m_fomThresholdForReclustering; ///< A threshold on the minimum figure of merit for reclustering
+    std::map<int,const pandora::Cluster*> m_newClustersUMap, m_newClustersVMap,m_newClustersWMap; ///< Per-view maps associating new 3D clusters with new 2D clusters 
+
+};
+
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+/**
+ *  @brief  ClusteringTool class
+ */
+class ClusteringTool: public pandora::AlgorithmTool {
+
+public:
+    ClusteringTool() = default;
+    virtual ~ClusteringTool() = default;
+    virtual bool Run(const pandora::Algorithm *const pAlgorithm, std::vector<pandora::CaloHitList*> &newCaloHitListsVector) = 0;
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_THREE_D_RECLUSTERING_ALGORITHM_H

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -90,7 +90,7 @@ private:
      *
      *  @return The figure of merit
      */
-    float GetFigureOfMerit(const std::vector<pandora::CaloHitList*> &newClustersCaloHitList3D);
+    float GetFigureOfMerit(const std::vector<std::reference_wrapper<pandora::CaloHitList>> &newClustersCaloHitList3D);
 
     /**
      *  @brief Calculate the specified figure of merit for each CaloHitList in the provided vector, and return the smallest FOM
@@ -100,7 +100,7 @@ private:
      *
      *  @return The figure of merit 
      */
-   float GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<pandora::CaloHitList*> &newClustersCaloHitLists3D);
+   float GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<std::reference_wrapper<pandora::CaloHitList>> &newClustersCaloHitLists3D);
 
     /** 
      *  @brief Get cheated FOM as an impurity: the fraction of hits that are NOT contributed by the main MC particle. If clustering was perfect, cheated FOM would always be 0.
@@ -120,6 +120,14 @@ private:
      */
     bool PassesCutsForReclustering(const pandora::ParticleFlowObject *const pPfo);
 
+    /**
+     *  @brief Copy a vector of reference wrappers into another 
+     *
+     *  @param listVectorSource the vector of reference wrappers to be copied
+     *  @param listVectorDestination the vector of reference wrappers to copy to
+     */
+    pandora::StatusCode CopyListVector(std::vector<std::reference_wrapper<pandora::CaloHitList>> listVectorSource, std::vector<std::reference_wrapper<pandora::CaloHitList>> listVectorDestination);
+
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     ClusteringToolVector m_algorithmToolVector; ///< The reclustering algorithm tool vector
@@ -133,7 +141,6 @@ private:
 
 };
 
-
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
@@ -144,7 +151,7 @@ class ClusteringTool: public pandora::AlgorithmTool {
 public:
     ClusteringTool() = default;
     virtual ~ClusteringTool() = default;
-    virtual bool Run(const pandora::Algorithm *const pAlgorithm, std::vector<pandora::CaloHitList*> &newCaloHitListsVector) = 0;
+    virtual std::vector<std::reference_wrapper<pandora::CaloHitList>> Run(const pandora::Algorithm *const pAlgorithm, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList) = 0;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -134,7 +134,7 @@ private:
     ClusteringToolVector m_algorithmToolVector; ///< The reclustering algorithm tool vector
     std::string m_pfoListName; ///< The input pfo list name
     pandora::StringVector m_figureOfMeritNames; ///< The names of the figures of merit to use
-    std::string m_newPfosListNameAllAfterReclustering; ///< Name of the list that contains new Pfos after reclustering
+    std::string m_PfosForReclusteringListName; ///< Name of the list that contains new Pfos before/after reclustering
     int m_hitThresholdForNewPfo; ///< Minimum nr. of hits to form new 3Dclusters
     std::string m_mcParticleListName; ///< The mc particle list name 
     float m_fomThresholdForReclustering; ///< A threshold on the minimum figure of merit for reclustering

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -90,7 +90,7 @@ private:
      *
      *  @return The figure of merit
      */
-    float GetFigureOfMerit(const std::vector<std::reference_wrapper<pandora::CaloHitList>> &newClustersCaloHitList3D);
+    float GetFigureOfMerit(const std::vector<pandora::CaloHitList> &newClustersCaloHitList3D);
 
     /**
      *  @brief Calculate the specified figure of merit for each CaloHitList in the provided vector, and return the smallest FOM
@@ -100,7 +100,7 @@ private:
      *
      *  @return The figure of merit 
      */
-   float GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<std::reference_wrapper<pandora::CaloHitList>> &newClustersCaloHitLists3D);
+   float GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<pandora::CaloHitList> &newClustersCaloHitLists3D);
 
     /** 
      *  @brief Get cheated FOM as an impurity: the fraction of hits that are NOT contributed by the main MC particle. If clustering was perfect, cheated FOM would always be 0.
@@ -119,14 +119,6 @@ private:
      *  @return bool corresponding to decision: recluster (1), do not recluster (0)
      */
     bool PassesCutsForReclustering(const pandora::ParticleFlowObject *const pPfo);
-
-    /**
-     *  @brief Copy a vector of reference wrappers into another 
-     *
-     *  @param listVectorSource the vector of reference wrappers to be copied
-     *  @param listVectorDestination the vector of reference wrappers to copy to
-     */
-    pandora::StatusCode CopyListVector(std::vector<std::reference_wrapper<pandora::CaloHitList>> listVectorSource, std::vector<std::reference_wrapper<pandora::CaloHitList>> listVectorDestination);
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
@@ -151,7 +143,7 @@ class ClusteringTool: public pandora::AlgorithmTool {
 public:
     ClusteringTool() = default;
     virtual ~ClusteringTool() = default;
-    virtual std::vector<std::reference_wrapper<pandora::CaloHitList>> Run(const pandora::Algorithm *const pAlgorithm, std::reference_wrapper<pandora::CaloHitList> &inputCaloHitList) = 0;
+    virtual bool Run(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector) = 0;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -130,6 +130,10 @@ private:
     std::string m_PfosForReclusteringListName; ///< Name of the internal list to contain new Pfos before/after reclustering
     std::string m_mcParticleListName; ///< The mc particle list name 
     float m_fomThresholdForReclustering; ///< A threshold on the minimum figure of merit for reclustering
+    long unsigned int m_minNumCaloHitsForReclustering;
+    std::string m_uClustersListName;
+    std::string m_vClustersListName;
+    std::string m_wClustersListName; //Names of U,V and W cluster lists
     std::map<int,const pandora::Cluster*> m_newClustersUMap, m_newClustersVMap,m_newClustersWMap; ///< Per-view maps associating new 3D clusters with new 2D clusters 
 };
 

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -120,15 +120,6 @@ private:
      */
     bool PassesCutsForReclustering(const pandora::ParticleFlowObject *const pPfo);
 
-    /**
-     *  @brief Get the MC index for the true particle that contributes most energy to the calo hit 
-     *
-     *  @param pCaloHit address of the calo hit
-     *
-     *  @return MCParticle Index
-     */
-    int GetMainMcParticleIndex(const pandora::CaloHit *const pCaloHit);
-
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     ClusteringToolVector m_algorithmToolVector; ///< The reclustering algorithm tool vector

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -125,6 +125,7 @@ private:
 
     ClusteringToolVector m_algorithmToolVector; ///< The reclustering algorithm tool vector
     std::string m_pfoListName; ///< Name of the list of pfos to consider for reclustering
+    std::string m_clusterListName; ///< Name of the list of clusters to consider for reclustering
     pandora::StringVector m_figureOfMeritNames; ///< The names of the figures of merit to use
     std::string m_PfosForReclusteringListName; ///< Name of the internal list to contain new Pfos before/after reclustering
     std::string m_mcParticleListName; ///< The mc particle list name 

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -143,7 +143,7 @@ class ClusteringTool: public pandora::AlgorithmTool {
 public:
     ClusteringTool() = default;
     virtual ~ClusteringTool() = default;
-    virtual bool Run(const pandora::Algorithm *const pAlgorithm, const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector) = 0;
+    virtual bool Run(const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector) = 0;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -14,17 +14,16 @@
 namespace lar_content
 {
 
- class ClusteringTool; 
- 
+class ClusteringTool;
+
 //------------------------------------------------------------------------------------------------------------------------------------------
 
- /**
+/**
   *  @brief  RecursivePfoMopUpAlgorithm class
   */
- class ThreeDReclusteringAlgorithm : public pandora::Algorithm
- {
- public:
-
+class ThreeDReclusteringAlgorithm : public pandora::Algorithm
+{
+public:
     /**
     *  @brief  FigureOfMerit type enumeration
     */
@@ -43,12 +42,10 @@ namespace lar_content
     */
     ~ThreeDReclusteringAlgorithm();
 
- private:
-
+private:
     typedef std::vector<ClusteringTool *> ClusteringToolVector;
 
     pandora::StatusCode Run();
-
 
     /**
      *  @brief Create new TwoD clusters and Pfos for each  new ThreeD cluster in newClustersList
@@ -58,7 +55,7 @@ namespace lar_content
      */
     pandora::StatusCode RebuildPfo(const pandora::Pfo *pPfoToRebuild, pandora::ClusterList &newClustersList);
 
-     /**
+    /**
      *  @brief Create new TwoD clusters for each  new ThreeD cluster in newClustersList 
      *
      *  @param pPfoToRebuild the address of the original pfo to rebuild 
@@ -82,7 +79,7 @@ namespace lar_content
      *  @return The figure of merit
      */
     float GetFigureOfMerit(const pandora::CaloHitList &mergedClusterCaloHitList3D);
-    
+
     /**
      *  @brief Calculate the specified figure of merit for the CaloHitList under consideration, and return the smallest FOM
      *
@@ -110,7 +107,7 @@ namespace lar_content
      *
      *  @return The figure of merit 
      */
-   float GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<pandora::CaloHitList> &newClustersCaloHitLists3D);
+    float GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<pandora::CaloHitList> &newClustersCaloHitLists3D);
 
     /** 
      *  @brief Get cheated FOM as an impurity: the fraction of hits that are NOT contributed by the main MC particle. If clustering was perfect, cheated FOM would always be 0.
@@ -133,17 +130,17 @@ namespace lar_content
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     ClusteringToolVector m_algorithmToolVector; ///< The reclustering algorithm tool vector
-    std::string m_pfoListName; ///< Name of the list of pfos to consider for reclustering
-    std::string m_clusterListName; ///< Name of the list of clusters to consider for reclustering
+    std::string m_pfoListName;                  ///< Name of the list of pfos to consider for reclustering
+    std::string m_clusterListName;              ///< Name of the list of clusters to consider for reclustering
     pandora::StringVector m_figureOfMeritNames; ///< The names of the figures of merit to use
-    std::string m_PfosForReclusteringListName; ///< Name of the internal list to contain new Pfos before/after reclustering
-    std::string m_mcParticleListName; ///< The mc particle list name 
-    float m_fomThresholdForReclustering; ///< A threshold on the minimum figure of merit for reclustering
+    std::string m_PfosForReclusteringListName;  ///< Name of the internal list to contain new Pfos before/after reclustering
+    std::string m_mcParticleListName;           ///< The mc particle list name
+    float m_fomThresholdForReclustering;        ///< A threshold on the minimum figure of merit for reclustering
     long unsigned int m_minNumCaloHitsForReclustering;
     std::string m_uClustersListName;
     std::string m_vClustersListName;
-    std::string m_wClustersListName; //Names of U,V and W cluster lists
-    std::map<int,const pandora::Cluster*> m_newClustersUMap, m_newClustersVMap,m_newClustersWMap; ///< Per-view maps associating new 3D clusters with new 2D clusters 
+    std::string m_wClustersListName;                                                                 //Names of U,V and W cluster lists
+    std::map<int, const pandora::Cluster *> m_newClustersUMap, m_newClustersVMap, m_newClustersWMap; ///< Per-view maps associating new 3D clusters with new 2D clusters
 
     static const std::unordered_map<std::string, ThreeDReclusteringAlgorithm::FigureOfMeritType> m_stringToEnumMap; //Figure of merit type enum to string map
 };
@@ -153,12 +150,12 @@ namespace lar_content
 /**
  *  @brief  ClusteringTool class
  */
-class ClusteringTool: public pandora::AlgorithmTool
+class ClusteringTool : public pandora::AlgorithmTool
 {
- public:
+public:
     ClusteringTool() = default;
     ~ClusteringTool() = default;
-    virtual bool Run(const pandora::CaloHitList &inputCaloHitList,std::vector<pandora::CaloHitList> &outputCaloHitListsVector) = 0;
+    virtual bool Run(const pandora::CaloHitList &inputCaloHitList, std::vector<pandora::CaloHitList> &outputCaloHitListsVector) = 0;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -71,36 +71,36 @@ private:
      *
      *  @return The figure of merit
      */
-    float GetFigureOfMerit(pandora::CaloHitList mergedClusterCaloHitList3D);
+    float GetFigureOfMerit(const pandora::CaloHitList &mergedClusterCaloHitList3D);
     
     /**
-     *  @brief Calculate the specified figure of merit for the CaloHitList under consideration, under consideration, and return the smallest FOM
+     *  @brief Calculate the specified figure of merit for the CaloHitList under consideration, and return the smallest FOM
      *
      *  @param figureOfMeritName the name of the figure of merit
      *  @param mergedClusterCaloHitList3D the CaloHitList under consideration 
      *
      *  @return The figure of merit
      */
-    float GetFigureOfMerit(std::string figureOfMeritName, pandora::CaloHitList mergedClusterCaloHitList3D);
+    float GetFigureOfMerit(const std::string &figureOfMeritName, const pandora::CaloHitList &mergedClusterCaloHitList3D);
 
     /**
-     *  @brief Loop over all specified figure of merit names, calculate figures of merit for each CaloHitList in the provided vector, under consideration, and return the smallest FOM
+     *  @brief Loop over all specified figure of merit names, calculate figures of merit for each CaloHitList in the provided vector, and return the smallest FOM
      *
      *  @param newClustersCaloHitLists3D the vector of CaloHitLists under consideration 
      *
      *  @return The figure of merit
      */
-    float GetFigureOfMerit(std::vector<pandora::CaloHitList*> newClustersCaloHitList3D);
+    float GetFigureOfMerit(const std::vector<pandora::CaloHitList*> &newClustersCaloHitList3D);
 
     /**
-     *  @brief Calculate the specified figure of merit for each CaloHitList in the provided vector, under consideration, and return the smallest FOM
+     *  @brief Calculate the specified figure of merit for each CaloHitList in the provided vector, and return the smallest FOM
      *
      *  @param figureOfMeritName the name of the figure of merit
      *  @param newClustersCaloHitLists3D the vector of CaloHitLists under consideration 
      *
      *  @return The figure of merit 
      */
-   float GetFigureOfMerit(std::string figureOfMeritName, std::vector<pandora::CaloHitList*> newClustersCaloHitLists3D);
+   float GetFigureOfMerit(const std::string &figureOfMeritName, const std::vector<pandora::CaloHitList*> &newClustersCaloHitLists3D);
 
     /** 
      *  @brief Get cheated FOM as an impurity: the fraction of hits that are NOT contributed by the main MC particle. If clustering was perfect, cheated FOM would always be 0.
@@ -109,7 +109,7 @@ private:
      *
      * @return The figure of merit (purity)
      */
-    float GetCheatedFigureOfMerit(pandora::CaloHitList mergedClusterCaloHitList3D);
+    float GetCheatedFigureOfMerit(const pandora::CaloHitList &mergedClusterCaloHitList3D);
     
     /**
      *  @brief Select pfos to be reclustered if it passes reclustering criteria
@@ -132,9 +132,9 @@ private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     ClusteringToolVector m_algorithmToolVector; ///< The reclustering algorithm tool vector
-    std::string m_pfoListName; ///< The input pfo list name
+    std::string m_pfoListName; ///< Name of the list of pfos to consider for reclustering
     pandora::StringVector m_figureOfMeritNames; ///< The names of the figures of merit to use
-    std::string m_PfosForReclusteringListName; ///< Name of the list that contains new Pfos before/after reclustering
+    std::string m_PfosForReclusteringListName; ///< Name of the internal list to contain new Pfos before/after reclustering
     int m_hitThresholdForNewPfo; ///< Minimum nr. of hits to form new 3Dclusters
     std::string m_mcParticleListName; ///< The mc particle list name 
     float m_fomThresholdForReclustering; ///< A threshold on the minimum figure of merit for reclustering


### PR DESCRIPTION
This PR introduces the 3D clusters reclustering mechanics with **ThreeDReclusteringAlgorithm**. This algorithm:

- Reads the list of shower pfos and examines their associated 3D clusters. At the moment tracks are not considered.
- Checks if new clustering outcomes should be proposed (at the moment, this is done via a cheated figure of merit, which is equivalent to an "impurity": it is given by the fraction of 3D hits with parent 2D hits that are not created by the "main" MC particle)
- If the decision to reclusters is positive, loops over a series of algorithm tools, specified via XML, which take the calo hits in the 3D cluster as input, and propose a new set of calo hit lists
- if a new set of calo hit lists contains at least one list that yields a figure of merit that is lower than the initial one, then persist this outcome: create new 3D clusters from this new set of lists.
- Also creates new 2D clusters and new Pfos matching the new 3D clusters
- If no better set of calo hit lists was found, persists the original clusters/pfos
- Does list book-keeping.

At the moment this PR does not support DL features. [A separate branch](https://github.com/MariaBrigida/LArContent/blob/feature/ReclusteringFramework_preparePR_dl/larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h) has been created with classes in larpandoracontent that enable those.

This PR is to be used with XMLs contained in [this LArReco branch](https://github.com/PandoraPFA/LArReco/compare/master...MariaBrigida:LArReco:feature/ReclusteringFramework_preparePR_2). These are set up to run these tool configurations:
* Only **cheated reclustering tool**: uses truth information on what particle contributed the largest energy to the 2D parent hit of each 3D calo hit, to split calo hits into a new set of lists
* Only **PCA-based tool**: this splits the calo hit lists in two, based on hits projections on secondary axis. The PCA is run twice, first on the original calo hit list, then on the two new lists, to refine the splitting.