### PR TITLE
2d clustering validation bug

### DIFF
--- a/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMonitoringHelper.cc
@@ -405,7 +405,10 @@ void LArMonitoringHelper::FillContingencyTable(
         for (const auto &[pMC, weight] : weightMap)
         {
             if (weight > maxWeight)
+            {
                 pMainMC = pMC;
+                maxWeight = weight;
+            }
         }
         if (pMainMC)
         {

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -139,7 +139,10 @@ void EventClusterValidationAlgorithm::GetHitParents(
         for (const auto &[pMC, weight] : weightMap)
         {
             if (weight > maxWeight)
+            {
                 pMainMC = pMC;
+                maxWeight = weight;
+            }
         }
         if (pMainMC)
         {


### PR DESCRIPTION
Pretty bad bug I made in calculation of a hit's main MC particle :disappointed:  . In the majority of cases where only one MC particle contributes to a hit, this makes no difference, but in the other cases the weight was not being taken into account and the last MC particle in the weight map was being taken as the main MC particle.