### PR TITLE
VisualMonitoring - option to inspect hit TPC+Daughter vols

### DIFF
--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
@@ -214,7 +214,7 @@ void VisualMonitoringAlgorithm::VisualizeCaloHitList(const std::string &listName
     for (const CaloHit *const pCaloHit : caloHitList)
     {
         const LArCaloHit *const pLArCaloHit{dynamic_cast<const LArCaloHit *>(pCaloHit)};
-        const std::pair<unsigned int, unsigned int> volId = { pLArCaloHit->GetLArTPCVolumeId(), pLArCaloHit->GetDaughterVolumeId() };
+        const std::pair<unsigned int, unsigned int> volId{ pLArCaloHit->GetLArTPCVolumeId(), pLArCaloHit->GetDaughterVolumeId() };
         volIdToCaloHits[volId].push_back(pCaloHit);
     }
 
@@ -223,7 +223,8 @@ void VisualMonitoringAlgorithm::VisualizeCaloHitList(const std::string &listName
     {
         const std::string label{(listName.empty() ? "CurrentCaloHits" : listName) +
             ", volId ("  + std::to_string(volId.first) + ", " + std::to_string(volId.second) + ")"};
-        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &caloHitListPartition, label.c_str(), static_cast<Color>(colorIter++)));
+        PANDORA_MONITORING_API(VisualizeCaloHits(
+            this->GetPandora(), &caloHitListPartition, label.c_str(), static_cast<Color>(colorIter++)));
         colorIter = static_cast<Color>(colorIter) == AUTO ? static_cast<int>(RED) : colorIter;
     }
 }

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
@@ -218,14 +218,15 @@ void VisualMonitoringAlgorithm::VisualizeCaloHitList(const std::string &listName
         volIdToCaloHits[volId].push_back(pCaloHit);
     }
 
-    int colorIter{static_cast<int>(RED)};
+    [[maybe_unused]] int colorIter{0};
     for (const auto &[volId, caloHitListPartition] : volIdToCaloHits)
     {
         const std::string label{(listName.empty() ? "CurrentCaloHits" : listName) +
             ", volId ("  + std::to_string(volId.first) + ", " + std::to_string(volId.second) + ")"};
-        PANDORA_MONITORING_API(VisualizeCaloHits(
-            this->GetPandora(), &caloHitListPartition, label.c_str(), static_cast<Color>(colorIter++)));
-        colorIter = static_cast<Color>(colorIter) == AUTO ? static_cast<int>(RED) : colorIter;
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &caloHitListPartition, label.c_str(),
+            static_cast<Color>(++colorIter) < AUTO          ? static_cast<Color>(colorIter)
+                : (colorIter % static_cast<int>(AUTO)) == 0 ? static_cast<Color>(++colorIter % static_cast<int>(AUTO))
+                                                            : static_cast<Color>(colorIter % static_cast<int>(AUTO))));
     }
 }
 

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
@@ -9,6 +9,7 @@
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h"
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
 
 using namespace pandora;
 
@@ -34,7 +35,8 @@ VisualMonitoringAlgorithm::VisualMonitoringAlgorithm() :
     m_energyScaleThresholdE(1.f),
     m_scalingFactor(1.f),
     m_showPfoVertices(true),
-    m_showPfoHierarchy(true)
+    m_showPfoHierarchy(true),
+    m_partitionCaloHitsByVolume(false)
 {
 }
 
@@ -201,8 +203,29 @@ void VisualMonitoringAlgorithm::VisualizeCaloHitList(const std::string &listName
         }
     }
 
-    PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &caloHitList, listName.empty() ? "CurrentCaloHits" : listName.c_str(),
-        (m_hitColors.find("energy") != std::string::npos ? AUTOENERGY : GRAY)));
+    if (!m_partitionCaloHitsByVolume)
+    {
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &caloHitList, listName.empty() ? "CurrentCaloHits" : listName.c_str(),
+            (m_hitColors.find("energy") != std::string::npos ? AUTOENERGY : GRAY)));
+        return;
+    }
+
+    std::map<std::pair<unsigned int, unsigned int>, CaloHitList> volIdToCaloHits;
+    for (const CaloHit *const pCaloHit : caloHitList)
+    {
+        const LArCaloHit *const pLArCaloHit{dynamic_cast<const LArCaloHit *>(pCaloHit)};
+        const std::pair<unsigned int, unsigned int> volId = { pLArCaloHit->GetLArTPCVolumeId(), pLArCaloHit->GetDaughterVolumeId() };
+        volIdToCaloHits[volId].push_back(pCaloHit);
+    }
+
+    int colorIter{static_cast<int>(RED)};
+    for (const auto &[volId, caloHitListPartition] : volIdToCaloHits)
+    {
+        const std::string label{(listName.empty() ? "CurrentCaloHits" : listName) +
+            ", volId ("  + std::to_string(volId.first) + ", " + std::to_string(volId.second) + ")"};
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &caloHitListPartition, label.c_str(), static_cast<Color>(colorIter++)));
+        colorIter = static_cast<Color>(colorIter) == AUTO ? static_cast<int>(RED) : colorIter;
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -430,6 +453,9 @@ StatusCode VisualMonitoringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ShowPfoHierarchy", m_showPfoHierarchy));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PartitionCaloHitsByVolume", m_partitionCaloHitsByVolume));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadVectorOfValues(xmlHandle, "SuppressMCParticles", m_suppressMCParticles));

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
@@ -218,16 +218,18 @@ void VisualMonitoringAlgorithm::VisualizeCaloHitList(const std::string &listName
         volIdToCaloHits[volId].push_back(pCaloHit);
     }
 
