### PR TITLE
Rand index helper function + 2d clustering validation alg

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -50,6 +50,7 @@
 
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
+#include "larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/CosmicRayTaggingMonitoringTool.h"
 #include "larpandoracontent/LArMonitoring/HierarchyMonitoringAlgorithm.h"
 #include "larpandoracontent/LArMonitoring/HierarchyValidationAlgorithm.h"
@@ -233,6 +234,7 @@
     d("LArMuonLeadingEventValidation",          MuonLeadingEventValidationAlgorithm)                                            \
     d("LArElectronInitialRegionRefinement",     ElectronInitialRegionRefinementAlgorithm)                                       \
     d("LArNeutrinoEventValidation",             NeutrinoEventValidationAlgorithm)                                               \
+    d("LArEventClusterValidation",              EventClusterValidationAlgorithm)                                                \
     d("LArTestBeamEventValidation",             TestBeamEventValidationAlgorithm)                                               \
     d("LArTestBeamHierarchyEventValidation",    TestBeamHierarchyEventValidationAlgorithm)                                      \
     d("LArHierarchyMonitoring",                 HierarchyMonitoringAlgorithm)                                                   \

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.h
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.h
@@ -80,8 +80,9 @@ public:
 
     /**
      *  @brief  Calculate the adjusted Rand Index for a given contingency table that summarises two clusterings A and B.
-     *          Adjusted Rand Index is a measure of the similarity of two clusterings that is bounded above by 1 (identical)
-     *          and is 0 when the two clusterings are as similar as two random clusterings with the same number of clusters.
+     *          Adjusted Rand Index is a measure of the similarity of two clusterings that is bounded above by 1 (identical),
+     *          is 0 when the two clusterings are as similar as two random clusterings with the same number of clusters,
+     *          and has no lower bound. An index < 0 means very discordant clusterings and is rare in most cases.
      *          Reference - https://link.springer.com/article/10.1007/BF01908075
      *
      *  @param[in] cTable Contingency table as a map of the object that defines the clustering A (e.g. pandora::Cluster)
@@ -93,8 +94,9 @@ public:
 
     /**
      *  @brief  Calculate the adjusted Rand Index for the clustering defined by MCPartices and by CaloHits.
-     *          Adjusted Rand Index is a measure of the similarity of two clusterings that is bounded above by 1 (identical)
-     *          and is 0 when the two clusterings are as similar as two random clusterings with the same number of clusters.
+     *          Adjusted Rand Index is a measure of the similarity of two clusterings that is bounded above by 1 (identical),
+     *          is 0 when the two clusterings are as similar as two random clusterings with the same number of clusters,
+     *          and has no lower bound. An index < 0 means very discordant clusterings and is rare in most cases.
      *          Reference - https://link.springer.com/article/10.1007/BF01908075
      *
      *  @param[in] caloHits List of hits

--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.h
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.h
@@ -75,6 +75,46 @@ public:
      */
     static void PrintMatchingTable(const pandora::PfoVector &orderedPfoVector, const pandora::MCParticleVector &orderedMCParticleVector,
         const LArMCParticleHelper::MCParticleToPfoHitSharingMap &mcParticleToPfoHitSharingMap, const unsigned int nMatches);
+
+    // -- Rand index helpers
+
+    /**
+     *  @brief  Calculate the adjusted Rand Index for a given contingency table that summarises two clusterings A and B.
+     *          Adjusted Rand Index is a measure of the similarity of two clusterings that is bounded above by 1 (identical)
+     *          and is 0 when the two clusterings are as similar as two random clusterings with the same number of clusters.
+     *          Reference - https://link.springer.com/article/10.1007/BF01908075
+     *
+     *  @param[in] cTable Contingency table as a map of the object that defines the clustering A (e.g. pandora::Cluster)
+     *                    to a map of the object that defines the clustering B (e.g. pandora::MCParticle)
+     *                    to the value of the table at this entry (which is the intersection of the two clusters)
+     */
+    template<typename Ti, typename Tj>
+    static float CalcRandIndex(const std::map<const Ti, std::map<const Tj, int>> &cTable);
+
+    /**
+     *  @brief  Calculate the adjusted Rand Index for the clustering defined by MCPartices and by CaloHits.
+     *          Adjusted Rand Index is a measure of the similarity of two clusterings that is bounded above by 1 (identical)
+     *          and is 0 when the two clusterings are as similar as two random clusterings with the same number of clusters.
+     *          Reference - https://link.springer.com/article/10.1007/BF01908075
+     *
+     *  @param[in] caloHits List of hits
+     *  @param[in] clusters List of clusters
+     */
+    static float CalcRandIndex(const pandora::CaloHitList &caloHits, const pandora::ClusterList &clusters);
+
+    /**
+     *  @brief  Fill the contingency table for a set of CaloHits partitioned by Cluster and parent MCParticle.
+     *
+     *  @param[in]  caloHits List of hits to be considered
+     *  @param[in]  clusters List of clusters that contain the hits
+     *  @param[out] cTable   Contingency table as a map of Cluster to a map of MCParticle to the value of the table at this entry
+     *                       which is the intersection of clusterings defined by each object
+     */
+    static void FillContingencyTable(const pandora::CaloHitList &caloHits,
+                                     const pandora::ClusterList &clusters,
+                                     std::map<const pandora::Cluster *const, std::map<const pandora::MCParticle *const, int>> &cTable);
+
+    // --
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -106,26 +106,7 @@ StatusCode EventClusterValidationAlgorithm::Run()
             ClusterMetrics metrics;
             GetMetrics(hitParentsValid, metrics);
 
