### PR TITLE
Fix Mac Build + Update CI.

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     # Use the latest ubuntu image: https://github.com/actions/runner-images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: LArContent - Coverity
 
     # Only run in the PandoraPFA repos.
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false # Don't quit other jobs if one job fails.
       matrix:
-        compiler: [ {cpp: g++-9, c: gcc-9} ]
+        compiler: [ {cpp: g++-12, c: gcc-12} ]
         monitoring: [ "ON" ]
         torch: [ "ON" ]
 
@@ -36,7 +36,7 @@ jobs:
 
       # Install ROOT dependencies to start with
       - name: apt Install Dependencies
-        run: sudo apt install -y xlibmesa-glu-dev
+        run: sudo apt install -y xlibmesa-glu-dev libvdt-dev
 
       # Make a central location to build from.
       - name: Create build folder
@@ -45,10 +45,10 @@ jobs:
       # Cache the build tool, to speed up subsequent runs.
       - name: Cache Coverity Build Tool
         id: cov-build-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /pandora/coverity/
-          key: cov-build-2022.6
+          key: cov-build-2023.12
 
       # Get Coverity build tool
       - name: Get Coverity Build Tool
@@ -80,50 +80,49 @@ jobs:
           make -j$(nproc) install
 
       # Sort ROOT install out.
-      # TODO: Does the version need to change with compiler?
       - name: Pull ROOT
         if: matrix.monitoring == 'ON'
-        run: wget https://root.cern/download/root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
+        run: wget https://root.cern/download/root_v6.28.12.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
       - name: Unpack ROOT
         if: matrix.monitoring == 'ON'
-        run: tar -xzvf root_v6.26.14.Linux-ubuntu22-x86_64-gcc11.4.tar.gz && mv root/ /pandora/root
+        run: tar -xzvf root_v6.28.12.Linux-ubuntu22-x86_64-gcc11.4.tar.gz && mv root/ /pandora/root
 
       # Sort LibTorch install out.
       - name: Pull Torch
         if: matrix.torch == 'ON'
-        run: wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.13.0%2Bcpu.zip
+        run: wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.1.1%2Bcpu.zip
       - name: Unpack Torch
         if: matrix.torch == 'ON'
-        run: unzip libtorch-cxx11-abi-shared-with-deps-1.13.0+cpu.zip && mv libtorch/ /pandora/libtorch
+        run: unzip libtorch-cxx11-abi-shared-with-deps-2.1.1+cpu.zip && mv libtorch/ /pandora/libtorch
 
       # Pull the various dependencies and LArContent.
       - name: Pull PandoraPFA
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/PandoraPFA'
           path: PandoraPFA
 
       - name: Pull PandoraSDK
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/PandoraSDK'
           path: PandoraSDK
 
       - name: Pull PandoraMonitoring
         if: matrix.monitoring == 'ON'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/PandoraMonitoring'
           path: PandoraMonitoring
 
       - name: Pull LArContent
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/LArContent'
           path: LArContent
 
       - name: Pull LArReco
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/LArReco'
           path: LArReco

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -32,10 +32,10 @@ jobs:
           - 'larpandoradlcontent'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check clang-format
-        uses: jidicula/clang-format-action@v4.10.2
+        uses: jidicula/clang-format-action@v4.13.0
         with:
