### PR TITLE
Adding functions to tag rock muons inside CosmicRayTaggingTool

### DIFF
--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
@@ -30,9 +30,9 @@ CosmicRayTaggingTool::CosmicRayTaggingTool() :
     m_inTimeMargin(5.f),
     m_inTimeMaxX0(1.f),
     m_tagRockMuons(false),
-    m_marginX(5.f), // [cm]
-    m_marginY(5.f),
-    m_marginZ(5.f),
+    m_marginX(20.f),
+    m_marginY(10.f),
+    m_marginZ(10.f),
     m_maxNeutrinoCosTheta(0.2f),
     m_minCosmicCosTheta(0.6f),
     m_maxCosmicCurvature(0.04f),
@@ -550,7 +550,6 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
     const PfoToBoolMap &pfoToIsTopToBottomMap, const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap, 
     const PfoToBoolMap &pfoToIsThroughgoingMap) const
 {
-    int nof_rock_mu_tagged = 0;
     for (const CRCandidate &candidate : candidates)
     {
         const bool likelyCRMuon(!neutrinoSliceSet.count(candidate.m_sliceId) &&
@@ -561,7 +560,6 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
 
         if(m_tagRockMuons && (pfoToIsThroughgoingMap.at(candidate.m_pPfo)))
         {
-          nof_rock_mu_tagged++;
           const bool likelyRockMuon = true;
           if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyRockMuon)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
@@ -571,7 +569,6 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
         }
     }
-    std::cout << "Number of rock muons tagged : " << nof_rock_mu_tagged << "\n";
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.cc
@@ -14,6 +14,7 @@
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
+#include <limits>
 
 using namespace pandora;
 
@@ -28,8 +29,10 @@ CosmicRayTaggingTool::CosmicRayTaggingTool() :
     m_minimumHits(15),
     m_inTimeMargin(5.f),
     m_inTimeMaxX0(1.f),
-    m_marginY(20.f),
-    m_marginZ(10.f),
+    m_tagRockMuons(false),
+    m_marginX(5.f), // [cm]
+    m_marginY(5.f),
+    m_marginZ(5.f),
     m_maxNeutrinoCosTheta(0.2f),
     m_minCosmicCosTheta(0.6f),
     m_maxCosmicCurvature(0.04f),
@@ -104,6 +107,12 @@ void CosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos,
     m_face_Yt = parentMaxY;
     m_face_Zu = parentMinZ;
     m_face_Zd = parentMaxZ;
+    
+    if(m_tagRockMuons)
+     std::cout << "Detector boundaries to tag rock muons : x [" 
+               << m_face_Xa + m_marginX <<"," << m_face_Xc - m_marginX<< "] "
+               << "y [" << m_face_Yb + m_marginY <<"," << m_face_Yt - m_marginY<< "] "
+               << "z [" << m_face_Zu + m_marginZ <<"," << m_face_Zd - m_marginZ << "] \n";
 
     PfoToPfoListMap pfoAssociationMap;
     this->GetPfoAssociations(parentCosmicRayPfos, pfoAssociationMap);
@@ -123,11 +132,15 @@ void CosmicRayTaggingTool::FindAmbiguousPfos(const PfoList &parentCosmicRayPfos,
     PfoToBoolMap pfoToIsTopToBottomMap;
     this->CheckIfTopToBottom(candidates, pfoToIsTopToBottomMap);
 
+    PfoToBoolMap pfoToIsThroughgoingMap;
+    if(m_tagRockMuons)
+      this->CheckIfThroughgoing(candidates, pfoToIsThroughgoingMap);
+
     UIntSet neutrinoSliceSet;
     this->GetNeutrinoSlices(candidates, pfoToInTimeMap, pfoToIsContainedMap, neutrinoSliceSet);
 
     PfoToBoolMap pfoToIsLikelyCRMuonMap;
-    this->TagCRMuons(candidates, pfoToInTimeMap, pfoToIsTopToBottomMap, neutrinoSliceSet, pfoToIsLikelyCRMuonMap);
+    this->TagCRMuons(candidates, pfoToInTimeMap, pfoToIsTopToBottomMap, neutrinoSliceSet, pfoToIsLikelyCRMuonMap, pfoToIsThroughgoingMap);
 
     for (const ParticleFlowObject *const pPfo : parentCosmicRayPfos)
     {
@@ -469,6 +482,40 @@ void CosmicRayTaggingTool::CheckIfTopToBottom(const CRCandidateList &candidates,
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
+bool CosmicRayTaggingTool::IsOutsideBox(const float x, const float y, const float z) const 
+{
+  const float BoxXmin = m_face_Xa + m_marginX;
+  const float BoxXmax = m_face_Xc - m_marginX;
+
+  const float BoxYmin = m_face_Yb + m_marginY;
+  const float BoxYmax = m_face_Yt - m_marginY;
+
+  const float BoxZmin = m_face_Zu + m_marginZ;
+  const float BoxZmax = m_face_Zd - m_marginZ;
+
+  bool IsOutRangeX = (x < BoxXmin || x > BoxXmax);
+  bool IsOutRangeY = (y < BoxYmin || y > BoxYmax);
+  bool IsOutRangeZ = (z < BoxZmin || z > BoxZmax);
+
+  return (IsOutRangeZ || IsOutRangeY || IsOutRangeX);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+void CosmicRayTaggingTool::CheckIfThroughgoing(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsThroughgoingMap) const
+{
+    for (const CRCandidate &candidate : candidates)
+    {
+      bool isThroughgoing = (
+          (candidate.m_endPoint1.GetX() != std::numeric_limits<float>::max()) && // for some reason some candidates happen to have "default" values set as inf 
+          IsOutsideBox(candidate.m_endPoint1.GetX(), candidate.m_endPoint1.GetY(), candidate.m_endPoint1.GetZ()) &&
+          IsOutsideBox(candidate.m_endPoint2.GetX(), candidate.m_endPoint2.GetY(), candidate.m_endPoint2.GetZ()));
+
+      if (!pfoToIsThroughgoingMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, isThroughgoing)).second)
+        throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+    }
+} 
+
+//------------------------------------------------------------------------------------------------------------------------------------------
 
 void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap,
     const PfoToBoolMap &pfoToIsContainedMap, UIntSet &neutrinoSliceSet) const
@@ -500,8 +547,10 @@ void CosmicRayTaggingTool::GetNeutrinoSlices(const CRCandidateList &candidates, 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap,
-    const PfoToBoolMap &pfoToIsTopToBottomMap, const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const
+    const PfoToBoolMap &pfoToIsTopToBottomMap, const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap, 
+    const PfoToBoolMap &pfoToIsThroughgoingMap) const
 {
+    int nof_rock_mu_tagged = 0;
     for (const CRCandidate &candidate : candidates)
     {
         const bool likelyCRMuon(!neutrinoSliceSet.count(candidate.m_sliceId) &&
@@ -510,9 +559,19 @@ void CosmicRayTaggingTool::TagCRMuons(const CRCandidateList &candidates, const P
                     (pfoToIsTopToBottomMap.at(candidate.m_pPfo) ||
                         ((candidate.m_theta > m_minCosmicCosTheta) && (candidate.m_curvature < m_maxCosmicCurvature))))));
 
-        if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyCRMuon)).second)
+        if(m_tagRockMuons && (pfoToIsThroughgoingMap.at(candidate.m_pPfo)))
+        {
+          nof_rock_mu_tagged++;
+          const bool likelyRockMuon = true;
+          if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyRockMuon)).second)
             throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+        }else