-            // Get adjusted Rand index
-            ContingencyTable cTable;
-            CaloHitList theseCaloHits;
-            // std::cout << "1" << std::endl;
-            for (const auto&[pCaloHit, parents] : hitParentsValid)
-                theseCaloHits.push_back(pCaloHit);
-            // float adjustedRandI(theseCaloHits, clusters);
-            LArMonitoringHelper::FillContingencyTable(theseCaloHits, clusters, cTable);
-            // std::cout << "2" << std::endl;
-            // for (const auto &[pCluster, pMCToVal] : cTable)
-            // {
-            //     std::cout << pCluster << ":\n";
-            //     for (const auto &[pMC, val] : pMCToVal)
-            //     {
-            //         std::cout << pMC << " -> " << val << "\n";
-            //     }
-            // }
-            float adjustedRandI {LArMonitoringHelper::CalcRandIndex(cTable)};
-            // std::cout << "3" << std::endl;
-            // float adjustedRandI {CalcRandIndex(hitParentsValid)};
+            float adjustedRandI {CalcRandIndex(hitParentsValid)};
 
             std::string branchPrefix;
             if (valType == ValidationType::ALL)
@@ -312,43 +293,6 @@ float EventClusterValidationAlgorithm::CalcRandIndex(std::map<const CaloHit *con
     }
 
     return LArMonitoringHelper::CalcRandIndex(cTable);
