### PR TITLE
Use Collection plane in ICARUS for track/shower discrimination

### DIFF
--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -410,10 +410,12 @@
     d("LArTwoDVertexDistanceFeatureTool",       TwoDVertexDistanceFeatureTool)                                                  \
     d("LArThreeDVertexDistanceFeatureTool",     ThreeDVertexDistanceFeatureTool)                                                \
     d("LArThreeDChargeFeatureTool",             ThreeDChargeFeatureTool)                                                        \
+    d("LArThreeDChargeFeatureTool_ICARUS",      ThreeDChargeFeatureTool_ICARUS)                                                 \
     d("LArThreeDPCAFeatureTool",                ThreeDPCAFeatureTool)                                                           \
     d("LArThreeDOpeningAngleFeatureTool",       ThreeDOpeningAngleFeatureTool)                                                  \
     d("LArPfoHierarchyFeatureTool",             PfoHierarchyFeatureTool)                                                        \
-    d("LArConeChargeFeatureTool",             	ConeChargeFeatureTool)
+    d("LArConeChargeFeatureTool",             	ConeChargeFeatureTool)                                                          \
+    d("LArConeChargeFeatureTool_ICARUS",        ConeChargeFeatureTool_ICARUS)
 
 #define LAR_PARTICLE_ID_LIST(d)                                                                                                 \
     d("LArMuonId",                              LArParticleIdPlugins::LArMuonId)

--- a/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc
@@ -162,18 +162,18 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
 
             // Based on whether the PFP crosses the cathode, views are combined to obtain Collection in ICARUS      
             // PFP crosses the cathode                                                          
-            if (LocatePointInCryostat(minX) == PositionInCryostat::BelowCathode &&
-                LocatePointInCryostat(maxX) == PositionInCryostat::AboveCathode) 
+            if (LocatePointInCryostat_ICARUS(minX) == PositionInCryostat::BelowCathode &&
+                LocatePointInCryostat_ICARUS(maxX) == PositionInCryostat::AboveCathode) 
             {
                 isChargeInfoEmpty = (uClusterList.empty() || vClusterList.empty()) ? wClusterList.empty() : false; ///< Need both U and V, otherwise fall back to Induction-1
             }
             // PFP is contained within TPC 2/3
-            else if (LocatePointInCryostat(minX) == PositionInCryostat::AboveCathode)
+            else if (LocatePointInCryostat_ICARUS(minX) == PositionInCryostat::AboveCathode)
             {
                 isChargeInfoEmpty = (!vClusterList.empty() ? vClusterList.empty() : uClusterList.empty()); ///< TPC 2/3, otherwise fall back to Induction-2
             }
             // PFP is contained within TPC 0/1
-            else if (LocatePointInCryostat(maxX) == PositionInCryostat::BelowCathode)
+            else if (LocatePointInCryostat_ICARUS(maxX) == PositionInCryostat::BelowCathode)
             {
                 isChargeInfoEmpty = (!uClusterList.empty() ? uClusterList.empty() : vClusterList.empty()); ///< TPC 0/1, otherwise fall back to Induction-2
             }

