### PR TITLE
Making sure file version actually written and read

### DIFF
--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
@@ -110,6 +110,9 @@ void EventReadingAlgorithm::MoveToNextEventFile()
     m_eventFileNameVector.pop_back();
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReplaceEventFileReader(m_eventFileName));
 
+    if (m_isEnhancedEventFile)
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileReader->ReadGlobalHeader());
+
     try
     {
         m_pEventFileReader->ReadEvent();

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
@@ -6,8 +6,6 @@
  *  $Log: $
  */
 
-#include "Api/PandoraApi.h"
-
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "Persistency/BinaryFileReader.h"

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
@@ -6,6 +6,8 @@
  *  $Log: $
  */
 
+#include "Api/PandoraApi.h"
+
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "Persistency/BinaryFileReader.h"
@@ -25,6 +27,7 @@ namespace lar_content
 
 EventReadingAlgorithm::EventReadingAlgorithm() :
     m_skipToEvent(0),
+    m_isEnhancedEventFile(false),
     m_useLArCaloHits(true),
     m_larCaloHitVersion(1),
     m_useLArMCParticles(true),
@@ -67,6 +70,10 @@ StatusCode EventReadingAlgorithm::Initialize()
     if (!m_eventFileName.empty())
     {
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReplaceEventFileReader(m_eventFileName));
+
+        if (m_isEnhancedEventFile)
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileReader->ReadGlobalHeader());
+
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileReader->GoToEvent(m_skipToEvent));
     }
 
@@ -224,6 +231,9 @@ StatusCode EventReadingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         std::cout << "EventReadingAlgorithm - nothing to do; neither geometry nor event file specified." << std::endl;
         return STATUS_CODE_NOT_INITIALIZED;
     }
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IsEnhancedEventFile", m_isEnhancedEventFile));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArCaloHits", m_useLArCaloHits));
 

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.h
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.h
@@ -83,6 +83,7 @@ private:
     pandora::StringVector m_eventFileNameVector; ///< Vector of file names to be processed
 
     unsigned int m_skipToEvent;          ///< Index of first event to consider in first input file
+    bool m_isEnhancedEventFile;          ///< Whether the event file has a 'file describing' block
     bool m_useLArCaloHits;               ///< Whether to read lar calo hits, or standard pandora calo hits
     unsigned int m_larCaloHitVersion;    ///< LArCaloHit version for LArCaloHitFactory
     bool m_useLArMCParticles;            ///< Whether to read lar mc particles, or standard pandora mc particles

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
@@ -329,7 +329,7 @@ StatusCode EventWritingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "FileMajorVersion", m_fileMajorVersion));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, m_fileMajorVersion, !=,
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "FileMinorVersion", m_fileMinorVersion));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
@@ -32,7 +32,7 @@ EventWritingAlgorithm::EventWritingAlgorithm() :
     m_shouldWriteGeometry(false),
     m_writtenGeometry(false),
     m_shouldWriteEvents(true),
-    m_fileMajorVersion(1),
+    m_fileMajorVersion(2),
     m_fileMinorVersion(0),
     m_writtenEventGlobalHeader(false),
     m_shouldWriteMCRelationships(true),

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
@@ -32,6 +32,9 @@ EventWritingAlgorithm::EventWritingAlgorithm() :
     m_shouldWriteGeometry(false),
     m_writtenGeometry(false),
     m_shouldWriteEvents(true),
+    m_fileMajorVersion(1),
+    m_fileMinorVersion(0),
+    m_writtenEventGlobalHeader(false),
     m_shouldWriteMCRelationships(true),
     m_shouldWriteTrackRelationships(true),
     m_shouldOverwriteEventFile(false),