-
-    // // Calculate Adjusted Rand Index
-    // double aTerm {0.};
-    // for (const auto &[pCluster, mcValMap] : cTable)
-    // {
-    //     int a {0};
-    //     for (const auto &[pMC, val] : mcValMap)
-    //         a += val;
-    //     aTerm += static_cast<double>(a * (a - 1)) / 2.;
-    // }
-    // double bTerm {0.};
-    // std::set<const MCParticle *> mcs;
-    // for (const auto &[pCluster, mcValMap] : cTable)
-    // {
-    //     for (const auto &[pMC, val] : mcValMap)
-    //         mcs.insert(pMC);
-    // }
-    // for (const MCParticle *pMC : mcs)
-    // {
-    //     int b {0};
-    //     for (const auto &[pCluster, mcValMap] : cTable)
-    //     {
-    //         if (mcValMap.find(pMC) != mcValMap.end())
-    //             b += cTable[pCluster][pMC];
-    //     }
-    //     bTerm += static_cast<double>(b * (b - 1)) / 2.;
-    // }
-    // double indexTerm {0.};
-    // for (const auto &[pCluster, mcValMap] : cTable)
-    //     for (const auto &[pMC, val] : mcValMap)
-    //         indexTerm += static_cast<double>(val * (val - 1)) / 2.;
-    // int n {static_cast<int>(hitParents.size())};
-    // double expIndexTerm {(aTerm * bTerm) / static_cast<double>(n * (n - 1)) / 2.};
-    // double maxIndexTerm {0.5 * (aTerm + bTerm)};
-    // double adjustedRandIndex {(indexTerm - expIndexTerm) / (maxIndexTerm - expIndexTerm)};
-
-    // return adjustedRandIndex;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -1,0 +1,390 @@
+/**
+ *  @file   larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+ *
+ *  @brief  Implementation of the event-level cluster validation.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+EventClusterValidationAlgorithm::ClusterMetrics::ClusterMetrics() :
+    m_pMainMCParticles{std::vector<const pandora::MCParticle *> {}},
+    m_nContributions{std::vector<int>{}},
+    m_nRecoHits{std::vector<int>{}},
+    m_purities{std::vector<float>{}},
+    m_completenesses{std::vector<float>{}},
+    m_fragmentationFractions{std::vector<float>{}}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+EventClusterValidationAlgorithm::EventClusterValidationAlgorithm() :
+    m_eventNumber{0},
+    m_caloHitListName{"CaloHitList2D"},
+    m_minMCHitsPerView{0.f}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+EventClusterValidationAlgorithm::~EventClusterValidationAlgorithm()
+{
+    // PANDORA_MONITORING_API(SaveTree(this->GetPandora(), m_treeName, m_fileName, "UPDATE"));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode EventClusterValidationAlgorithm::Run()
+{
+    m_eventNumber++;
+
+    const CaloHitList *pFullCaloHitList {};
+    PANDORA_THROW_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=,
+        PandoraContentApi::GetList(*this, m_caloHitListName, pFullCaloHitList)
+    );
+
+    std::map<HitType, CaloHitList> viewCaloHits;
+    for (const CaloHit *const pCaloHit : *pFullCaloHitList)
+        viewCaloHits[pCaloHit->GetHitType()].emplace_back(pCaloHit);
+
+    // Collect the sum of hit weights for each MCParticle on each view
+    std::map<HitType, MCSumHitWeightMap> mcIDSumHitWeight;
+    GetMCParticleViewSumHits(pFullCaloHitList, mcIDSumHitWeight);
+
+    // Gather clusters from each view list into one container
+    std::map<HitType, ClusterList> viewClustersMap;
+    for (std::string listName : m_clusterListNames)
+    {
+        const ClusterList *pClusterList {};
+        PANDORA_RETURN_RESULT_IF(
+            STATUS_CODE_SUCCESS, !=,
+            PandoraContentApi::GetList(*this, listName, pClusterList)
+        );
+        for (const Cluster *const pCluster : *pClusterList)
+        {
+            const HitType view {LArClusterHelper::GetClusterHitType(pCluster)};
+            viewClustersMap[view].emplace_back(pCluster);
+        }
+    }
+
+    for (const auto &[view, clusterList] : viewClustersMap) {
+        const CaloHitList caloHitList {viewCaloHits[view]};
+        ClusterMetrics clusterMetrics;
+        GetMetrics(clusterList, caloHitList, clusterMetrics);
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "event", m_eventNumber - 1));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "view", static_cast<int>{view}));
+
+        // TODO
+        // Write everything out to tree, think I will need to go back an make explicit vectors for each MC particle propery
+        // Write out mean purity and completeness too
+        // Test this all works and returns purity and completeness in line with the ClusterValidations
+        // Apply minMCHit threshold in GetMetrics
+        // Calculate Rand index
+
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "pdg", metrics.m_pMC->GetParticleId()));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "energy", metrics.m_pMC->GetEnergy()));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "tier", LArMCParticleHelper::GetHierarchyTier(metrics.m_pMC)));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "mom_x", mom.GetX()));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "mom_y", mom.GetY()));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "mom_z", mom.GetZ()));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_contribs", metrics.m_nContributions));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_mc_hits", metrics.m_nTotalMCHits));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "weighted_mc_hits", metrics.m_wTotalMCHits));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_reco_hits", metrics.m_nRecoHits));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "purity", metrics.m_purity));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "completeness", metrics.m_completeness));
+        // PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "fragmentation", metrics.m_fragmentationFraction));
+        // PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_treeName));
+    }
+
+
+    // ClusterMetricsMap metricsMap;
+    // this->GetMetrics(viewClustersMap, metricsMap);
+
+    // if (m_writeFile)
+    // {
+    //     for (const auto &[pCluster, metrics] : metricsMap)
+    //     {
+    //         int view{LArClusterHelper::GetClusterHitType(pCluster)};
+    //         const CartesianVector &mom{metrics.m_pMC->GetMomentum()};
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "event", m_eventNumber - 1));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "view", view));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "pdg", metrics.m_pMC->GetParticleId()));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "energy", metrics.m_pMC->GetEnergy()));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "tier", LArMCParticleHelper::GetHierarchyTier(metrics.m_pMC)));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "mom_x", mom.GetX()));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "mom_y", mom.GetY()));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "mom_z", mom.GetZ()));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_contribs", metrics.m_nContributions));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_mc_hits", metrics.m_nTotalMCHits));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "weighted_mc_hits", metrics.m_wTotalMCHits));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_reco_hits", metrics.m_nRecoHits));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "purity", metrics.m_purity));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "completeness", metrics.m_completeness));
+    //         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "fragmentation", metrics.m_fragmentationFraction));
+    //         PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_treeName));
+    //     }
+    // }
+
+    // if (m_visualize)
+    // {
+    //     PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+    // }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void EventClusterValidationAlgorithm::GetMCParticleViewSumHits(
+    const pandora::CaloHitList *const pCaloHitList, std::map<HitType, MCSumHitWeightMap> &mcIDSumHitWeight
+) const
+{
+    for (const CaloHit *const pCaloHit : *pCaloHitList)
+    {
+        const HitType view {pCaloHit->GetHitType()};
+        if (mcIDSumHitWeight.find(view) == mcIDSumHitWeight.end())
+            mcIDSumHitWeight[view] = MCSumHitWeightMap{};
+
+        const MCParticleWeightMap &weightMap {pCaloHit->GetMCParticleWeightMap()};
+        for (const auto &[pMC, weight] : weightMap)
+        {
+            if (mcIDSumHitWeight[view].find(pMC->GetUid()) == mcIDSumHitWeight[view].end())
+                mcIDSumHitWeight[view][pMC->GetUid()] = 0.0f;
+            mcIDSumHitWeight[view][pMC->GetUid()] += weight;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void EventClusterValidationAlgorithm::GetMetrics(
+    const ClusterList &viewClusters, const CaloHitList &viewCaloHits, ClusterMetrics &metrics
+) const
+{
+    // Adapted from Andy's code for calculating cluster purity and completeness (ClusterValidationAlgorithm)
+    for (const Cluster *const pCluster : viewClusters)
+    {
+        const CaloHitList &isolatedHits {pCluster->GetIsolatedCaloHitList()};
+        CaloHitList caloHits;
+        pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHits);
+        caloHits.insert(caloHits.end(), isolatedHits.begin(), isolatedHits.end());
+
+        // Aggregate MC particle weights from each calo hit in the cluster
+        MCParticleWeightMap clusterMCWeightMap;
+        float totalClusterWeight {0.f};
+        for (const CaloHit *const pCaloHit : caloHits)
+        {
+            const MCParticleWeightMap &weightMap {pCaloHit->GetMCParticleWeightMap()};
+            for (const auto &[pMC, weight] : weightMap)
+            {
+                if (clusterMCWeightMap.find(pMC) == clusterMCWeightMap.end())
+                    clusterMCWeightMap[pMC] = 0.f;
+                clusterMCWeightMap[pMC] += weight;
+                totalClusterWeight += weight;
+            }
+        }
+        if (totalClusterWeight > 0)
+        {
+            for (const auto &[pMC, weight] : clusterMCWeightMap)
+                clusterMCWeightMap[pMC] /= totalClusterWeight;
+        }
+
+        // Determine which MC particle contributes the most weight across the cluster
+        const MCParticle *pMainMC {nullptr};
+        float maxWeight {std::numeric_limits<float>::lowest()};
+        for (const auto &[pMC, weight] : clusterMCWeightMap)
+        {
+            if (weight > maxWeight)
+            {
+                pMainMC = pMC;
+                maxWeight = weight;
+            }
+        }
+
+        // Calculate the cluster purity
+        float wMatchedHits {0};
+        int nTotalRecoHits {0};
+        for (const CaloHit *const pCaloHit : caloHits)
+        {
+            const MCParticleWeightMap &weightMap {pCaloHit->GetMCParticleWeightMap()};
+            if (weightMap.find(pMainMC) != weightMap.end())
+                wMatchedHits += weightMap.at(pMainMC);
+            if (!weightMap.empty())
+                nTotalRecoHits++;
+        }
+        if (nTotalRecoHits > 0)
+        {
+            metrics.m_purities.push_back(wMatchedHits / nTotalRecoHits);
+            metrics.m_pMainMCParticles.push_back(pMainMC);
+            metrics.m_nRecoHits.push_back(nTotalRecoHits);
+        }
+
+        // Calculate Cluster completeness
+        float wTotalMCHits {0};
+        for (const CaloHit *const pCaloHit : viewCaloHits)
+        {
+            const MCParticleWeightMap &weightMap {pCaloHit->GetMCParticleWeightMap()};
+            if (weightMap.find(pMainMC) != weightMap.end())
+                wTotalMCHits += weightMap.at(pMainMC);
+        }
+
+        if (wTotalMCHits > 0)
+            metrics.m_completenesses.push_back(wMatchedHits / wTotalMCHits);
+        float accountedWeight {0.f};
+        int nContributions {0};
+        for (const auto &[pMC, weight] : clusterMCWeightMap)
+        {
+            if (weight > 0.2f)
+            {
+                ++nContributions;
+                accountedWeight += weight;
+            }
+        }
+        metrics.m_nContributions.push_back(nContributions);
+        metrics.m_fragmentationFractions.push_back(1.f - accountedWeight);
+    }
+}
+// {
+//     const CaloHitList *pFullCaloHitList{nullptr};
+//     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_caloHitListName, pFullCaloHitList));
+//     for (const auto &[view, clusterList] : viewClustersMap)
+//     {
+//         CaloHitList viewCaloHitList;
+//         for (const CaloHit *const pCaloHit : *pFullCaloHitList)
+//             if (pCaloHit->GetHitType() == view)
+//                 viewCaloHitList.emplace_back(pCaloHit);
+//         for (const Cluster *const pCluster : clusterList)
+//         {
+//             MCParticleWeightMap clusterMCWeightMap;
+//             const CaloHitList &isolatedHits{pCluster->GetIsolatedCaloHitList()};
+//             CaloHitList caloHits;
+//             pCluster->GetOrderedCaloHitList().FillCaloHitList(caloHits);
+//             caloHits.insert(caloHits.end(), isolatedHits.begin(), isolatedHits.end());
+//             float totalClusterWeight{0.f};
+//             for (const CaloHit *const pCaloHit : caloHits)
+//             {
+//                 const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
+//                 for (const auto &[pMC, weight] : weightMap)
+//                 {
+//                     if (clusterMCWeightMap.find(pMC) == clusterMCWeightMap.end())
+//                         clusterMCWeightMap[pMC] = 0.f;
+//                     clusterMCWeightMap[pMC] += weight;
+//                     totalClusterWeight += weight;
+//                 }
+//             }
+//             if (totalClusterWeight > 0)
+//                 for (const auto &[pMC, weight] : clusterMCWeightMap)
+//                     clusterMCWeightMap[pMC] /= totalClusterWeight;
+//             // Determine which MC particle contributes the most weight across the cluster
+//             const MCParticle *pMainMC{metricsMap.find(pCluster) != metricsMap.end() ? metricsMap[pCluster].m_pMC : nullptr};
+//             if (!pMainMC)
+//             {
+//                 float maxWeight{std::numeric_limits<float>::lowest()};
+//                 for (const auto &[pMC, weight] : clusterMCWeightMap)
+//                 {
+//                     if (weight > maxWeight)
+//                     {
+//                         pMainMC = pMC;
+//                         maxWeight = weight;
+//                     }
+//                 }
+//             }
+//             if (pMainMC)
+//             {
+//                 float wMatchedHits{0};
+//                 int nTotalRecoHits{0};
+//                 for (const CaloHit *const pCaloHit : caloHits)
+//                 {
+//                     const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
+//                     if (weightMap.find(pMainMC) != weightMap.end())
+//                     {
+//                         wMatchedHits += weightMap.at(pMainMC);
+//                     }
+//                     if (!weightMap.empty())
+//                         nTotalRecoHits++;
+//                 }
+//                 if (nTotalRecoHits > 0)
+//                 {
+//                     metricsMap[pCluster].m_purity = wMatchedHits / nTotalRecoHits;
+//                     metricsMap[pCluster].m_pMC = pMainMC;
+//                     metricsMap[pCluster].m_nRecoHits = nTotalRecoHits;
+//                 }
+//                 float wTotalMCHits{0};
+//                 int nTotalMCHits{0};
+//                 for (const CaloHit *const pCaloHit : viewCaloHitList)
+//                 {
+//                     const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
+//                     if (weightMap.find(pMainMC) != weightMap.end())
+//                     {
+//                         wTotalMCHits += weightMap.at(pMainMC);
+//                         nTotalMCHits++;
+//                     }
+//                 }
+
+//                 if (wTotalMCHits > 0)
+//                 {
+//                     metricsMap[pCluster].m_completeness = wMatchedHits / wTotalMCHits;
+//                     metricsMap[pCluster].m_nTotalMCHits = nTotalMCHits;
+//                     metricsMap[pCluster].m_wTotalMCHits = wTotalMCHits;
+//                 }
+//                 float accountedWeight{0.f};
+//                 for (const auto &[pMC, weight] : clusterMCWeightMap)
+//                 {
+//                     if (weight > 0.2f)
+//                     {
+//                         ++metricsMap[pCluster].m_nContributions;
+//                         accountedWeight += weight;
+//                     }
+//                 }
+//                 metricsMap[pCluster].m_fragmentationFraction = 1.f - accountedWeight;
+//             }
+//         }
+//     }
+// }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode EventClusterValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=,
+        XmlHelper::ReadValue(xmlHandle, "FileName", m_fileName)
+    );
+    PANDORA_RETURN_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=,
+        XmlHelper::ReadValue(xmlHandle, "TreeName", m_treeName)
+    );
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName)
+    );
+    PANDORA_RETURN_RESULT_IF(
+        STATUS_CODE_SUCCESS, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames)
+    );
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinMCHitsPerView", m_minMCHitsPerView)
+    );
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content
+

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
@@ -52,7 +52,10 @@ public:
     */
     EventClusterValidationAlgorithm();
 
