### PR TITLE
LArRecoND: Algorithm Optim

### DIFF
--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -781,11 +781,11 @@ bool LArClusterHelper::SortCoordinatesByPosition(const CartesianVector &lhs, con
 {
     constexpr float epsilon(std::numeric_limits<float>::epsilon());
 
-    float deltaZ(rhs.GetZ() - lhs.GetZ());
+    const float deltaZ(rhs.GetZ() - lhs.GetZ());
     if (std::fabs(deltaZ) > epsilon)
         return (deltaZ > epsilon);
 
-    float deltaX(rhs.GetX() - lhs.GetX());
+    const float deltaX(rhs.GetX() - lhs.GetX());
     if (std::fabs(deltaX) > epsilon)
         return (deltaX > epsilon);
 

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -779,15 +779,17 @@ bool LArClusterHelper::SortHitsByPulseHeight(const CaloHit *const pLhs, const Ca
 
 bool LArClusterHelper::SortCoordinatesByPosition(const CartesianVector &lhs, const CartesianVector &rhs)
 {
-    const CartesianVector deltaPosition(rhs - lhs);
+    constexpr float epsilon(std::numeric_limits<float>::epsilon());
 
-    if (std::fabs(deltaPosition.GetZ()) > std::numeric_limits<float>::epsilon())
-        return (deltaPosition.GetZ() > std::numeric_limits<float>::epsilon());
+    float deltaZ(rhs.GetZ() - lhs.GetZ());
+    if (std::fabs(deltaZ) > epsilon)
+        return (deltaZ > epsilon);
 
-    if (std::fabs(deltaPosition.GetX()) > std::numeric_limits<float>::epsilon())
-        return (deltaPosition.GetX() > std::numeric_limits<float>::epsilon());
+    float deltaX(rhs.GetX() - lhs.GetX());
+    if (std::fabs(deltaX) > epsilon)
+        return (deltaX > epsilon);
 
-    return (deltaPosition.GetY() > std::numeric_limits<float>::epsilon());
+    return (rhs.GetY() - lhs.GetY() > epsilon);
 }
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
@@ -1333,11 +1333,9 @@ void LArHierarchyHelper::MatchInfo::Match()
             RecoHierarchy::NodeVector recoNodes;
             m_recoHierarchy.GetFlattenedNodes(pRootPfo, recoNodes);
 
-            std::sort(mcNodes.begin(), mcNodes.end(),
-                [](const MCHierarchy::Node *lhs, const MCHierarchy::Node *rhs)
+            std::sort(mcNodes.begin(), mcNodes.end(), [](const MCHierarchy::Node *lhs, const MCHierarchy::Node *rhs)
                 { return lhs->GetCaloHits().size() > rhs->GetCaloHits().size(); });
-            std::sort(recoNodes.begin(), recoNodes.end(),
-                [](const RecoHierarchy::Node *lhs, const RecoHierarchy::Node *rhs)
+            std::sort(recoNodes.begin(), recoNodes.end(), [](const RecoHierarchy::Node *lhs, const RecoHierarchy::Node *rhs)
                 { return lhs->GetCaloHits().size() > rhs->GetCaloHits().size(); });
 
             for (const RecoHierarchy::Node *pRecoNode : recoNodes)
@@ -1498,7 +1496,7 @@ const CaloHitList LArHierarchyHelper::MatchInfo::GetSelectedRecoHits(const RecoH
 {
     // Select all of the reco node hit Ids that overlap with the allMCHits Ids
     CaloHitList selectedHits;
-    if (! pRecoNode)
+    if (!pRecoNode)
         return selectedHits;
 
     // Build a map of MC hit IDs, for fast lookup
@@ -1513,7 +1511,7 @@ const CaloHitList LArHierarchyHelper::MatchInfo::GetSelectedRecoHits(const RecoH
     {
         const int recoId = reinterpret_cast<intptr_t>(pRecoHit->GetParentAddress());
         if (mcHitIds.find(recoId) != mcHitIds.end())
-                selectedHits.emplace_back(pRecoHit);
+            selectedHits.emplace_back(pRecoHit);
     }
     return selectedHits;
 }

--- a/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.cc
@@ -449,7 +449,7 @@ void ShowerGrowingAlgorithm::PreComputeClusterLengths(const ClusterList *const p
         CartesianVector innerCoordinate(0.f, 0.f, 0.f), outerCoordinate(0.f, 0.f, 0.f);
         LArClusterHelper::GetExtremalCoordinates(pCluster, innerCoordinate, outerCoordinate);
 
-        m_clusterLengthCache[pCluster] = (outerCoordinate - innerCoordinate).GetMagnitude();
+        m_clusterLengthCache[pCluster] = (outerCoordinate - innerCoordinate).GetMagnitudeSquared();
     }
 }
 

--- a/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.cc
+++ b/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.cc
@@ -16,9 +16,6 @@
 
 #include "larpandoracontent/LArObjects/LArPointingCluster.h"
 #include "larpandoracontent/LArTrackShowerId/BranchGrowingAlgorithm.h"
-#include "larpandoracontent/LArUtility/KDTreeLinkerAlgoT.h"
-#include "larpandoracontent/LArUtility/KDTreeLinkerToolsT.h"
-#include <limits>
 
 #include "larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.h"
 

--- a/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.h
+++ b/larpandoracontent/LArTrackShowerId/ShowerGrowingAlgorithm.h
@@ -8,8 +8,8 @@
 #ifndef LAR_SHOWER_GROWING_ALGORITHM_H
 #define LAR_SHOWER_GROWING_ALGORITHM_H 1
 
-#include "Pandora/Algorithm.h"
 #include "Objects/CaloHit.h"
+#include "Pandora/Algorithm.h"
 
 #include "larpandoracontent/LArHelpers/LArVertexHelper.h"
 
@@ -60,12 +60,15 @@ protected:
     class ClusterSeedComparator
     {
     public:
-        ClusterSeedComparator(const ClusterLengthMap *const pClusterLengthCache) : m_pClusterLengthCache(pClusterLengthCache) {}
+        ClusterSeedComparator(const ClusterLengthMap *const pClusterLengthCache) :
+            m_pClusterLengthCache(pClusterLengthCache)
+        {
+        }
 
         bool operator()(const pandora::Cluster *const pLhs, const pandora::Cluster *const pRhs) const;
 
     private:
-        const ClusterLengthMap* m_pClusterLengthCache; ///< The cluster length cache
+        const ClusterLengthMap *m_pClusterLengthCache; ///< The cluster length cache
     };
 
     typedef std::unordered_map<const pandora::Cluster *, LArVertexHelper::ClusterDirection> ClusterDirectionMap;


### PR DESCRIPTION
This is a few hopefully non-controversial changes to LArContent algorithms to help speed up LArRecoND.

This doesn't include my more comprehensive, but potentially Physics-changing changes to the tensor tools, which I've left out until they can actually be verified.

To list the changes made:

 - `LArClusterHelper::SortCoordinatesByPosition`: Avoid the allocation of a unnecessary `CartesianVector` object, reduce the amount of calculations in early return cases.
 - `LArHierarchyHelper::MatchInfo::GetSelectedRecoHits`: Add a lookup table rather than the existing search.
 - `BranchGrowingAlgorithm::FindAssociatedClusters`: Cache result of any cluster-cluster comparisons, to skip expensive calls to `AreClustersAssociated`.
 - `ShowerGrowingAlgorithm` - Use cached cluster lengths to speed up lots of sorting calls and add an early return to `AreClustersAssociated` to skip the costly later `GetClosestDistance` calls if the clusters will never pass the later checks.
