### PR TITLE
DL Shower Growing Alg Update

### DIFF
--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -773,7 +773,7 @@ void EventClusterValidationAlgorithm::GetMatchedParticleMetrics(
     {
         metrics.m_pdg.emplace_back(pMC->GetParticleId());
         metrics.m_causesShower.emplace_back(this->CausesShower(pMC, 0));
-        metrics.m_isPrimary.emplace_back(pMC->GetParentList().front()->IsRootParticle());
+        metrics.m_isPrimary.emplace_back(pMC->IsRootParticle() || pMC->GetParentList().front()->IsRootParticle());
         metrics.m_trueEnergy.emplace_back(pMC->GetEnergy());
         metrics.m_nTrueHits.emplace_back(mcNTrueHits.at(pMC));
         metrics.m_trueHitsSumEnergy.emplace_back(mcTrueHitsSumEnergy.at(pMC));

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -42,6 +42,7 @@ EventClusterValidationAlgorithm::ClusterMetrics::ClusterMetrics() :
     m_trackAri{0.},
     m_nHits{0},
     m_nHitsNullCluster{0},
+    m_nHitsFromBeam{0},
     m_nShowerTrueHits{0},
     m_nTrackTrueHits{0},
     m_nRecoClusters{0},
@@ -166,6 +167,13 @@ StatusCode EventClusterValidationAlgorithm::Run()
         std::map<const CaloHit *const, CaloHitParents> hitParents;
         this->GetHitParents(caloHits, clusters, hitParents);
         clusterMetrics.m_nHits = hitParents.size();
+        for (const auto &[pCaloHit, parents] : hitParents)
+        {
+            if ((LArMCParticleHelper::IsBeamParticle(parents.m_pMainMC) || LArMCParticleHelper::IsNeutrino(parents.m_pMainMC)))
+            {
+                clusterMetrics.m_nHitsFromBeam++;
+            }
+        }
 
         // Drop any hits with a main MC particle with insufficient activity
         this->ApplyMCParticleMinSumHits(hitParents);
@@ -873,6 +881,7 @@ void EventClusterValidationAlgorithm::SetBranches([[maybe_unused]] const Cluster
     // Just the all-hits ARI with some values that might be needed for cuts
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_hits", clusterMetrics.m_nHits));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_hits_null", clusterMetrics.m_nHitsNullCluster));
+    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_hits_from_beam", clusterMetrics.m_nHitsFromBeam));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "adjusted_rand_idx", clusterMetrics.m_ari));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_true_clusters", clusterMetrics.m_nTrueClusters));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_treeName, "n_ari_reco_clusters", clusterMetrics.m_nAriRecoClusters));

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
@@ -33,6 +33,7 @@ private:
         double m_trackAri;
         int m_nHits;
         int m_nHitsNullCluster;
+        int m_nHitsFromBeam;
         int m_nShowerTrueHits;
         int m_nTrackTrueHits;
         int m_nRecoClusters;

--- a/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/VisualMonitoringAlgorithm.cc
@@ -214,6 +214,7 @@ void VisualMonitoringAlgorithm::VisualizeCaloHitList(const std::string &listName
     for (const CaloHit *const pCaloHit : caloHitList)
     {
         const LArCaloHit *const pLArCaloHit{dynamic_cast<const LArCaloHit *>(pCaloHit)};
+        PANDORA_THROW_IF(STATUS_CODE_FAILURE, !pLArCaloHit);
         const std::pair<unsigned int, unsigned int> volId{pLArCaloHit->GetLArTPCVolumeId(), pLArCaloHit->GetDaughterVolumeId()};
         volIdToCaloHits[volId].push_back(pCaloHit);
     }

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -148,7 +148,10 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
                 mcToID.insert({pMainMC, currMCID++});
                 mcID.emplace_back(mcToID.at(pMainMC));
                 mcPDG.emplace_back(pMainMC->GetParticleId());
-                mcIsFromBeam.emplace_back(LArMCParticleHelper::IsBeamParticle(LArMCParticleHelper::GetParentMCParticle(pMainMC)) ? 1 : 0);
+                const MCParticle *const pMainMCParent{LArMCParticleHelper::GetParentMCParticle(pMainMC)};
+                mcIsFromBeam.emplace_back(
+                  (LArMCParticleHelper::IsBeamParticle(pMainMCParent) || LArMCParticleHelper::IsNeutrino(pMainMCParent)) ? 1 : 0
+                );
             }
 
             hitClusterID.emplace_back(currClusterID);

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -887,7 +887,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
         XmlHelper::ReadValue(xmlHandle, "MaxIterations", m_maxIterations));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