-    virtual ~EventClusterValidationAlgorithm();
+    /**
+     *  @brief  Destructor saves the validation TTree along with making and saving a metadata TTree
+     */
+    ~EventClusterValidationAlgorithm();
 
 private:
     typedef std::map<const pandora::Cluster *const, std::map<const pandora::MCParticle *const, int>> ContingencyTable;

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
@@ -23,15 +23,30 @@ private:
     {
         ClusterMetrics();
 
-        std::vector<const pandora::MCParticle *> m_pMainMCParticles;
-        std::vector<int> m_nContributions;
         std::vector<int> m_nRecoHits;
         std::vector<float> m_purities;
         std::vector<float> m_completenesses;
-        std::vector<float> m_fragmentationFractions;
+        int m_nHits;
+        int m_nClusters;
+        int m_nMainMCs;
+    };
+
+    enum ValidationType
+    {
+        ALL,
+        SHOWER,
+        TRACK
     };
 
 public:
+    struct CaloHitParents
+    {
+        CaloHitParents();
+
+        const pandora::MCParticle *m_pMainMC;
+        const pandora::Cluster *m_pCluster;
+    };
+
     /**
     *  @brief  Default constructor
     */
@@ -40,7 +55,7 @@ public:
     virtual ~EventClusterValidationAlgorithm();
 
 private:
