### PR TITLE
Small bug fixes for event clustering validation

### DIFF
--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -226,10 +226,21 @@ void EventClusterValidationAlgorithm::GetMetrics(const std::map<const CaloHit *c
 
     for (const Cluster *const pCluster : validClusters)
     {
-        const CaloHitList &isolatedHits{pCluster->GetIsolatedCaloHitList()};
         CaloHitList clusterCaloHits;
-        pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterCaloHits);
-        clusterCaloHits.insert(clusterCaloHits.end(), isolatedHits.begin(), isolatedHits.end());
+        if (pCluster)
+        {
+            const CaloHitList &isolatedHits{pCluster->GetIsolatedCaloHitList()};
+            pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterCaloHits);
+            clusterCaloHits.insert(clusterCaloHits.end(), isolatedHits.begin(), isolatedHits.end());
+        }
+        else // The hit has a null cluster ie. it is unclustered, treat all such hits as being clustered together
+        {
+            for (const auto &[pCaloHit, parents] : hitParents)
+            {
+                if (!parents.m_pCluster)
+                    clusterCaloHits.emplace_back(pCaloHit);
+            }
+        }
 
         std::map<const MCParticle *const, int> mainMCParticleHits;
         float totalHits{0};

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -330,7 +330,7 @@ void EventClusterValidationAlgorithm::SetBranches(
 StatusCode EventClusterValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "FileName", m_fileName));
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "treeName", m_treeName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "TreeName", m_treeName));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
     PANDORA_RETURN_RESULT_IF_AND_IF(

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -279,7 +279,7 @@ void EventClusterValidationAlgorithm::GetMetrics(const std::map<const CaloHit *c
             if (pMainMC == parents.m_pMainMC)
                 nTotalMainMCHits++;
         }
-        metrics.m_completenesses.emplace_back(maxHits / nTotalMainMCHits);
+        metrics.m_completenesses.emplace_back(maxHits / static_cast<float>(nTotalMainMCHits));
     }
 }
 


### PR DESCRIPTION
- Noticed by Andy - the monitoring does not handle hits without clusters. Now just treat the hits that belong to no cluster as belonging to a single mop-up cluster
- The completeness calculation needs an explicit int -> float conversion!