--- a/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc
@@ -8,6 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArFileHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
@@ -84,6 +86,10 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const Cluster *const pClus
 template <typename T>
 bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlowObject *const pPfo) const
 {
+    
+    //std::cout << "==============================================" << std::endl;
+    //std::cout << "Starting now with IsClearTrack..." << std::endl;
+
     if (!LArPfoHelper::IsThreeD(pPfo))
     {
         if (m_enableProbability)
@@ -95,12 +101,167 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
         return (pPfo->GetParticleId() == MU_MINUS);
     }
 
-    // Charge related features are only calculated using hits in W view
+    /* 
+     *  Standard code!
+     */
+
+    // // Charge related features are only calculated using hits in W view
+    // ClusterList wClusterList;
+    // LArPfoHelper::GetClusters(pPfo, TPC_VIEW_W, wClusterList);
+
+    // const PfoCharacterisationFeatureTool::FeatureToolMap &chosenFeatureToolMap(wClusterList.empty() ? m_featureToolMapNoChargeInfo : m_featureToolMapThreeD);
+    // const StringVector chosenFeatureToolOrder(wClusterList.empty() ? m_algorithmToolNamesNoChargeInfo : m_algorithmToolNames);
+    // StringVector featureOrder;
+    // const LArMvaHelper::MvaFeatureMap featureMap(
+    //     LArMvaHelper::CalculateFeatures(chosenFeatureToolOrder, chosenFeatureToolMap, featureOrder, this, pPfo));
+
+    //std::cout << "Looking for the Collection plane..." << std::endl;
+
+    /*
+     *  Find Collection plane.
+     */
+
+    bool IsCollectionEmpty;
+
+    // W (Ind-1)
+    bool selectViewW = true;
     ClusterList wClusterList;
     LArPfoHelper::GetClusters(pPfo, TPC_VIEW_W, wClusterList);
+    float minX(9999.), maxX(9999.);
+    if (wClusterList.empty()) { selectViewW = false; }
+    else { wClusterList.front()->GetClusterSpanX(minX, maxX); }
 
-    const PfoCharacterisationFeatureTool::FeatureToolMap &chosenFeatureToolMap(wClusterList.empty() ? m_featureToolMapNoChargeInfo : m_featureToolMapThreeD);
-    const StringVector chosenFeatureToolOrder(wClusterList.empty() ? m_algorithmToolNamesNoChargeInfo : m_algorithmToolNames);
+    // U (Ind-2 or Coll, based on TPC)
+    bool selectViewU = true;
+    ClusterList uClusterList;
+    LArPfoHelper::GetClusters(pPfo, TPC_VIEW_U, uClusterList);
+    float minX_U(9999.), maxX_U(9999.);
+    if (uClusterList.empty()) { selectViewU = false; }
+    else { uClusterList.front()->GetClusterSpanX(minX_U, maxX_U); }
+
+    // V (Ind-2 or Coll, based on TPC)
+    bool selectViewV = true;
+    ClusterList vClusterList;
+    LArPfoHelper::GetClusters(pPfo, TPC_VIEW_V, vClusterList);
+    float minX_V(9999.), maxX_V(9999.);
+    if (vClusterList.empty()) { selectViewV = false; }
+    else  { vClusterList.front()->GetClusterSpanX(minX_V, maxX_V); }
+
+    // If no view is available
+    if (!selectViewW && !selectViewU && !selectViewV)
+        IsCollectionEmpty = true;
+
+    // Create the CaloHitList based on Collection whenever possible                                                                                      
+    CaloHitList orderedCaloHitList;
+
+    // Fallback to standard case if there are no U/V views                                                                               
+    if (!selectViewU && !selectViewV) 
+        this->OrderCaloHitsByDistanceToVertex(wClusterList.front(), orderedCaloHitList);
+
+    // Find the drift span with the available views, and find out whether the particle is cathode-crossing
+    if (selectViewU && selectViewV) { minX = std::min(minX_U, minX_V); maxX = std::max(maxX_U, maxX_V); }
+    else if(selectViewU && !selectViewV) { minX = minX_U; maxX = maxX_U; }
+    else if(!selectViewU && selectViewV) { minX = minX_V; maxX = maxX_V; }
+    bool particleCrossingCathode = false;
+    if(LocatePointInCryostat(minX) == PositionInCryostat::BelowCathode &&
+       LocatePointInCryostat(maxX) == PositionInCryostat::AboveCathode)
+        particleCrossingCathode = true;
+
+    //std::cout << "Particle crosses the cathode? " << particleCrossingCathode << std::endl;
+    //std::cout << "Particle X span " << minX << "\t" << maxX << std::endl;
+    
+    // Cathode-crossing particle
+    if(!particleCrossingCathode)
+    {
+
+        //std::cout << "Particle does not cross the cathode..." << std::endl;
+
+        // TPC 2/3 -> V
+        if(LocatePointInCryostat(minX) == PositionInCryostat::AboveCathode && selectViewV) {                                                            
+            this->OrderCaloHitsByDistanceToVertex(vClusterList.front(), orderedCaloHitList);
+        }
+
+        // TPC 0/1 -> U
+        else if(LocatePointInCryostat(maxX) == PositionInCryostat::BelowCathode && selectViewU) {                                          
+            this->OrderCaloHitsByDistanceToVertex(uClusterList.front(), orderedCaloHitList);
+        }
+
+        // TPC 2/3, but V ill-defined
+        else if( LocatePointInCryostat( minX ) == PositionInCryostat::AboveCathode && !selectViewV ) {
+            this->OrderCaloHitsByDistanceToVertex(uClusterList.front(),orderedCaloHitList);
+        }
+
+        // TPC 0/1, but U ill-defined
+        else if( LocatePointInCryostat( maxX ) == PositionInCryostat::BelowCathode && !selectViewU ) {
+            this->OrderCaloHitsByDistanceToVertex(vClusterList.front(), orderedCaloHitList);
+        }
+
+        //std::cout << "-> Chose U or V." << std::endl;
+    }
+
+
+    // Particles that cross the cathode (need both U and V)
+    else {
+
+        //std::cout << "Particle does cross the cathode..." << std::endl;
+
+        if (!selectViewU || !selectViewV) {
+            //std::cout << "-> But falling back to Induction-1 either way." << std::endl;
+            this->OrderCaloHitsByDistanceToVertex(wClusterList.front(), orderedCaloHitList);
+        }
+
+        else {                                                                                                                     
+                                                                                                                                                                               
+            CaloHitList orderedCaloHitListU;
+            this->OrderCaloHitsByDistanceToVertex(uClusterList.front(), orderedCaloHitListU);
+                                                                                                                                                                                 
+            CaloHitList orderedCaloHitListV;
+            this->OrderCaloHitsByDistanceToVertex(vClusterList.front(), orderedCaloHitListV);
+
+            if (!orderedCaloHitListU.empty() && !orderedCaloHitListV.empty()) {                                                   
+                
+                // get vertex
+                const VertexList *pVertexList(nullptr);
+                (void) PandoraContentApi::GetCurrentList(*this, pVertexList);
+                const float pVertexX = pVertexList->front()->GetPosition().GetX();
+                
+                // TPC 2/3 -> V, then U
+                if(LocatePointInCryostat(pVertexX) == PositionInCryostat::AboveCathode) 
+                    this->CombineCaloHitListsToHaveCollection(orderedCaloHitListV, orderedCaloHitListU, orderedCaloHitList);
+
+                // TPC 0/1 -> U, then V
+                else if(LocatePointInCryostat(pVertexX) == PositionInCryostat::BelowCathode)
+                    this->CombineCaloHitListsToHaveCollection(orderedCaloHitListU, orderedCaloHitListV, orderedCaloHitList);
+
+                // vertex within cathode, cannot enstablish the ordering
+                else {
+                    this->CombineCaloHitListsToHaveCollection(orderedCaloHitListU, orderedCaloHitListV, orderedCaloHitList);
+                }
+            } 
+
+            // this means no vertex exists and either list is fine (similarly to what happens for W)                                                                                                                                                               
+            else                                                    
+                orderedCaloHitList = orderedCaloHitListU;
+
+            //std::cout << "-> Merged U and V views." << std::endl;
+        }
+      }
+
+    // Determine if the Collection plane hit list is empty
+    IsCollectionEmpty = orderedCaloHitList.empty();
+
+    // clear hit list
+    orderedCaloHitList.clear();
+
+    //std::cout << "Created the Collection hit list. Is it empty? " << IsCollectionEmpty << std::endl;
+
+    /*
+     *  End of new code. After this, change wClusterList.empty() to IsCollectionEmpty.
+     */
+
+    // Use the dedicated BDT without charge information if the Collection plane is not usable
+    const PfoCharacterisationFeatureTool::FeatureToolMap &chosenFeatureToolMap(IsCollectionEmpty ? m_featureToolMapNoChargeInfo : m_featureToolMapThreeD);
+    const StringVector chosenFeatureToolOrder(IsCollectionEmpty ? m_algorithmToolNamesNoChargeInfo : m_algorithmToolNames);
     StringVector featureOrder;
     const LArMvaHelper::MvaFeatureMap featureMap(
         LArMvaHelper::CalculateFeatures(chosenFeatureToolOrder, chosenFeatureToolMap, featureOrder, this, pPfo));
@@ -229,7 +390,7 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
             if (completeness >= 0.f && purity >= 0.f && !mischaracterisedPfo && (!m_applyFiducialCut || this->PassesFiducialCut(threeDVertexPosition)))
             {
                 std::string outputFile(m_trainingOutputFile);
-                const std::string end = ((wClusterList.empty()) ? "noChargeInfo.txt" : ".txt");
+                const std::string end = (IsCollectionEmpty ? "noChargeInfo.txt" : ".txt");
                 outputFile.append(end);
                 LArMvaHelper::ProduceTrainingExample(outputFile, isTrueTrack, featureOrder, featureMap);
             }
@@ -239,6 +400,8 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
     }
     else if (m_trainingSetMode)
     {
+        //std::cout << "Entering training set mode..." << std::endl;
+
         bool isTrueTrack(false);
         bool isMainMCParticleSet(false);
 
@@ -255,7 +418,7 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
         if (isMainMCParticleSet)
         {
             std::string outputFile(m_trainingOutputFile);
-            outputFile.append(wClusterList.empty() ? "noChargeInfo.txt" : ".txt");
+            outputFile.append(IsCollectionEmpty ? "noChargeInfo.txt" : ".txt");
             LArMvaHelper::ProduceTrainingExample(outputFile, isTrueTrack, featureOrder, featureMap);
         }
 
@@ -265,11 +428,16 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
     // If no failures, proceed with MvaPfoCharacterisationAlgorithm classification
     if (!m_enableProbability)
     {
-        return LArMvaHelper::Classify((wClusterList.empty() ? m_mvaNoChargeInfo : m_mva), featureOrder, featureMap);
+        //std::cout << "Proceeding with classification..." << std::endl;
+        return LArMvaHelper::Classify((IsCollectionEmpty ? m_mvaNoChargeInfo : m_mva), featureOrder, featureMap);
+        //std::cout << "Classified the particle. " << std::endl;
     }
     else
     {
-        const double score(LArMvaHelper::CalculateProbability((wClusterList.empty() ? m_mvaNoChargeInfo : m_mva), featureOrder, featureMap));
+        //std::cout << "Calculating the track score..." << std::endl;
+        const double score(LArMvaHelper::CalculateProbability((IsCollectionEmpty ? m_mvaNoChargeInfo : m_mva), featureOrder, featureMap));
+        //std::cout << "-> Calculated the track score: " << score << std::endl;
+
         object_creation::ParticleFlowObject::Metadata metadata;
         metadata.m_propertiesToAdd["TrackScore"] = score;
         if (m_persistFeatures)
@@ -280,8 +448,226 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
             }
         }
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::AlterMetadata(*this, pPfo, metadata));
+        //std::cout << "-> Updated metadata with features." << std::endl;
+
+        //std::cout << "DONE WITH MVA!" << std::endl;
+        //std::cout << "==============================================" << std::endl;
+        
         return (m_minProbabilityCut <= score);
     }
