### PR TITLE
Add Rock Muon Tagging option into Cosmic Ray tagging tools 

### DIFF
--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
@@ -14,6 +14,7 @@
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
+#include <limits>
 
 using namespace pandora;
 
@@ -109,9 +110,9 @@ void CosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos,
     
     if(m_tagRockMuons)
      std::cout << "Detector boundaries to tag rock muons : x [" 
-               << parentMinX <<"," << parentMaxX << "] "
-               << "y [" << parentMinY <<"," << parentMaxY << "] "
-               << "z [" << parentMinZ <<"," << parentMaxZ << "] \n";
+               << m_face_Xa + m_marginX <<"," << m_face_Xc - m_marginX<< "] "
+               << "y [" << m_face_Yb + m_marginY <<"," << m_face_Yt - m_marginY<< "] "
+               << "z [" << m_face_Zu + m_marginZ <<"," << m_face_Zd - m_marginZ << "] \n";
 
     PfoToPfoListMap pfoAssociationMap;
     this->GetPfoAssociations(parentCosmicRayPfos, pfoAssociationMap);
@@ -504,13 +505,13 @@ void CosmicRayTaggingTool::CheckIfThroughgoing(const CRCandidateList &candidates
 {
     for (const CRCandidate &candidate : candidates)
     {
-      bool isEndPoint1Outside = IsOutsideBox(candidate.m_endPoint1.GetX(), candidate.m_endPoint1.GetY(), candidate.m_endPoint1.GetZ());
-      bool isEndPoint2Outside = IsOutsideBox(candidate.m_endPoint2.GetX(), candidate.m_endPoint2.GetY(), candidate.m_endPoint2.GetZ());
-
-      bool isThroughgoing = (isEndPoint1Outside && isEndPoint2Outside);
+      bool isThroughgoing = (
+          (candidate.m_endPoint1.GetX() != std::numeric_limits<float>::max()) && // for some reason some candidates happen to have "default" values set as inf 
+          IsOutsideBox(candidate.m_endPoint1.GetX(), candidate.m_endPoint1.GetY(), candidate.m_endPoint1.GetZ()) &&
+          IsOutsideBox(candidate.m_endPoint2.GetX(), candidate.m_endPoint2.GetY(), candidate.m_endPoint2.GetZ()));
 
       if (!pfoToIsThroughgoingMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, isThroughgoing)).second)
-            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+        throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
     }
 } 
 
@@ -549,6 +550,7 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
     const PfoToBoolMap &pfoToIsTopToBottomMap, const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap, 
     const PfoToBoolMap &pfoToIsThroughgoingMap) const
 {
+    int nof_rock_mu_tagged = 0;
     for (const CRCandidate &candidate : candidates)
     {
         const bool likelyCRMuon(!neutrinoSliceSet.count(candidate.m_sliceId) &&
@@ -559,6 +561,7 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
 
         if(m_tagRockMuons && (pfoToIsThroughgoingMap.at(candidate.m_pPfo)))
         {
+          nof_rock_mu_tagged++;
           const bool likelyRockMuon = true;
           if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyRockMuon)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
@@ -568,6 +571,7 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
         }
     }
+    std::cout << "Number of rock muons tagged : " << nof_rock_mu_tagged << "\n";
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -653,7 +657,7 @@ StatusCode CosmicRayTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMaxX0", m_inTimeMaxX0));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagCRMuons", m_tagRockMuons));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagRockMuons", m_tagRockMuons));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginX", m_marginX));
 

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
@@ -28,8 +28,10 @@ CosmicRayTaggingTool::CosmicRayTaggingTool() :
     m_minimumHits(15),
     m_inTimeMargin(5.f),
     m_inTimeMaxX0(1.f),
-    m_marginY(20.f),
-    m_marginZ(10.f),
+    m_tagRockMuons(false),
+    m_marginX(5.f), // [cm]
+    m_marginY(5.f),
+    m_marginZ(5.f),
     m_maxNeutrinoCosTheta(0.2f),
     m_minCosmicCosTheta(0.6f),
     m_maxCosmicCurvature(0.04f),
@@ -104,6 +106,12 @@ void CosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos,
     m_face_Yt = parentMaxY;
     m_face_Zu = parentMinZ;
     m_face_Zd = parentMaxZ;
+    
+    if(m_tagRockMuons)
+     std::cout << "Detector boundaries to tag rock muons : x [" 
+               << parentMinX <<"," << parentMaxX << "] "
+               << "y [" << parentMinY <<"," << parentMaxY << "] "
+               << "z [" << parentMinZ <<"," << parentMaxZ << "] \n";
 
     PfoToPfoListMap pfoAssociationMap;
     this->GetPfoAssociations(parentCosmicRayPfos, pfoAssociationMap);