-    typedef std::map<pandora::Uid, float> MCSumHitWeightMap;
+    typedef std::map<const pandora::Cluster *const, std::map<const pandora::MCParticle *const, int>> ContingencyTable;
 
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
@@ -48,37 +63,65 @@ private:
     /**
      *  @brief  Retrieve the metrics of every cluster in a view
      *
-     *  @param viewClusters The clusters for this view
-     *  @param viewCaloHits The calo hits for this view
-     *  @param metricsMap The output metrics for the clusters in this view
+     *  @param hitParents Map of hits being considered to the Cluster/MCParticle they belong to
+     *  @param metrics The output metrics for the clusters in this view
      */
     void GetMetrics(
-        const pandora::ClusterList &viewClusters,
-        const pandora::CaloHitList &viewCaloHits,
+        const std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents,
         ClusterMetrics &metrics
     ) const;
 
     /**
-     *  @brief  Collect the sum of hit weights for each MCParticle in each view
+     *  @brief  Calculate Rand Index for the clusters with the clusters of true MCParticles.
+     *          (Ref. for Adjusted Rand Index: https://link.springer.com/article/10.1007/BF01908075)
      *
-     *  @param pCaloHitList The input calo hit list
-     *  @param mcParticleSumWeight The output map of view to MCParticle to sum of all hit weights
+     *  @param hitParents Map of hits being considered to the Cluster/MCParticle they belong to
      */