-        XmlHelper::ReadVectorOfValues(xmlHandle, "EncodeLarTpcVolIDs", m_encodeLArTPCVolIDs));
+        XmlHelper::ReadVectorOfValues(xmlHandle, "EncodeLArTPCVolIDs", m_encodeLArTPCVolIDs));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadVectorOfValues(xmlHandle, "EncodeDaughterVolIDs", m_encodeDaughterVolIDs));
     PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, m_encodeLArTPCVolIDs.size() != m_encodeDaughterVolIDs.size());

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -431,8 +431,15 @@ StatusCode DLTwoDShowerGrowingAlgorithm::CalculateHitFeatures(const CaloHit *con
     hitFeatures.m_energy = pCaloHit->GetMipEquivalentEnergy();
 
     const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
-    hitFeatures.m_larTpcVolId = pLArCaloHit->GetLArTPCVolumeId();
-    hitFeatures.m_daughterVolId = pLArCaloHit->GetDaughterVolumeId();
+    if (pLArCaloHit)
+    {
+        hitFeatures.m_larTpcVolId = pLArCaloHit->GetLArTPCVolumeId();
+        hitFeatures.m_daughterVolId = pLArCaloHit->GetDaughterVolumeId();
+    }
+    else if (!m_encodeLArTPCVolIDs.empty())
+    {
+        return STATUS_CODE_FAILURE;
+    }
 
     return STATUS_CODE_SUCCESS;
 }
@@ -577,14 +584,9 @@ StatusCode DLTwoDShowerGrowingAlgorithm::MakeClusterTensor(const std::vector<Hit
         for (size_t j = 12, k = 0; k < m_encodeLArTPCVolIDs.size(); j++, k++)
         {
             if (hitFeatures.m_larTpcVolId == m_encodeLArTPCVolIDs.at(k) && hitFeatures.m_daughterVolId == m_encodeDaughterVolIDs.at(k))
-            {
                 accessor[0][i][j] = 1.f;
-            }
             else
-            {
                 accessor[0][i][j] = 0.f;
-            }
-
         }
         if (m_includeHitCardinalityFeatures)
         {
@@ -592,9 +594,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::MakeClusterTensor(const std::vector<Hit
             accessor[0][i][m_hitFeaturesNClustersIdx] = nClustersFeat;
         }
         if (m_includeHitNIterationNumFeature)
-        {
             accessor[0][i][m_hitFeaturesIterationNumIdx] = iterationNumFeat;
-        }
     }
 
     return STATUS_CODE_SUCCESS;
@@ -892,9 +892,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
         XmlHelper::ReadVectorOfValues(xmlHandle, "EncodeDaughterVolIDs", m_encodeDaughterVolIDs));
     PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, m_encodeLArTPCVolIDs.size() != m_encodeDaughterVolIDs.size());
     if (!m_encodeLArTPCVolIDs.empty())
-    {
         m_hitFeatureDim += m_encodeLArTPCVolIDs.size();
-    }
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "IncludeHitCardinalityFeatures", m_includeHitCardinalityFeatures));
@@ -906,9 +904,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "IncludeHitNIterationNumFeature", m_includeHitNIterationNumFeature));
     if (m_includeHitNIterationNumFeature)