@@ -123,11 +131,15 @@ void CosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos,
     PfoToBoolMap pfoToIsTopToBottomMap;
     this->CheckIfTopToBottom(candidates, pfoToIsTopToBottomMap);
 
+    PfoToBoolMap pfoToIsThroughgoingMap;
+    if(m_tagRockMuons)
+      this->CheckIfThroughgoing(candidates, pfoToIsThroughgoingMap);
+
     UIntSet neutrinoSliceSet;
     this->GetNeutrinoSlices(candidates, pfoToInTimeMap, pfoToIsContainedMap, neutrinoSliceSet);
 
     PfoToBoolMap pfoToIsLikelyCRMuonMap;
-    this->TagCRMuons(candidates, pfoToInTimeMap, pfoToIsTopToBottomMap, neutrinoSliceSet, pfoToIsLikelyCRMuonMap);
+    this->TagCRMuons(candidates, pfoToInTimeMap, pfoToIsTopToBottomMap, neutrinoSliceSet, pfoToIsLikelyCRMuonMap, pfoToIsThroughgoingMap);
 
     for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
     {
@@ -469,6 +481,40 @@ void CosmicRayTaggingTool::CheckIfTopToBottom(const CRCandidateList &candidates,
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
+bool CosmicRayTaggingTool::IsOutsideBox(const float x, const float y, const float z) const 
+{
+  const float BoxXmin = m_face_Xa + m_marginX;
+  const float BoxXmax = m_face_Xc - m_marginX;
+
+  const float BoxYmin = m_face_Yb + m_marginY;
+  const float BoxYmax = m_face_Yt - m_marginY;
+
+  const float BoxZmin = m_face_Zu + m_marginZ;
+  const float BoxZmax = m_face_Zd - m_marginZ;
+
+  bool IsOutRangeX = (x < BoxXmin || x > BoxXmax);
+  bool IsOutRangeY = (y < BoxYmin || y > BoxYmax);
+  bool IsOutRangeZ = (z < BoxZmin || z > BoxZmax);
+
+  return (IsOutRangeZ || IsOutRangeY || IsOutRangeX);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+void CosmicRayTaggingTool::CheckIfThroughgoing(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsThroughgoingMap) const
+{
+    for (const CRCandidate &candidate : candidates)
+    {
+      bool isEndPoint1Outside = IsOutsideBox(candidate.m_endPoint1.GetX(), candidate.m_endPoint1.GetY(), candidate.m_endPoint1.GetZ());
+      bool isEndPoint2Outside = IsOutsideBox(candidate.m_endPoint2.GetX(), candidate.m_endPoint2.GetY(), candidate.m_endPoint2.GetZ());
+
+      bool isThroughgoing = (isEndPoint1Outside && isEndPoint2Outside);
+
+      if (!pfoToIsThroughgoingMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, isThroughgoing)).second)
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+    }
+} 
+
+//------------------------------------------------------------------------------------------------------------------------------------------
 
 void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap,
     const PfoToBoolMap &pfoToIsContainedMap, UIntSet &neutrinoSliceSet) const
@@ -500,7 +546,8 @@ void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap,
-    const PfoToBoolMap &pfoToIsTopToBottomMap, const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const
+    const PfoToBoolMap &pfoToIsTopToBottomMap, const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap, 
+    const PfoToBoolMap &pfoToIsThroughgoingMap) const
 {
     for (const CRCandidate &candidate : candidates)
     {
@@ -510,8 +557,16 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
                     (pfoToIsTopToBottomMap.at(candidate.m_pPfo) ||
                         ((candidate.m_theta > m_minCosmicCosTheta) && (candidate.m_curvature < m_maxCosmicCurvature))))));
 
-        if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyCRMuon)).second)
+        if(m_tagRockMuons && (pfoToIsThroughgoingMap.at(candidate.m_pPfo)))
+        {
+          const bool likelyRockMuon = true;
+          if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyRockMuon)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+        }else
+        {
+          if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyCRMuon)).second)
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+        }
     }
 }
 
@@ -597,6 +652,10 @@ StatusCode CosmicRayTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMargin", m_inTimeMargin));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMaxX0", m_inTimeMaxX0));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagCRMuons", m_tagRockMuons));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginX", m_marginX));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginY", m_marginY));
 

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
@@ -156,6 +156,23 @@ private:
      */
     void CheckIfTopToBottom(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsTopToBottomMap) const;
 
+     /**
+     *  @brief Check if a 3D point is inside the detector boundaies with margins 
+     *
+     *  @param  x point x coordinate
+     *  @param  y point y coordinate
+     *  @param  z point z coordinate
+     */   
+    bool IsOutsideBox(const float x, const float y, const float z) const;
+
+    /**
+     *  @brief  Check if each candidate is throughgoing (i.e emerging and exiting from any of the detector boundaies)
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToIsThroughgoingMap output mapping between candidates Pfos and if they are top to bottom
+     */
+    void CheckIfThroughgoing(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsThroughgoingMap) const;
+
     typedef std::set<unsigned int> UIntSet;
     typedef std::unordered_map<int, bool> IntBoolMap;
 