-    void GetMCParticleViewSumHits(
-        const pandora::CaloHitList *const pCaloHitList,
-        std::map<pandora::HitType, MCSumHitWeightMap> &mcIDSumHitWeight
+    float CalcRandIndex(std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents) const;
+
+    /**
+     *  @brief  Find the cluster and MCParticle each hit belongs to
+     *
+     *  @param caloHits list of hits
+     *  @param clusters list of clusters
+     *  @param hitParents Output map of hits to the Cluster/MCParticle they belong to
+     */
+    void GetHitParents(
+        const pandora::CaloHitList &caloHits, const pandora::ClusterList &clusters,
+        std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents
     ) const;
+
+    /**
+     *  @brief  Erase hits associated to an MCParticle that does meet a minimum
+     *          number of hits in the view
+     *
+     *  @param hitParents Map of hits to the Cluster/MCParticle they belong to
+     */
+    void ApplyMCParticleMinSumHits(
+        std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents
+    ) const;
+
+    /**
+     *  @brief  Erase hits not associated with an MCParticle PDG incompatible with track/shower/all
+     *
+     *  @param hitParents Map of hits to the Cluster/MCParticle they belong to
+     *  @param valType Enum for track/shower/all
+     */
+    std::map<const pandora::CaloHit *const, EventClusterValidationAlgorithm::CaloHitParents> ApplyPDGCut(
+        std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents, const ValidationType &valType
+    ) const;
+
+    void SetBranches(ClusterMetrics &metrics, float randIdx, std::string branchPrefix) const;
 
     int m_eventNumber;                           ///< To track the current event number
     std::string m_fileName;                      ///< The filename of the ROOT output file
     std::string m_treeName;                      ///< The name of the ROOT tree
     std::string m_caloHitListName;               ///< The name of the hit list containing all hits in all views
     std::vector<std::string> m_clusterListNames; ///< The names of the lists of clusters to process
-    float m_minMCHitsPerView;                    ///< Threshold on MCParticle hits in each view
+    int m_minMCHitsPerView;                      ///< Threshold on total maint MCParticle hits in each view
                                                  ///  for consideration in metric calculations
 };
 
 } // namespace lar_content
 
 #endif // LAR_EVENT_CLUSTER_VALIDATION_ALGORITHM_H
