### PR TITLE
Refactor of roll-up code & DL shower growing hit feature vector construction

### DIFF
--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -1033,6 +1033,25 @@ bool LArMCParticleHelper::IsPairProduction(const MCParticle *const pMCParticle)
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+bool LArMCParticleHelper::CausesShower(const MCParticle *const pMC, int nDescendantElectrons)
+{
+    if (nDescendantElectrons > 1)
+        return true;
+
+    if (std::abs(pMC->GetParticleId()) == E_MINUS)
+        nDescendantElectrons++; // Including the parent particle, ie. the first in the recursion, as a descendant
+
+    for (const MCParticle *pChildMC : pMC->GetDaughterList())
+    {
+        if (LArMCParticleHelper::CausesShower(pChildMC, nDescendantElectrons))
+            return true;
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 CaloHitList LArMCParticleHelper::GetSharedHits(const CaloHitList &hitListA, const CaloHitList &hitListB)
 {
     CaloHitList sharedHits;

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -19,6 +19,7 @@
 #include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
 #include "larpandoracontent/LArHelpers/LArMonitoringHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -266,14 +267,17 @@ const MCParticle *LArMCParticleHelper::GetParentMCParticle(const MCParticle *con
     const MCParticle *pParentMCParticle = pMCParticle;
 
     while (pParentMCParticle->GetParentList().empty() == false)
-    {
-        if (1 != pParentMCParticle->GetParentList().size())
-            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
-
-        pParentMCParticle = *(pParentMCParticle->GetParentList().begin());
-    }
+        pParentMCParticle = LArMCParticleHelper::GetNextParentMCParticle(pParentMCParticle);
 
     return pParentMCParticle;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const MCParticle *LArMCParticleHelper::GetNextParentMCParticle(const MCParticle *const pMCParticle)
+{
+    PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, pMCParticle->GetParentList().size() != 1);
+    return *(pMCParticle->GetParentList().begin());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -587,6 +587,8 @@ public:
      */
     static bool IsPairProduction(const pandora::MCParticle *const pMCParticle);
 
+    static bool CausesShower(const pandora::MCParticle *const pMC, int nDescendantElectrons = 0);
+
     /**
      *  @brief  Determine if two MC particles are topologically continuous within a given tolerance.
      *          If the parent does not travel any distance, a travelling parent is sought and the comparison made between this and the child.

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -245,6 +245,15 @@ public:
     static const pandora::MCParticle *GetParentMCParticle(const pandora::MCParticle *const pMCParticle);
 
     /**
+     *  @brief  Get the next parent mc particle one tier below the current mc particle
+     *
+     *  @param  pMCParticle the input mc particle
+     *
+     *  @return address of the parent mc particle one tier away
+     */
+    static const pandora::MCParticle *GetNextParentMCParticle(const pandora::MCParticle *const pMCParticle);
+
+    /**
      *  @brief  Get all descendent mc particles
      *
      *  @param  pMCParticle the input mc particle

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -587,6 +587,15 @@ public:
      */
     static bool IsPairProduction(const pandora::MCParticle *const pMCParticle);
 
+    /**
+     *  @brief  Check whether an MC particle's decay tree contains more than one electron, indicating an EM shower.
+     *
+     *  @param  pMC                   The MC particle that defines the root of the subtree to check
+     *  @param  nDescendantElectrons  The running count of electrons seen so far,
+     *                                this is a recursive parameter that should be 0 at the top level
+     *
+     *  @return  Whether the MC particle's subtree contains more than one electron
+     */
     static bool CausesShower(const pandora::MCParticle *const pMC, int nDescendantElectrons = 0);
 
     /**

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -77,8 +77,6 @@ EventClusterValidationAlgorithm::MatchedParticleMetrics::MatchedParticleMetrics(
 
 EventClusterValidationAlgorithm::EventClusterValidationAlgorithm() :
     m_eventNumber{0},
-    m_deltaRayLengthThresholdSquared{std::map<HitType, float>{}},
-    m_deltaRayParentWeightThreshold{0.f},
     m_caloHitListNames{{"CaloHitList2D"}},
     m_minMCHitsPerView{0},
     m_onlyRandIndex{false},
@@ -125,6 +123,7 @@ EventClusterValidationAlgorithm::~EventClusterValidationAlgorithm()
 StatusCode EventClusterValidationAlgorithm::Run()
 {
     m_eventNumber++;
+    m_rollUpper.Reset();
 
     // Gather hits by view
     std::map<HitType, CaloHitList> viewToCaloHits;
@@ -219,60 +218,13 @@ StatusCode EventClusterValidationAlgorithm::Run()
 void EventClusterValidationAlgorithm::GetHitParents(
     const CaloHitList &caloHits, const ClusterList &clusters, std::map<const CaloHit *const, CaloHitParents> &hitParents) const
 {
-    std::map<const MCParticle *const, const MCParticle *const> mcFoldTo;
     for (const CaloHit *const pCaloHit : caloHits)
     {
-        MCParticleWeightMap weightMap{pCaloHit->GetMCParticleWeightMap()};
-
-        if (m_foldShowers)
-        {
-            MCParticleWeightMap foldedWeightMap;
-            for (const auto &[pMC, weight] : weightMap)
-            {
-                const MCParticle *pFoldedMC{nullptr};
-                if (mcFoldTo.find(pMC) != mcFoldTo.end())
-                {
-                    pFoldedMC = mcFoldTo.at(pMC);
-                }
-                else
-                {
-                    pFoldedMC = this->FoldMCTo(pMC);
-                    mcFoldTo.insert({pMC, pFoldedMC});
-                }
-                foldedWeightMap[pFoldedMC] += weight;
-            }
-            weightMap = std::move(foldedWeightMap);
-        }
-
-        const MCParticle *pMainMC{nullptr};
-        float maxWeight{0.f};
-        for (const auto &[pMC, weight] : weightMap)
-        {
-            if (weight > maxWeight)
-            {
-                pMainMC = pMC;
-                maxWeight = weight;
-            }
-            if (weight == maxWeight && pMainMC) // tie-breaker (very unlikely)
-            {
-                if (LArMCParticleHelper::SortByMomentum(pMC, pMainMC))
-                {
-                    pMainMC = pMC;
-                }
-            }
-        }
+        const MCParticle *const pMainMC{m_rollUpper.RollUpCaloHit(pCaloHit)};
         if (pMainMC)
         {
             hitParents[pCaloHit] = CaloHitParents();
             hitParents[pCaloHit].m_pMainMC = pMainMC;
-        }
-    }
-
-    if (m_handleDeltaRays)
-    {
-        for (auto &[pCaloHit, parents] : hitParents)
-        {
-            parents.m_pMainMC = this->FoldPotentialDeltaRayTo(pCaloHit, parents.m_pMainMC);
         }
     }
 
@@ -292,118 +244,6 @@ void EventClusterValidationAlgorithm::GetHitParents(
             hitParents[pCaloHit].m_pCluster = pCluster;
         }
     }
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-const MCParticle *EventClusterValidationAlgorithm::FoldMCTo(const MCParticle *const pMC) const
-{
-    if (!LArMCParticleHelper::IsEM(pMC))
-    {
-        return pMC;
-    }
-
-    bool hasAncestorElectron{false};
-    const MCParticle *pCurrentMC{pMC};
-    const MCParticle *pLeadingMC{pMC};
-    while (!pCurrentMC->IsRootParticle())
-    {
-        const MCParticle *const pParentMC{*(pCurrentMC->GetParentList().begin())};
-        const int parentPdg{std::abs(pParentMC->GetParticleId())};
-        if (parentPdg == PHOTON || parentPdg == E_MINUS)
-        {
-            if (parentPdg == E_MINUS)
-            {
-                hasAncestorElectron = true;
-            }
-            pCurrentMC = pParentMC;
-            continue;
-        }
-        pLeadingMC = pCurrentMC;
-        break;
-    }
-
-    // Don't fold "showers" that consist of only compton scatters
-    // Trying to prevents distant diffuse hits disconnected from a "real" bremm + pair production shower being clustered together
-    if (hasAncestorElectron || std::abs(pLeadingMC->GetParticleId()) == E_MINUS)
-    {
-        return pLeadingMC;
-    }
-    else if (this->CausesShower(pLeadingMC, 0))
-    {
-        return pLeadingMC;
-    }
-    else
-    {
-        return pMC;
-    }
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-bool EventClusterValidationAlgorithm::CausesShower(const MCParticle *const pMC, int nDescendentElectrons) const
-{
-    if (nDescendentElectrons > 1)
-    {
-        return true;
-    }
-
-    if (std::abs(pMC->GetParticleId()) == E_MINUS)
-    {
-        nDescendentElectrons++; // Including the parent particle, ie. the first in the recursion, as a descendent
-    }
-    for (const MCParticle *pChildMC : pMC->GetDaughterList())
-    {
-        if (this->CausesShower(pChildMC, nDescendentElectrons))
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-const MCParticle *EventClusterValidationAlgorithm::FoldPotentialDeltaRayTo(const CaloHit *const pCaloHit, const MCParticle *const pMC) const
-{
-    // Not an electron -> not a delta ray -> do nothing
-    if (pMC->IsRootParticle() || pMC->GetParticleId() != E_MINUS)
-    {
-        return pMC;
-    }
-
-    // Did not come from a track-like particle -> not a delta ray -> do nothing
-    const MCParticle *const pParentMC{*(pMC->GetParentList().begin())};
-    const int parentPdg{std::abs(pParentMC->GetParticleId())};
-    if (parentPdg == PHOTON || parentPdg == E_MINUS || PdgTable::GetParticleCharge(parentPdg) == 0)
-    {
-        return pMC;
-    }
-
-    // Delta ray that does not start a shower and is short -> fold into parent particle
-    if (!this->CausesShower(pMC, 0) &&
-        (pMC->GetVertex() - pMC->GetEndpoint()).GetMagnitudeSquared() < m_deltaRayLengthThresholdSquared.at(pCaloHit->GetHitType()))
-    {
-        return pParentMC;
-    }
-
-    // Now have a delta ray that we would like to cluster but only the hits that are not overlapping with the parent particle
-    float parentWeight{std::numeric_limits<float>::lowest()};
-    const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
-    for (const auto &[pContributingMC, weight] : weightMap)
-    {
-        if (pContributingMC == pParentMC)
-        {
-            parentWeight = weight;
-            break;
-        }
-    }
-    if (parentWeight > m_deltaRayParentWeightThreshold)
-    {
-        return pParentMC;
-    }
-    return pMC;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -772,7 +612,7 @@ void EventClusterValidationAlgorithm::GetMatchedParticleMetrics(
     for (const auto &[pMC, pCluster] : mcMatchedCluster)
     {
         metrics.m_pdg.emplace_back(pMC->GetParticleId());
-        metrics.m_causesShower.emplace_back(this->CausesShower(pMC, 0));
+        metrics.m_causesShower.emplace_back(LArMCParticleHelper::CausesShower(pMC));
         metrics.m_isPrimary.emplace_back(pMC->IsRootParticle() || pMC->GetParentList().front()->IsRootParticle());
         metrics.m_trueEnergy.emplace_back(pMC->GetEnergy());
         metrics.m_nTrueHits.emplace_back(mcNTrueHits.at(pMC));
@@ -1029,11 +869,21 @@ StatusCode EventClusterValidationAlgorithm::ReadSettings(const TiXmlHandle xmlHa
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "OnlyRandIndex", m_onlyRandIndex));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FoldShowers", m_foldShowers));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "HandleDeltaRays", m_handleDeltaRays));
-    if (m_handleDeltaRays)
+    if (m_handleDeltaRays && !m_foldShowers)
     {
-        m_deltaRayLengthThresholdSquared = {{TPC_VIEW_U, static_cast<float>(pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U), 2.))},
-            {TPC_VIEW_V, static_cast<float>(pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V), 2.))},
-            {TPC_VIEW_W, static_cast<float>(pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W), 2.))}};
+        return STATUS_CODE_INVALID_PARAMETER;
+    }
+    else if (m_handleDeltaRays)
+    {
+        const std::map<HitType, float> lengthThresholds{
+            { TPC_VIEW_U, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U) },
+            { TPC_VIEW_V, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V) },
+            { TPC_VIEW_W, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W) }};
+        m_rollUpper = RollUpper(std::make_unique<RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy>(0.f, lengthThresholds));
+    }
+    else if (m_foldShowers)
+    {
+        m_rollUpper = RollUpper(std::make_unique<RollUpEMPolicy>());
     }
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "MergeShowerClustersForRandIndex", m_mergeShowerClustersForRandIndex));

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.cc
@@ -168,7 +168,8 @@ StatusCode EventClusterValidationAlgorithm::Run()
         clusterMetrics.m_nHits = hitParents.size();
         for (const auto &[pCaloHit, parents] : hitParents)
         {
-            if ((LArMCParticleHelper::IsBeamParticle(parents.m_pMainMC) || LArMCParticleHelper::IsNeutrino(parents.m_pMainMC)))
+            const MCParticle *const pMainMCParent{LArMCParticleHelper::GetParentMCParticle(parents.m_pMainMC)};
+            if ((LArMCParticleHelper::IsBeamParticle(pMainMCParent) || LArMCParticleHelper::IsNeutrino(pMainMCParent)))
             {
                 clusterMetrics.m_nHitsFromBeam++;
             }

--- a/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
+++ b/larpandoracontent/LArMonitoring/EventClusterValidationAlgorithm.h
@@ -9,6 +9,8 @@
 
 #include "Pandora/Algorithm.h"
 
+#include "larpandoracontent/LArUtility/RollUp.h"
+
 namespace lar_content
 {
 
@@ -137,37 +139,6 @@ private:
     void GetClusterMainMC(std::map<const pandora::CaloHit *const, CaloHitParents> &hitParents) const;
 
     /**
-     *  @brief Tries to identify and deal with impossible-to-cluster-correctly delta ray hits by assigning the hit to the
-     *         parent particle's cluster if some conditions are met.
-     *
-     *  @param[in] pCaloHit The hit
-     *  @param[in] pMC      The main MC particle of the hit
-     *
-     *  @return The MC particle the hit should be assigned to, this will either be the inputted MC particle or the parent MC particle
-     */
-    const pandora::MCParticle *FoldPotentialDeltaRayTo(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pMC) const;
-
-    /**
-     *  @brief Finds the ancestor that a child MC particle should be associated with to roll-up an EM shower
-     *
-     *  @param[in] pMC The MC particle
-     *
-     *  @return The ancestor MC particle, this will be the inputted MC particle for an MC particle that should not be rolled-up
-     */
-    const pandora::MCParticle *FoldMCTo(const pandora::MCParticle *const pMC) const;
-
-    /**
-     *  @brief Recursive function to check descendent particles for signature of a shower (e -> gamma -> e).
-     *         Used to identify delta-rays that shower and photons that only undergo compton scatters leaving diffuse hits.
-     *
-     *  @param[in] pMC                  The MC particle to check descendents of
-     *  @param[in] nDescendentElectrons The number of electrons seen while descending from the original photon MC particle
-     *
-     *  @return Flag to indicate if more than 1 electron was seen while descending any of the descendent particle association paths
-     */
-    bool CausesShower(const pandora::MCParticle *const pMC, int nDescendentElectrons) const;
-
-    /**
      *  @brief Draw the true clusters being compared to
      *
      *  @param[in] hitParents Map of hits to the cluster/MC particle they belong to
@@ -209,9 +180,8 @@ private:
     void SetBranches(const ClusterMetrics &clusterMetrics, const MatchedParticleMetrics &matchedParticleMetrics, const int view) const;
 
     // members
-    int m_eventNumber;                                                  ///< To track the current event number
-    std::map<pandora::HitType, float> m_deltaRayLengthThresholdSquared; ///< Threshold for defining small delta rays that will be folded to the parent particle
-    float m_deltaRayParentWeightThreshold; ///< Threshold for weight contribution of parent particle for it take the delta ray's hit
+    int m_eventNumber;     ///< To track the current event number
+    RollUpper m_rollUpper; ///< To perform rolling up of EM activity
 
     // members that may be set from xml
     std::string m_fileName;                      ///< The filename of the ROOT output file

--- a/larpandoracontent/LArUtility/RollUp.cc
+++ b/larpandoracontent/LArUtility/RollUp.cc
@@ -1,0 +1,193 @@
+/**
+ *  @file   
+ *
+ *  @brief  
+ *
+ *  $Log: $
+ */
+
+#include "larpandoracontent/LArUtility/RollUp.h"
+
+#include "larpandoracontent/LArHelpers/LArMCParticleHelper.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+RollUpper::RollUpper(std::unique_ptr<IRollUpPolicy> policy) :
+    m_policy{std::move(policy)}
+{
+}
+
+const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC)
+{
+    if (m_mcCache.find(pMC) != m_mcCache.end())
+        return m_mcCache.at(pMC);
+
+    const MCParticle *pLeadingMC{pMC};
+    while (!pLeadingMC->IsRootParticle())
+    {
+        if (!m_policy->ShouldRollUpMC(pLeadingMC))
+            break;
+        pLeadingMC = LArMCParticleHelper::GetNextParentMCParticle(pLeadingMC);
+    }
+
+    m_mcCache.insert({pMC, pLeadingMC});
+
+    return pLeadingMC;
+}
+
+const MCParticle *RollUpper::RollUpCaloHit(const CaloHit *const pCaloHit)
+{
+    if (m_caloHitCache.find(pCaloHit) != m_caloHitCache.end())
+        return m_caloHitCache.at(pCaloHit);
+
+    const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
+    MCParticleWeightMap rollUpWeightMap;
+    for (const auto &[pMC, weight] : weightMap)
+        rollUpWeightMap[this->RollUpMC(pMC)] += weight;
+
+    const MCParticle *pMainMC{nullptr};
+    float maxWeight{0.f};
+    for (const auto &[pMC, weight] : rollUpWeightMap)
+    {
+        if (weight > maxWeight)
+        {
+            pMainMC = pMC;
+            maxWeight = weight;
+        }
+        else if (weight == maxWeight) // tie-breaker (very unlikely)
+        {
+            if (LArMCParticleHelper::SortByMomentum(pMC, pMainMC))
+                pMainMC = pMC;
+        }
+    }
+
+    if (pMainMC && m_policy->ShouldRollUpCaloHit(pCaloHit, pMainMC))
+        pMainMC = LArMCParticleHelper::GetNextParentMCParticle(pMainMC);
+
+    m_caloHitCache.insert({pCaloHit, pMainMC});
+
+    return pMainMC;
+}
+
+bool RollUpEMPolicy::ShouldRollUpMC(const MCParticle *const pMC) const
+{
+    if (pMC->IsRootParticle() || !LArMCParticleHelper::IsEM(pMC))
+        return false;
+
+    const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pMC)};
+
+    if (LArMCParticleHelper::IsEM(pParentMC))
+        return true;
+
+    return false;
+}
+
+bool RollUpEMPolicy::ShouldRollUpCaloHit(
+    [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
+{
+    return false;
+}
+
+bool RollUpEMAndDeltaRayPolicy::ShouldRollUpMC(const MCParticle *const pMC) const
+{
+    if (pMC->IsRootParticle() || !LArMCParticleHelper::IsEM(pMC))
+        return false;
+
+    const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pMC)};
+
+    if (LArMCParticleHelper::IsEM(pParentMC))
+        return true;
+
+    // is electron and parent is not EM and parent is charged -> is delta ray -> roll-up
+    const bool parentIsCharged{PdgTable::GetParticleCharge(pParentMC->GetParticleId()) != 0};
+    if (pMC->GetParticleId() == E_MINUS && parentIsCharged)
+        return true;
+
+    return false;
+}
+
+bool RollUpEMAndDeltaRayPolicy::ShouldRollUpCaloHit(
+    [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
+{
+    return false;
+}
+
+RollUpEMAndAmbiguousDeltaRayHitsPolicy::RollUpEMAndAmbiguousDeltaRayHitsPolicy(
+    const float deltaRayParentWeightThreshold, const std::map<HitType, float> deltaRayLengthThresholds) :
+    m_deltaRayParentWeightThreshold{deltaRayParentWeightThreshold}
+{
+    for (const auto &[view, threshold] : deltaRayLengthThresholds)
+        m_deltaRayLengthThresholdsSquared[view] = threshold * threshold;
+}
+
+bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldRollUpMC(const MCParticle *const pMC) const
+{
+    if (pMC->IsRootParticle() || !LArMCParticleHelper::IsEM(pMC))
+        return false;
+
+    const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pMC)};
+
+    if (LArMCParticleHelper::IsEM(pParentMC))
+        return true;
+
+    return false;
+}
+
+bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldRollUpCaloHit(
+    const CaloHit *const pCaloHit, const MCParticle *const pRolledUpMainMC) const
+{
+    // Can't be a delta ray? -> don't roll-up this hit
+    if (pRolledUpMainMC->IsRootParticle() || pRolledUpMainMC->GetParticleId() != E_MINUS)
+        return false;
+
+    const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pRolledUpMainMC)};
+
+    // Is not a delta ray? -> don't roll-up this hit
+    const bool parentIsCharged{PdgTable::GetParticleCharge(pParentMC->GetParticleId()) != 0};
+    if (LArMCParticleHelper::IsEM(pParentMC) || !parentIsCharged)
+        return false;
+
+    // Delta ray starts a shower and is short? -> roll-up this hit
+    const float lengthThresholdSquared{m_deltaRayLengthThresholdsSquared.at(pCaloHit->GetHitType())};
+    if (!this->CausesShower(pRolledUpMainMC, 0) &&
+        (pRolledUpMainMC->GetVertex() - pRolledUpMainMC->GetEndpoint()).GetMagnitudeSquared() < lengthThresholdSquared)
+        return true;
+
+    // Delta ray hit that has a significant contribution from the parent -> roll-up this hit
+    float parentWeight{std::numeric_limits<float>::lowest()};
+    const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
+    for (const auto &[pContributingMC, weight] : weightMap)
+    {
+        if (pContributingMC == pParentMC)
+        {
+            parentWeight = weight;
+            break;
+        }
+    }
+    if (parentWeight > m_deltaRayParentWeightThreshold)
+        return true;
+
+    return false;
+}
+
+bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::CausesShower(const MCParticle *const pMC, int nDescendantElectrons) const
+{
+    if (nDescendantElectrons > 1)
+        return true;
+
+    if (std::abs(pMC->GetParticleId()) == E_MINUS)
+        nDescendantElectrons++; // Including the parent particle, ie. the first in the recursion, as a descendent
+
+    for (const MCParticle *pChildMC : pMC->GetDaughterList())
+    {
+        if (this->CausesShower(pChildMC, nDescendantElectrons))
+            return true;
+    }
+
+    return false;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArUtility/RollUp.cc
+++ b/larpandoracontent/LArUtility/RollUp.cc
@@ -1,7 +1,7 @@
 /**
- *  @file   
+ *  @file   larpandoracontent/LArUtility/RollUp.cc
  *
- *  @brief  
+ *  @brief  Implementation file for classes related to roll-up of EM activity. 
  *
  *  $Log: $
  */
@@ -20,16 +20,22 @@ RollUpper::RollUpper() :
 {
 }
 
+//-----------------------------------------------------------------------------------------------------------------------------------------
+
 RollUpper::RollUpper(std::unique_ptr<IRollUpPolicy> policy) :
     m_policy{std::move(policy)}
 {
 }
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
 
 void RollUpper::Reset() const
 {
     m_mcCache.clear();
     m_caloHitCache.clear();
 }
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
 
 const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC) const
 {
@@ -38,6 +44,8 @@ const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC) const
 
     return m_mcCache.at(pMC);
 }
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
 
 const MCParticle *RollUpper::RollUpCaloHit(const CaloHit *const pCaloHit) const
 {
@@ -73,16 +81,24 @@ const MCParticle *RollUpper::RollUpCaloHit(const CaloHit *const pCaloHit) const
     return m_caloHitCache.at(pCaloHit);
 }
 