@@ -178,9 +195,10 @@ private:
      *  @param  pfoToIsTopToBottomMap input mapping between candidate Pfos and if they are top to bottom
      *  @param  neutrinoSliceSet input set of slice indices containing a likely neutrino Pfo
      *  @param  pfoToIsLikelyCRMuonMap to receive the output mapping between Pfos and a boolean deciding if they are likely a CR muon
+     *  @param  pfoToIsLikelyCRMuonMap to receive the output mapping between Pfos and a boolean deciding if they are likely a rock muon
      */
     void TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsTopToBottomMap,
-        const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const;
+        const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap, const PfoToBoolMap &pfoToIsThroughgoingMap) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
@@ -203,6 +221,8 @@ private:
 
     float m_inTimeMargin; ///< The maximum distance outside of the physical detector volume that a Pfo may be to still be considered in time
     float m_inTimeMaxX0;  ///< The maximum pfo x0 (determined from shifted vertex) to allow pfo to still be considered in time
+    bool m_tagRockMuons;  ///< bool to activate tagging of rock muons
+    float m_marginX;      ///< The minimum distance from a detector X-face for a Pfo to be associated
     float m_marginY;      ///< The minimum distance from a detector Y-face for a Pfo to be associated
     float m_marginZ;      ///< The minimum distance from a detector Z-face for a Pfo to be associated
     float m_maxNeutrinoCosTheta; ///< The maximum cos(theta) that a Pfo can have to be classified as a likely neutrino

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -154,8 +154,9 @@ StatusCode MasterAlgorithm::Run()
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Reset());
 
+    WorkerToLArTPCMap workerToLArTPCMap;
     if (!m_workerInstancesInitialized)
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->InitializeWorkerInstances());
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->InitializeWorkerInstances(workerToLArTPCMap));
 
     if (m_passMCParticlesToWorkerInstances)
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CopyMCParticles());
@@ -166,7 +167,7 @@ StatusCode MasterAlgorithm::Run()
 
     if (m_shouldRunAllHitsCosmicReco)
     {
-        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayReconstruction(volumeIdToHitListMap));
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RunCosmicRayReconstruction(volumeIdToHitListMap, workerToLArTPCMap));
 
         PfoToLArTPCMap pfoToLArTPCMap;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->RecreateCosmicRayPfos(pfoToLArTPCMap));
@@ -197,7 +198,7 @@ StatusCode MasterAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode MasterAlgorithm::InitializeWorkerInstances()
+StatusCode MasterAlgorithm::InitializeWorkerInstances(WorkerToLArTPCMap& workerToLArTPCMap)
 {
     // ATTN Used to be in the regular Initialize callback, but detector gap list cannot be extracted in client app before the first event
     if (m_workerInstancesInitialized)
@@ -213,6 +214,8 @@ StatusCode MasterAlgorithm::InitializeWorkerInstances()
             const unsigned int volumeId(mapEntry.second->GetLArTPCVolumeId());
             m_crWorkerInstances.push_back(
                 this->CreateWorkerInstance(*(mapEntry.second), gapList, m_crSettingsFile, "CRWorkerInstance" + std::to_string(volumeId)));
+
+            workerToLArTPCMap[volumeId].push_back(mapEntry.second);
         }
 
         if (m_shouldRunSlicing)
