### PR TITLE
Bring the DL Secondary vertexing accessor inline with rest of code.

### DIFF
--- a/larpandoradlcontent/LArVertex/DlSecondaryVertexingAlgorithm.cc
+++ b/larpandoradlcontent/LArVertex/DlSecondaryVertexingAlgorithm.cc
@@ -234,7 +234,7 @@ StatusCode DlSecondaryVertexingAlgorithm::Infer()
         // we want the maximum value in the num_classes dimension (1) for every pixel
         auto classes{torch::argmax(output, 1)};
         // the argmax result is a 1 x height x width tensor where each element is a class id
-        auto classesAccessor{classes.accessor<long, 3>()};
+        auto classesAccessor{classes.accessor<int64_t, 3>()};
         const double scaleFactor{std::sqrt(m_height * m_height + m_width * m_width)};
         std::map<int, bool> haveSeenMap;
         for (const auto &[row, col] : pixelVector)


### PR DESCRIPTION
Tiny change to help unblock the documentation CI, as well as help Mac users.