-    {
         m_hitFeaturesIterationNumIdx = m_hitFeatureDim++;
-    }
 
     if (m_trainingMode)
     {

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -30,7 +30,9 @@ DLTwoDShowerGrowingAlgorithm::HitFeatures::HitFeatures() :
     m_sinThetaRel{0.f},
     m_distToXGap{0.f},
     m_xWidth{0.f},
-    m_energy{0.f}
+    m_energy{0.f},
+    m_larTpcVolId{0},
+    m_daughterVolId{0}
 {
 }
 
@@ -71,7 +73,9 @@ DLTwoDShowerGrowingAlgorithm::DLTwoDShowerGrowingAlgorithm() :
     m_accessoryClustersMaxHits{2},
     m_maxIterations{1},
     m_includeHitCardinalityFeatures{true},
-    m_includeHitNIterationNumFeature{false}
+    m_includeHitNIterationNumFeature{false},
+    m_encodeLArTPCVolIDs{std::vector<unsigned int>{}},
+    m_encodeDaughterVolIDs{std::vector<unsigned int>{}}
 {
 }
 
@@ -157,12 +161,10 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
             hitXWidth.emplace_back(hitFeatures.m_xWidth);
             hitDistToXGap.emplace_back(hitFeatures.m_distToXGap);
             hitEnergy.emplace_back(hitFeatures.m_energy);
+            hitLArTPCVolID.emplace_back(static_cast<int>(hitFeatures.m_larTpcVolId));
+            hitDaughterVolID.emplace_back(static_cast<int>(hitFeatures.m_daughterVolId));
 
             hitMCID.emplace_back(mcToID.at(pMainMC));
-
-            const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
-            hitLArTPCVolID.emplace_back(static_cast<int>(pLArCaloHit->GetLArTPCVolumeId()));
-            hitDaughterVolID.emplace_back(static_cast<int>(pLArCaloHit->GetDaughterVolumeId()));
         }
         currClusterID++;
     }
@@ -424,6 +426,10 @@ StatusCode DLTwoDShowerGrowingAlgorithm::CalculateHitFeatures(const CaloHit *con
     hitFeatures.m_xWidth = pCaloHit->GetCellSize1();
     hitFeatures.m_energy = pCaloHit->GetMipEquivalentEnergy();
 
+    const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
+    hitFeatures.m_larTpcVolId = pLArCaloHit->GetLArTPCVolumeId();
+    hitFeatures.m_daughterVolId = pLArCaloHit->GetDaughterVolumeId();
+
     return STATUS_CODE_SUCCESS;
 }
 
@@ -564,6 +570,18 @@ StatusCode DLTwoDShowerGrowingAlgorithm::MakeClusterTensor(const std::vector<Hit
         accessor[0][i][9] = view == TPC_VIEW_U ? 1.f : 0.f;
         accessor[0][i][10] = view == TPC_VIEW_V ? 1.f : 0.f;
         accessor[0][i][11] = view == TPC_VIEW_W ? 1.f : 0.f;
+        for (size_t j = 12, k = 0; k < m_encodeLArTPCVolIDs.size(); j++, k++)
+        {
+            if (hitFeatures.m_larTpcVolId == m_encodeLArTPCVolIDs.at(k) && hitFeatures.m_daughterVolId == m_encodeDaughterVolIDs.at(k))
+            {
+                accessor[0][i][j] = 1.f;
+            }
+            else
+            {
+                accessor[0][i][j] = 0.f;
+            }
+
+        }
         if (m_includeHitCardinalityFeatures)
         {
             accessor[0][i][m_hitFeaturesNHitsIdx] = nHitsFeat;
@@ -863,6 +881,16 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "MaxIterations", m_maxIterations));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "EncodeLarTpcVolIDs", m_encodeLArTPCVolIDs));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "EncodeDaughterVolIDs", m_encodeDaughterVolIDs));
+    PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, m_encodeLArTPCVolIDs.size() != m_encodeDaughterVolIDs.size());
+    if (!m_encodeLArTPCVolIDs.empty())
+    {
+        m_hitFeatureDim += m_encodeLArTPCVolIDs.size();
+    }
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "IncludeHitCardinalityFeatures", m_includeHitCardinalityFeatures));

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -115,9 +115,9 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
     const ClusterList clusterList{this->GetAllClusters()};
 
     int currClusterID{0}, currMCID{0};