@@ -295,23 +298,33 @@ StatusCode MasterAlgorithm::GetVolumeIdToHitListMap(VolumeIdToHitListMap &volume
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-StatusCode MasterAlgorithm::RunCosmicRayReconstruction(const VolumeIdToHitListMap &volumeIdToHitListMap) const
+StatusCode MasterAlgorithm::RunCosmicRayReconstruction(const VolumeIdToHitListMap &volumeIdToHitListMap, WorkerToLArTPCMap& workerToLArTPCMap) const
 {
-    unsigned int workerCounter(0);
-
     for (const Pandora *const pCRWorker : m_crWorkerInstances)
     {
-        const LArTPC &larTPC(pCRWorker->GetGeometry()->GetLArTPC());
-        VolumeIdToHitListMap::const_iterator iter(volumeIdToHitListMap.find(larTPC.GetLArTPCVolumeId()));
+        const LArTPC &worker_larTPC(pCRWorker->GetGeometry()->GetLArTPC());
+        const unsigned int worker_id = worker_larTPC.GetLArTPCVolumeId();
+        
+        // loop over worker's TPCs
+        for (const pandora::LArTPC * pLArTPC : workerToLArTPCMap[worker_id])
+        {
+          const unsigned int larTPC_id = (*pLArTPC).GetLArTPCVolumeId();
 
-        if (volumeIdToHitListMap.end() == iter)
+          // get all TPC's hits
+          VolumeIdToHitListMap::const_iterator iter(volumeIdToHitListMap.find(larTPC_id));
+
+          if (volumeIdToHitListMap.end() == iter)
             continue;
 
-        for (const CaloHit *const pCaloHit : iter->second.m_allHitList)
+          // copy hits into the worker
+          std::cout << "Copying " << iter->second.m_allHitList.size() << " hits from LArTPC " << larTPC_id << " to worker " << worker_id << "\n"; 
+          for (const CaloHit *const pCaloHit : iter->second.m_allHitList)
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->Copy(pCRWorker, pCaloHit));
+        }
+
 
         if (m_printOverallRecoStatus)
-            std::cout << "Running cosmic-ray reconstruction worker instance " << ++workerCounter << " of " << m_crWorkerInstances.size() << std::endl;
+            std::cout << "Running cosmic-ray reconstruction worker instance " << worker_id << " of " << m_crWorkerInstances.size() << std::endl;
 
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ProcessEvent(*pCRWorker));
     }

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -28,6 +28,7 @@ class LArMCParticleFactory;
 
 typedef std::vector<pandora::CaloHitList> SliceVector;
 typedef std::vector<pandora::PfoList> SliceHypotheses;
+typedef std::unordered_map<unsigned int, std::vector<const pandora::LArTPC *>> WorkerToLArTPCMap; 
 typedef std::unordered_map<const pandora::ParticleFlowObject *, const pandora::LArTPC *> PfoToLArTPCMap;
 typedef std::unordered_map<const pandora::ParticleFlowObject *, float> PfoToFloatMap;
 
@@ -99,8 +100,10 @@ protected:
 
     /**
      *  @brief  Initialize pandora worker instances
+     *  
+     *  @param workerToLArTPCMap to map each CR worker instance to the list of TPCs it acts on
      */
-    pandora::StatusCode InitializeWorkerInstances();
+    pandora::StatusCode InitializeWorkerInstances(WorkerToLArTPCMap& workerToLArTPCMap);
 
     /**
      *  @brief  Copy mc particles in the named input list to all pandora worker instances
@@ -118,8 +121,9 @@ protected:
      *  @brief  Run the cosmic-ray reconstruction worker instances
      *
      *  @param  volumeIdToHitListMap the volume id to hit list map
+     *  @param  workerToLArTPCMap the worker id to LArTPC list map
      */
-    pandora::StatusCode RunCosmicRayReconstruction(const VolumeIdToHitListMap &volumeIdToHitListMap) const;
+    pandora::StatusCode RunCosmicRayReconstruction(const VolumeIdToHitListMap &volumeIdToHitListMap, WorkerToLArTPCMap& workerToLArTPCMap) const;
 
     /**
      *  @brief  Recreate cosmic-ray pfos (created by worker instances) in the master instance

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -56,6 +56,7 @@ public:
         pandora::InputBool m_shouldRunSlicing;            ///< Whether to slice events into separate regions for processing
         pandora::InputBool m_shouldRunNeutrinoRecoOption; ///< Whether to run neutrino reconstruction for each slice
         pandora::InputBool m_shouldRunCosmicRecoOption;   ///< Whether to run cosmic-ray reconstruction for each slice
+        pandora::InputBool m_shouldRunRockMus_Xworkers;   ///< Whether to run rock muons reconstruction using a columnar X worker
         pandora::InputBool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
         pandora::InputBool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
     };
@@ -318,6 +319,7 @@ protected:
     bool m_shouldRunSlicing;            ///< Whether to slice events into separate regions for processing
     bool m_shouldRunNeutrinoRecoOption; ///< Whether to run neutrino reconstruction for each slice
     bool m_shouldRunCosmicRecoOption;   ///< Whether to run cosmic-ray reconstruction for each slice
+    bool m_shouldRunRockMus_Xworkers;   ///< Whether to run rock muons reconstruction using a columnar X worker
     bool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
     bool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
     bool m_visualizeOverallRecoStatus;  ///< Whether to display results of current operations


### PR DESCRIPTION
In this PR, I added tools to tag rock muons. The DUNE ND will be exposed to a high rate of rock muons (~100 per spill), so we would like to give users the possibility, when running cosmic-ray reconstruction, to tag “clear rock muons,” i.e., PFOs whose endpoints fall outside the fiducial volume specified in the input XML.

A parallel draft PR was created in LArRecoND [here](https://github.com/PandoraPFA/LArRecoND/pull/59) to handle the rock muons reconstruction within the cosmic pass. The PR also includes a few slides for a more detailed explanation.