+
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+void MvaPfoCharacterisationAlgorithm<T>::OrderCaloHitsByDistanceToVertex(
+    // const Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, CaloHitList &caloHitList)
+    const pandora::Cluster *const pCluster, CaloHitList &caloHitList) const
+{
+    const VertexList *pVertexList(nullptr);
+    (void)PandoraContentApi::GetCurrentList(*this, pVertexList);
+
+    if (!pVertexList || pVertexList->empty())
+        return;
+
+    unsigned int nInteractionVertices(0);
+    const Vertex *pInteractionVertex(nullptr);
+
+    for (const Vertex *pVertex : *pVertexList)
+    {
+        if ((pVertex->GetVertexLabel() == VERTEX_INTERACTION) && (pVertex->GetVertexType() == VERTEX_3D))
+        {
+            ++nInteractionVertices;
+            pInteractionVertex = pVertex;
+        }
+    }
+    bool debug = false;
+    
+    if (pInteractionVertex && (1 == nInteractionVertices))
+    {
+        const HitType hitType(LArClusterHelper::GetClusterHitType(pCluster));
+        const CartesianVector vertexPosition2D(LArGeometryHelper::ProjectPosition(this->GetPandora(), pInteractionVertex->GetPosition(), hitType));
+        if (debug)
+        {
+            if( hitType == TPC_VIEW_U )
+                std::cout << "[OrderCaloHitsByDistanceToVertex] This is interaction vertex (view U)" << vertexPosition2D.GetX() << "\t" << vertexPosition2D.GetY() << "\t" << vertexPosition2D.GetZ() << std::endl;
+            else if( hitType == TPC_VIEW_V )
+                std::cout << "[OrderCaloHitsByDistanceToVertex] This is interaction vertex (view V)" << vertexPosition2D.GetX() << "\t" << vertexPosition2D.GetY() << "\t" << vertexPosition2D.GetZ() << std::endl;
+            else
+                std::cout << "[OrderCaloHitsByDistanceToVertex] This is interaction vertex (view W)" << vertexPosition2D.GetX() << "\t" << vertexPosition2D.GetY() << "\t" << vertexPosition2D.GetZ() << std::endl;
+        }
+        CaloHitList clusterCaloHitList;
+        pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterCaloHitList);
+
+        clusterCaloHitList.sort(MvaPfoCharacterisationAlgorithm<T>::VertexComparator(vertexPosition2D));
+        caloHitList.insert(caloHitList.end(), clusterCaloHitList.begin(), clusterCaloHitList.end());
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+void MvaPfoCharacterisationAlgorithm<T>::CombineCaloHitListsToHaveCollection(
+    const pandora::CaloHitList &orderedCaloHitList1, const pandora::CaloHitList &orderedCaloHitList2, 
+    pandora::CaloHitList &mergedCaloHitList) const
+ {
+   bool debug = false;
+   // identify the interaction vertex                                                                                                                                                                    
+   const VertexList *pVertexList(nullptr);
+   (void)PandoraContentApi::GetCurrentList(*this, pVertexList);
+   const CartesianVector vertexPosition2DU(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertexList->front()->GetPosition(), TPC_VIEW_U));
+   const CartesianVector vertexPosition2DV(LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertexList->front()->GetPosition(), TPC_VIEW_V));
+   if( debug )
+     std::cout << "This is vertex position on view U " << vertexPosition2DU.GetX() << "\t " << vertexPosition2DU.GetY() << "\t " << vertexPosition2DU.GetZ() << std::endl;
+   if( debug )
+     std::cout << "This is vertex position on view V " << vertexPosition2DV.GetX() << "\t " << vertexPosition2DV.GetY() << "\t " << vertexPosition2DV.GetZ() << std::endl;
+   float distance_hit_vertex = 0.;
+   float min_distance_hit_vertex_included_1 = 0.;
+   float max_distance_hit_vertex_included_1 = 0.;
+   float min_distance_hit_vertex_included_2 = 0.;
+   float max_distance_hit_vertex_included_2 = 0.;
+   bool set_min_1 = false;
+   bool set_min_2 = false;
+   bool reorderingNeeded = false;
+   // loop over first CaloHitList                                                                                                                                                                        
+   /*                                                                                                                                                                                                    
+    * view U: COLL below cathode, IND2 above cathode                                                                                                                                                     
+    * view V: IND2 below cathode, COLL above cathode                                                                                                                                                     
+    */
+   // if this is from view V take hits ABOVE cathode otherwise below 
+   for (CaloHitList::const_iterator hIter = orderedCaloHitList1.begin(); hIter != orderedCaloHitList1.end(); hIter++) {
+     const CaloHit *const pCaloHit = *hIter;
+     const CartesianVector &hit(pCaloHit->GetPositionVector());
+     if( pCaloHit->GetHitType() == TPC_VIEW_U )
+       distance_hit_vertex = pow( vertexPosition2DU.GetX() - hit.GetX(), 2 ) + pow( vertexPosition2DU.GetY()- hit.GetY(), 2 ) + pow( vertexPosition2DU.GetZ()- hit.GetZ(), 2 );
+     else
+       distance_hit_vertex = pow( vertexPosition2DV.GetX() - hit.GetX(), 2 ) + pow( vertexPosition2DV.GetY()- hit.GetY(), 2 ) + pow( vertexPosition2DV.GetZ()- hit.GetZ(), 2 );
+     if( debug )
+       std::cout << hit.GetX() << "\t" << hit.GetY() << "\t" << hit.GetZ() << " whose distance^2 from vertex is " << distance_hit_vertex << std::endl;
+     bool selectHitViewU = pCaloHit->GetHitType() == TPC_VIEW_U && LocatePointInCryostat( hit.GetX() ) == PositionInCryostat::BelowCathode;
+     bool selectHitViewV = pCaloHit->GetHitType() == TPC_VIEW_V && LocatePointInCryostat( hit.GetX() ) == PositionInCryostat::AboveCathode;
+     bool selectHit = selectHitViewU || selectHitViewV;
+     if( selectHit ){
+       if( debug )
+         std::cout << "This hit should be added to hit list to have COLLECTION plane" << std::endl;
+       mergedCaloHitList.push_back( pCaloHit );
+       if( !set_min_1 ) {
+         min_distance_hit_vertex_included_1 = distance_hit_vertex;
+         set_min_1 = true;
+       }
+       if( distance_hit_vertex > max_distance_hit_vertex_included_1 )
+         max_distance_hit_vertex_included_1 = distance_hit_vertex;
+     }
+   }
+   std::cout << "This is (min,max) from the 1st CaloHitList: ( " << min_distance_hit_vertex_included_1 << ", " << max_distance_hit_vertex_included_1 << " )." << std::endl;
+
+   // loop over second CaloHitList                                                                                                                                                                       
+   for (CaloHitList::const_iterator hIter = orderedCaloHitList2.begin(); hIter != orderedCaloHitList2.end(); hIter++) {
+     const CaloHit *const pCaloHit = *hIter;
+     const CartesianVector &hit(pCaloHit->GetPositionVector());
+     if( pCaloHit->GetHitType() == TPC_VIEW_U )
+       distance_hit_vertex = pow( vertexPosition2DU.GetX() - hit.GetX(), 2 ) + pow( vertexPosition2DU.GetY()- hit.GetY(), 2 ) + pow( vertexPosition2DU.GetZ()- hit.GetZ(), 2 );
+     else
+       distance_hit_vertex = pow( vertexPosition2DV.GetX() - hit.GetX(), 2 ) + pow( vertexPosition2DV.GetY()- hit.GetY(), 2 ) + pow( vertexPosition2DV.GetZ()- hit.GetZ(), 2 );
+     if( debug )
+       std::cout << hit.GetX() << "\t" << hit.GetY() << "\t" << hit.GetZ() << " whose distance^2 from vertex is " << distance_hit_vertex << std::endl;
+     bool selectHitViewU = pCaloHit->GetHitType() == TPC_VIEW_U && LocatePointInCryostat( hit.GetX() ) == PositionInCryostat::BelowCathode;
+     bool selectHitViewV = pCaloHit->GetHitType() == TPC_VIEW_V && LocatePointInCryostat( hit.GetX() ) == PositionInCryostat::AboveCathode;
+     bool selectHit = selectHitViewU || selectHitViewV;
+     if( selectHit ){
+       if( debug )
+         std::cout << "This hit should be added to hit list to have COLLECTION plane" << std::endl;
+       mergedCaloHitList.push_back( pCaloHit );
+       if( !set_min_2 ) {
+         min_distance_hit_vertex_included_2 = distance_hit_vertex;
+         set_min_2 = true;
+       }
+       if( distance_hit_vertex > max_distance_hit_vertex_included_2 )
+         max_distance_hit_vertex_included_2 = distance_hit_vertex;
+     }
+   }
+   std::cout << "This is (min,max) from the 2nd CaloHitList: ( " << min_distance_hit_vertex_included_2 << ", " << max_distance_hit_vertex_included_2 << " )." << std::endl;
+
+   // reorder if needed                                                                                                                                                                                  
+   reorderingNeeded = ( min_distance_hit_vertex_included_2 < max_distance_hit_vertex_included_1 ) ? 1 : 0;
+   if( reorderingNeeded ){
+     std::cerr << "[ThreeDChargeFeatureTool::CombineCaloHitListsToHaveCollection()] Reordering necessary, proceeding to do it." << std::endl;
+     mergedCaloHitList.sort(MvaPfoCharacterisationAlgorithm<T>::DistanceToVertexComparator( vertexPosition2DU, vertexPosition2DV, TPC_VIEW_U, TPC_VIEW_V ) );
+   }
+   
+   if( debug ){
+     std::cout << " Listing the final content of the mergedCaloHitList " << std::endl;
+     std::string isBeforeCathode = "";
+     std::string belongsToView = "";
+     for(CaloHitList::const_iterator it = mergedCaloHitList.begin() ; it != mergedCaloHitList.end() ; it++){
+       const CaloHit *const pCaloHit = *it;
+       const CartesianVector &hit(pCaloHit->GetPositionVector());
+       if( pCaloHit->GetHitType() == TPC_VIEW_U )
+         distance_hit_vertex = pow( vertexPosition2DU.GetX() - hit.GetX(), 2 ) + pow( vertexPosition2DU.GetY()- hit.GetY(), 2 ) + pow( vertexPosition2DU.GetZ()- hit.GetZ(), 2 );
+       else
+         distance_hit_vertex = pow( vertexPosition2DV.GetX() - hit.GetX(), 2 ) + pow( vertexPosition2DV.GetY()- hit.GetY(), 2 ) + pow( vertexPosition2DV.GetZ()- hit.GetZ(), 2 );
+       isBeforeCathode = (LocatePointInCryostat( hit.GetX() ) == PositionInCryostat::BelowCathode )
+         ? ", is before the cathode" : ", is after the cathode";
+       belongsToView = ( pCaloHit->GetHitType() == TPC_VIEW_U ) ? " and belongs to view U " : " and belongs to view V";
+       if( pCaloHit->GetHitType() == TPC_VIEW_U )
+         std::cout << "This hit has distance " << distance_hit_vertex << isBeforeCathode << belongsToView
+              << ". Its position is ( " << hit.GetX() << ", " << hit.GetY() << ", " << hit.GetZ() << " )."
+              << " Vertex is ( " << vertexPosition2DU.GetX() << ", " <<  vertexPosition2DU.GetY() << ", " << vertexPosition2DU.GetZ() << " )"
+              << std::endl;
+       else
+         std::cout << "This hit has distance " << distance_hit_vertex << isBeforeCathode << belongsToView
+              << ". Its position is ( " << hit.GetX() << ", " << hit.GetY() << ", " << hit.GetZ() << " )."
+              << " Vertex is ( " << vertexPosition2DV.GetX() << ", " <<  vertexPosition2DV.GetY() << ", " << vertexPosition2DV.GetZ() << " )"
+              << std::endl;
+     }
+   }
+ }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+MvaPfoCharacterisationAlgorithm<T>::VertexComparator::VertexComparator(const CartesianVector vertexPosition2D) : m_neutrinoVertex(vertexPosition2D)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+bool MvaPfoCharacterisationAlgorithm<T>::VertexComparator::operator()(const CaloHit *const left, const CaloHit *const right) const
+{
+    const float distanceL((left->GetPositionVector() - m_neutrinoVertex).GetMagnitudeSquared());
+    const float distanceR((right->GetPositionVector() - m_neutrinoVertex).GetMagnitudeSquared());
+    return distanceL < distanceR;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+MvaPfoCharacterisationAlgorithm<T>::DistanceToVertexComparator::DistanceToVertexComparator(const CartesianVector vertexPosition2D_A, const CartesianVector vertexPosition2D_B,
+                                                                                const HitType hitType_A, const HitType hitType_B) :
+  m_neutrinoVertex_A(vertexPosition2D_A), m_neutrinoVertex_B(vertexPosition2D_B), m_hitType_A(hitType_A), m_hitType_B(hitType_B)
+{
+  // FIX ME: Throw error if the hit types passed coincide?                                                                                                                                              
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+bool MvaPfoCharacterisationAlgorithm<T>::DistanceToVertexComparator::operator()(const CaloHit *const left, const CaloHit *const right) const
+{
+  // FIX ME: Throw an error here if the hit type is different from any of the two possibilities?                                                                                                         
+  float distanceL;
+  float distanceR;
+  if( left->GetHitType() == m_hitType_A )
+    distanceL = ( left->GetPositionVector() - m_neutrinoVertex_A ).GetMagnitudeSquared();
+  else
+    distanceL = ( left->GetPositionVector() - m_neutrinoVertex_B ).GetMagnitudeSquared();
+  if( right->GetHitType() == m_hitType_A )
+    distanceR = ( right->GetPositionVector() - m_neutrinoVertex_A ).GetMagnitudeSquared();
+  else
+    distanceR = ( right->GetPositionVector() - m_neutrinoVertex_B ).GetMagnitudeSquared();
+  return distanceL < distanceR;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.cc
@@ -132,7 +132,7 @@ bool MvaPfoCharacterisationAlgorithm<T>::IsClearTrack(const pandora::ParticleFlo
         if (!vClusterList.empty())
             vClusterList.front()->GetClusterSpanX(minX_V, maxX_V);
 
-        // Further checks
+        // Checks
         if (wClusterList.empty() && uClusterList.empty() && vClusterList.empty()) 
         {
             isChargeInfoEmpty = true;

--- a/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.h
@@ -33,6 +33,56 @@ public:
      */
     MvaPfoCharacterisationAlgorithm();
 
+    /**
+     *  @brief  VertexComparator class for comparison of two points wrt neutrino vertex position
+     */
+    class VertexComparator
+    {
+    public:
+        /**
+         *  @brief  Constructor
+         */
+        VertexComparator(const pandora::CartesianVector vertexPosition2D);
+
+        /**
+         *  @brief  operator <
+         *
+         *  @param  rhs object for comparison
+         *
+         *  @return boolean
+         */
+        bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
+
+        pandora::CartesianVector m_neutrinoVertex; //The neutrino vertex used to sort
+    };
+
+    /**                                                                                                                                                                                                    
+     *  @brief  DistanceToVertexComparator class for comparison of two points with different hit type (left and right) wrt neutrino vertex position                                                        
+     */
+    class DistanceToVertexComparator
+    {
+    public:
+      /**                                                                                                                                                                                                  
+       * @brief Constructor                                                                                                                                                                                
+       */
+      DistanceToVertexComparator(const pandora::CartesianVector vertexPosition2D_A, const pandora::CartesianVector vertexPosition2D_B, 
+        const pandora::HitType hitType_A, const pandora::HitType hitType_B);
+
+      /**                                                                                                                                                                                                  
+         @brief operator <                                                                                                                                                                                 
+         *                                                                                                                                                                                                 
+         * @param  rhs object for comparison                                                                                                                                                               
+         *                                                                                                                                                                                                 
+         * @return boolean                                                                                                                                                                                 
+         */
+      bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
+
+      pandora::CartesianVector m_neutrinoVertex_A; // The neutrino vertex used to sort for hit type A, i.e. position is projected onto the correct view based on the hit type                              
+      pandora::CartesianVector m_neutrinoVertex_B; // same for hit type B                                                                                                                                  
+      pandora::HitType m_hitType_A;
+      pandora::HitType m_hitType_B;
+    };
+    
 protected:
     virtual bool IsClearTrack(const pandora::ParticleFlowObject *const pPfo) const;
     virtual bool IsClearTrack(const pandora::Cluster *const pCluster) const;
@@ -84,6 +134,15 @@ private:
      *  @param  vertex The coordinates of the vertex
      */
     bool PassesFiducialCut(const pandora::CartesianVector &vertex) const;
+
+    // void OrderCaloHitsByDistanceToVertex(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, 
+    //     pandora::CaloHitList &caloHitList);
+
+    void OrderCaloHitsByDistanceToVertex(const pandora::Cluster *const pCluster, pandora::CaloHitList &caloHitList) const;
+
+    void CombineCaloHitListsToHaveCollection(const pandora::CaloHitList &orderedCaloHitList1, const pandora::CaloHitList &orderedCaloHitList2, 
+        pandora::CaloHitList &mergedCaloHitList) const;
+
 };
 
 typedef MvaPfoCharacterisationAlgorithm<AdaBoostDecisionTree> BdtPfoCharacterisationAlgorithm;

--- a/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/MvaPfoCharacterisationAlgorithm.h
@@ -32,56 +32,6 @@ public:
      *  @brief  Default constructor
      */
     MvaPfoCharacterisationAlgorithm();
-
-    /**
-     *  @brief  VertexComparator class for comparison of two points wrt neutrino vertex position
-     */
-    class VertexComparator
-    {
-    public:
-        /**
-         *  @brief  Constructor
-         */
-        VertexComparator(const pandora::CartesianVector vertexPosition2D);
-
-        /**
-         *  @brief  operator <
-         *
-         *  @param  rhs object for comparison
-         *
-         *  @return boolean
-         */
-        bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
-
-        pandora::CartesianVector m_neutrinoVertex; //The neutrino vertex used to sort
-    };
-
-    /**                                                                                                                                                                                                    
-     *  @brief  DistanceToVertexComparator class for comparison of two points with different hit type (left and right) wrt neutrino vertex position                                                        
-     */
-    class DistanceToVertexComparator
-    {
-    public:
-      /**                                                                                                                                                                                                  
-       * @brief Constructor                                                                                                                                                                                
-       */
-      DistanceToVertexComparator(const pandora::CartesianVector vertexPosition2D_A, const pandora::CartesianVector vertexPosition2D_B, 
-        const pandora::HitType hitType_A, const pandora::HitType hitType_B);
-
-      /**                                                                                                                                                                                                  
-         @brief operator <                                                                                                                                                                                 
-         *                                                                                                                                                                                                 
-         * @param  rhs object for comparison                                                                                                                                                               
-         *                                                                                                                                                                                                 
-         * @return boolean                                                                                                                                                                                 
-         */
-      bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
-
-      pandora::CartesianVector m_neutrinoVertex_A; // The neutrino vertex used to sort for hit type A, i.e. position is projected onto the correct view based on the hit type                              
-      pandora::CartesianVector m_neutrinoVertex_B; // same for hit type B                                                                                                                                  
-      pandora::HitType m_hitType_A;
-      pandora::HitType m_hitType_B;
-    };
     
 protected:
     virtual bool IsClearTrack(const pandora::ParticleFlowObject *const pPfo) const;
@@ -91,14 +41,15 @@ protected:
     ClusterCharacterisationFeatureTool::FeatureToolMap m_featureToolMap; ///< The feature tool map
 
     PfoCharacterisationFeatureTool::FeatureToolMap m_featureToolMapThreeD;       ///< FeatureToolMap as a map for 3D info
-    PfoCharacterisationFeatureTool::FeatureToolMap m_featureToolMapNoChargeInfo; ///< FeatureToolMap as a map for missing W view
+    PfoCharacterisationFeatureTool::FeatureToolMap m_featureToolMapNoChargeInfo; ///< FeatureToolMap as a map for missing view
 
     pandora::StringVector m_algorithmToolNames; ///< Vector of strings saving feature tool order for use in feature calculation
     pandora::StringVector m_algorithmToolNamesNoChargeInfo; ///< Vector of strings saving feature tool order for use in feature calculation (missing W view)
 
     T m_mva;             ///< The mva
-    T m_mvaNoChargeInfo; ///< The mva for missing W view
+    T m_mvaNoChargeInfo; ///< The mva for missing view
 
+    bool m_useICARUSCollectionPlane;      ///< Whether to change the view logic in order to match the ICARUS Collection plane
     bool m_persistFeatures;               ///< Whether to write the features to the properties map
     bool m_trainingSetMode;               ///< Whether to train
     bool m_testBeamMode;                  ///< Whether the training set is from a test beam experiment
@@ -134,14 +85,6 @@ private:
      *  @param  vertex The coordinates of the vertex
      */
     bool PassesFiducialCut(const pandora::CartesianVector &vertex) const;
-
-    // void OrderCaloHitsByDistanceToVertex(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, 
-    //     pandora::CaloHitList &caloHitList);
-
-    void OrderCaloHitsByDistanceToVertex(const pandora::Cluster *const pCluster, pandora::CaloHitList &caloHitList) const;
-
-    void CombineCaloHitListsToHaveCollection(const pandora::CaloHitList &orderedCaloHitList1, const pandora::CaloHitList &orderedCaloHitList2, 
-        pandora::CaloHitList &mergedCaloHitList) const;
 
 };
 

--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
@@ -451,6 +451,7 @@ StatusCode PfoHierarchyFeatureTool::ReadSettings(const TiXmlHandle /*xmlHandle*/
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 ConeChargeFeatureTool::ConeChargeFeatureTool() :
+    m_useICARUSCollectionPlane(false),
     m_conMinHits(3),
     m_minCharge(0.1f),
     m_conFracRange(0.2f),
@@ -1055,6 +1056,7 @@ float ConeChargeFeatureTool::CalculateConicalness(
 
 StatusCode ConeChargeFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseICARUSCollectionPlane", m_useICARUSCollectionPlane));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConMinHits", m_conMinHits));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MinCharge", m_minCharge));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ConFracRange", m_conFracRange));
@@ -1583,7 +1585,7 @@ StatusCode ThreeDPCAFeatureTool::ReadSettings(const TiXmlHandle /*xmlHandle*/)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-ThreeDChargeFeatureTool::ThreeDChargeFeatureTool() : m_endChargeFraction(0.1f)
+ThreeDChargeFeatureTool::ThreeDChargeFeatureTool() : m_useICARUSCollectionPlane(false), m_endChargeFraction(0.1f)
 {
 }
 
@@ -1598,17 +1600,7 @@ void ThreeDChargeFeatureTool::Run(
     float totalCharge(-1.f), chargeSigma(-1.f), chargeMean(-1.f), endCharge(-1.f);
     LArMvaHelper::MvaFeature charge1, charge2;
 
-    // debugging
     bool debug = false;
-    if(debug)
-        std::cout << "=================================================================" << std::endl;
-    if(debug)
-        std::cout << "RUNNING 3D CHARGE TOOL!" << std::endl;
-    if(debug)
-        std::cout << "This is particle " << pInputPfo->GetParticleId()
-                  << " with mass " << pInputPfo->GetMass() << " [GeV] "
-                  << " with " << pInputPfo->GetVertexList().size() << " vertices."
-                  << std::endl;
 
     /*                                                                                                                                                                                                   
      * Check if the particle crosses the cathode                                                                                                                                                        
@@ -2086,6 +2078,8 @@ void ThreeDChargeFeatureTool::CombineCaloHitListsToHaveCollection(const pandora:
 
 StatusCode ThreeDChargeFeatureTool::ReadSettings(const TiXmlHandle xmlHandle)
 {
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseICARUSCollectionPlane", m_useICARUSCollectionPlane));
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EndChargeFraction", m_endChargeFraction));
 

--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.cc
@@ -26,56 +26,36 @@ namespace lar_content
 
 PositionInCryostat LocatePointInCryostat(const float point_X)
 {       
-
-    PositionInCryostat point_position;
-
-    // nominal cathode position for cryo 1
-    // to be extracted from geometry possibly
-    const float CathodeMinX = 210.14;
+    PositionInCryostat position;
+    const float CathodeMinX = 210.14; ///< Cathode position for ICARUS cryostat #1
     const float CathodeMaxX = 210.29;
 
-    // get cathode position for both cryostats
-    float RealCathodeMinX = 0.;
-    float RealCathodeMaxX = 0.;
-    if(point_X < 0.) // cryo 0 
+    float RealCathodeMinX = 0., RealCathodeMaxX = 0.;
+    if (point_X < 0.) ///< ICARUS cryostat #0 
     {                                                                                                                                                                         
         RealCathodeMinX = CathodeMaxX*(-1.);
         RealCathodeMaxX = CathodeMinX*(-1.);
     }
-    else // cryo 1 
+    else ///< ICARUS cryostat #0 
     {                                                                                                                                                                                       
         RealCathodeMinX = CathodeMinX;
         RealCathodeMaxX = CathodeMaxX;
     }
 
-    // determine hit position with respect to cathode
-    if(point_X < RealCathodeMinX)
-        point_position = PositionInCryostat::BelowCathode;
-
-    else if(point_X > RealCathodeMaxX)
-        point_position = PositionInCryostat::AboveCathode;
-
-    else
-        point_position = PositionInCryostat::WithinCathode;
-
-    // debugging
-    bool debug = false;
-    if(debug)
+    if (point_X < RealCathodeMinX)
     {
-        switch(point_position)
-        {
-            case PositionInCryostat::AboveCathode:
-                std::cout << "This point: X = " << point_X << " is above the cathode." << std::endl;
-                break;
-            case PositionInCryostat::BelowCathode:
-                std::cout << "This point: X = " << point_X << " is below the cathode." << std::endl;
-                break;
-            case PositionInCryostat::WithinCathode:
-                std::cout << "This point: X = " << point_X << " is inside the cathode." << std::endl;
-                break;
-        }
+        position = PositionInCryostat::BelowCathode;
     }
-    return point_position;
+    else if (point_X > RealCathodeMaxX)
+    {
+        position = PositionInCryostat::AboveCathode;
+    }
+    else
+    {
+        position = PositionInCryostat::WithinCathode;
+    }
+
+    return position;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h
@@ -18,7 +18,7 @@ namespace lar_content
 typedef MvaFeatureTool<const pandora::Algorithm *const, const pandora::Cluster *const> ClusterCharacterisationFeatureTool;
 typedef MvaFeatureTool<const pandora::Algorithm *const, const pandora::ParticleFlowObject *const> PfoCharacterisationFeatureTool;
 
-// returns the position of the point with respect to the cathode 
+// Helper function to get the position of a point with respect to the cathode in ICARUS
 enum PositionInCryostat {AboveCathode, BelowCathode, WithinCathode};
 PositionInCryostat LocatePointInCryostat( const float point_X ); 
 
@@ -248,25 +248,25 @@ public:
     class DistanceToVertexComparator
     {
     public:
-      /**                                                                                                                                                                                                  
-       * @brief Constructor                                                                                                                                                                                
-       */
-      DistanceToVertexComparator(const pandora::CartesianVector vertexPosition2D_A, const pandora::CartesianVector vertexPosition2D_B, 
+        /**                                                                                                                                                                                                  
+         * @brief Constructor                                                                                                                                                                                
+         */
+        DistanceToVertexComparator(const pandora::CartesianVector vertexPosition2D_A, const pandora::CartesianVector vertexPosition2D_B, 
         const pandora::HitType hitType_A, const pandora::HitType hitType_B);
 
-      /**                                                                                                                                                                                                  
+        /**                                                                                                                                                                                                  
          @brief operator <                                                                                                                                                                                 
-         *                                                                                                                                                                                                 
-         * @param  rhs object for comparison                                                                                                                                                               
-         *                                                                                                                                                                                                 
-         * @return boolean                                                                                                                                                                                 
-         */
-      bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
+            *                                                                                                                                                                                                 
+            * @param  rhs object for comparison                                                                                                                                                               
+            *                                                                                                                                                                                                 
+            * @return boolean                                                                                                                                                                                 
+            */
+        bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
 
-      pandora::CartesianVector m_neutrinoVertex_A; // The neutrino vertex used to sort for hit type A, i.e. position is projected onto the correct view based on the hit type                              
-      pandora::CartesianVector m_neutrinoVertex_B; // same for hit type B                                                                                                                                  
-      pandora::HitType m_hitType_A;
-      pandora::HitType m_hitType_B;
+        pandora::CartesianVector m_neutrinoVertex_A; // The neutrino vertex used to sort for hit type A, i.e. position is projected onto the correct view based on the hit type                              
+        pandora::CartesianVector m_neutrinoVertex_B; // same for hit type B                                                                                                                                  
+        pandora::HitType m_hitType_A;
+        pandora::HitType m_hitType_B;
     };
     
     void Run(LArMvaHelper::MvaFeatureVector &featureVector, const pandora::Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo);
@@ -293,9 +293,15 @@ private:
     float m_MoliereRadius;
     float m_MoliereRadiusFrac;
 
+    /**
+     *  @brief  Functions to order the calo hit list by distance to neutrino vertex
+     *
+     *  @param  pAlgorithm, the algorithm
+     *  @param  pCluster the cluster we are characterizing
+     *  @param  caloHitList to receive the ordered calo hit list
+     */
     void OrderCaloHitsByDistanceToVertex(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, 
         pandora::CaloHitList &caloHitList);
-
     void CombineCaloHitListsToHaveCollection(const pandora::Algorithm *const pAlgorithm,
         const pandora::CaloHitList &orderedCaloHitList1, const pandora::CaloHitList &orderedCaloHitList2, pandora::CaloHitList &mergedCaloHitList);
 
@@ -434,25 +440,25 @@ public:
     class DistanceToVertexComparator
     {
     public:
-      /**                                                                                                                                                                                                  
-       * @brief Constructor                                                                                                                                                                                
-       */
-      DistanceToVertexComparator(const pandora::CartesianVector vertexPosition2D_A, const pandora::CartesianVector vertexPosition2D_B, 
+        /**                                                                                                                                                                                                  
+         * @brief Constructor                                                                                                                                                                                
+         */
+        DistanceToVertexComparator(const pandora::CartesianVector vertexPosition2D_A, const pandora::CartesianVector vertexPosition2D_B, 
         const pandora::HitType hitType_A, const pandora::HitType hitType_B);
 
-      /**                                                                                                                                                                                                  
+        /**                                                                                                                                                                                                  
          @brief operator <                                                                                                                                                                                 
-         *                                                                                                                                                                                                 
-         * @param  rhs object for comparison                                                                                                                                                               
-         *                                                                                                                                                                                                 
-         * @return boolean                                                                                                                                                                                 
-         */
-      bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
+            *                                                                                                                                                                                                 
+            * @param  rhs object for comparison                                                                                                                                                               
+            *                                                                                                                                                                                                 
+            * @return boolean                                                                                                                                                                                 
+            */
+        bool operator()(const pandora::CaloHit *const left, const pandora::CaloHit *const right) const;
 
-      pandora::CartesianVector m_neutrinoVertex_A; // The neutrino vertex used to sort for hit type A, i.e. position is projected onto the correct view based on the hit type                              
-      pandora::CartesianVector m_neutrinoVertex_B; // same for hit type B                                                                                                                                  
-      pandora::HitType m_hitType_A;
-      pandora::HitType m_hitType_B;
+        pandora::CartesianVector m_neutrinoVertex_A; // The neutrino vertex used to sort for hit type A, i.e. position is projected onto the correct view based on the hit type                              
+        pandora::CartesianVector m_neutrinoVertex_B; // same for hit type B                                                                                                                                  
+        pandora::HitType m_hitType_A;
+        pandora::HitType m_hitType_B;
     };
 
     void Run(LArMvaHelper::MvaFeatureVector &featureVector, const pandora::Algorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pInputPfo);
@@ -478,7 +484,6 @@ private:
      *  @param  pAlgorithm, the algorithm
      *  @param  pCluster the cluster we are characterizing
      *  @param  caloHitList to receive the ordered calo hit list
-     *
      */
     void OrderCaloHitsByDistanceToVertex(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, 
         pandora::CaloHitList &caloHitList);

--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h
@@ -276,6 +276,8 @@ public:
 private:
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
+    bool m_useICARUSCollectionPlane; ///< Whether to change the view logic in order to match the ICARUS Collection plane
+
     /**
      *  @brief Configurable parameters to calculate cone charge variables
      *
@@ -471,23 +473,22 @@ private:
         float &chargeSigma, float &chargeMean, float &endCharge);
 
     /**
-     *  @brief  Function to order the calo hit list by distance to neutrino vertex
+     *  @brief  Functions to order the calo hit list by distance to neutrino vertex
      *
      *  @param  pAlgorithm, the algorithm
      *  @param  pCluster the cluster we are characterizing
      *  @param  caloHitList to receive the ordered calo hit list
      *
      */
-    
     void OrderCaloHitsByDistanceToVertex(const pandora::Algorithm *const pAlgorithm, const pandora::Cluster *const pCluster, 
         pandora::CaloHitList &caloHitList);
-
     void CombineCaloHitListsToHaveCollection(const pandora::Algorithm *const pAlgorithm,
         const pandora::CaloHitList &orderedCaloHitList1, const pandora::CaloHitList &orderedCaloHitList2, pandora::CaloHitList &mergedCaloHitList);
     
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    float m_endChargeFraction; ///< Fraction of hits that will be considered to calculate end charge (default 10%)
+    bool m_useICARUSCollectionPlane; ///< Whether to change the view logic in order to match the ICARUS Collection plane
+    float m_endChargeFraction;       ///< Fraction of hits that will be considered to calculate end charge (default 10%)
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h
+++ b/larpandoracontent/LArTrackShowerId/TrackShowerIdFeatureTool.h
@@ -20,7 +20,7 @@ typedef MvaFeatureTool<const pandora::Algorithm *const, const pandora::ParticleF
 
 // Helper function to get the position of a point with respect to the cathode in ICARUS
 enum PositionInCryostat {AboveCathode, BelowCathode, WithinCathode};
-PositionInCryostat LocatePointInCryostat( const float point_X ); 
+PositionInCryostat LocatePointInCryostat(const float point_X); 
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR (based off `v04_07_00`) introduces some changes to the MVA track/shower discrimination modules and charge-based tools (`ConeChargeFeatureTool` and `ThreeDChargeFeatureTool`) specifically for ICARUS. The change consists in selecting the views that are mapped to the Collection wire plane in ICARUS, instead of defaulting to the W view (which is mapped to the Induction-1 wire plane in ICARUS). The choice of views for Collection depends on whether the reconstructed PFP crosses the cathode (in which case a combination of U and V is needed) or not (in which case we just need to pick either U or V).

As a starting point, the changes are made directly to the standard track/shower MVA classes and are optional, enabled by a `UseICARUSCollectionPlane` XML parameter set to `false` by default.

For context, attached is a scheme of the wire planes for one of the two ICARUS modules:
<img width="1159" alt="ICARUSWirePlanesScheme" src="https://github.com/user-attachments/assets/27083c33-0bef-4cd5-812a-e6185fff8f27" />

Tagging @absolution1, @brucehoward-physics, and @cerati: thanks!