+        {
+          if (!pfoToIsLikelyCRMuonMap.insert(PfoToBoolMap::value_type(candidate.m_pPfo, likelyCRMuon)).second)
+            throw StatusCodeException(STATUS_CODE_ALREADY_PRESENT);
+        }
     }
+    std::cout << "Number of rock muons tagged : " << nof_rock_mu_tagged << "\n";
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -597,6 +656,10 @@ StatusCode CosmicRayTaggingTool::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMargin", m_inTimeMargin));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "InTimeMaxX0", m_inTimeMaxX0));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "TagRockMuons", m_tagRockMuons));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginX", m_marginX));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MarginY", m_marginY));
 

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
@@ -156,6 +156,23 @@ private:
      */
     void CheckIfTopToBottom(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsTopToBottomMap) const;
 
+     /**
+     *  @brief Check if a 3D point is inside the detector boundaies with margins 
+     *
+     *  @param  x point x coordinate
+     *  @param  y point y coordinate
+     *  @param  z point z coordinate
+     */   
+    bool IsOutsideBox(const float x, const float y, const float z) const;
+
+    /**
+     *  @brief  Check if each candidate is throughgoing (i.e emerging and exiting from any of the detector boundaies)
+     *
+     *  @param  candidates input list of candidates
+     *  @param  pfoToIsThroughgoingMap output mapping between candidates Pfos and if they are top to bottom
+     */
+    void CheckIfThroughgoing(const CRCandidateList &candidates, PfoToBoolMap &pfoToIsThroughgoingMap) const;
+
     typedef std::set<unsigned int> UIntSet;
     typedef std::unordered_map<int, bool> IntBoolMap;
 