-    std::map<const MCParticle *const, int> mcToID = {{nullptr, -1}}, mcToPDG = {{nullptr, 0}};
+    std::map<const MCParticle *const, int> mcToID = {{nullptr, -1}}; // Initialise for null MCParticle
     std::vector<int> clusterView, clusterID;
-    std::vector<int> mcID = {-1}, mcPDG = {0};
+    std::vector<int> mcID = {-1}, mcPDG = {0}, mcIsFromBeam = {0}; // Initialise for null MCParticle
     std::vector<int> hitClusterID;
     std::vector<float> hitXRelPos, hitZRelPos;
     std::vector<float> hitRRelPos, hitSinThetaRelPos, hitCosThetaRelPos; // Polar coordinates
@@ -146,9 +146,9 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
             if (mcToID.find(pMainMC) == mcToID.end())
             {
                 mcToID.insert({pMainMC, currMCID++});
-                mcToPDG.insert({pMainMC, pMainMC->GetParticleId()});
                 mcID.emplace_back(mcToID.at(pMainMC));
-                mcPDG.emplace_back(mcToPDG.at(pMainMC));
+                mcPDG.emplace_back(pMainMC->GetParticleId());
+                mcIsFromBeam.emplace_back(LArMCParticleHelper::IsBeamParticle(LArMCParticleHelper::GetParentMCParticle(pMainMC)) ? 1 : 0);
             }
 
             hitClusterID.emplace_back(currClusterID);
@@ -173,6 +173,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "cluster_view", &clusterView));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "mc_id", &mcID));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "mc_pdg", &mcPDG));
+    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "mc_is_from_beam", &mcIsFromBeam));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_cluster_id", &hitClusterID));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_x_rel_pos", &hitXRelPos));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_z_rel_pos", &hitZRelPos));

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -14,6 +14,7 @@
 #include "larpandoracontent/LArHelpers/LArFileHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
 
 using namespace pandora;
 using namespace lar_content;
@@ -120,6 +121,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
     std::vector<float> hitDistToXGap;
     std::vector<float> hitEnergy;
     std::vector<int> hitMCID;
+    std::vector<int> hitLArTPCVolID, hitDaughterVolID;
 
     std::map<const MCParticle *const, const MCParticle *const> mcFoldTo;
 
@@ -157,6 +159,10 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
             hitEnergy.emplace_back(hitFeatures.m_energy);
 
             hitMCID.emplace_back(mcToID.at(pMainMC));
+
+            const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
+            hitLArTPCVolID.emplace_back(static_cast<int>(pLArCaloHit->GetLArTPCVolumeId()));
+            hitDaughterVolID.emplace_back(static_cast<int>(pLArCaloHit->GetDaughterVolumeId()));
         }
         currClusterID++;
     }
@@ -175,6 +181,8 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_x_gap_dist", &hitDistToXGap));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_energy", &hitEnergy));
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_mc_id", &hitMCID));
+    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_tpc_vol_id", &hitLArTPCVolID));
+    PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_daughter_vol_id", &hitDaughterVolID));
 
     PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_trainingTreeName));
 
@@ -195,6 +203,15 @@ void DLTwoDShowerGrowingAlgorithm::WriteTrainingSample() const
         PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_trainingTreeName + "_view_data"));
     }
     PANDORA_MONITORING_API(SaveTree(this->GetPandora(), m_trainingTreeName + "_view_data", m_trainingFileName, "UPDATE"));