@@ -81,11 +84,13 @@ StatusCode EventWritingAlgorithm::Initialize()
 
         if (BINARY == m_geometryFileType)
         {
-            m_pGeometryFileWriter = new BinaryFileWriter(this->GetPandora(), m_geometryFileName, fileMode);
+            m_pGeometryFileWriter = new BinaryFileWriter(this->GetPandora(), m_geometryFileName, fileMode,
+                m_fileMajorVersion, m_fileMinorVersion);
         }
         else if (XML == m_geometryFileType)
         {
-            m_pGeometryFileWriter = new XmlFileWriter(this->GetPandora(), m_geometryFileName, fileMode);
+            m_pGeometryFileWriter = new XmlFileWriter(this->GetPandora(), m_geometryFileName, fileMode,
+                m_fileMajorVersion, m_fileMinorVersion);
         }
         else
         {
@@ -99,11 +104,13 @@ StatusCode EventWritingAlgorithm::Initialize()
 
         if (BINARY == m_eventFileType)
         {
-            m_pEventFileWriter = new BinaryFileWriter(this->GetPandora(), m_eventFileName, fileMode);
+            m_pEventFileWriter = new BinaryFileWriter(this->GetPandora(), m_eventFileName, fileMode,
+                m_fileMajorVersion, m_fileMinorVersion);
         }
         else if (XML == m_eventFileType)
         {
-            m_pEventFileWriter = new XmlFileWriter(this->GetPandora(), m_eventFileName, fileMode);
+            m_pEventFileWriter = new XmlFileWriter(this->GetPandora(), m_eventFileName, fileMode,
+                m_fileMajorVersion, m_fileMinorVersion);
         }
         else
         {
@@ -145,6 +152,12 @@ StatusCode EventWritingAlgorithm::Run()
 
         const MCParticleList *pMCParticleList = nullptr;
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pMCParticleList));
+
+        if (!m_writtenEventGlobalHeader)
+        {
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileWriter->WriteGlobalHeader());
+            m_writtenEventGlobalHeader = true;
+        }
 
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=,
             m_pEventFileWriter->WriteEvent(*pCaloHitList, *pTrackList, *pMCParticleList, m_shouldWriteMCRelationships, m_shouldWriteTrackRelationships));
@@ -312,6 +325,12 @@ StatusCode EventWritingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
             return STATUS_CODE_INVALID_PARAMETER;
         }
     }
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "FileMajorVersion", m_fileMajorVersion));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, m_fileMajorVersion, !=,
+        XmlHelper::ReadValue(xmlHandle, "FileMinorVersion", m_fileMinorVersion));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "ShouldWriteMCRelationships", m_shouldWriteMCRelationships));

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.h
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.h
@@ -78,6 +78,10 @@ private:
     bool m_shouldWriteEvents;    ///< Whether to write events to a specified file
     std::string m_eventFileName; ///< Name of the output event file
 
+    unsigned int m_fileMajorVersion; ///< Major version of the output file
+    unsigned int m_fileMinorVersion; ///< Minor version of the output file
+    bool m_writtenEventGlobalHeader; ///< Whether the global header has been written to the output event file
+
     bool m_shouldWriteMCRelationships;    ///< Whether to write mc relationship information to the events file
     bool m_shouldWriteTrackRelationships; ///< Whether to write track relationship information to the events file
 


### PR DESCRIPTION
Hello!

This PR makes sure that the 'global header' is written to the event file and is subsequently read. At the moment, the global header contains file version information. For example, the xml looks like:

```
<Header>
    <Version>
        <MajorVersion>2</MajorVersion>
        <MinorVersion>0</MinorVersion>
    </Version>
</Header>
<Event>
    <CaloHit>
        <LArTPCVolumeId>0</LArTPCVolumeId>
        <DaughterVolumeId>5</DaughterVolumeId>
        <CellGeometry>0</CellGeometry>
        <PositionVector>-114.319160461 0 251.014801025</PositionVector>
...
```

If the file major version == 2 the event information i.e. run:subrun:event will be written to the output pndrs/xmls. A flag (isEnhancedFile) is added to the event readers to inform the reader that this new block exists and that it should be read. 