### PR TITLE
Now impossible to throw exception if MC start/end momentum is zero

### DIFF
--- a/larpandoracontent/LArMetrics/PFPValidationTool.cc
+++ b/larpandoracontent/LArMetrics/PFPValidationTool.cc
@@ -174,13 +174,20 @@ void PFPValidationTool::GetRecoParticleInfo(const MCParticle *const pMCTarget, c
         pfpTreeVars.m_recoVertexZ.push_back(pRecoVertex->GetPosition().GetZ());
 
         // Signed vertexAcc
-        const CartesianVector &trueVertex((pMCTarget->GetParticleId() == 22) ? pMCTarget->GetEndpoint() : pMCTarget->GetVertex());
-        const float vertexAcc((pRecoVertex->GetPosition() - trueVertex).GetMagnitude());
-        const float sign(
-            (vertexAcc < std::numeric_limits<float>::epsilon() || pMCTarget->GetMomentum().GetMagnitude() < std::numeric_limits<float>::epsilon()) ? 1.f
+        float vertexAcc(m_invalidLargeFloat);
+        try
+        {
+            const CartesianVector &trueVertex((pMCTarget->GetParticleId() == PHOTON) ? pMCTarget->GetEndpoint() : pMCTarget->GetVertex());
+            vertexAcc = (pRecoVertex->GetPosition() - trueVertex).GetMagnitude();
+            const float sign(
+                (vertexAcc < std::numeric_limits<float>::epsilon() || pMCTarget->GetMomentum().GetMagnitude() < std::numeric_limits<float>::epsilon()) ? 1.f
                 : (pRecoVertex->GetPosition() - trueVertex).GetOpeningAngle(pMCTarget->GetMomentum()) < (M_PI * 0.5) ? 1.f
-                                                                                                                     : -1.f);
-        pfpTreeVars.m_vertexAcc.push_back(vertexAcc * sign);
+                : -1.f);
+            vertexAcc *= sign;
+        }
+        catch (StatusCodeException &) { vertexAcc = m_invalidLargeFloat; }
+
+        pfpTreeVars.m_vertexAcc.push_back(vertexAcc);
 
         try
         {

--- a/larpandoracontent/LArMetrics/PFPValidationTool.cc
+++ b/larpandoracontent/LArMetrics/PFPValidationTool.cc
@@ -174,20 +174,13 @@ void PFPValidationTool::GetRecoParticleInfo(const MCParticle *const pMCTarget, c
         pfpTreeVars.m_recoVertexZ.push_back(pRecoVertex->GetPosition().GetZ());
 
         // Signed vertexAcc
-        float vertexAcc(m_invalidLargeFloat);
-        try
-        {
-            const CartesianVector &trueVertex((pMCTarget->GetParticleId() == PHOTON) ? pMCTarget->GetEndpoint() : pMCTarget->GetVertex());
-            vertexAcc = (pRecoVertex->GetPosition() - trueVertex).GetMagnitude();
-            const float sign(
-                (vertexAcc < std::numeric_limits<float>::epsilon() || pMCTarget->GetMomentum().GetMagnitude() < std::numeric_limits<float>::epsilon()) ? 1.f
-                : (pRecoVertex->GetPosition() - trueVertex).GetOpeningAngle(pMCTarget->GetMomentum()) < (M_PI * 0.5) ? 1.f
-                : -1.f);
-            vertexAcc *= sign;
-        }
-        catch (StatusCodeException &) { vertexAcc = m_invalidLargeFloat; }
-
-        pfpTreeVars.m_vertexAcc.push_back(vertexAcc);
+        const CartesianVector &trueVertex((pMCTarget->GetParticleId() == PHOTON) ? pMCTarget->GetEndpoint() : pMCTarget->GetVertex());
+        const float vertexAcc((pRecoVertex->GetPosition() - trueVertex).GetMagnitude());
+        const float sqrtEpsilon(std::sqrt(std::numeric_limits<float>::epsilon()));
+        const float sign((vertexAcc < sqrtEpsilon || pMCTarget->GetMomentum().GetMagnitude() < sqrtEpsilon) ? 1.f
+            : (pRecoVertex->GetPosition() - trueVertex).GetOpeningAngle(pMCTarget->GetMomentum()) < (M_PI * 0.5) ? 1.f
+            : -1.f);
+        pfpTreeVars.m_vertexAcc.push_back(vertexAcc * sign);
 
         try
         {

--- a/larpandoracontent/LArMetrics/ShowerValidationTool.cc
+++ b/larpandoracontent/LArMetrics/ShowerValidationTool.cc
@@ -314,7 +314,7 @@ void ShowerValidationTool::GetRecoVertexInfo(const CartesianVector &recoShrVtx, 
     if (pMC)
     {
         const CartesianVector trueDir(pMC->GetMomentum().GetUnitVector());
-        float recoShrDirAcc(m_invalidLargeFloat);
+        float recoShrDirAcc(m_invalidAngle);
         try { recoShrDirAcc = trueDir.GetOpeningAngle(recoShrDir); } 
         catch (StatusCodeException &) { recoShrDirAcc = m_invalidLargeFloat; }
         showerTreeVars.m_recoShrDirAcc.push_back(recoShrDirAcc);

--- a/larpandoracontent/LArMetrics/ShowerValidationTool.cc
+++ b/larpandoracontent/LArMetrics/ShowerValidationTool.cc
@@ -314,7 +314,10 @@ void ShowerValidationTool::GetRecoVertexInfo(const CartesianVector &recoShrVtx, 
     if (pMC)
     {
         const CartesianVector trueDir(pMC->GetMomentum().GetUnitVector());
-        showerTreeVars.m_recoShrDirAcc.push_back(trueDir.GetOpeningAngle(recoShrDir));
+        float recoShrDirAcc(m_invalidLargeFloat);
+        try { recoShrDirAcc = trueDir.GetOpeningAngle(recoShrDir); } 
+        catch (StatusCodeException &) { recoShrDirAcc = m_invalidLargeFloat; }
+        showerTreeVars.m_recoShrDirAcc.push_back(recoShrDirAcc);
     }
 }
 

--- a/larpandoracontent/LArMetrics/ShowerValidationTool.cc
+++ b/larpandoracontent/LArMetrics/ShowerValidationTool.cc
@@ -313,10 +313,9 @@ void ShowerValidationTool::GetRecoVertexInfo(const CartesianVector &recoShrVtx, 
 
     if (pMC)
     {
-        const CartesianVector trueDir(pMC->GetMomentum().GetUnitVector());
-        float recoShrDirAcc(m_invalidAngle);
-        try { recoShrDirAcc = trueDir.GetOpeningAngle(recoShrDir); } 
-        catch (StatusCodeException &) { recoShrDirAcc = m_invalidLargeFloat; }
+        const bool doesMCHaveStartDir(pMC->GetMomentum().GetMagnitudeSquared() > std::numeric_limits<float>::epsilon());
+        const bool doesRecoHaveStartDir(recoShrDir.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon());
+        const float recoShrDirAcc((doesMCHaveStartDir && doesRecoHaveStartDir) ? pMC->GetMomentum().GetOpeningAngle(recoShrDir) : m_invalidAngle);
         showerTreeVars.m_recoShrDirAcc.push_back(recoShrDirAcc);
     }
 }

--- a/larpandoracontent/LArMetrics/TrackValidationTool.cc
+++ b/larpandoracontent/LArMetrics/TrackValidationTool.cc
@@ -165,28 +165,41 @@ void TrackValidationTool::GetRecoVertexAndEndpointVars(const MCParticle *const p
     const CartesianVector trueEndpoint(pLArMC->GetEndpoint());
 
     // Endpoint accuracy
-    float endpointAcc((recoEndpoint - trueEndpoint).GetMagnitude());
-    const float sign((endpointAcc < std::numeric_limits<float>::epsilon() || !doesMCHaveEndDir)       ? 1.f
-            : (recoEndpoint - trueEndpoint).GetOpeningAngle(pLArMC->GetEndDirection()) < (M_PI * 0.5) ? 1.f
-                                                                                                      : -1.f);
-    endpointAcc *= sign;
+    float endpointAcc(m_invalidLargeFloat);
+    try
+    {
+        endpointAcc = (recoEndpoint - trueEndpoint).GetMagnitude();
+        const float sign((endpointAcc < std::numeric_limits<float>::epsilon() || !doesMCHaveEndDir)       ? 1.f
+                : (recoEndpoint - trueEndpoint).GetOpeningAngle(pLArMC->GetEndDirection()) < (M_PI * 0.5) ? 1.f
+                                                                                                          : -1.f);
+        endpointAcc *= sign;
+    }
+    catch (StatusCodeException &) { endpointAcc = m_invalidLargeFloat; }
 
     // Start direction
-    float startDirAcc(doesMCHaveStartDir ? pMCParticle->GetMomentum().GetOpeningAngle(recoVertexDir) : m_invalidAngle);
+    float startDirAcc(m_invalidAngle);
+    try { startDirAcc = (doesMCHaveStartDir ? pMCParticle->GetMomentum().GetOpeningAngle(recoVertexDir) : m_invalidAngle); }
+    catch (StatusCodeException &) { startDirAcc = m_invalidAngle; }
 
     // End direction
-    float endDirAcc(doesMCHaveEndDir ? pLArMC->GetEndDirection().GetOpeningAngle(recoEndpointDir) : m_invalidAngle);
+    float endDirAcc(m_invalidAngle);
+    try { endDirAcc = (doesMCHaveEndDir ? pLArMC->GetEndDirection().GetOpeningAngle(recoEndpointDir) : m_invalidAngle); }
+    catch (StatusCodeException &) { endDirAcc = m_invalidAngle; }
 
     // Is flipped?
     int isOrientationCorrect(m_invalidInt);
-    const CartesianVector trueOrientation(trueEndpoint - pMCParticle->GetVertex());
-    const CartesianVector recoOrientation(recoEndpoint - recoVertex);
-
-    if ((trueOrientation.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()) &&
-        (recoOrientation.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()))
+    try
     {
-        isOrientationCorrect = (trueOrientation.GetOpeningAngle(recoOrientation) > (M_PI * 0.5f) ? 0 : 1);
+        const CartesianVector trueOrientation(trueEndpoint - pMCParticle->GetVertex());
+        const CartesianVector recoOrientation(recoEndpoint - recoVertex);
+
+        if ((trueOrientation.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()) &&
+            (recoOrientation.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()))
+        {
+            isOrientationCorrect = (trueOrientation.GetOpeningAngle(recoOrientation) > (M_PI * 0.5f) ? 0 : 1);
+        }
     }
+    catch (StatusCodeException &) { isOrientationCorrect = m_invalidInt; }
 
     trackTreeVars.m_recoEndpointX.push_back(recoEndpoint.GetX());
     trackTreeVars.m_recoEndpointY.push_back(recoEndpoint.GetY());

--- a/larpandoracontent/LArMetrics/TrackValidationTool.cc
+++ b/larpandoracontent/LArMetrics/TrackValidationTool.cc
@@ -157,49 +157,41 @@ void TrackValidationTool::GetRecoVertexAndEndpointVars(const MCParticle *const p
 {
     const LArMCParticle *const pLArMC(dynamic_cast<const LArMCParticle *>(pMCParticle));
     if (!pLArMC)
-    {
         throw StatusCodeException(STATUS_CODE_FAILURE);
-    }
+
     const bool doesMCHaveStartDir(pMCParticle->GetMomentum().GetMagnitudeSquared() > std::numeric_limits<float>::epsilon());
+    const bool doesRecoHaveStartDir(recoVertexDir.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon());
     const bool doesMCHaveEndDir(pLArMC->GetEndDirection().GetMagnitudeSquared() > std::numeric_limits<float>::epsilon());
+    const bool doesRecoHaveEndDir(recoEndpointDir.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon());    
     const CartesianVector trueEndpoint(pLArMC->GetEndpoint());
 
     // Endpoint accuracy
     float endpointAcc(m_invalidLargeFloat);
-    try
+    if (doesMCHaveEndDir)
     {
-        endpointAcc = (recoEndpoint - trueEndpoint).GetMagnitude();
-        const float sign((endpointAcc < std::numeric_limits<float>::epsilon() || !doesMCHaveEndDir)       ? 1.f
-                : (recoEndpoint - trueEndpoint).GetOpeningAngle(pLArMC->GetEndDirection()) < (M_PI * 0.5) ? 1.f
-                                                                                                          : -1.f);
-        endpointAcc *= sign;
+        const float endpointAccSq((recoEndpoint - trueEndpoint).GetMagnitudeSquared());
+        const float sign((endpointAcc < std::numeric_limits<float>::epsilon()) ? 1.f
+            : (recoEndpoint - trueEndpoint).GetOpeningAngle(pLArMC->GetEndDirection()) < (M_PI * 0.5) ? 1.f
+            : -1.f);
+        endpointAcc = std::sqrt(endpointAccSq) * sign;
     }
-    catch (StatusCodeException &) { endpointAcc = m_invalidLargeFloat; }
 
     // Start direction
-    float startDirAcc(m_invalidAngle);
-    try { startDirAcc = (doesMCHaveStartDir ? pMCParticle->GetMomentum().GetOpeningAngle(recoVertexDir) : m_invalidAngle); }
-    catch (StatusCodeException &) { startDirAcc = m_invalidAngle; }
+    const float startDirAcc((doesMCHaveStartDir && doesRecoHaveStartDir) ? pMCParticle->GetMomentum().GetOpeningAngle(recoVertexDir) : m_invalidAngle);
 
     // End direction
-    float endDirAcc(m_invalidAngle);
-    try { endDirAcc = (doesMCHaveEndDir ? pLArMC->GetEndDirection().GetOpeningAngle(recoEndpointDir) : m_invalidAngle); }
-    catch (StatusCodeException &) { endDirAcc = m_invalidAngle; }
+    const float endDirAcc((doesMCHaveEndDir && doesRecoHaveEndDir) ? pLArMC->GetEndDirection().GetOpeningAngle(recoEndpointDir) : m_invalidAngle);
 
     // Is flipped?
     int isOrientationCorrect(m_invalidInt);
-    try
-    {
-        const CartesianVector trueOrientation(trueEndpoint - pMCParticle->GetVertex());
-        const CartesianVector recoOrientation(recoEndpoint - recoVertex);
+    const CartesianVector trueOrientation(trueEndpoint - pMCParticle->GetVertex());
+    const CartesianVector recoOrientation(recoEndpoint - recoVertex);
 
-        if ((trueOrientation.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()) &&
-            (recoOrientation.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()))
-        {
-            isOrientationCorrect = (trueOrientation.GetOpeningAngle(recoOrientation) > (M_PI * 0.5f) ? 0 : 1);
-        }
+    if ((trueOrientation.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()) &&
+        (recoOrientation.GetMagnitudeSquared() > std::numeric_limits<float>::epsilon()))
+    {
+        isOrientationCorrect = (trueOrientation.GetOpeningAngle(recoOrientation) > (M_PI * 0.5f) ? 0 : 1);
     }
-    catch (StatusCodeException &) { isOrientationCorrect = m_invalidInt; }
 
     trackTreeVars.m_recoEndpointX.push_back(recoEndpoint.GetX());
     trackTreeVars.m_recoEndpointY.push_back(recoEndpoint.GetY());


### PR DESCRIPTION
Hello,

When running on 6K files, there was one event where the momentum magnitude was > epsilon, but the calculation of the opening angle failed because of a (momentum magnitude * momentum magnitude) denominator in which both momentum magnitudes were very small :'( 

I've now protected all instances of this via try/catch blocks. It is very rare that the code flow should enter the catch block.

This should be the end of this issue.

Thanks!