+
+    PANDORA_MONITORING_API(SetTreeVariable(
+        this->GetPandora(), m_trainingTreeName + "_event_data", "scalefactor_polar_r", m_polarRScaleFactor))
+    PANDORA_MONITORING_API(SetTreeVariable(
+        this->GetPandora(), m_trainingTreeName + "_event_data", "scalefactor_cartesian_x", m_cartesianXScaleFactor))
+    PANDORA_MONITORING_API(SetTreeVariable(
+        this->GetPandora(), m_trainingTreeName + "_event_data", "scalefactor_cartesian_z", m_cartesianZScaleFactor))
+    PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_trainingTreeName + "_event_data"));
+    PANDORA_MONITORING_API(SaveTree(this->GetPandora(), m_trainingTreeName + "_event_data", m_trainingFileName, "UPDATE"));
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -827,7 +827,8 @@ bool DLTwoDShowerGrowingAlgorithm::IsSingletonPartition(const std::vector<Cluste
 
 StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TrainingMode", m_trainingMode));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "TrainingMode", m_trainingMode));
     if (m_trainingMode)
     {
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "TrainingTreeName", m_trainingTreeName));
@@ -847,17 +848,22 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
         LArDLHelper::LoadModel(modelSimName, m_modelSim);
     }
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "VertexListName", m_vertexListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "VertexListName", m_vertexListName));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SimilarityThreshold", m_similarityThreshold));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "SimilarityThreshold", m_similarityThreshold));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "SimilarityThresholdBeta", m_similarityThresholdBeta));
+
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "AccessoryClusterMaxHits", m_accessoryClustersMaxHits));
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxIterations", m_maxIterations));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MaxIterations", m_maxIterations));
+
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "IncludeHitCardinalityFeatures", m_includeHitCardinalityFeatures));
     if (m_includeHitCardinalityFeatures)
@@ -872,25 +878,32 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
         m_hitFeaturesIterationNumIdx = m_hitFeatureDim++;
     }
 
-    m_deltaRayLengthThresholdSquared = {
-        {TPC_VIEW_U, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U), 2.))},
-        {TPC_VIEW_V, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V), 2.))},
-        {TPC_VIEW_W, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W), 2.))}};
-
-    const LArGeometryHelper::DetectorBoundaries detBounds{LArGeometryHelper::GetDetectorBoundaries(this->GetPandora())};
-    double xLow{static_cast<double>(detBounds.m_xBoundaries.first)}, xHigh{static_cast<double>(detBounds.m_xBoundaries.second)};
-    double yLow{static_cast<double>(detBounds.m_yBoundaries.first)}, yHigh{static_cast<double>(detBounds.m_yBoundaries.second)};
-    double zLow{static_cast<double>(detBounds.m_zBoundaries.first)}, zHigh{static_cast<double>(detBounds.m_zBoundaries.second)};
-    m_polarRScaleFactor = static_cast<float>(1. / std::sqrt(std::pow(xHigh - xLow, 2.) + std::pow(yHigh - yLow, 2.) + std::pow(zHigh - zLow, 2.)));
-    m_cartesianXScaleFactor = static_cast<float>(1. / (xHigh - xLow));
-    m_cartesianZScaleFactor = static_cast<float>(1. / (zHigh - zLow));
     if (m_trainingMode)
     {
+        const LArGeometryHelper::DetectorBoundaries detBounds{LArGeometryHelper::GetDetectorBoundaries(this->GetPandora())};
+        double xLow{static_cast<double>(detBounds.m_xBoundaries.first)}, xHigh{static_cast<double>(detBounds.m_xBoundaries.second)};
+        double yLow{static_cast<double>(detBounds.m_yBoundaries.first)}, yHigh{static_cast<double>(detBounds.m_yBoundaries.second)};
+        double zLow{static_cast<double>(detBounds.m_zBoundaries.first)}, zHigh{static_cast<double>(detBounds.m_zBoundaries.second)};
+        m_polarRScaleFactor = static_cast<float>(
+            1. / std::sqrt(std::pow(xHigh - xLow, 2.) + std::pow(yHigh - yLow, 2.) + std::pow(zHigh - zLow, 2.)));
+        m_cartesianXScaleFactor = static_cast<float>(1. / (xHigh - xLow));
+        m_cartesianZScaleFactor = static_cast<float>(1. / (zHigh - zLow));
         std::cout << "Scalefactors for this geometry\n"
                   << "Polar R:     " << m_polarRScaleFactor << "\n"
                   << "Cartesian X: " << m_cartesianXScaleFactor << "\n"
                   << "Cartesian Z: " << m_cartesianZScaleFactor << "\n";
     }