@@ -178,9 +195,10 @@ private:
      *  @param  pfoToIsTopToBottomMap input mapping between candidate Pfos and if they are top to bottom
      *  @param  neutrinoSliceSet input set of slice indices containing a likely neutrino Pfo
      *  @param  pfoToIsLikelyCRMuonMap to receive the output mapping between Pfos and a boolean deciding if they are likely a CR muon
+     *  @param  pfoToIsLikelyCRMuonMap to receive the output mapping between Pfos and a boolean deciding if they are likely a rock muon
      */
     void TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsTopToBottomMap,
-        const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const;
+        const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap, const PfoToBoolMap &pfoToIsThroughgoingMap) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
@@ -203,6 +221,8 @@ private:
 
     float m_inTimeMargin; ///< The maximum distance outside of the physical detector volume that a Pfo may be to still be considered in time
     float m_inTimeMaxX0;  ///< The maximum pfo x0 (determined from shifted vertex) to allow pfo to still be considered in time
+    bool m_tagRockMuons;  ///< bool to activate tagging of rock muons
+    float m_marginX;      ///< The minimum distance from a detector X-face for a Pfo to be associated
     float m_marginY;      ///< The minimum distance from a detector Y-face for a Pfo to be associated
     float m_marginZ;      ///< The minimum distance from a detector Z-face for a Pfo to be associated
     float m_maxNeutrinoCosTheta; ///< The maximum cos(theta) that a Pfo can have to be classified as a likely neutrino

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -56,6 +56,7 @@ public:
         pandora::InputBool m_shouldRunSlicing;            ///< Whether to slice events into separate regions for processing
         pandora::InputBool m_shouldRunNeutrinoRecoOption; ///< Whether to run neutrino reconstruction for each slice
         pandora::InputBool m_shouldRunCosmicRecoOption;   ///< Whether to run cosmic-ray reconstruction for each slice
+        pandora::InputBool m_shouldRunRockMus_Xworkers;   ///< Whether to run rock muons reconstruction using a columnar X worker
         pandora::InputBool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
         pandora::InputBool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
     };
@@ -318,6 +319,7 @@ protected:
     bool m_shouldRunSlicing;            ///< Whether to slice events into separate regions for processing
     bool m_shouldRunNeutrinoRecoOption; ///< Whether to run neutrino reconstruction for each slice
     bool m_shouldRunCosmicRecoOption;   ///< Whether to run cosmic-ray reconstruction for each slice
+    bool m_shouldRunRockMus_Xworkers;   ///< Whether to run rock muons reconstruction using a columnar X worker
     bool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
     bool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
     bool m_visualizeOverallRecoStatus;  ///< Whether to display results of current operations


### PR DESCRIPTION
In this PR, I added two functions inside CosmicRayTaggingTool to tag rock muons. The DUNE ND will be exposed to a high rate of rock muons (~100 per spill), so we would like to give users the possibility, when running cosmic-ray reconstruction, to tag “clear rock muons,” i.e., PFOs whose endpoints fall outside the fiducial volume specified in the input XML.

A parallel draft PR was created in LArRecoND https://github.com/PandoraPFA/LArRecoND/pull/59 to handle the rock muons reconstruction within the cosmic pass. The PR also includes a few slides for a more detailed explanation.