### PR TITLE
Small updates to 3D reclustering tools

### DIFF
--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -113,7 +113,7 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
             }
             catch (const StatusCodeException &)
             {
-                std::cout << "Exception caught! Cannot run reclustering tool!" << std::endl;
+                std::cout << pTool->GetType() << ": Exception caught! Cannot run reclustering tool!: " << std::endl;
                 continue;
             }
 
@@ -409,7 +409,7 @@ float ThreeDReclusteringAlgorithm::GetCheatedFigureOfMerit(const CaloHitList &me
     }
     if (mainMcParticleMap.size() == 0)
     {
-        std::cout << "Cheated figure of merit is incalculable - found cluster with missing truth matching for all hits" << std::endl;
+        std::cout << "Cheated figure of merit is incalculable - all hits in a cluster have missing truth matching" << std::endl;
         throw StatusCodeException(STATUS_CODE_NOT_INITIALIZED);
     }
     const auto maxSharedHits =

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -61,7 +61,7 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
         return STATUS_CODE_SUCCESS;
     }
 
-    m_PfosForReclusteringListName = "newShowerParticles3D";
+    m_pfosForReclusteringListName = "newShowerParticles3D";
     PfoList changedPfoList;
 
     //Save current pfo list name, so that this can be set as current again at the end of reclustering
@@ -162,10 +162,10 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Delete<Pfo>(*this, pfo, m_pfoListName));
     // Any remaining pfos (those that didnt undergo reclustering) get moved to the new pfo list
     if (!pShowerPfoList->empty())
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, m_pfoListName, m_PfosForReclusteringListName));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, m_pfoListName, m_pfosForReclusteringListName));
 
     //Save list of Pfos after reclustering and save into list called m_pfoListName
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, m_PfosForReclusteringListName, m_pfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, m_pfosForReclusteringListName, m_pfoListName));
 
     //Set current list to be the same as before reclustering
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Pfo>(*this, initialPfoListName));
@@ -329,7 +329,7 @@ StatusCode ThreeDReclusteringAlgorithm::BuildNewPfos(const Pfo *pPfoToRebuild, C
 
         iCluster++;
     }
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, newPfoListName, m_PfosForReclusteringListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, newPfoListName, m_pfosForReclusteringListName));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -52,14 +52,10 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
     const PfoList *pShowerPfoList(nullptr);
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_INITIALIZED, !=, PandoraContentApi::GetList(*this, m_pfoListName, pShowerPfoList));
     if (!pShowerPfoList)
-    {
         return STATUS_CODE_SUCCESS;
-    }
 
     if (pShowerPfoList->empty())
-    {
         return STATUS_CODE_SUCCESS;
-    }
 
     m_pfosForReclusteringListName = "newShowerParticles3D";
     PfoList changedPfoList;
@@ -73,9 +69,7 @@ StatusCode ThreeDReclusteringAlgorithm::Run()
     PandoraContentApi::GetList(*this, m_clusterListName, pShowerClusters);
 
     if (!pShowerClusters)
-    {
         return STATUS_CODE_NOT_FOUND;
-    }
 
     for (const Pfo *const pShowerPfo : *pShowerPfoList)
     {

--- a/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.h
@@ -136,7 +136,7 @@ private:
     std::string m_pfoListName;                  ///< Name of the list of pfos to consider for reclustering
     std::string m_clusterListName;              ///< Name of the list of clusters to consider for reclustering
     pandora::StringVector m_figureOfMeritNames; ///< The names of the figures of merit to use
-    std::string m_PfosForReclusteringListName;  ///< Name of the internal list to contain new Pfos before/after reclustering
+    std::string m_pfosForReclusteringListName;  ///< Name of the internal list to contain new Pfos before/after reclustering
     std::string m_mcParticleListName;           ///< The mc particle list name
     float m_fomThresholdForReclustering;        ///< A threshold on the minimum figure of merit for reclustering
     long unsigned int m_minNumCaloHitsForReclustering;


### PR DESCRIPTION
Some small updates following my testing of the code in PR #228 :

- Handle expected exceptions - the shower pfo list may be empty and the truth matching may not be present for some hits, this was consistently throwing exceptions previously
- Small refactor to ensure old pfos (no longer having any cluster associated with them) do not remain in the pfo list. Track the pfos that have been reclustered, delete them at the end of the reclustering loop and move all the remaining original pfos into the new list.