+    else
+    {
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PolarRScaleFactor", m_polarRScaleFactor));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CartesianXScaleFactor", m_cartesianXScaleFactor));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CartesianZScaleFactor", m_cartesianZScaleFactor));
+    }
+
+    m_deltaRayLengthThresholdSquared = {
+        {TPC_VIEW_U, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U), 2.))},
+        {TPC_VIEW_V, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V), 2.))},
+        {TPC_VIEW_W, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W), 2.))}};
 
     for (const DetectorGap *const pDetectorGap : this->GetPandora().GetGeometry()->GetDetectorGapList())
     {

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.h
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.h
@@ -35,6 +35,8 @@ private:
         float m_distToXGap;
         float m_xWidth;
         float m_energy;
+        unsigned int m_larTpcVolId;
+        unsigned int m_daughterVolId;
     };
 
     struct ClusterGroup
@@ -341,17 +343,19 @@ private:
 
     /* Start configurable via xml members */
 
-    bool m_trainingMode;                      ///< Training mode
-    std::string m_trainingTreeName;           ///< Tree name for training data output
-    std::string m_trainingFileName;           ///< File name for training data output
-    pandora::StringVector m_clusterListNames; ///< Names of cluster lists
-    std::string m_vertexListName;             ///< Name of vertex list
-    float m_similarityThreshold;              ///< Threshold value on similarity for clusters to be connected
-    float m_similarityThresholdBeta;          ///< Scaling factor for an optional second clustering pass
-    unsigned int m_accessoryClustersMaxHits;  ///< Clusters with this number of less hits are treated as accessory clusters during merging
-    unsigned int m_maxIterations;             ///< Max iterative applications of the cluster merging
-    bool m_includeHitCardinalityFeatures;     ///< Option to include in hit feature vector the no. hits in cluster and no. clusters in event
-    bool m_includeHitNIterationNumFeature;    ///< Option to include in hit feature vector the inference iteration number
+    bool m_trainingMode;                              ///< Training mode
+    std::string m_trainingTreeName;                   ///< Tree name for training data output
+    std::string m_trainingFileName;                   ///< File name for training data output
+    pandora::StringVector m_clusterListNames;         ///< Names of cluster lists
+    std::string m_vertexListName;                     ///< Name of vertex list
+    float m_similarityThreshold;                      ///< Threshold value on similarity for clusters to be connected
+    float m_similarityThresholdBeta;                  ///< Scaling factor for an optional second clustering pass
+    unsigned int m_accessoryClustersMaxHits;          ///< Clusters with this number of less hits are treated as accessory clusters during merging
+    unsigned int m_maxIterations;                     ///< Max iterative applications of the cluster merging
+    bool m_includeHitCardinalityFeatures;             ///< Option to include in hit feature vector the no. hits in cluster and no. clusters in event
+    bool m_includeHitNIterationNumFeature;            ///< Option to include in hit feature vector the inference iteration number
+    std::vector<unsigned int> m_encodeLArTPCVolIDs;   ///< LArTPC vol IDs for one-hot encoding of drift vols in hit feature vector, must be same size as m_encodeDaughterVolIDs
+    std::vector<unsigned int> m_encodeDaughterVolIDs; ///< Daughter vol IDs for one-hot encoding of drift vols in hit feature vector, must be sae size as m_encodeLArTPCVolIDs
 
     /* End configurable via xml members */
 };


### PR DESCRIPTION
A few updates necessitated by training on detectors other than FD-HD:
- "Events" in the training data TTree may now actually be slices, added variables to the training TTree for calculating slice purity which can be used to balance the training dataset.
- Option to encode problematic drift vols in the hit feature vectors
- Make scalefactors explicitly configured rather than taken from the geometry.