-

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
@@ -1,0 +1,84 @@
+/**
+ *  @file   larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
+ *
+ *  @brief  Header file of the event-level cluster validation.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_EVENT_CLUSTER_VALIDATION_ALGORITHM_H
+#define LAR_EVENT_CLUSTER_VALIDATION_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  EventClusterValidationAlgorithm class
+ */
+class EventClusterValidationAlgorithm : public pandora::Algorithm
+{
+private:
+    struct ClusterMetrics
+    {
+        ClusterMetrics();
+
+        std::vector<const pandora::MCParticle *> m_pMainMCParticles;
+        std::vector<int> m_nContributions;
+        std::vector<int> m_nRecoHits;
+        std::vector<float> m_purities;
+        std::vector<float> m_completenesses;
+        std::vector<float> m_fragmentationFractions;
+    };
+
+public:
+    /**
+    *  @brief  Default constructor
+    */
+    EventClusterValidationAlgorithm();
+
+    virtual ~EventClusterValidationAlgorithm();
+
+private:
+    typedef std::map<pandora::Uid, float> MCSumHitWeightMap;
+
+    pandora::StatusCode Run();
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief  Retrieve the metrics of every cluster in a view
+     *
+     *  @param viewClusters The clusters for this view
+     *  @param viewCaloHits The calo hits for this view
+     *  @param metricsMap The output metrics for the clusters in this view
+     */
+    void GetMetrics(
+        const pandora::ClusterList &viewClusters,
+        const pandora::CaloHitList &viewCaloHits,
+        ClusterMetrics &metrics
+    ) const;
+
+    /**
+     *  @brief  Collect the sum of hit weights for each MCParticle in each view
+     *
+     *  @param pCaloHitList The input calo hit list
+     *  @param mcParticleSumWeight The output map of view to MCParticle to sum of all hit weights
+     */
+    void GetMCParticleViewSumHits(
+        const pandora::CaloHitList *const pCaloHitList,
+        std::map<pandora::HitType, MCSumHitWeightMap> &mcIDSumHitWeight
+    ) const;
+
+    int m_eventNumber;                           ///< To track the current event number
+    std::string m_fileName;                      ///< The filename of the ROOT output file
+    std::string m_treeName;                      ///< The name of the ROOT tree
+    std::string m_caloHitListName;               ///< The name of the hit list containing all hits in all views
+    std::vector<std::string> m_clusterListNames; ///< The names of the lists of clusters to process
+    float m_minMCHitsPerView;                    ///< Threshold on MCParticle hits in each view
+                                                 ///  for consideration in metric calculations
+};
+
+} // namespace lar_content
+
+#endif // LAR_EVENT_CLUSTER_VALIDATION_ALGORITHM_H
+

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
@@ -61,65 +61,63 @@ private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     /**
-     *  @brief  Retrieve the metrics of every cluster in a view
+     *  @brief Retrieve the metrics of every cluster in a view
      *
-     *  @param hitParents Map of hits being considered to the Cluster/MCParticle they belong to
-     *  @param metrics The output metrics for the clusters in this view
+     *  @param[in]  hitParents Map of hits being considered to the Cluster/MCParticle they belong to
+     *  @param[out] metrics    Metrics for the clusters in this view
      */
