### PR TITLE
CosmicRayTaggingTool attributes from private to protected

### DIFF
--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
@@ -32,7 +32,7 @@ public:
     pandora::StatusCode Initialize();
     void FindAmbiguousPfos(const pandora::PfoList &parentCosmicRayPfos, pandora::PfoList &ambiguousPfos, const MasterAlgorithm *const pAlgorithm);
 
-private:
+protected:
     /**
      *  @brief  Class to encapsulate the logic required determine if a Pfo should or shouldn't be tagged as a cosmic ray
      */

--- a/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
+++ b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h
@@ -68,6 +68,8 @@ protected:
 
     typedef std::list<CRCandidate> CRCandidateList;
 
+private:
+
     /**
      *  @brief  Get the 3D calo hit cluster associated with a given Pfo, and check if it has sufficient hits
      *
@@ -182,8 +184,6 @@ protected:
     void TagCRMuons(const CRCandidateList &candidates, const PfoToBoolMap &pfoToInTimeMap, const PfoToBoolMap &pfoToIsTopToBottomMap,
         const UIntSet &neutrinoSliceSet, PfoToBoolMap &pfoToIsLikelyCRMuonMap) const;
 
-    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
-
     typedef std::pair<const ThreeDSlidingFitResult, const ThreeDSlidingFitResult> SlidingFitPair;
     typedef std::unordered_map<const pandora::ParticleFlowObject *, SlidingFitPair> PfoToSlidingFitsMap;
     typedef std::vector<pandora::PfoList> SliceList;
@@ -208,6 +208,10 @@ protected:
     float m_maxNeutrinoCosTheta; ///< The maximum cos(theta) that a Pfo can have to be classified as a likely neutrino
     float m_minCosmicCosTheta;   ///< The minimum cos(theta) that a Pfo can have to be classified as a likely CR muon
     float m_maxCosmicCurvature;  ///< The maximum curvature that a Pfo can have to be classified as a likely CR muon
+
+protected:
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     float m_face_Xa; ///< Anode      X face
     float m_face_Xc; ///< Cathode    X face

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -142,7 +142,7 @@ protected:
      *  @param  clearCosmicRayPfos to receive the list of clear cosmic-ray pfos
      *  @param  ambiguousPfos to receive the list of ambiguous cosmic-ray pfos for further analysis
      */
-    pandora::StatusCode TagCosmicRayPfos(
+    virtual pandora::StatusCode TagCosmicRayPfos(
         const PfoToFloatMap &stitchedPfosToX0Map, pandora::PfoList &clearCosmicRayPfos, pandora::PfoList &ambiguousPfos) const;
 
     /**


### PR DESCRIPTION
Following the discussion on [PR#275](https://github.com/PandoraPFA/LArContent/pull/275), I've created a new tool in LArRecoND called RockMuonTaggingTool, which is a derived class from CosmicRayTaggingTool. However to access the parent class attributes (such as [CRCandidates ](https://github.com/PandoraPFA/LArContent/blob/bd0903d3253508cb86b9a6899eb651e516ee0c6b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h#L49), [dector boundaries](https://github.com/PandoraPFA/LArContent/blob/bd0903d3253508cb86b9a6899eb651e516ee0c6b/larpandoracontent/LArControlFlow/CosmicRayTaggingTool.h#L212-L217), etc. )) these need to be declared protected.