-          clang-format-version: '13'
+          clang-format-version: '18'
           check-path: ${{ matrix.path }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         if: matrix.torch == 'ON'
         run: |
           wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.1.1%2Bcpu.zip
-          unzip libtorch-cxx11-abi-shared-with-deps-2.1.1%2Bcpu.zip && mv libtorch/ /pandora/libtorch
+          unzip libtorch-cxx11-abi-shared-with-deps-2.1.1+cpu.zip && mv libtorch/ /pandora/libtorch
 
       # Pull the various Pandora repos...
       - name: Pull PandoraPFA

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,31 +72,31 @@ jobs:
 
       # Pull the various Pandora repos...
       - name: Pull PandoraPFA
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/PandoraPFA'
           path: PandoraPFA
 
       - name: Pull PandoraSDK
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/PandoraSDK'
           path: PandoraSDK
 
       - name: Pull PandoraMonitoring
         if: matrix.monitoring == 'ON'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/PandoraMonitoring'
           path: PandoraMonitoring
 
       - name: Pull LArContent
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: LArContent
 
       - name: Pull LArReco
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'PandoraPFA/LArReco'
           path: LArReco

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       # Setup dependencies and build folder...
       - name: Install Dependencies
         run: |
-          sudo apt install -y xlibmesa-glu-dev
+          sudo apt install -y xlibmesa-glu-dev libvdt-dev
           sudo mkdir -m 0777 -p /pandora
 
       # Pull and Install Eigen...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       # Setup dependencies and build folder...
       - name: Install Dependencies
         run: |
-          sudo apt install -y xlibmesa-glu-dev gcc-8 g++-8
+          sudo apt install -y xlibmesa-glu-dev
           sudo mkdir -m 0777 -p /pandora
 
       # Pull and Install Eigen...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
   build:
 
     # Use the latest ubuntu image: https://github.com/actions/runner-images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: LArContent - ${{ matrix.compiler.c }} - Monitoring ${{ matrix.monitoring }} - DL ${{ matrix.torch }}
 
     # Only run in the PandoraPFA repos.
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false # Don't quit other jobs if one job fails.
       matrix:
-        compiler: [ {cpp: g++-8, c: gcc-8}, {cpp: clang++, c: clang} ]
+        compiler: [ {cpp: g++-12, c: gcc-12}, {cpp: clang++, c: clang} ]
         monitoring: [ "ON", "OFF" ]
         torch: [ "ON", "OFF" ]
 
@@ -60,15 +60,15 @@ jobs:
       - name: Install ROOT
         if: matrix.monitoring == 'ON'
         run: |
-          wget https://root.cern/download/root_v6.26.14.Linux-ubuntu20-x86_64-gcc9.4.tar.gz
-          tar -xzvf root_v6.26.14.Linux-ubuntu20-x86_64-gcc9.4.tar.gz && mv root/ /pandora/root
+          wget https://root.cern/download/root_v6.28.12.Linux-ubuntu22-x86_64-gcc11.4.tar.gz
+          tar -xzvf root_v6.28.12.Linux-ubuntu22-x86_64-gcc11.4.tar.gz && mv root/ /pandora/root
 
       # Sort LibTorch install out...
       - name: Install Torch
         if: matrix.torch == 'ON'
         run: |
-          wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.13.0%2Bcpu.zip
-          unzip libtorch-cxx11-abi-shared-with-deps-1.13.0+cpu.zip && mv libtorch/ /pandora/libtorch
+          wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.1.1%2Bcpu.zip
+          unzip libtorch-cxx11-abi-shared-with-deps-2.1.1%2Bcpu.zip && mv libtorch/ /pandora/libtorch
 
       # Pull the various Pandora repos...
       - name: Pull PandoraPFA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,11 @@ else()
         set_target_properties(${PROJ} PROPERTIES VERSION ${${PROJ}_VERSION} SOVERSION ${${PROJ}_SOVERSION})
     endforeach()
 
+    # If we are building the DL Library, it needs to link to the default library
+    if(PANDORA_LIBTORCH)
+        target_link_libraries(${DL_PROJECT_NAME} ${PROJECT_NAME})
+    endif()
+
     # - Optional documents
     if(LArContent_BUILD_DOCS)
         add_subdirectory(doc)

--- a/larpandoracontent/LArMonitoring/MuonLeadingEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/MuonLeadingEventValidationAlgorithm.cc
@@ -443,13 +443,11 @@ void MuonLeadingEventValidationAlgorithm::ProcessOutput(
                          << LArMonitoringHelper::CountHitsByType(TPC_VIEW_W, leadingParticleHitList) << ")" << std::endl;
 
             // Look at the pfo matches
-            int nMatches(0), nAboveThresholdMatches(0);
+            int nAboveThresholdMatches(0);
             bool isCorrectParentLink(false);
 
             for (const LArMCParticleHelper::PfoCaloHitListPair &pfoToSharedHits : foldedMCToPfoHitSharingMap.at(pLeadingParticle))
             {
-                ++nMatches;
-
                 const ParticleFlowObject *const pMatchedPfo(pfoToSharedHits.first);
                 const CaloHitList &pfoHitList(foldedPfoToHitsMap.at(pMatchedPfo));
                 const CaloHitList &sharedHitList(pfoToSharedHits.second);

--- a/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamEventValidationAlgorithm.cc
@@ -96,9 +96,9 @@ void TestBeamEventValidationAlgorithm::ProcessOutput(
     static int eventNumber{-1};
     ++eventNumber;
     if (printToScreen && useInterpretedMatching)
-        std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
+        std::cout << "---EVENT-" << eventNumber << "-INTERPRETED-MATCHING-OUTPUT----------------------------------------------------------" << std::endl;
     else if (printToScreen)
-        std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
+        std::cout << "---EVENT-" << eventNumber << "-RAW-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
 
     const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcToPfoHitSharingMap(
         useInterpretedMatching ? validationInfo.GetInterpretedMCToPfoHitSharingMap() : validationInfo.GetMCToPfoHitSharingMap());

--- a/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
@@ -176,7 +176,7 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(
     PfoSet recoTestBeamHierarchies;
     MCParticleList associatedMCPrimaries;
 
-    int nCorrectTB(0), nTotalTB(0), nCorrectTBHierarchy(0), nTotalTBHierarchy(0), nCorrectCR(0), nTotalCR(0);
+    int nCorrectTBHierarchy(0), nTotalTBHierarchy(0), nCorrectCR(0), nTotalCR(0);
     int nFakeTBHierarchy(0), nFakeCR(0), nSplitTBHierarchy(0), nSplitCR(0), nLost(0), mcPrimaryIndex(0), nTargetMatches(0),
         nTargetTBHierarchyMatches(0);
     int nTargetCRMatches(0), nTargetGoodTBHierarchyMatches(0), nTargetTBHierarchySplits(0), nTargetTBHierarchyLosses(0);
@@ -461,7 +461,6 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(
             const int interactionTypeInt(static_cast<int>(interactionType));
 #endif
             // ATTN Some redundancy introduced to contributing variables
-            const int isCorrectTB(isBeamParticle && (nTargetTBHierarchyMatches == 1) && (nTargetCRMatches == 0));
             const int isCorrectTBHierarchy(isLeadingBeamParticle && (nTargetGoodTBHierarchyMatches == nTargetTBHierarchyMatches) &&
                 (nTargetGoodTBHierarchyMatches == nTargetPrimaries) && (nTargetCRMatches == 0) && (nTargetTBHierarchySplits == 0) &&
                 (nTargetTBHierarchyLosses == 0));
@@ -477,14 +476,10 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(
             outcomeSS << LArInteractionTypeHelper::ToString(interactionType) << " (Nuance " << mcNuanceCode << ", TB " << isBeamHierarchy
                       << ", CR " << isCosmicRay << ")" << std::endl;
 
-            if (isBeamParticle)
-                ++nTotalTB;
             if (isLastTestBeamLeading)
                 ++nTotalTBHierarchy;
             if (isCosmicRay)
                 ++nTotalCR;
-            if (isCorrectTB)
-                ++nCorrectTB;
             if (isCorrectTBHierarchy)
                 ++nCorrectTBHierarchy;
             if (isCorrectCR)

--- a/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/TestBeamHierarchyEventValidationAlgorithm.cc
@@ -104,9 +104,9 @@ void TestBeamHierarchyEventValidationAlgorithm::ProcessOutput(
     static int eventNumber{-1};
     ++eventNumber;
     if (printToScreen && useInterpretedMatching)
-        std::cout << "---INTERPRETED-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
+        std::cout << "---EVENT-" << eventNumber << "-INTERPRETED-MATCHING-OUTPUT----------------------------------------------------------" << std::endl;
     else if (printToScreen)
-        std::cout << "---RAW-MATCHING-OUTPUT--------------------------------------------------------------------------" << std::endl;
+        std::cout << "---EVENT-" << eventNumber << "-RAW-MATCHING-OUTPUT------------------------------------------------------------------" << std::endl;
 
     PfoVector primaryPfoVector;
     LArMonitoringHelper::GetOrderedPfoVector(validationInfo.GetPfoToHitsMap(), primaryPfoVector);

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/CrossGapsAssociationAlgorithm.cc
@@ -141,16 +141,14 @@ bool CrossGapsAssociationAlgorithm::IsAssociated(
     const HitType hitType(LArClusterHelper::GetClusterHitType(targetFitResult.GetCluster()));
     const float ratio{LArGeometryHelper::GetWirePitchRatio(this->GetPandora(), hitType)};
     const float sampleStepSizeAdjusted{ratio * m_sampleStepSize};
-    unsigned int nSamplingPoints(0), nGapSamplingPoints(0), nMatchedSamplingPoints(0), nUnmatchedSampleRun(0);
+    unsigned int nMatchedSamplingPoints(0), nUnmatchedSampleRun(0);
 
     for (unsigned int iSample = 0; iSample < m_maxSamplingPoints; ++iSample)
     {
-        ++nSamplingPoints;
         const CartesianVector samplingPoint(startPosition + startDirection * static_cast<float>(iSample) * sampleStepSizeAdjusted);
 
         if (LArGeometryHelper::IsInGap(this->GetPandora(), samplingPoint, hitType, m_gapTolerance))
         {
-            ++nGapSamplingPoints;
             nUnmatchedSampleRun = 0; // ATTN Choose to also reset run when entering gap region
             continue;
         }

--- a/larpandoracontent/LArTwoDReco/LArClusterAssociation/MvaLowEClusterMergingAlgorithm.cc
+++ b/larpandoracontent/LArTwoDReco/LArClusterAssociation/MvaLowEClusterMergingAlgorithm.cc
@@ -183,8 +183,6 @@ StatusCode MvaLowEClusterMergingAlgorithm<T>::EdgeHitComparer(const pandora::Clu
         if (!cluster || hits.empty())
             continue;
 
-        const int nClusters(pClusterList->size());
-
         if (!this->IsValidToUse(cluster, clusterIsUsed))
             continue;
 
@@ -210,7 +208,6 @@ StatusCode MvaLowEClusterMergingAlgorithm<T>::EdgeHitComparer(const pandora::Clu
         this->EdgeHitFinder(cluster, clusterEdgeHits);
 
         const unsigned int clusterNHits{cluster->GetNCaloHits()};
-        const unsigned long int clusterNEdgeHits{clusterEdgeHits.size()};
 
         for (auto iter2 = std::next(iter); iter2 != pClusterList->end(); ++iter2)
         {
@@ -267,7 +264,6 @@ StatusCode MvaLowEClusterMergingAlgorithm<T>::EdgeHitComparer(const pandora::Clu
             this->EdgeHitFinder(otherCluster, otherClusterEdgeHits);
 
             const unsigned int otherClusterNHits{otherCluster->GetNCaloHits()};
-            const unsigned long int otherClusterNEdgeHits{otherClusterEdgeHits.size()};
             CaloHitList largestList, smallestList;
             CartesianVector vectorTool(0.f, 0.f, 0.f);
 
@@ -345,7 +341,6 @@ StatusCode MvaLowEClusterMergingAlgorithm<T>::EdgeHitComparer(const pandora::Clu
                 distanceDistribution.push_back(finalDistance);
             }
 
-            float combinedNClusterHits(clusterNHits + otherClusterNHits), combinedNClusterEdgeHits(clusterNEdgeHits + otherClusterNEdgeHits);
             const double avgDistance{!distanceDistribution.empty()
                     ? std::accumulate(distanceDistribution.begin(), distanceDistribution.end(), 0.0) / distanceDistribution.size()
                     : -1.0};
@@ -415,6 +410,12 @@ StatusCode MvaLowEClusterMergingAlgorithm<T>::EdgeHitComparer(const pandora::Clu
 
             if (m_writeTree)
             {
+#ifdef MONITORING
+                const int nClusters(pClusterList->size());
+                const unsigned long int clusterNEdgeHits{clusterEdgeHits.size()};
+                const unsigned long int otherClusterNEdgeHits{otherClusterEdgeHits.size()};
+                float combinedNClusterHits(clusterNHits + otherClusterNHits), combinedNClusterEdgeHits(clusterNEdgeHits + otherClusterNEdgeHits);
+#endif
                 PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "EventNumber", m_event));
                 PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "VertexClusterAngle", vtxClusterAngle));
                 PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName.c_str(), "maxEdgeHitSeparation", maxEdgeHitSeparation));

--- a/larpandoradlcontent/LArSignalId/DlSNSignalAlgorithm.cc
+++ b/larpandoradlcontent/LArSignalId/DlSNSignalAlgorithm.cc
@@ -935,18 +935,16 @@ void DlSNSignalAlgorithm::GetHitRegion(const CaloHitList &caloHitList, float &xM
     if (m_simpleZoom && m_pass > 1)
     {
         float xPos{-std::numeric_limits<float>::max()}, zPos{-std::numeric_limits<float>::max()}, adcMax{0.f};
-        int nSum{0}, tCount{0}, hCount{0};
+        int nSum{0};
         for (const CaloHit *pCaloHit : caloHitList)
         {
             const float xC{pCaloHit->GetPositionVector().GetX()}, zC{pCaloHit->GetPositionVector().GetZ()}, adc{pCaloHit->GetMipEquivalentEnergy()};
             ;
-            tCount += 1;
             if (xC >= xMin && xC < xMax)
             {
                 nSum += 1;
                 if (adc > adcMax)
                 {
-                    hCount += 1;
                     adcMax = adc;
                     xPos = xC;
                     zPos = zC;

--- a/larpandoradlcontent/LArSignalId/DlSNSignalAlgorithm.cc
+++ b/larpandoradlcontent/LArSignalId/DlSNSignalAlgorithm.cc
@@ -428,7 +428,7 @@ StatusCode DlSNSignalAlgorithm::Infer()
         // we want the maximum value in the num_classes dimension (1) for every pixel
         auto classes{torch::argmax(output, 1)};
         // the argmax result is a 1 x height x width tensor where each element is a class id
-        auto classesAccessor{classes.accessor<long, 3>()};
+        auto classesAccessor{classes.accessor<int64_t, 3>()};
         std::map<int, bool> haveSeenMap;
 
         for (const auto &[pCaloHit, pixel] : pixelMap)

--- a/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.cc
+++ b/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.cc
@@ -225,7 +225,7 @@ StatusCode DlVertexingAlgorithm::Infer()
         // we want the maximum value in the num_classes dimension (1) for every pixel
         auto classes{torch::argmax(output, 1)};
         // the argmax result is a 1 x height x width tensor where each element is a class id
-        auto classesAccessor{classes.accessor<long, 3>()};
+        auto classesAccessor{classes.accessor<int64_t, 3>()};
         const double scaleFactor{std::sqrt(m_height * m_height + m_width * m_width)};
         std::map<int, bool> haveSeenMap;
         for (const auto &[row, col] : pixelVector)
@@ -445,7 +445,7 @@ void DlVertexingAlgorithm::GetCanvasParameters(const LArDLHelper::TorchOutput &n
     // we want the maximum value in the num_classes dimension (1) for every pixel
     auto classes{torch::argmax(networkOutput, 1)};
     // the argmax result is a 1 x height x width tensor where each element is a class id
-    auto classesAccessor{classes.accessor<long, 3>()};
+    auto classesAccessor{classes.accessor<int64_t, 3>()};
     int colOffsetMin{0}, colOffsetMax{0}, rowOffsetMin{0}, rowOffsetMax{0};
     for (const auto &[row, col] : pixelVector)
     {


### PR DESCRIPTION
Few small changes to make the Mac build happy:

 - Fix some unused variables.
 - PyTorch/LibTorch on Mac doesn't seem to like the use of `long`, so I've swapped to `int64_t` there....I've been using this locally on mac for the past 12 months or so, but I (and ideally someone else) need to test this on Linux.
 - Link LArDLContent against LArContent, to access the helpers etc. Again, I've used this on Mac for a while, but would be good to test on Linux.

To help prevent this again, I've also bumped the CI to more modern versions (GCC 12 to match LArSoft v10_00_X, and the latest Clang in Ubuntu 24.04), as well as fixing a few other bits in the CI (i.e. bumping the tools we use in the actions to their latest versions, to prevent some deprecation warnings).

The ROOT and LibTorch versions used here should match the versions used by LArSoft V10_00_02.

Whilst testing this in my local branch, I found that when jumping to the newer compiler versions, I got even more "set but not used variable" warnings, so I've fixed them too.

There is maybe also a question of if we want to bother adding a Mac config to the CI....that would catch these errors quickly, but would be an extra thing running each time (and make the CI config a touch more complicated to support picking the right versions of ROOT / LibTorch, setup steps etcetc).