### PR TITLE
Small DL shower growing misconfiguration check

### DIFF
--- a/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
+++ b/larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -794,6 +794,7 @@ StatusCode DLTwoDShowerGrowingAlgorithm::ReadSettings(const TiXmlHandle xmlHandl
             m_detectorXGaps.insert(static_cast<double>(pLineGap->GetLineEndX()));
         }
     }
+    PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, !m_trainingMode && m_includeDistToXGapFeature && m_detectorXGaps.empty());
 
     return STATUS_CODE_SUCCESS;
 }


### PR DESCRIPTION
Explicitly fail if the model is asked to construct a feature that is not possible for the provided geometry. I misconfigured the VD 1x8x6 model to not set this distance to x gap feature to false which resulted in an infinite feature and so a segfault. This should make that mistake easier to track down.