-    [[maybe_unused]] int colorIter{0};
+#ifdef MONITORING
+    Color colorIter{BLACK};
     for (const auto &[volId, caloHitListPartition] : volIdToCaloHits)
     {
         const std::string label{(listName.empty() ? "CurrentCaloHits" : listName) +
             ", volId ("  + std::to_string(volId.first) + ", " + std::to_string(volId.second) + ")"};
-        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &caloHitListPartition, label.c_str(),
-            static_cast<Color>(++colorIter) < AUTO          ? static_cast<Color>(colorIter)
-                : (colorIter % static_cast<int>(AUTO)) == 0 ? static_cast<Color>(++colorIter % static_cast<int>(AUTO))
-                                                            : static_cast<Color>(colorIter % static_cast<int>(AUTO))));
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &caloHitListPartition, label.c_str(), colorIter));
+        colorIter = static_cast<Color>(static_cast<int>(colorIter) + 1);
+        if (colorIter >= AUTO)
+            colorIter = BLACK;
     }
+#endif
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h
@@ -103,8 +103,8 @@ private:
     float m_energyScaleThresholdE;  ///< Cell energy for which color is at top end of continous color palette
     float m_scalingFactor;          ///< TEve works with [cm], Pandora usually works with [mm] (but LArContent went with cm too)
 
-    bool m_showPfoVertices;  ///< Whether to display pfo vertices
-    bool m_showPfoHierarchy; ///< Whether to display daughter pfos only under parent pfo elements
+    bool m_showPfoVertices;           ///< Whether to display pfo vertices
+    bool m_showPfoHierarchy;          ///< Whether to display daughter pfos only under parent pfo elements
     bool m_partitionCaloHitsByVolume; ///< Whether to partition calo hits into unique TPC + daughter volumes for display
 
     pandora::StringVector m_suppressMCParticles; ///< List of PDG numbers and energies for MC particles to be suppressed (e.g. " 22:0.1 2112:1.0 ")

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.h
@@ -97,7 +97,7 @@ private:
 
     bool m_showOnlyAvailable;       ///< Whether to show only available  (i.e. non-clustered) calohits and tracks
     bool m_showAssociatedTracks;    ///< Whether to display tracks associated to clusters when viewing cluster lists
-    std::string m_hitColors;        ///< Define the hit coloring scheme (default: pfo, choices: pfo, particleid)
+    std::string m_hitColors;        ///< Define the hit coloring scheme (default: iterate, choices: iterate, energy, particleid)
     float m_thresholdEnergy;        ///< Cell energy threshold for display (em scale)
     float m_transparencyThresholdE; ///< Cell energy for which transparency is saturated (0%, fully opaque)
     float m_energyScaleThresholdE;  ///< Cell energy for which color is at top end of continous color palette
@@ -105,6 +105,7 @@ private:
 
     bool m_showPfoVertices;  ///< Whether to display pfo vertices
     bool m_showPfoHierarchy; ///< Whether to display daughter pfos only under parent pfo elements
+    bool m_partitionCaloHitsByVolume; ///< Whether to partition calo hits into unique TPC + daughter volumes for display
 
     pandora::StringVector m_suppressMCParticles; ///< List of PDG numbers and energies for MC particles to be suppressed (e.g. " 22:0.1 2112:1.0 ")
     PdgCodeToEnergyMap m_particleSuppressionMap; ///< Map from pdg-codes to energy for suppression of particles types below specific energies


### PR DESCRIPTION
I think this is useful. Especially as the Pandora geometry doesn't know about the Daughter volumes afaik, so the only way to inspect them is through the CaloHits. 

<img width="1169" height="706" alt="Screenshot from 2026-02-20 17-59-44" src="https://github.com/user-attachments/assets/89521771-b598-4912-9835-d1b165f3c2ca" />