-    void GetMetrics(
-        const std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents,
-        ClusterMetrics &metrics
-    ) const;
+    void GetMetrics(const std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents, ClusterMetrics &metrics) const;
 
     /**
-     *  @brief  Calculate Rand Index for the clusters with the clusters of true MCParticles.
+     *  @brief Calculate Rand Index for the clusters with the clusters of true MCParticles.
      *          (Ref. for Adjusted Rand Index: https://link.springer.com/article/10.1007/BF01908075)
      *
-     *  @param hitParents Map of hits being considered to the Cluster/MCParticle they belong to
+     *  @param[in] hitParents Map of hits being considered to the Cluster/MCParticle they belong to
      */
     float CalcRandIndex(std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents) const;
 
     /**
-     *  @brief  Find the cluster and MCParticle each hit belongs to
+     *  @brief Find the cluster and MCParticle each hit belongs to
      *
-     *  @param caloHits list of hits
-     *  @param clusters list of clusters
-     *  @param hitParents Output map of hits to the Cluster/MCParticle they belong to
+     *  @param[in]  caloHits   List of hits
+     *  @param[in]  clusters   List of clusters
+     *  @param[out] hitParents Map of hits to the Cluster/MCParticle they belong to
      */
-    void GetHitParents(
-        const pandora::CaloHitList &caloHits, const pandora::ClusterList &clusters,
-        std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents
-    ) const;
+    void GetHitParents(const pandora::CaloHitList &caloHits,
+                       const pandora::ClusterList &clusters,
+                       std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents) const;
 
     /**
-     *  @brief  Erase hits associated to an MCParticle that does meet a minimum
-     *          number of hits in the view
+     *  @brief Erase hits associated to an MCParticle that does meet a minimum number of hits in the view
      *
-     *  @param hitParents Map of hits to the Cluster/MCParticle they belong to
+     *  @param[in,out] hitParents Map of hits to the Cluster/MCParticle they belong to
      */
-    void ApplyMCParticleMinSumHits(
-        std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents
-    ) const;
+    void ApplyMCParticleMinSumHits(std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents) const;
 
     /**
-     *  @brief  Erase hits not associated with an MCParticle PDG incompatible with track/shower/all
+     *  @brief Erase hits not associated with an MCParticle PDG incompatible with track/shower/all
      *
-     *  @param hitParents Map of hits to the Cluster/MCParticle they belong to
-     *  @param valType Enum for track/shower/all
+     *  @param[in] hitParents Map of hits to the Cluster/MCParticle they belong to
+     *  @param[in] valType    Enum for track/shower/all
      */
-    std::map<const pandora::CaloHit *const, EventClusterValidationAlgorithm::CaloHitParents> ApplyPDGCut(
-        std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents, const ValidationType &valType
-    ) const;
+    std::map<const pandora::CaloHit *const, CaloHitParents> ApplyPDGCut(std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents,
+                                                                        const ValidationType &valType) const;
 
+    /**
+     *  @brief Update the branches of the TTree for this entry
+     *
+     *  @param[in] metrics      Metrics for clusters in a view
+     *  @param[in] randIfx      Adjusted Rand index
+     *  @param[in] branchPrefix Prefix for the branch name
+     */
     void SetBranches(ClusterMetrics &metrics, float randIdx, std::string branchPrefix) const;
 
     int m_eventNumber;                           ///< To track the current event number
     std::string m_fileName;                      ///< The filename of the ROOT output file
     std::string m_treeName;                      ///< The name of the ROOT tree
-    std::string m_caloHitListName;               ///< The name of the hit list containing all hits in all views
-    std::vector<std::string> m_clusterListNames; ///< The names of the lists of clusters to process
-    int m_minMCHitsPerView;                      ///< Threshold on total maint MCParticle hits in each view
-                                                 ///  for consideration in metric calculations
+    std::string m_caloHitListName;               ///< The name of the hit list containing all 2D hits
+    std::vector<std::string> m_clusterListNames; ///< The names of the lists of 2D clusters to process
+    int m_minMCHitsPerView;                      ///< Threshold on total main MCParticle hits in each view for consideration in metric calculations
 };
 
 } // namespace lar_content


### PR DESCRIPTION
Thought it might be useful to get the adjusted rand index (a measure of the similarity of two clusterings) calculation into a helper function. The helper function calculates the index from a contingency table (a map of map which encodes all non-zero intersections between the two clusterings) which the user should make. I included additional helpers to make the contingency table for the case of `Cluster` and `MCParticle` clusterings which I think would be the most common use case.

I also included my 2D clustering monitoring algorithm that computes the rand index (and other aggregate metrics) for the 2D clustering in each view of an event.