+//-----------------------------------------------------------------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------------------------------------------------------------------
+
 const MCParticle *RollUpNullPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const
 {
     return pMC;
 }
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
 
 bool RollUpNullPolicy::ShouldFoldCaloHit(
     [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
 {
     return false;
 }
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------------------------------------------------------------------
 
 const MCParticle *RollUpEMPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const
 {
@@ -101,11 +117,16 @@ const MCParticle *RollUpEMPolicy::GetRollUpTargetMC(const MCParticle *const pMC)
     return pLeadingMC;
 }
 
+//-----------------------------------------------------------------------------------------------------------------------------------------
+
 bool RollUpEMPolicy::ShouldFoldCaloHit(
     [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
 {
     return false;
 }
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------------------------------------------------------------------
 
 const MCParticle *RollUpEMAndDeltaRayPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const
 {
@@ -130,6 +151,9 @@ const MCParticle *RollUpEMAndDeltaRayPolicy::GetRollUpTargetMC(const MCParticle 
     return pLeadingMC;
 }
 
+//-----------------------------------------------------------------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------------------------------------------------------------------
+
 RollUpEMAndAmbiguousDeltaRayHitsPolicy::RollUpEMAndAmbiguousDeltaRayHitsPolicy(
     const float deltaRayParentWeightThreshold, const std::map<HitType, float> deltaRayLengthThresholds) :
     m_deltaRayParentWeightThreshold{deltaRayParentWeightThreshold}
@@ -137,6 +161,8 @@ RollUpEMAndAmbiguousDeltaRayHitsPolicy::RollUpEMAndAmbiguousDeltaRayHitsPolicy(
     for (const auto &[view, threshold] : deltaRayLengthThresholds)
         m_deltaRayLengthThresholdsSquared[view] = threshold * threshold;
 }
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
 
 bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldFoldCaloHit(
     const CaloHit *const pCaloHit, const MCParticle *const pRolledUpMainMC) const
@@ -174,6 +200,9 @@ bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldFoldCaloHit(
 
     return false;
 }
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
+//-----------------------------------------------------------------------------------------------------------------------------------------
 
 const MCParticle *RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const
 {

--- a/larpandoracontent/LArUtility/RollUp.cc
+++ b/larpandoracontent/LArUtility/RollUp.cc
@@ -31,7 +31,7 @@ void RollUpper::Reset()
     m_caloHitCache.clear();
 }
 
-const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC)
+const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC) const
 {
     if (m_mcCache.find(pMC) == m_mcCache.end())
         m_mcCache.insert({pMC, m_policy->GetRollUpTargetMC(pMC)});
@@ -39,7 +39,7 @@ const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC)
     return m_mcCache.at(pMC);
 }
 
-const MCParticle *RollUpper::RollUpCaloHit(const CaloHit *const pCaloHit)
+const MCParticle *RollUpper::RollUpCaloHit(const CaloHit *const pCaloHit) const
 {
     if (m_caloHitCache.find(pCaloHit) == m_caloHitCache.end())
     {
@@ -154,7 +154,7 @@ bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldFoldCaloHit(
 
     // Delta ray doesn't shower and is short? -> roll-up this hit
     const float lengthThresholdSquared{m_deltaRayLengthThresholdsSquared.at(pCaloHit->GetHitType())};
-    if (!LArMCParticleHelper::CausesShower(pRolledUpMainMC, 0) &&
+    if (!LArMCParticleHelper::CausesShower(pRolledUpMainMC) &&
         (pRolledUpMainMC->GetVertex() - pRolledUpMainMC->GetEndpoint()).GetMagnitudeSquared() < lengthThresholdSquared)
         return true;
 
@@ -193,7 +193,7 @@ const MCParticle *RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy::GetRo
     }
 
     // Don't roll-up chains of EM that consist only of compton scatters, prevents distant diffuse hits sharing the same true mc
-    if (!hasAncestorElectron && std::abs(pLeadingMC->GetParticleId()) != E_MINUS && !LArMCParticleHelper::CausesShower(pLeadingMC, 0))
+    if (!hasAncestorElectron && std::abs(pLeadingMC->GetParticleId()) != E_MINUS && !LArMCParticleHelper::CausesShower(pLeadingMC))
         return pMC;
 
     return pLeadingMC;

--- a/larpandoracontent/LArUtility/RollUp.cc
+++ b/larpandoracontent/LArUtility/RollUp.cc
@@ -25,7 +25,7 @@ RollUpper::RollUpper(std::unique_ptr<IRollUpPolicy> policy) :
 {
 }
 
-void RollUpper::Reset()
+void RollUpper::Reset() const
 {
     m_mcCache.clear();
     m_caloHitCache.clear();

--- a/larpandoracontent/LArUtility/RollUp.cc
+++ b/larpandoracontent/LArUtility/RollUp.cc
@@ -22,97 +22,90 @@ RollUpper::RollUpper(std::unique_ptr<IRollUpPolicy> policy) :
 
 const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC)
 {
-    if (m_mcCache.find(pMC) != m_mcCache.end())
-        return m_mcCache.at(pMC);
+    if (m_mcCache.find(pMC) == m_mcCache.end())
+        m_mcCache.insert({pMC, m_policy->GetRollUpTargetMC(pMC)});
 
-    const MCParticle *pLeadingMC{pMC};
-    while (!pLeadingMC->IsRootParticle())
-    {
-        if (!m_policy->ShouldRollUpMC(pLeadingMC))
-            break;
-        pLeadingMC = LArMCParticleHelper::GetNextParentMCParticle(pLeadingMC);
-    }
-
-    m_mcCache.insert({pMC, pLeadingMC});
-
-    return pLeadingMC;
+    return m_mcCache.at(pMC);
 }
 
 const MCParticle *RollUpper::RollUpCaloHit(const CaloHit *const pCaloHit)
 {
-    if (m_caloHitCache.find(pCaloHit) != m_caloHitCache.end())
-        return m_caloHitCache.at(pCaloHit);
-
-    const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
-    MCParticleWeightMap rollUpWeightMap;
-    for (const auto &[pMC, weight] : weightMap)
-        rollUpWeightMap[this->RollUpMC(pMC)] += weight;
-
-    const MCParticle *pMainMC{nullptr};
-    float maxWeight{0.f};
-    for (const auto &[pMC, weight] : rollUpWeightMap)
+    if (m_caloHitCache.find(pCaloHit) == m_caloHitCache.end())
     {
-        if (weight > maxWeight)
+        const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
+        MCParticleWeightMap rolledUpWeightMap;
+        for (const auto &[pMC, weight] : weightMap)
+            rolledUpWeightMap[this->RollUpMC(pMC)] += weight;
+
+        const MCParticle *pMainMC{nullptr};
+        float maxWeight{0.f};
+        for (const auto &[pMC, weight] : rolledUpWeightMap)
         {
-            pMainMC = pMC;
-            maxWeight = weight;
-        }
-        else if (weight == maxWeight) // tie-breaker (very unlikely)
-        {
-            if (LArMCParticleHelper::SortByMomentum(pMC, pMainMC))
+            if (weight > maxWeight)
+            {
                 pMainMC = pMC;
+                maxWeight = weight;
+            }
+            else if (weight == maxWeight) // tie-breaker (very unlikely)
+            {
+                if (LArMCParticleHelper::SortByMomentum(pMC, pMainMC))
+                    pMainMC = pMC;
+            }
         }
+
+        if (pMainMC && m_policy->ShouldFoldCaloHit(pCaloHit, pMainMC))
+            pMainMC = LArMCParticleHelper::GetNextParentMCParticle(pMainMC);
+
+        m_caloHitCache.insert({pCaloHit, pMainMC});
     }
 
-    if (pMainMC && m_policy->ShouldRollUpCaloHit(pCaloHit, pMainMC))
-        pMainMC = LArMCParticleHelper::GetNextParentMCParticle(pMainMC);
-
-    m_caloHitCache.insert({pCaloHit, pMainMC});
-
-    return pMainMC;
+    return m_caloHitCache.at(pCaloHit);
 }
 
-bool RollUpEMPolicy::ShouldRollUpMC(const MCParticle *const pMC) const
+const MCParticle *RollUpEMPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const
 {
-    if (pMC->IsRootParticle() || !LArMCParticleHelper::IsEM(pMC))
-        return false;
+    if (!LArMCParticleHelper::IsEM(pMC))
+        return pMC;
 
-    const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pMC)};
+    const MCParticle *pLeadingMC{pMC};
+    while (!pLeadingMC->IsRootParticle())
+    {
+        const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pLeadingMC)};
+        if (!LArMCParticleHelper::IsEM(pParentMC))
+            break;
+        pLeadingMC = pParentMC;
+    }
 
-    if (LArMCParticleHelper::IsEM(pParentMC))
-        return true;
-
-    return false;
+    return pLeadingMC;
 }
 
-bool RollUpEMPolicy::ShouldRollUpCaloHit(
+bool RollUpEMPolicy::ShouldFoldCaloHit(
     [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
 {
     return false;
 }
 
-bool RollUpEMAndDeltaRayPolicy::ShouldRollUpMC(const MCParticle *const pMC) const
+const MCParticle *RollUpEMAndDeltaRayPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const
 {
-    if (pMC->IsRootParticle() || !LArMCParticleHelper::IsEM(pMC))
-        return false;
+    if (!LArMCParticleHelper::IsEM(pMC))
+        return pMC;
 
-    const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pMC)};
+    const MCParticle *pLeadingMC{pMC};
+    while (!pLeadingMC->IsRootParticle())
+    {
+        const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pLeadingMC)};
+        if (!LArMCParticleHelper::IsEM(pParentMC))
+        {
+            // Is electron and parent is a charged track -> jump up the chain by one to roll-up delta ray
+            const bool parentIsCharged{PdgTable::GetParticleCharge(pParentMC->GetParticleId()) != 0};
+            if (pLeadingMC->GetParticleId() == E_MINUS && parentIsCharged)
+                pLeadingMC = pParentMC;
+            break;
+        }
+        pLeadingMC = pParentMC;
+    }
 
-    if (LArMCParticleHelper::IsEM(pParentMC))
-        return true;
-
-    // is electron and parent is not EM and parent is charged -> is delta ray -> roll-up
-    const bool parentIsCharged{PdgTable::GetParticleCharge(pParentMC->GetParticleId()) != 0};
-    if (pMC->GetParticleId() == E_MINUS && parentIsCharged)
-        return true;
-
-    return false;
-}
-
-bool RollUpEMAndDeltaRayPolicy::ShouldRollUpCaloHit(
-    [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
-{
-    return false;
+    return pLeadingMC;
 }
 
 RollUpEMAndAmbiguousDeltaRayHitsPolicy::RollUpEMAndAmbiguousDeltaRayHitsPolicy(
@@ -123,20 +116,7 @@ RollUpEMAndAmbiguousDeltaRayHitsPolicy::RollUpEMAndAmbiguousDeltaRayHitsPolicy(
         m_deltaRayLengthThresholdsSquared[view] = threshold * threshold;
 }
 
-bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldRollUpMC(const MCParticle *const pMC) const
-{
-    if (pMC->IsRootParticle() || !LArMCParticleHelper::IsEM(pMC))
-        return false;
-
-    const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pMC)};
-
-    if (LArMCParticleHelper::IsEM(pParentMC))
-        return true;
-
-    return false;
-}
-
-bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldRollUpCaloHit(
+bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldFoldCaloHit(
     const CaloHit *const pCaloHit, const MCParticle *const pRolledUpMainMC) const
 {
     // Can't be a delta ray? -> don't roll-up this hit
@@ -150,7 +130,7 @@ bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldRollUpCaloHit(
     if (LArMCParticleHelper::IsEM(pParentMC) || !parentIsCharged)
         return false;
 
-    // Delta ray starts a shower and is short? -> roll-up this hit
+    // Delta ray doesn't shower and is short? -> roll-up this hit
     const float lengthThresholdSquared{m_deltaRayLengthThresholdsSquared.at(pCaloHit->GetHitType())};
     if (!this->CausesShower(pRolledUpMainMC, 0) &&
         (pRolledUpMainMC->GetVertex() - pRolledUpMainMC->GetEndpoint()).GetMagnitudeSquared() < lengthThresholdSquared)
@@ -188,6 +168,30 @@ bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::CausesShower(const MCParticle *cons
     }
 
     return false;
+}
+
+const MCParticle *RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const
+{
+    if (!LArMCParticleHelper::IsEM(pMC))
+        return pMC;
+
+    bool hasAncestorElectron{false};
+    const MCParticle *pLeadingMC{pMC};
+    while (!pLeadingMC->IsRootParticle())
+    {
+        const MCParticle *const pParentMC{LArMCParticleHelper::GetNextParentMCParticle(pLeadingMC)};
+        if (!LArMCParticleHelper::IsEM(pParentMC))
+            break;
+        if (std::abs(pParentMC->GetParticleId()) == E_MINUS)
+            hasAncestorElectron = true;
+        pLeadingMC = pParentMC;
+    }
+
+    // Don't roll-up chains of EM that consist only of compton scatters, prevents distant diffuse hits sharing the same true mc
+    if (!hasAncestorElectron && std::abs(pLeadingMC->GetParticleId()) != E_MINUS && !this->CausesShower(pLeadingMC, 0))
+        return pMC;
+
+    return pLeadingMC;
 }
 
 } // namespace lar_content

--- a/larpandoracontent/LArUtility/RollUp.cc
+++ b/larpandoracontent/LArUtility/RollUp.cc
@@ -15,6 +15,11 @@ using namespace pandora;
 namespace lar_content
 {
 
+RollUpper::RollUpper() :
+    m_policy{std::make_unique<RollUpNullPolicy>()}
+{
+}
+
 RollUpper::RollUpper(std::unique_ptr<IRollUpPolicy> policy) :
     m_policy{std::move(policy)}
 {
@@ -66,6 +71,17 @@ const MCParticle *RollUpper::RollUpCaloHit(const CaloHit *const pCaloHit)
     }
 
     return m_caloHitCache.at(pCaloHit);
+}
+
+const MCParticle *RollUpNullPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const
+{
+    return pMC;
+}
+
+bool RollUpNullPolicy::ShouldFoldCaloHit(
+    [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
+{
+    return false;
 }
 
 const MCParticle *RollUpEMPolicy::GetRollUpTargetMC(const MCParticle *const pMC) const

--- a/larpandoracontent/LArUtility/RollUp.cc
+++ b/larpandoracontent/LArUtility/RollUp.cc
@@ -20,6 +20,12 @@ RollUpper::RollUpper(std::unique_ptr<IRollUpPolicy> policy) :
 {
 }
 
+void RollUpper::Reset()
+{
+    m_mcCache.clear();
+    m_caloHitCache.clear();
+}
+
 const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC)
 {
     if (m_mcCache.find(pMC) == m_mcCache.end())
@@ -132,7 +138,7 @@ bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldFoldCaloHit(
 
     // Delta ray doesn't shower and is short? -> roll-up this hit
     const float lengthThresholdSquared{m_deltaRayLengthThresholdsSquared.at(pCaloHit->GetHitType())};
-    if (!this->CausesShower(pRolledUpMainMC, 0) &&
+    if (!LArMCParticleHelper::CausesShower(pRolledUpMainMC, 0) &&
         (pRolledUpMainMC->GetVertex() - pRolledUpMainMC->GetEndpoint()).GetMagnitudeSquared() < lengthThresholdSquared)
         return true;
 
@@ -149,23 +155,6 @@ bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldFoldCaloHit(
     }
     if (parentWeight > m_deltaRayParentWeightThreshold)
         return true;
-
-    return false;
-}
-
-bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::CausesShower(const MCParticle *const pMC, int nDescendantElectrons) const
-{
-    if (nDescendantElectrons > 1)
-        return true;
-
-    if (std::abs(pMC->GetParticleId()) == E_MINUS)
-        nDescendantElectrons++; // Including the parent particle, ie. the first in the recursion, as a descendent
-
-    for (const MCParticle *pChildMC : pMC->GetDaughterList())
-    {
-        if (this->CausesShower(pChildMC, nDescendantElectrons))
-            return true;
-    }
 
     return false;
 }
@@ -188,7 +177,7 @@ const MCParticle *RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy::GetRo
     }
 
     // Don't roll-up chains of EM that consist only of compton scatters, prevents distant diffuse hits sharing the same true mc
-    if (!hasAncestorElectron && std::abs(pLeadingMC->GetParticleId()) != E_MINUS && !this->CausesShower(pLeadingMC, 0))
+    if (!hasAncestorElectron && std::abs(pLeadingMC->GetParticleId()) != E_MINUS && !LArMCParticleHelper::CausesShower(pLeadingMC, 0))
         return pMC;
 
     return pLeadingMC;

--- a/larpandoracontent/LArUtility/RollUp.cc
+++ b/larpandoracontent/LArUtility/RollUp.cc
@@ -39,6 +39,9 @@ void RollUpper::Reset() const
 
 const MCParticle *RollUpper::RollUpMC(const MCParticle *const pMC) const
 {
+    if (!pMC)
+        return pMC;
+
     if (m_mcCache.find(pMC) == m_mcCache.end())
         m_mcCache.insert({pMC, m_policy->GetRollUpTargetMC(pMC)});
 
@@ -72,7 +75,7 @@ const MCParticle *RollUpper::RollUpCaloHit(const CaloHit *const pCaloHit) const
             }
         }
 
-        if (pMainMC && m_policy->ShouldFoldCaloHit(pCaloHit, pMainMC))
+        if (pMainMC && m_policy->ShouldFurtherRollUpCaloHit(pCaloHit, pMainMC))
             pMainMC = LArMCParticleHelper::GetNextParentMCParticle(pMainMC);
 
         m_caloHitCache.insert({pCaloHit, pMainMC});
@@ -91,7 +94,7 @@ const MCParticle *RollUpNullPolicy::GetRollUpTargetMC(const MCParticle *const pM
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 
-bool RollUpNullPolicy::ShouldFoldCaloHit(
+bool RollUpNullPolicy::ShouldFurtherRollUpCaloHit(
     [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
 {
     return false;
@@ -119,7 +122,7 @@ const MCParticle *RollUpEMPolicy::GetRollUpTargetMC(const MCParticle *const pMC)
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 
-bool RollUpEMPolicy::ShouldFoldCaloHit(
+bool RollUpEMPolicy::ShouldFurtherRollUpCaloHit(
     [[maybe_unused]] const CaloHit *const pCaloHit, [[maybe_unused]] const MCParticle *const pRolledUpMainMC) const
 {
     return false;
@@ -164,7 +167,7 @@ RollUpEMAndAmbiguousDeltaRayHitsPolicy::RollUpEMAndAmbiguousDeltaRayHitsPolicy(
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 
-bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldFoldCaloHit(
+bool RollUpEMAndAmbiguousDeltaRayHitsPolicy::ShouldFurtherRollUpCaloHit(
     const CaloHit *const pCaloHit, const MCParticle *const pRolledUpMainMC) const
 {
     // Can't be a delta ray? -> don't roll-up this hit

--- a/larpandoracontent/LArUtility/RollUp.h
+++ b/larpandoracontent/LArUtility/RollUp.h
@@ -43,7 +43,8 @@ public:
      *
      *  @return  whether the hit should be further folded to the parent of hit's rolled-up MC particle
      */
-    virtual bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const = 0;
+    virtual bool ShouldFurtherRollUpCaloHit(
+        const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const = 0;
 };
 
 /**
@@ -55,7 +56,8 @@ class RollUpNullPolicy : public IRollUpPolicy
 {
 public:
     const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const override;
-    bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+    bool ShouldFurtherRollUpCaloHit(
+        const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 };
 
 /**
@@ -67,7 +69,8 @@ class RollUpEMPolicy : public IRollUpPolicy
 {
 public:
     const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const override;
-    bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+    bool ShouldFurtherRollUpCaloHit(
+        const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 };
 
 /**
@@ -100,7 +103,8 @@ public:
     RollUpEMAndAmbiguousDeltaRayHitsPolicy(
         const float deltaRayParentWeightThreshold, const std::map<pandora::HitType, float> deltaRayLengthThresholds);
 
-    bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+    bool ShouldFurtherRollUpCaloHit(
+        const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 
 private:
     float m_deltaRayParentWeightThreshold;                               ///< Minimum parent weight for a hit to be folded to the parent track
@@ -111,8 +115,8 @@ private:
  *  @brief  The RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy class
  *
  *  A concisely named class that extends RollUpEMAndAmbiguousDeltaRayHitsPolicy with a Compton scatter filter.
- *  Pure Compton chains (photon → electron(s) with no bremms) are not rolled up,
- *  preventing potential associations been distant and diffuse hits.
+ *  Pure Compton scatter chains (photon → electron(s) with succeeding Brems) are blocked from roll-up,
+ *  preventing potential associations between distant and diffuse hits.
  */
 class RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy : public RollUpEMAndAmbiguousDeltaRayHitsPolicy
 {

--- a/larpandoracontent/LArUtility/RollUp.h
+++ b/larpandoracontent/LArUtility/RollUp.h
@@ -1,0 +1,75 @@
+/**
+ *  @file   
+ *
+ *  @brief  
+ *
+ *  $Log: $
+ */
+#ifndef LAR_ROLL_UP_H
+#define LAR_ROLL_UP_H 1
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include <memory>
+
+namespace lar_content
+{
+
+class IRollUpPolicy
+{
+public:
+    virtual ~IRollUpPolicy() = default;
+
+    virtual bool ShouldRollUpMC(const pandora::MCParticle *const pMC) const = 0;
+
+    virtual bool ShouldRollUpCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const = 0;
+};
+
+class RollUpEMPolicy : public IRollUpPolicy
+{
+public:
+    bool ShouldRollUpMC(const pandora::MCParticle *const pMC) const override;
+    bool ShouldRollUpCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+};
+
+class RollUpEMAndDeltaRayPolicy : public IRollUpPolicy
+{
+public:
+    bool ShouldRollUpMC(const pandora::MCParticle *const pMC) const override;
+    bool ShouldRollUpCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+};
+
+class RollUpEMAndAmbiguousDeltaRayHitsPolicy : public IRollUpPolicy
+{
+public:
+    RollUpEMAndAmbiguousDeltaRayHitsPolicy(
+        const float deltaRayParentWeightThreshold, const std::map<pandora::HitType, float> deltaRayLengthThresholds);
+
+    bool ShouldRollUpMC(const pandora::MCParticle *const pMC) const override;
+    bool ShouldRollUpCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+
+private:
+    bool CausesShower(const pandora::MCParticle *const pMC, int nDescendantElectrons) const;
+
+    float m_deltaRayParentWeightThreshold;
+    std::map<pandora::HitType, float> m_deltaRayLengthThresholdsSquared;
+};
+
+class RollUpper
+{
+public:
+    RollUpper(std::unique_ptr<IRollUpPolicy> policy);
+
+    const pandora::MCParticle *RollUpMC(const pandora::MCParticle *const pMC);
+
+    const pandora::MCParticle *RollUpCaloHit(const pandora::CaloHit *const pCaloHit);
+
+private:
+    std::unique_ptr<IRollUpPolicy> m_policy;
+    std::unordered_map<const pandora::MCParticle*, const pandora::MCParticle*> m_mcCache;
+    std::unordered_map<const pandora::CaloHit*, const pandora::MCParticle*> m_caloHitCache;
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_ROLL_UP_H

--- a/larpandoracontent/LArUtility/RollUp.h
+++ b/larpandoracontent/LArUtility/RollUp.h
@@ -73,7 +73,7 @@ public:
 
     RollUpper(std::unique_ptr<IRollUpPolicy> policy);
 
-    void Reset();
+    void Reset() const;
 
     const pandora::MCParticle *RollUpMC(const pandora::MCParticle *const pMC) const;
 

--- a/larpandoracontent/LArUtility/RollUp.h
+++ b/larpandoracontent/LArUtility/RollUp.h
@@ -25,6 +25,13 @@ public:
     virtual bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const = 0;
 };
 
+class RollUpNullPolicy : public IRollUpPolicy
+{
+public:
+    const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const override;
+    bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+};
+
 class RollUpEMPolicy : public IRollUpPolicy
 {
 public:
@@ -62,6 +69,7 @@ public:
 class RollUpper
 {
 public:
+    RollUpper();
     RollUpper(std::unique_ptr<IRollUpPolicy> policy);
 
     void Reset();

--- a/larpandoracontent/LArUtility/RollUp.h
+++ b/larpandoracontent/LArUtility/RollUp.h
@@ -46,9 +46,6 @@ public:
 
     bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 
-protected:
-    bool CausesShower(const pandora::MCParticle *const pMC, int nDescendantElectrons) const;
-
 private:
     float m_deltaRayParentWeightThreshold;
     std::map<pandora::HitType, float> m_deltaRayLengthThresholdsSquared;
@@ -66,6 +63,8 @@ class RollUpper
 {
 public:
     RollUpper(std::unique_ptr<IRollUpPolicy> policy);
+
+    void Reset();
 
     const pandora::MCParticle *RollUpMC(const pandora::MCParticle *const pMC);
 

--- a/larpandoracontent/LArUtility/RollUp.h
+++ b/larpandoracontent/LArUtility/RollUp.h
@@ -20,39 +20,46 @@ class IRollUpPolicy
 public:
     virtual ~IRollUpPolicy() = default;
 
-    virtual bool ShouldRollUpMC(const pandora::MCParticle *const pMC) const = 0;
+    virtual const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const = 0;
 
-    virtual bool ShouldRollUpCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const = 0;
+    virtual bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const = 0;
 };
 
 class RollUpEMPolicy : public IRollUpPolicy
 {
 public:
-    bool ShouldRollUpMC(const pandora::MCParticle *const pMC) const override;
-    bool ShouldRollUpCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+    const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const override;
+    bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 };
 
-class RollUpEMAndDeltaRayPolicy : public IRollUpPolicy
+class RollUpEMAndDeltaRayPolicy : public RollUpEMPolicy
 {
 public:
-    bool ShouldRollUpMC(const pandora::MCParticle *const pMC) const override;
-    bool ShouldRollUpCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+    const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const override;
 };
 
-class RollUpEMAndAmbiguousDeltaRayHitsPolicy : public IRollUpPolicy
+class RollUpEMAndAmbiguousDeltaRayHitsPolicy : public RollUpEMPolicy
 {
 public:
     RollUpEMAndAmbiguousDeltaRayHitsPolicy(
         const float deltaRayParentWeightThreshold, const std::map<pandora::HitType, float> deltaRayLengthThresholds);
 
-    bool ShouldRollUpMC(const pandora::MCParticle *const pMC) const override;
-    bool ShouldRollUpCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
+    bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 
-private:
+protected:
     bool CausesShower(const pandora::MCParticle *const pMC, int nDescendantElectrons) const;
 
+private:
     float m_deltaRayParentWeightThreshold;
     std::map<pandora::HitType, float> m_deltaRayLengthThresholdsSquared;
+};
+
+class RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy : public RollUpEMAndAmbiguousDeltaRayHitsPolicy
+{
+public:
+    using RollUpEMAndAmbiguousDeltaRayHitsPolicy::RollUpEMAndAmbiguousDeltaRayHitsPolicy;
+
+    const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const override;
 };
 
 class RollUpper

--- a/larpandoracontent/LArUtility/RollUp.h
+++ b/larpandoracontent/LArUtility/RollUp.h
@@ -1,7 +1,7 @@
 /**
- *  @file   
+ *  @file   larpandoracontent/LArUtility/RollUp.h
  *
- *  @brief  
+ *  @brief  Header file for classes related to roll-up of EM activity. 
  *
  *  $Log: $
  */
@@ -15,16 +15,42 @@
 namespace lar_content
 {
 
+/**
+ *  @brief  The IRollUpPolicy class
+ *
+ *  Interface for policies that define how MC particles and calo hits are rolled up. Roll-up maps a given MC particle to an ancestor,
+ *  collapsing EM shower or delta ray sub-trees into a single representative particle.
+ */
 class IRollUpPolicy
 {
 public:
     virtual ~IRollUpPolicy() = default;
 
+    /**
+     *  @brief  Get the MC particle a given MC particle should be rolled-up to
+     *
+     *  @param[in]  pMC  the input MC particle
+     *
+     *  @return  the target MC particle (may be the input MC particle itself if no roll-up applies)
+     */
     virtual const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const = 0;
 
+    /**
+     *  @brief  Whether a calo hit should be folded into the parent of its rolled-up main MC particle
+     *
+     *  @param[in]  pCaloHit         the calo hit
+     *  @param[in]  pRolledUpMainMC  the main MC particle after MC particle level roll-up
+     *
+     *  @return  whether the hit should be further folded to the parent of hit's rolled-up MC particle
+     */
     virtual bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const = 0;
 };
 
+/**
+ *  @brief  The RollUpNullPolicy class
+ *
+ *  A no-op policy, no MC particles are rolled-up and no calo hits are folded.
+ */
 class RollUpNullPolicy : public IRollUpPolicy
 {
 public:
@@ -32,6 +58,11 @@ public:
     bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 };
 
+/**
+ *  @brief  The RollUpEMPolicy class
+ *
+ *  Roll up EM particles to the highest ancestor that is still EM.
+ */
 class RollUpEMPolicy : public IRollUpPolicy
 {
 public:
@@ -39,25 +70,50 @@ public:
     bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 };
 
+/**
+ *  @brief  The RollUpEMAndDeltaRayPolicy class
+ *
+ *  Extends RollUpEMPolicy to also roll up delta ray electrons to their parent track particle.
+ */
 class RollUpEMAndDeltaRayPolicy : public RollUpEMPolicy
 {
 public:
     const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const override;
 };
 
+/**
+ *  @brief  The RollUpEMAndAmbiguousDeltaRayHitsPolicy class
+ *
+ *  Extends RollUpEMPolicy to handle ambiguous delta ray hits at the calo hit level, rolling up parts of delta rays that
+ *  significantly overlap with the parent track in an attempt to stop discontinuities in the parent track.
+ */
 class RollUpEMAndAmbiguousDeltaRayHitsPolicy : public RollUpEMPolicy
 {
 public:
+    /**
+     *  @brief  Constructor
+     *
+     *  @param[in]  deltaRayParentWeightThreshold  minimum weight contribution of the parent track to a hit for that hit to be folded
+     *  @param[in]  deltaRayLengthThresholds       per-view length thresholds below which a non-showering delta ray is folded
+     *                                             to its parent track
+     */
     RollUpEMAndAmbiguousDeltaRayHitsPolicy(
         const float deltaRayParentWeightThreshold, const std::map<pandora::HitType, float> deltaRayLengthThresholds);
 
     bool ShouldFoldCaloHit(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pRolledUpMainMC) const override;
 
 private:
-    float m_deltaRayParentWeightThreshold;
-    std::map<pandora::HitType, float> m_deltaRayLengthThresholdsSquared;
+    float m_deltaRayParentWeightThreshold;                               ///< Minimum parent weight for a hit to be folded to the parent track
+    std::map<pandora::HitType, float> m_deltaRayLengthThresholdsSquared; ///< Squared per-view length thresholds for short delta ray folding
 };
 
+/**
+ *  @brief  The RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy class
+ *
+ *  A concisely named class that extends RollUpEMAndAmbiguousDeltaRayHitsPolicy with a Compton scatter filter.
+ *  Pure Compton chains (photon → electron(s) with no bremms) are not rolled up,
+ *  preventing potential associations been distant and diffuse hits.
+ */
 class RollUpEMWithComptonFilterAndAmbiguousDeltaRayHitsPolicy : public RollUpEMAndAmbiguousDeltaRayHitsPolicy
 {
 public:
@@ -66,23 +122,57 @@ public:
     const pandora::MCParticle *GetRollUpTargetMC(const pandora::MCParticle *const pMC) const override;
 };
 
+/**
+ *  @brief  The RollUpper class
+ *
+ *  Applies a configurable roll-up policy to MC particles and calo hits using per-event caching to save compute.
+ *  Construct with a IRollUpPolicy to control the roll-up logic. Reset() must be called between events to clear the caches.
+ */
 class RollUpper
 {
 public:
+    /**
+     *  @brief  Default constructor, uses the no roll-up policy
+     */
     RollUpper();
 
+    /**
+     *  @brief  Constructor
+     *
+     *  @param[in]  policy  the roll-up policy to apply
+     */
     RollUpper(std::unique_ptr<IRollUpPolicy> policy);
 
+    /**
+     *  @brief  Clear the per-event MC particle and calo hit caches
+     */
     void Reset() const;
 
+    /**
+     *  @brief  Get the MC particle that the input MC particle rolls up to under the current policy
+     *
+     *  @param[in]  pMC  the input MC particle
+     *
+     *  @return  the rolled-up MC particle (may be the input MC Particle itself)
+     */
     const pandora::MCParticle *RollUpMC(const pandora::MCParticle *const pMC) const;
 
+    /**
+     *  @brief  Get the main rolled-up MC particle for a calo hit
+     *
+     *  Aggregates the hit's MC particle weight map after rolling up each contributing MC particle, selects the highest-weight result,
+     *  then applies any hit-level folding defined by the policy.
+     *
+     *  @param[in]  pCaloHit  the input calo hit
+     *
+     *  @return  the main rolled-up MC particle for the hit (may be null if the hit's weight map is empty)
+     */
     const pandora::MCParticle *RollUpCaloHit(const pandora::CaloHit *const pCaloHit) const;
 
 private:
-    std::unique_ptr<IRollUpPolicy> m_policy;
-    mutable std::unordered_map<const pandora::MCParticle*, const pandora::MCParticle*> m_mcCache;
-    mutable std::unordered_map<const pandora::CaloHit*, const pandora::MCParticle*> m_caloHitCache;
+    std::unique_ptr<IRollUpPolicy> m_policy;                                                          ///< The roll-up policy
+    mutable std::unordered_map<const pandora::MCParticle *, const pandora::MCParticle *> m_mcCache;   ///< Per-event cache of MC roll-up results
+    mutable std::unordered_map<const pandora::CaloHit *, const pandora::MCParticle *> m_caloHitCache; ///< Per-event cache of calo hit roll-up results
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArUtility/RollUp.h
+++ b/larpandoracontent/LArUtility/RollUp.h
@@ -70,18 +70,19 @@ class RollUpper
 {
 public:
     RollUpper();
+
     RollUpper(std::unique_ptr<IRollUpPolicy> policy);
 
     void Reset();
 
-    const pandora::MCParticle *RollUpMC(const pandora::MCParticle *const pMC);
+    const pandora::MCParticle *RollUpMC(const pandora::MCParticle *const pMC) const;
 
-    const pandora::MCParticle *RollUpCaloHit(const pandora::CaloHit *const pCaloHit);
+    const pandora::MCParticle *RollUpCaloHit(const pandora::CaloHit *const pCaloHit) const;
 
 private:
     std::unique_ptr<IRollUpPolicy> m_policy;
-    std::unordered_map<const pandora::MCParticle*, const pandora::MCParticle*> m_mcCache;
-    std::unordered_map<const pandora::CaloHit*, const pandora::MCParticle*> m_caloHitCache;
+    mutable std::unordered_map<const pandora::MCParticle*, const pandora::MCParticle*> m_mcCache;
+    mutable std::unordered_map<const pandora::CaloHit*, const pandora::MCParticle*> m_caloHitCache;
 };
 
 } // namespace lar_content

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -56,20 +56,18 @@ void DLTwoDShowerGrowingAlgorithm::ClusterGroup::insert(const Cluster *pCluster)
 //-----------------------------------------------------------------------------------------------------------------------------------------
 
 DLTwoDShowerGrowingAlgorithm::DLTwoDShowerGrowingAlgorithm() :
+    m_hitFeatureDim{11},
     m_polarRScaleFactor{1.f},
     m_cartesianXScaleFactor{1.f},
     m_cartesianZScaleFactor{1.f},
     m_detectorXGaps{std::set<double>{}},
-    m_hitFeaturesNHitsIdx{-1},
-    m_hitFeaturesNClustersIdx{-1},
-    m_hitFeaturesIterationNumIdx{-1},
-    m_hitFeatureDim{12},
     m_trainingMode{false},
     m_trainingTreeName{""},
     m_similarityThreshold{0.5f},
     m_similarityThresholdBeta{1.f},
     m_accessoryClustersMaxHits{2},
     m_maxIterations{1},
+    m_includeDistToXGapFeature{true},
     m_includeHitCardinalityFeatures{true},
     m_includeHitNIterationNumFeature{false},
     m_encodeLArTPCVolIDs{std::vector<unsigned int>{}},
@@ -418,35 +416,41 @@ StatusCode DLTwoDShowerGrowingAlgorithm::MakeClusterTensor(const std::vector<Hit
     tensorCluster = torch::zeros({1, nHits, m_hitFeatureDim});
     auto accessor = tensorCluster.accessor<float, 3>();
 
-    for (int i = 0; i < nHits; i++)
+    for (int iHit = 0; iHit < nHits; iHit++)
     {
-        const HitFeatures hitFeatures{clusterFeatures.at(i)};
-        accessor[0][i][0] = hitFeatures.m_rRel * m_polarRScaleFactor;
-        accessor[0][i][1] = hitFeatures.m_cosThetaRel;
-        accessor[0][i][2] = hitFeatures.m_sinThetaRel;
-        accessor[0][i][3] = hitFeatures.m_xRel * m_cartesianXScaleFactor;
-        accessor[0][i][4] = hitFeatures.m_zRel * m_cartesianZScaleFactor;
-        accessor[0][i][5] = hitFeatures.m_xWidth * m_cartesianXScaleFactor;
-        accessor[0][i][6] = zWidthFeat;
-        accessor[0][i][7] = hitFeatures.m_distToXGap * m_cartesianXScaleFactor;
-        accessor[0][i][8] = std::log(hitFeatures.m_energy);
-        accessor[0][i][9] = view == TPC_VIEW_U ? 1.f : 0.f;
-        accessor[0][i][10] = view == TPC_VIEW_V ? 1.f : 0.f;
-        accessor[0][i][11] = view == TPC_VIEW_W ? 1.f : 0.f;
-        for (size_t j = 12, k = 0; k < m_encodeLArTPCVolIDs.size(); j++, k++)
+        const HitFeatures &hitFeatures = clusterFeatures.at(iHit);
+        int iFeat{0};
+        auto addFeat = [&accessor, &iHit, &iFeat](const float val) -> void { accessor[0][iHit][iFeat++] = val; };
+        addFeat(hitFeatures.m_rRel * m_polarRScaleFactor);
+        addFeat(hitFeatures.m_cosThetaRel);
+        addFeat(hitFeatures.m_sinThetaRel);
+        addFeat(hitFeatures.m_xRel * m_cartesianXScaleFactor);
+        addFeat(hitFeatures.m_zRel * m_cartesianZScaleFactor);
+        addFeat(hitFeatures.m_xWidth * m_cartesianXScaleFactor);
+        addFeat(zWidthFeat);
+        if (m_includeDistToXGapFeature)
+            addFeat(hitFeatures.m_distToXGap * m_cartesianXScaleFactor);
+        addFeat(std::log(hitFeatures.m_energy));
+        addFeat(view == TPC_VIEW_U ? 1.f : 0.f);
+        addFeat(view == TPC_VIEW_V ? 1.f : 0.f);
+        addFeat(view == TPC_VIEW_W ? 1.f : 0.f);
+        for (size_t iVol = 0; iVol < m_encodeLArTPCVolIDs.size(); iVol++)
         {
-            if (hitFeatures.m_larTpcVolId == m_encodeLArTPCVolIDs.at(k) && hitFeatures.m_daughterVolId == m_encodeDaughterVolIDs.at(k))
-                accessor[0][i][j] = 1.f;
+            if (hitFeatures.m_larTpcVolId == m_encodeLArTPCVolIDs.at(iVol) &&
+                hitFeatures.m_daughterVolId == m_encodeDaughterVolIDs.at(iVol))
+                addFeat(1.f);
             else
-                accessor[0][i][j] = 0.f;
+                addFeat(0.f);
         }
         if (m_includeHitCardinalityFeatures)
         {
-            accessor[0][i][m_hitFeaturesNHitsIdx] = nHitsFeat;
-            accessor[0][i][m_hitFeaturesNClustersIdx] = nClustersFeat;
+            addFeat(nHitsFeat);
+            addFeat(nClustersFeat);
         }
         if (m_includeHitNIterationNumFeature)
-            accessor[0][i][m_hitFeaturesIterationNumIdx] = iterationNumFeat;
+            addFeat(iterationNumFeat);
+
+        PANDORA_RETURN_IF(STATUS_CODE_NOT_ALLOWED, iFeat != m_hitFeatureDim);
     }
 
     return STATUS_CODE_SUCCESS;
@@ -748,17 +752,17 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
     if (!m_encodeLArTPCVolIDs.empty())
         m_hitFeatureDim += m_encodeLArTPCVolIDs.size();
 
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IncludeDistToXGapFeature", m_includeDistToXGapFeature));
+    if (m_includeDistToXGapFeature)
+        ++m_hitFeatureDim;
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "IncludeHitCardinalityFeatures", m_includeHitCardinalityFeatures));
     if (m_includeHitCardinalityFeatures)
-    {
-        m_hitFeaturesNHitsIdx = m_hitFeatureDim++;
-        m_hitFeaturesNClustersIdx = m_hitFeatureDim++;
-    }
+        m_hitFeatureDim += 2;
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "IncludeHitNIterationNumFeature", m_includeHitNIterationNumFeature));
     if (m_includeHitNIterationNumFeature)
-        m_hitFeaturesIterationNumIdx = m_hitFeatureDim++;
+        ++m_hitFeatureDim;
 
     if (m_trainingMode)
     {

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -63,8 +63,6 @@ DLTwoDShowerGrowingAlgorithm::DLTwoDShowerGrowingAlgorithm() :
     m_hitFeaturesNHitsIdx{-1},
     m_hitFeaturesNClustersIdx{-1},
     m_hitFeaturesIterationNumIdx{-1},
-    m_deltaRayLengthThresholdSquared{std::map<HitType, float>{}},
-    m_deltaRayParentWeightThreshold{0.f},
     m_hitFeatureDim{12},
     m_trainingMode{false},
     m_trainingTreeName{""},
@@ -110,6 +108,8 @@ StatusCode DLTwoDShowerGrowingAlgorithm::Run()
 
 StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
 {
+    m_rollUpper.Reset();
+
     const std::map<HitType, CartesianVector> viewToVtxPos{this->Get2DVertices()};
 
     const ClusterList clusterList{this->GetAllClusters()};
@@ -127,7 +127,6 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
     std::vector<int> hitMCID;
     std::vector<int> hitLArTPCVolID, hitDaughterVolID;
 
-    std::map<const MCParticle *const, const MCParticle *const> mcFoldTo;
 
     for (const Cluster *const pCluster : clusterList)
     {
@@ -142,7 +141,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::PrepareTrainingSample() const
             HitFeatures hitFeatures;
             PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->CalculateHitFeatures(pCaloHit, viewToVtxPos.at(view), hitFeatures));
 
-            const MCParticle *const pMainMC{this->GetMainMC(pCaloHit, mcFoldTo)};
+            const MCParticle *const pMainMC{m_rollUpper.RollUpCaloHit(pCaloHit)};
             if (mcToID.find(pMainMC) == mcToID.end())
             {
                 mcToID.insert({pMainMC, currMCID++});
@@ -214,149 +213,6 @@ void DLTwoDShowerGrowingAlgorithm::WriteTrainingSample() const
     PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName + "_event_data", "scalefactor_cartesian_z", m_cartesianZScaleFactor))
     PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_trainingTreeName + "_event_data"));
     PANDORA_MONITORING_API(SaveTree(this->GetPandora(), m_trainingTreeName + "_event_data", m_trainingFileName, "UPDATE"));
-}
-
-//-----------------------------------------------------------------------------------------------------------------------------------------
-
-const MCParticle *DLTwoDShowerGrowingAlgorithm::GetMainMC(
-    const CaloHit *const pCaloHit, std::map<const MCParticle *const, const MCParticle *const> &mcFoldTo) const
-{
-    MCParticleWeightMap weightMap{pCaloHit->GetMCParticleWeightMap()};
-    MCParticleWeightMap foldedWeightMap;
-    for (const auto &[pMC, weight] : weightMap)
-    {
-        const MCParticle *pFoldedMC{nullptr};
-        if (mcFoldTo.find(pMC) != mcFoldTo.end())
-        {
-            pFoldedMC = mcFoldTo.at(pMC);
-        }
-        else
-        {
-            pFoldedMC = this->FoldMCTo(pMC);
-            mcFoldTo.insert({pMC, pFoldedMC});
-        }
-        foldedWeightMap[pFoldedMC] += weight;
-    }
-    weightMap = std::move(foldedWeightMap);
-
-    const MCParticle *pMainMC{nullptr};
-    float maxWeight{0.f};
-    for (const auto &[pMC, weight] : weightMap)
-    {
-        if (weight > maxWeight)
-        {
-            pMainMC = pMC;
-            maxWeight = weight;
-        }
-        if (weight == maxWeight) // tie-breaker (very unlikely)
-        {
-            if (LArMCParticleHelper::SortByMomentum(pMC, pMainMC))
-            {
-                pMainMC = pMC;
-            }
-        }
-    }
-
-    if (pMainMC)
-    {
-        pMainMC = this->FoldPotentialDeltaRayTo(pCaloHit, pMainMC);
-    }
-
-    return pMainMC;
-}
-
-//-----------------------------------------------------------------------------------------------------------------------------------------
-
-const MCParticle *DLTwoDShowerGrowingAlgorithm::FoldMCTo(const MCParticle *const pMC) const
-{
-    if (!LArMCParticleHelper::IsEM(pMC))
-    {
-        return pMC;
-    }
-
-    const MCParticle *pCurrentMC{pMC};
-    const MCParticle *pLeadingMC{pMC};
-    while (!pCurrentMC->IsRootParticle())
-    {
-        const MCParticle *const pParentMC{*(pCurrentMC->GetParentList().begin())};
-        const int parentPdg{std::abs(pParentMC->GetParticleId())};
-        if (parentPdg == PHOTON || parentPdg == E_MINUS)
-        {
-            pCurrentMC = pParentMC;
-            continue;
-        }
-        pLeadingMC = pCurrentMC;
-        break;
-    }
-
-    return pLeadingMC;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-const MCParticle *DLTwoDShowerGrowingAlgorithm::FoldPotentialDeltaRayTo(const CaloHit *const pCaloHit, const MCParticle *const pMC) const
-{
-    // Not an electron -> not a delta ray -> do nothing
-    if (pMC->IsRootParticle() || pMC->GetParticleId() != E_MINUS)
-    {
-        return pMC;
-    }
-
-    // Did not come from a track-like particle -> not a delta ray -> do nothing
-    const MCParticle *const pParentMC{*(pMC->GetParentList().begin())};
-    const int parentPdg{std::abs(pParentMC->GetParticleId())};
-    if (parentPdg == PHOTON || parentPdg == E_MINUS || PdgTable::GetParticleCharge(parentPdg) == 0)
-    {
-        return pMC;
-    }
-
-    // Delta ray that does not start a shower and is short -> fold into parent particle
-    if (!this->CausesShower(pMC, 0) &&
-        (pMC->GetVertex() - pMC->GetEndpoint()).GetMagnitudeSquared() < m_deltaRayLengthThresholdSquared.at(pCaloHit->GetHitType()))
-    {
-        return pParentMC;
-    }
-
-    // Now have a delta ray that we would like to cluster but only the hits that are not overlapping with the parent particle
-    float parentWeight{std::numeric_limits<float>::lowest()};
-    const MCParticleWeightMap &weightMap{pCaloHit->GetMCParticleWeightMap()};
-    for (const auto &[pContributingMC, weight] : weightMap)
-    {
-        if (pContributingMC == pParentMC)
-        {
-            parentWeight = weight;
-            break;
-        }
-    }
-    if (parentWeight > m_deltaRayParentWeightThreshold)
-    {
-        return pParentMC;
-    }
-    return pMC;
-}
-
-//-----------------------------------------------------------------------------------------------------------------------------------------
-
-bool DLTwoDShowerGrowingAlgorithm::CausesShower(const MCParticle *const pMC, int nDescendentElectrons) const
-{
-    if (nDescendentElectrons > 1)
-    {
-        return true;
-    }
-
-    if (std::abs(pMC->GetParticleId()) == E_MINUS)
-    {
-        nDescendentElectrons++; // Including the parent particle, ie. the first in the recursion, as a descendent
-    }
-    for (const MCParticle *pChildMC : pMC->GetDaughterList())
-    {
-        if (this->CausesShower(pChildMC, nDescendentElectrons))
-        {
-            return true;
-        }
-    }
-
-    return false;
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
@@ -850,6 +706,11 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
     {
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "TrainingTreeName", m_trainingTreeName));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "TrainingFileName", m_trainingFileName));
+        const std::map<HitType, float> lengthThresholds{
+            { TPC_VIEW_U, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U) },
+            { TPC_VIEW_V, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V) },
+            { TPC_VIEW_W, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W) }};
+        m_rollUpper = RollUpper(std::make_unique<RollUpEMAndAmbiguousDeltaRayHitsPolicy>(0.f, lengthThresholds));
     }
     else
     {
@@ -905,6 +766,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
         double xLow{static_cast<double>(detBounds.m_xBoundaries.first)}, xHigh{static_cast<double>(detBounds.m_xBoundaries.second)};
         double yLow{static_cast<double>(detBounds.m_yBoundaries.first)}, yHigh{static_cast<double>(detBounds.m_yBoundaries.second)};
         double zLow{static_cast<double>(detBounds.m_zBoundaries.first)}, zHigh{static_cast<double>(detBounds.m_zBoundaries.second)};
+        // NOTE this should really be in the x-z plane, too much of a pain to fix and shouldn't matter (I hope)
         m_polarRScaleFactor =
             static_cast<float>(1. / std::sqrt(std::pow(xHigh - xLow, 2.) + std::pow(yHigh - yLow, 2.) + std::pow(zHigh - zLow, 2.)));
         m_cartesianXScaleFactor = static_cast<float>(1. / (xHigh - xLow));
@@ -920,11 +782,6 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CartesianXScaleFactor", m_cartesianXScaleFactor));
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CartesianZScaleFactor", m_cartesianZScaleFactor));
     }
-
-    m_deltaRayLengthThresholdSquared = {
-        {TPC_VIEW_U, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U), 2.))},
-        {TPC_VIEW_V, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V), 2.))},
-        {TPC_VIEW_W, static_cast<float>(std::pow(LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W), 2.))}};
 
     for (const DetectorGap *const pDetectorGap : this->GetPandora().GetGeometry()->GetDetectorGapList())
     {

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.h
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.h
@@ -281,20 +281,16 @@ private:
     LArDLHelper::TorchModel m_modelEncoder; ///< TorchScript model for encoding hits in a cluster
     LArDLHelper::TorchModel m_modelAttn;    ///< TorchScript model for attention over encoded clusters in a view
     LArDLHelper::TorchModel m_modelSim;     ///< TorchScript model for pairwise similarities over clusters after attention
+    int m_hitFeatureDim;                    ///< Feature dimensions of each hit
     float m_polarRScaleFactor;              ///< Scale factor for polar r coordinate input features
     float m_cartesianXScaleFactor;          ///< Scale factor for cartesian x coordinate input features
     float m_cartesianZScaleFactor;          ///< Scale factor for cartesian z coordinate input features
     std::set<double> m_detectorXGaps;       ///< X coordinates where gaps in X direction start/end
-    int m_hitFeaturesNHitsIdx;              ///< Hit feature vector index for the optional no. hits in cluster feature
-    int m_hitFeaturesNClustersIdx;          ///< Hit feature vector index for the optional no. clusters in event feature
-    int m_hitFeaturesIterationNumIdx;       ///< Hit feature vector index for the optional no. clusters in event feature
     lar_content::RollUpper m_rollUpper;                  ///< Class to perform rolling up of EM activity
 
     /* End shared mutable members */
 
     /* Start hardcoded members */
-
-    int m_hitFeatureDim; ///< Feature dimensions of each hit
 
     /* End hardcoded members */
 
@@ -309,6 +305,7 @@ private:
     float m_similarityThresholdBeta;          ///< Scaling factor for an optional second clustering pass
     unsigned int m_accessoryClustersMaxHits;  ///< Clusters with this number of less hits are treated as accessory clusters during merging
     unsigned int m_maxIterations;             ///< Max iterative applications of the cluster merging
+    bool m_includeDistToXGapFeature;          ///< Option to include in hit feature vector the X distance to the nearest drift gap
     bool m_includeHitCardinalityFeatures;     ///< Option to include in hit feature vector the no. hits in cluster and no. clusters in event
     bool m_includeHitNIterationNumFeature;    ///< Option to include in hit feature vector the inference iteration number
     std::vector<unsigned int> m_encodeLArTPCVolIDs; ///< LArTPC vol IDs for one-hot encoding of drift vols in hit feature vector, must be same size as m_encodeDaughterVolIDs

--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.h
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.h
@@ -14,6 +14,7 @@
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "larpandoradlcontent/LArHelpers/LArDLHelper.h"
+#include "larpandoracontent/LArUtility/RollUp.h"
 
 namespace lar_dl_content
 {
@@ -109,49 +110,6 @@ private:
     pandora::StatusCode Infer();
 
     /* Start training sample preparation methods */
-
-    /**
-     *  @brief Get the folded MCParticle that contributes the most to the CaloHit.
-     *
-     *  @param[in]     pCaloHit The hit
-     *  @param[in,out] mcFoldTo A map for the folding of MCParticles, updates as new MCParticles are seen by the method
-     *
-     *  @return The folded MCParticle that contributed the most to the CaloHit
-     */
-    const pandora::MCParticle *GetMainMC(const pandora::CaloHit *const pCaloHit,
-        std::map<const pandora::MCParticle *const, const pandora::MCParticle *const> &mcFoldTo) const;
-
-    /**
-     *  @brief Finds the ancestor that a MCParticle should be folded to in order to roll-up an EM shower
-     *
-     *  @param[in] pMC The MCParticle
-     *
-     *  @return The ancestor MCParticle, this will be the input pMC an MCParticle that should not be rolled-up
-     */
-    const pandora::MCParticle *FoldMCTo(const pandora::MCParticle *const pMC) const;
-
-    /**
-     *  @brief Recursive function to check descendent particles for signature of a shower (e -> gamma -> e).
-     *         Used to identify delta-rays that shower and photons that only undergo compton scatters leaving diffuse hits.
-     *
-     *  @param[in] pMC                  The MCParticle to check descendents of
-     *  @param[in] nDescendentElectrons The number of electrons seen while descending from the original photon MCParticle
-     *
-     *  @return Flag to indicate if more than 1 electron was seen while descending any of the descendent particle association paths
-     */
-    bool CausesShower(const pandora::MCParticle *const pMC, int nDescendentElectrons) const;
-
-    /**
-     *  @brief Tries to identify and deal with impossible-to-cluster-correctly delta ray hits by assigning the hit to the
-     *         parent particle's cluster if the delta-ray is short and does not shower
-     *         or the hit has charge contribution from the parent particle.
-     *
-     *  @param[in] pCaloHit The hit
-     *  @param[in] pMC      The main MCParticle of the hit
-     *
-     *  @return The MCParticle the hit should be assigned to, this will either be the inputted MCParticle or the parent MCParticle
-     */
-    const pandora::MCParticle *FoldPotentialDeltaRayTo(const pandora::CaloHit *const pCaloHit, const pandora::MCParticle *const pMC) const;
 
     /**
      *  @brief Write out the filled training sample tree and fill and write out a tree containing auxiliary view information.
@@ -330,14 +288,13 @@ private:
     int m_hitFeaturesNHitsIdx;              ///< Hit feature vector index for the optional no. hits in cluster feature
     int m_hitFeaturesNClustersIdx;          ///< Hit feature vector index for the optional no. clusters in event feature
     int m_hitFeaturesIterationNumIdx;       ///< Hit feature vector index for the optional no. clusters in event feature
+    lar_content::RollUpper m_rollUpper;                  ///< Class to perform rolling up of EM activity
 
     /* End shared mutable members */
 
     /* Start hardcoded members */
 
-    std::map<pandora::HitType, float> m_deltaRayLengthThresholdSquared; ///< Threshold for defining small delta rays that will be folded to the parent particle
-    float m_deltaRayParentWeightThreshold; ///< Threshold for weight contribution of parent particle for it take the delta ray's hit
-    int m_hitFeatureDim;                   ///< Feature dimensions of each hit
+    int m_hitFeatureDim; ///< Feature dimensions of each hit
 
     /* End hardcoded members */
 


### PR DESCRIPTION
I put all the code related to roll-up of EM activity in a RollUp utility as there is growing duplication of the same methods. This also included moving a couple of functions to the MC particle helper class.

The refactored roll up uses a controller class `RollUp` that you initialise with the desired roll up policy class (classes that inherit from the policy interface `IRollUpPolicy`). So to use the roll up you would have something like this in your code
```
RollUpper rollUpper = RollUpper(std::make_unique<RollUpEMPolicy>());
MCParticle *pMC1 = rollUpper.RollUpCaloHit(pCaloHit);
MCParticle *pMC2 = rollUpper.RollUpMC(pMC);
```
`RollUp` contains a cache of previously computed mappings while the policy classes define the roll-up logic. `RollUp::Reset()` is used to clear the cache, this must be done at the start of a new event.

@AndyChappell Does this follow the your suggested design? 