### PR TITLE
DL Vertexing Slicing + MicroBooNE Considerations

### DIFF
--- a/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.cc
+++ b/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.cc
@@ -47,10 +47,20 @@ StatusCode CandidateVertexCreationAlgorithm::Run()
 {
     try
     {
+        // INFO: See if there is already a vertex, and quit early if there is.
+        //       The vertex has likely already been defined by another algorithm.
+        const VertexList *pVertexList(nullptr);
+        PandoraContentApi::GetCurrentList(*this, pVertexList);
+        if (pVertexList != nullptr && ! pVertexList->empty()) {
+            if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
+                std::cout << "CandidateVertexCreationAlgorithm: Vertex already defined, skipping" << std::endl;
+
+            return STATUS_CODE_SUCCESS;
+        }
+
         ClusterVector clusterVectorU, clusterVectorV, clusterVectorW;
         this->SelectClusters(clusterVectorU, clusterVectorV, clusterVectorW);
 
-        const VertexList *pVertexList(NULL);
         std::string temporaryListName;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pVertexList, temporaryListName));
 

--- a/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.cc
+++ b/larpandoracontent/LArVertex/CandidateVertexCreationAlgorithm.cc
@@ -51,7 +51,8 @@ StatusCode CandidateVertexCreationAlgorithm::Run()
         //       The vertex has likely already been defined by another algorithm.
         const VertexList *pVertexList(nullptr);
         PandoraContentApi::GetCurrentList(*this, pVertexList);
-        if (pVertexList != nullptr && ! pVertexList->empty()) {
+        if (pVertexList != nullptr && !pVertexList->empty())
+        {
             if (PandoraContentApi::GetSettings(*this)->ShouldDisplayAlgorithmInfo())
                 std::cout << "CandidateVertexCreationAlgorithm: Vertex already defined, skipping" << std::endl;
 

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
@@ -150,7 +150,8 @@ StatusCode VertexSelectionBaseAlgorithm::Run()
     }
     else
     {
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputVertexListName, pInputVertexList));
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=,
+            PandoraContentApi::GetList(*this, m_inputVertexListName, pInputVertexList));
     }
 
     if (!pInputVertexList || pInputVertexList->empty())

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
@@ -403,7 +403,8 @@ StatusCode VertexSelectionBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputCaloHitListNames", m_inputCaloHitListNames));
 
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputVertexListName", m_inputVertexListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InputVertexListName", m_inputVertexListName));
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_outputVertexListName));
 

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.cc
@@ -20,6 +20,7 @@ namespace lar_content
 {
 
 VertexSelectionBaseAlgorithm::VertexSelectionBaseAlgorithm() :
+    m_inputVertexListName(""),
     m_replaceCurrentVertexList(true),
     m_beamMode(true),
     m_nDecayLengthsInZSpan(2.f),
@@ -142,7 +143,15 @@ void VertexSelectionBaseAlgorithm::CalculateClusterSlidingFits(const ClusterList
 StatusCode VertexSelectionBaseAlgorithm::Run()
 {
     const VertexList *pInputVertexList(NULL);
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pInputVertexList));
+
+    if (m_inputVertexListName == "")
+    {
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pInputVertexList));
+    }
+    else
+    {
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_inputVertexListName, pInputVertexList));
+    }
 
     if (!pInputVertexList || pInputVertexList->empty())
     {
@@ -393,6 +402,8 @@ pandora::CartesianPointVector VertexSelectionBaseAlgorithm::ShowerCluster::GetCl
 StatusCode VertexSelectionBaseAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputCaloHitListNames", m_inputCaloHitListNames));
+
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputVertexListName", m_inputVertexListName));
 
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "OutputVertexListName", m_outputVertexListName));
 

--- a/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
+++ b/larpandoracontent/LArVertex/VertexSelectionBaseAlgorithm.h
@@ -392,6 +392,7 @@ private:
 
 private:
     pandora::StringVector m_inputCaloHitListNames; ///< The list of calo hit list names
+    std::string m_inputVertexListName;             ///< The name of an input vertex list to check
     std::string m_outputVertexListName;            ///< The name under which to save the output vertex list
 
     bool m_replaceCurrentVertexList; ///< Whether to replace the current vertex list with the output list

--- a/larpandoradlcontent/LArControlFlow/DLMasterAlgorithm.h
+++ b/larpandoradlcontent/LArControlFlow/DLMasterAlgorithm.h
@@ -26,6 +26,8 @@ public:
 
 private:
     pandora::StatusCode Run();
+
+protected:
     pandora::StatusCode RegisterCustomContent(const pandora::Pandora *const pPandora) const;
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 };

--- a/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.cc
+++ b/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.cc
@@ -186,7 +186,6 @@ StatusCode DlVertexingAlgorithm::Infer()
         }
     }
 
-
     std::map<HitType, float> wireMin, wireMax;
     float driftMin{std::numeric_limits<float>::max()}, driftMax{-std::numeric_limits<float>::max()};
     for (const std::string &listname : m_caloHitListNames)

--- a/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.cc
+++ b/larpandoradlcontent/LArVertex/DlVertexingAlgorithm.cc
@@ -171,7 +171,21 @@ StatusCode DlVertexingAlgorithm::PrepareTrainingSample()
 StatusCode DlVertexingAlgorithm::Infer()
 {
     if (m_pass == 1)
+    {
         ++m_event;
+    }
+    else
+    {
+        // INFO: Check if there is a zoom in region for the second pass.
+        const VertexList *pVertexList(nullptr);
+        PandoraContentApi::GetList(*this, m_inputVertexListName, pVertexList);
+        if (pVertexList == nullptr || pVertexList->empty())
+        {
+            std::cout << "DLVertexing: Input vertex list is empty! Can't perform pass " << m_pass << std::endl;
+            return STATUS_CODE_SUCCESS;
+        }
+    }
+
 
     std::map<HitType, float> wireMin, wireMax;
     float driftMin{std::numeric_limits<float>::max()}, driftMax{-std::numeric_limits<float>::max()};


### PR DESCRIPTION
Two main changes here:

 - In a slicing context, it is technically possible for the DL Vertexing to either not return anything, or return something useless (this will be even more the case if/when we add filter to the DL Vertexing to skip cosmic hits etc). This can happen more frequently for cosmic ray slices. For that reason, its nice to have the existing, SVM-based candidate selection work alongside the newer vertexing. This change simply allows a specific vertexing list to be loaded (not just the current, as that could be set already), and also to stop processing if either a pass 1 vertex wasn't made for the DL vertexing, or if there is any vertex already made, the older vertexing just quits early.

 - The only other change is to make some of the DL Master algorithms methods be protected, not private. This is required for the MicroBooNE wrapper, and matches the functionality of the non-DL master algorithm I think.