### PR TITLE
Adding DLShowerMatching algorithms

### DIFF
--- a/cmake/LArDLContent_sources.cmake
+++ b/cmake/LArDLContent_sources.cmake
@@ -5,6 +5,7 @@ set(LAR_DL_CONTENT_SRCS
     larpandoradlcontent/LArEventClassification/CNNTrackShowerCountingAlgorithm.cc
     larpandoradlcontent/LArHelpers/LArCanvasHelper.cc
     larpandoradlcontent/LArHelpers/LArDLHelper.cc
+    larpandoradlcontent/LArHelpers/LArDLShowerHelper.cc
     larpandoradlcontent/LArMonitoring/DlHitValidationAlgorithm.cc
     larpandoradlcontent/LArObjects/VertexTuple.cc
     larpandoradlcontent/LArShowerGrowing/DLTwoDShowerGrowingAlgorithm.cc
@@ -13,6 +14,11 @@ set(LAR_DL_CONTENT_SRCS
     larpandoradlcontent/LArThreeDReco/LArEventBuilding/DLLaterTierHierarchyTool.cc
     larpandoradlcontent/LArThreeDReco/LArEventBuilding/DLNeutrinoHierarchyAlgorithm.cc
     larpandoradlcontent/LArThreeDReco/LArEventBuilding/DLPrimaryHierarchyTool.cc
+    larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.cc
+    larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.cc
+    larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.cc
+    larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.cc
+    larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.cc
     larpandoradlcontent/LArTrackShowerId/DlClusterCharacterisationAlgorithm.cc
     larpandoradlcontent/LArTrackShowerId/DlHitTrackShowerIdAlgorithm.cc
     larpandoradlcontent/LArTrackShowerId/DlPfoCharacterisationAlgorithm.cc

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -362,7 +362,8 @@ void LArClusterHelper::GetClosestPositions(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArClusterHelper::GetClusterBoundingBox(const Cluster *const pCluster, CartesianVector &minimumCoordinate, CartesianVector &maximumCoordinate)
+void LArClusterHelper::GetClusterBoundingBox(const Cluster *const pCluster, CartesianVector &minimumCoordinate, CartesianVector &maximumCoordinate,
+    bool useHitWidth)
 {
     const OrderedCaloHitList &orderedCaloHitList(pCluster->GetOrderedCaloHitList());
 
@@ -379,8 +380,9 @@ void LArClusterHelper::GetClusterBoundingBox(const Cluster *const pCluster, Cart
         {
             const CaloHit *const pCaloHit = *hIter;
             const CartesianVector &hit(pCaloHit->GetPositionVector());
-            xmin = std::min(hit.GetX(), xmin);
-            xmax = std::max(hit.GetX(), xmax);
+            const float halfWidth = useHitWidth ? 0.5f * pCaloHit->GetCellSize1() : 0.f;
+            xmin = std::min(hit.GetX() - halfWidth, xmin);
+            xmax = std::max(hit.GetX() + halfWidth, xmax);
             ymin = std::min(hit.GetY(), ymin);
             ymax = std::max(hit.GetY(), ymax);
             zmin = std::min(hit.GetZ(), zmin);

--- a/larpandoracontent/LArHelpers/LArClusterHelper.h
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.h
@@ -270,9 +270,10 @@ public:
      *  @param  pCluster address of the cluster
      *  @param  the minimum positions (x,y,z)
      *  @param  the maximum positions (x,y,z)
+     *  @param  useHitWidth whether to use the hit width in the calculation
      */
-    static void GetClusterBoundingBox(
-        const pandora::Cluster *const pCluster, pandora::CartesianVector &minimumCoordinate, pandora::CartesianVector &maximumCoordinate);
+    static void GetClusterBoundingBox(const pandora::Cluster *const pCluster, pandora::CartesianVector &minimumCoordinate,
+        pandora::CartesianVector &maximumCoordinate, bool useHitWidth = false);
 
     /**
      *  @brief  Get vector of hit coordinates from an input cluster

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -620,6 +620,21 @@ LArGeometryHelper::DetectorBoundaries LArGeometryHelper::GetDetectorBoundaries(c
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void LArGeometryHelper::GetDetectorXGaps(const Pandora &pandora, std::set<float> &detXGaps)
+{
+    for (const DetectorGap *const pDetectorGap : pandora.GetGeometry()->GetDetectorGapList())
+    {
+        const LineGap *const pLineGap = dynamic_cast<const LineGap *>(pDetectorGap);
+        if (pLineGap->GetLineGapType() == TPC_DRIFT_GAP)
+        {
+            detXGaps.insert(static_cast<double>(pLineGap->GetLineStartX()));
+            detXGaps.insert(static_cast<double>(pLineGap->GetLineEndX()));
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 bool LArGeometryHelper::IsInDetector(const DetectorBoundaries &detectorBoundaries, const CartesianVector &position)
 {
     if ((position.GetX() < detectorBoundaries.m_xBoundaries.first) || (position.GetX() > detectorBoundaries.m_xBoundaries.second))

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -624,11 +624,15 @@ void LArGeometryHelper::GetDetectorXGaps(const Pandora &pandora, std::set<float>
 {
     for (const DetectorGap *const pDetectorGap : pandora.GetGeometry()->GetDetectorGapList())
     {
-        const LineGap *const pLineGap = dynamic_cast<const LineGap *>(pDetectorGap);
+        const LineGap *const pLineGap(dynamic_cast<const LineGap *>(pDetectorGap));
+
+        if (!pLineGap)
+            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+        
         if (pLineGap->GetLineGapType() == TPC_DRIFT_GAP)
         {
-            detXGaps.insert(static_cast<double>(pLineGap->GetLineStartX()));
-            detXGaps.insert(static_cast<double>(pLineGap->GetLineEndX()));
+            detXGaps.insert(pLineGap->GetLineStartX());
+            detXGaps.insert(pLineGap->GetLineEndX());
         }
     }
 }

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -296,6 +296,15 @@ public:
     static DetectorBoundaries GetDetectorBoundaries(const pandora::Pandora &pandora);
 
     /**
+     *  @brief  Obtain the list of 'line gap' boundaries in the detector,
+                'line gaps' are those that span the drift coordinate
+     *
+     *  @param  pandora the pandora instance
+     *  @param[out] detXGaps the set of x positions of the detector gaps
+     */    
+    static void GetDetectorXGaps(const pandora::Pandora &pandora, std::set<float> &detXGaps);
+
+    /**
      *  @brief  Return whether an input point is within the bounds of the detector
      *
      *  @param detectorBoundaries the detector boundaries

--- a/larpandoracontent/LArObjects/LArCaloHit.h
+++ b/larpandoracontent/LArObjects/LArCaloHit.h
@@ -27,9 +27,16 @@ namespace lar_content
 class LArCaloHitParameters : public object_creation::CaloHit::Parameters
 {
 public:
-    pandora::InputUInt m_larTPCVolumeId;   ///< The lar tpc volume id
-    pandora::InputUInt m_daughterVolumeId; ///< The daughter volume id
-
+    pandora::InputUInt m_larTPCVolumeId;    ///< The lar tpc volume id
+    pandora::InputUInt m_daughterVolumeId;  ///< The daughter volume id
+    pandora::InputUInt m_plane;             ///< The plane id    
+    pandora::InputUInt m_wireId;            ///< The wire id (only unique to daughter volume)
+    pandora::InputUInt m_plane1;            ///< The first projection plane id
+    pandora::InputUInt m_minIntersectWire1; ///< The id of the first (lowest wire id) intersecting wire (in proj plane 1)
+    pandora::InputUInt m_maxIntersectWire1; ///< The id of the last (highest wire id) intersecting wire (in proj plane 1)
+    pandora::InputUInt m_plane2;            ///< The second projection plane id    
+    pandora::InputUInt m_minIntersectWire2; ///< The id of the first (lowest wire id) intersecting wire (in proj plane 2)
+    pandora::InputUInt m_maxIntersectWire2; ///< The id of the last (highest wire id) intersecting wire (in proj plane 2)
     pandora::FloatVector m_hitScores;       ///< Hit scores
     pandora::StringVector m_hitScoreLabels; ///< Labels for the hit scores
 };
@@ -63,6 +70,62 @@ public:
      */
     unsigned int GetDaughterVolumeId() const;
 
+    /**
+     *  @brief  Get the plane id
+     *
+     *  @return the plane id
+     */
+    unsigned int GetPlane() const;
+    
+    /**
+     *  @brief  Get the wire id
+     *
+     *  @return the wire id
+     */
+    unsigned int GetWireId() const;
+
+    /**
+     *  @brief  Get the first projection plane id
+     *
+     *  @return the first projection plane id
+     */
+    unsigned int GetPlane1() const;
+    
+    /**
+     *  @brief  Get the id of the minimum (lowest wire id) intersecting wire in proj plane 1
+     *
+     *  @return the minimum intersecting wire id for proj plane 1
+     */
+    unsigned int GetMinIntersectWire1() const;
+
+    /**
+     *  @brief  Get the id of the maximum (highest wire id) intersecting wire in proj plane 1
+     *
+     *  @return the maximum intersecting wire id for proj plane 1
+     */
+    unsigned int GetMaxIntersectWire1() const;
+
+    /**
+     *  @brief  Get the second projection plane id
+     *
+     *  @return the second projection plane id
+     */
+    unsigned int GetPlane2() const;
+    
+    /**
+     *  @brief  Get the id of the minimum (lowest wire id) intersecting wire in proj plane 2
+     *
+     *  @return the minimum intersecting wire id for proj plane 2
+     */
+    unsigned int GetMinIntersectWire2() const;
+
+    /**
+     *  @brief  Get the id of the maximum (highest wire id) intersecting wire in proj plane 2
+     *
+     *  @return the maximum intersecting wire id for proj plane 2
+     */
+    unsigned int GetMaxIntersectWire2() const;    
+    
     /**
      *  @brief  Fill the parameters associated with this calo hit
      *
@@ -115,6 +178,14 @@ public:
 private:
     unsigned int m_larTPCVolumeId;          ///< The lar tpc volume id
     unsigned int m_daughterVolumeId;        ///< The daughter volume id
+    unsigned int m_plane;                   ///< The plane id
+    unsigned int m_wireId;                  ///< The wire id (only unique to daughter volume)
+    unsigned int m_plane1;                  ///< The first projection plane id        
+    unsigned int m_minIntersectWire1;       ///< The id of the first (lowest wire id) intersecting wire (in proj plane 1)
+    unsigned int m_maxIntersectWire1;       ///< The id of the last (highest wire id) intersecting wire (in proj plane 1)
+    unsigned int m_plane2;                  ///< The second projection plane id    
+    unsigned int m_minIntersectWire2;       ///< The id of the first (lowest wire id) intersecting wire (in proj plane 2)
+    unsigned int m_maxIntersectWire2;       ///< The id of the last (highest wire id) intersecting wire (in proj plane 2)
     pandora::FloatVector m_hitScores;       ///< Hit scores
     pandora::StringVector m_hitScoreLabels; ///< Labels for the hit scores
     pandora::InputFloat m_pTrack;           ///< The probability that the hit is track-like
@@ -178,6 +249,14 @@ inline LArCaloHit::LArCaloHit(const LArCaloHitParameters &parameters) :
     object_creation::CaloHit::Object(parameters),
     m_larTPCVolumeId(parameters.m_larTPCVolumeId.Get()),
     m_daughterVolumeId(parameters.m_daughterVolumeId.IsInitialized() ? parameters.m_daughterVolumeId.Get() : 0),
+    m_plane(parameters.m_plane.Get()),
+    m_wireId(parameters.m_wireId.Get()),
+    m_plane1(parameters.m_plane1.Get()),
+    m_minIntersectWire1(parameters.m_minIntersectWire1.Get()),
+    m_maxIntersectWire1(parameters.m_maxIntersectWire1.Get()),
+    m_plane2(parameters.m_plane2.Get()),
+    m_minIntersectWire2(parameters.m_minIntersectWire2.Get()),
+    m_maxIntersectWire2(parameters.m_maxIntersectWire2.Get()),
     m_hitScores(parameters.m_hitScores),
     m_hitScoreLabels(parameters.m_hitScoreLabels)
 {
@@ -195,6 +274,62 @@ inline unsigned int LArCaloHit::GetLArTPCVolumeId() const
 inline unsigned int LArCaloHit::GetDaughterVolumeId() const
 {
     return m_daughterVolumeId;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline unsigned int LArCaloHit::GetPlane() const
+{
+    return m_plane;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline unsigned int LArCaloHit::GetWireId() const
+{
+    return m_wireId;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline unsigned int LArCaloHit::GetPlane1() const
+{
+    return m_plane1;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline unsigned int LArCaloHit::GetMinIntersectWire1() const
+{
+    return m_minIntersectWire1;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline unsigned int LArCaloHit::GetMaxIntersectWire1() const
+{
+    return m_maxIntersectWire1;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline unsigned int LArCaloHit::GetPlane2() const
+{
+    return m_plane2;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline unsigned int LArCaloHit::GetMinIntersectWire2() const
+{
+    return m_minIntersectWire2;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline unsigned int LArCaloHit::GetMaxIntersectWire2() const
+{
+    return m_maxIntersectWire2;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -238,6 +373,14 @@ inline void LArCaloHit::FillParameters(LArCaloHitParameters &parameters) const
     parameters.m_pParentAddress = static_cast<const void *>(this);
     parameters.m_larTPCVolumeId = this->GetLArTPCVolumeId();
     parameters.m_daughterVolumeId = this->GetDaughterVolumeId();
+    parameters.m_plane = this->GetPlane();
+    parameters.m_wireId = this->GetWireId();
+    parameters.m_plane1 = this->GetPlane1();
+    parameters.m_minIntersectWire1 = this->GetMinIntersectWire1();
+    parameters.m_maxIntersectWire1 = this->GetMaxIntersectWire1();
+    parameters.m_plane2 = this->GetPlane2();
+    parameters.m_minIntersectWire2 = this->GetMinIntersectWire2();
+    parameters.m_maxIntersectWire2 = this->GetMaxIntersectWire2();
     parameters.m_hitScores = this->GetHitScores();
     parameters.m_hitScoreLabels = this->GetHitScoreLabels();
 }
@@ -311,6 +454,10 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
     unsigned int nLabels(0);
     pandora::FloatVector hitScores;
     pandora::StringVector hitScoreLabels;
+    unsigned int plane(0), plane1(0), plane2(0);
+    unsigned int wireId(0);
+    unsigned int minIntersectWire1(0), maxIntersectWire1(0);
+    unsigned int minIntersectWire2(0), maxIntersectWire2(0);     
 
     if (pandora::BINARY == fileReader.GetFileType())
     {
@@ -334,6 +481,18 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
                 hitScoreLabels.emplace_back(std::move(label));
             }
         }
+        if (m_version > 3)
+        {
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(plane));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(wireId));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(plane1));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(minIntersectWire1));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(maxIntersectWire1));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(plane2));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(minIntersectWire2));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(maxIntersectWire2));
+        }
+        
     }
     else if (pandora::XML == fileReader.GetFileType())
     {
@@ -357,6 +516,17 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
                 hitScoreLabels.emplace_back(std::move(label));
             }
         }
+        if (m_version > 3)
+        {
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("Plane", plane));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("WireID", wireId));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("Plane1", plane1));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("MinIntersectWire1", minIntersectWire1));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("MaxIntersectWire1", maxIntersectWire1));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("Plane2", plane2));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("MinIntersectWire2", minIntersectWire2));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("MaxIntersectWire2", maxIntersectWire2));
+        }
     }
     else
     {
@@ -368,6 +538,14 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
     larCaloHitParameters.m_daughterVolumeId = daughterVolumeId;
     larCaloHitParameters.m_hitScores = std::move(hitScores);
     larCaloHitParameters.m_hitScoreLabels = std::move(hitScoreLabels);
+    larCaloHitParameters.m_plane = plane;
+    larCaloHitParameters.m_wireId = wireId;
+    larCaloHitParameters.m_plane1 = plane1;
+    larCaloHitParameters.m_minIntersectWire1 = minIntersectWire1;
+    larCaloHitParameters.m_maxIntersectWire1 = maxIntersectWire1;
+    larCaloHitParameters.m_plane2 = plane2;
+    larCaloHitParameters.m_minIntersectWire2 = minIntersectWire2;
+    larCaloHitParameters.m_maxIntersectWire2 = maxIntersectWire2;    
 
     return pandora::STATUS_CODE_SUCCESS;
 }
@@ -400,6 +578,17 @@ inline pandora::StatusCode LArCaloHitFactory::Write(const Object *const pObject,
                 PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(hitScoreLabels.at(i)));
             }
         }
+        if (m_version > 3)
+        {
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetPlane()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetWireId()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetPlane1()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetMinIntersectWire1()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetMaxIntersectWire1()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetPlane2()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetMinIntersectWire2()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetMaxIntersectWire2()));
+        }
     }
     else if (pandora::XML == fileWriter.GetFileType())
     {
@@ -419,6 +608,17 @@ inline pandora::StatusCode LArCaloHitFactory::Write(const Object *const pObject,
                 PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("HitScore", hitScores.at(i)));
                 PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("HitScoreLabel", hitScoreLabels.at(i)));
             }
+        }
+        if (m_version > 3)
+        {
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("Plane", pLArCaloHit->GetPlane()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("WireId", pLArCaloHit->GetWireId()));
+             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("Plane1", pLArCaloHit->GetPlane1()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("MinIntersectWire1", pLArCaloHit->GetMinIntersectWire1()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("MaxIntersectWire1", pLArCaloHit->GetMaxIntersectWire1()));
+             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("Plane2", pLArCaloHit->GetPlane2()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("MinIntersectWire2", pLArCaloHit->GetMinIntersectWire2()));
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("MaxIntersectWire2", pLArCaloHit->GetMaxIntersectWire2()));            
         }
     }
     else

--- a/larpandoracontent/LArObjects/LArCaloHit.h
+++ b/larpandoracontent/LArObjects/LArCaloHit.h
@@ -27,16 +27,9 @@ namespace lar_content
 class LArCaloHitParameters : public object_creation::CaloHit::Parameters
 {
 public:
-    pandora::InputUInt m_larTPCVolumeId;    ///< The lar tpc volume id
-    pandora::InputUInt m_daughterVolumeId;  ///< The daughter volume id
-    pandora::InputUInt m_plane;             ///< The plane id    
-    pandora::InputUInt m_wireId;            ///< The wire id (only unique to daughter volume)
-    pandora::InputUInt m_plane1;            ///< The first projection plane id
-    pandora::InputUInt m_minIntersectWire1; ///< The id of the first (lowest wire id) intersecting wire (in proj plane 1)
-    pandora::InputUInt m_maxIntersectWire1; ///< The id of the last (highest wire id) intersecting wire (in proj plane 1)
-    pandora::InputUInt m_plane2;            ///< The second projection plane id    
-    pandora::InputUInt m_minIntersectWire2; ///< The id of the first (lowest wire id) intersecting wire (in proj plane 2)
-    pandora::InputUInt m_maxIntersectWire2; ///< The id of the last (highest wire id) intersecting wire (in proj plane 2)
+    pandora::InputUInt m_larTPCVolumeId;   ///< The lar tpc volume id
+    pandora::InputUInt m_daughterVolumeId; ///< The daughter volume id
+
     pandora::FloatVector m_hitScores;       ///< Hit scores
     pandora::StringVector m_hitScoreLabels; ///< Labels for the hit scores
 };
@@ -70,62 +63,6 @@ public:
      */
     unsigned int GetDaughterVolumeId() const;
 
-    /**
-     *  @brief  Get the plane id
-     *
-     *  @return the plane id
-     */
-    unsigned int GetPlane() const;
-    
-    /**
-     *  @brief  Get the wire id
-     *
-     *  @return the wire id
-     */
-    unsigned int GetWireId() const;
-
-    /**
-     *  @brief  Get the first projection plane id
-     *
-     *  @return the first projection plane id
-     */
-    unsigned int GetPlane1() const;
-    
-    /**
-     *  @brief  Get the id of the minimum (lowest wire id) intersecting wire in proj plane 1
-     *
-     *  @return the minimum intersecting wire id for proj plane 1
-     */
-    unsigned int GetMinIntersectWire1() const;
-
-    /**
-     *  @brief  Get the id of the maximum (highest wire id) intersecting wire in proj plane 1
-     *
-     *  @return the maximum intersecting wire id for proj plane 1
-     */
-    unsigned int GetMaxIntersectWire1() const;
-
-    /**
-     *  @brief  Get the second projection plane id
-     *
-     *  @return the second projection plane id
-     */
-    unsigned int GetPlane2() const;
-    
-    /**
-     *  @brief  Get the id of the minimum (lowest wire id) intersecting wire in proj plane 2
-     *
-     *  @return the minimum intersecting wire id for proj plane 2
-     */
-    unsigned int GetMinIntersectWire2() const;
-
-    /**
-     *  @brief  Get the id of the maximum (highest wire id) intersecting wire in proj plane 2
-     *
-     *  @return the maximum intersecting wire id for proj plane 2
-     */
-    unsigned int GetMaxIntersectWire2() const;    
-    
     /**
      *  @brief  Fill the parameters associated with this calo hit
      *
@@ -178,14 +115,6 @@ public:
 private:
     unsigned int m_larTPCVolumeId;          ///< The lar tpc volume id
     unsigned int m_daughterVolumeId;        ///< The daughter volume id
-    unsigned int m_plane;                   ///< The plane id
-    unsigned int m_wireId;                  ///< The wire id (only unique to daughter volume)
-    unsigned int m_plane1;                  ///< The first projection plane id        
-    unsigned int m_minIntersectWire1;       ///< The id of the first (lowest wire id) intersecting wire (in proj plane 1)
-    unsigned int m_maxIntersectWire1;       ///< The id of the last (highest wire id) intersecting wire (in proj plane 1)
-    unsigned int m_plane2;                  ///< The second projection plane id    
-    unsigned int m_minIntersectWire2;       ///< The id of the first (lowest wire id) intersecting wire (in proj plane 2)
-    unsigned int m_maxIntersectWire2;       ///< The id of the last (highest wire id) intersecting wire (in proj plane 2)
     pandora::FloatVector m_hitScores;       ///< Hit scores
     pandora::StringVector m_hitScoreLabels; ///< Labels for the hit scores
     pandora::InputFloat m_pTrack;           ///< The probability that the hit is track-like
@@ -249,14 +178,6 @@ inline LArCaloHit::LArCaloHit(const LArCaloHitParameters &parameters) :
     object_creation::CaloHit::Object(parameters),
     m_larTPCVolumeId(parameters.m_larTPCVolumeId.Get()),
     m_daughterVolumeId(parameters.m_daughterVolumeId.IsInitialized() ? parameters.m_daughterVolumeId.Get() : 0),
-    m_plane(parameters.m_plane.Get()),
-    m_wireId(parameters.m_wireId.Get()),
-    m_plane1(parameters.m_plane1.Get()),
-    m_minIntersectWire1(parameters.m_minIntersectWire1.Get()),
-    m_maxIntersectWire1(parameters.m_maxIntersectWire1.Get()),
-    m_plane2(parameters.m_plane2.Get()),
-    m_minIntersectWire2(parameters.m_minIntersectWire2.Get()),
-    m_maxIntersectWire2(parameters.m_maxIntersectWire2.Get()),
     m_hitScores(parameters.m_hitScores),
     m_hitScoreLabels(parameters.m_hitScoreLabels)
 {
@@ -274,62 +195,6 @@ inline unsigned int LArCaloHit::GetLArTPCVolumeId() const
 inline unsigned int LArCaloHit::GetDaughterVolumeId() const
 {
     return m_daughterVolumeId;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline unsigned int LArCaloHit::GetPlane() const
-{
-    return m_plane;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline unsigned int LArCaloHit::GetWireId() const
-{
-    return m_wireId;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline unsigned int LArCaloHit::GetPlane1() const
-{
-    return m_plane1;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline unsigned int LArCaloHit::GetMinIntersectWire1() const
-{
-    return m_minIntersectWire1;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline unsigned int LArCaloHit::GetMaxIntersectWire1() const
-{
-    return m_maxIntersectWire1;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline unsigned int LArCaloHit::GetPlane2() const
-{
-    return m_plane2;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline unsigned int LArCaloHit::GetMinIntersectWire2() const
-{
-    return m_minIntersectWire2;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline unsigned int LArCaloHit::GetMaxIntersectWire2() const
-{
-    return m_maxIntersectWire2;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -373,14 +238,6 @@ inline void LArCaloHit::FillParameters(LArCaloHitParameters &parameters) const
     parameters.m_pParentAddress = static_cast<const void *>(this);
     parameters.m_larTPCVolumeId = this->GetLArTPCVolumeId();
     parameters.m_daughterVolumeId = this->GetDaughterVolumeId();
-    parameters.m_plane = this->GetPlane();
-    parameters.m_wireId = this->GetWireId();
-    parameters.m_plane1 = this->GetPlane1();
-    parameters.m_minIntersectWire1 = this->GetMinIntersectWire1();
-    parameters.m_maxIntersectWire1 = this->GetMaxIntersectWire1();
-    parameters.m_plane2 = this->GetPlane2();
-    parameters.m_minIntersectWire2 = this->GetMinIntersectWire2();
-    parameters.m_maxIntersectWire2 = this->GetMaxIntersectWire2();
     parameters.m_hitScores = this->GetHitScores();
     parameters.m_hitScoreLabels = this->GetHitScoreLabels();
 }
@@ -454,10 +311,6 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
     unsigned int nLabels(0);
     pandora::FloatVector hitScores;
     pandora::StringVector hitScoreLabels;
-    unsigned int plane(0), plane1(0), plane2(0);
-    unsigned int wireId(0);
-    unsigned int minIntersectWire1(0), maxIntersectWire1(0);
-    unsigned int minIntersectWire2(0), maxIntersectWire2(0);     
 
     if (pandora::BINARY == fileReader.GetFileType())
     {
@@ -481,18 +334,6 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
                 hitScoreLabels.emplace_back(std::move(label));
             }
         }
-        if (m_version > 3)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(plane));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(wireId));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(plane1));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(minIntersectWire1));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(maxIntersectWire1));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(plane2));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(minIntersectWire2));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(maxIntersectWire2));
-        }
-        
     }
     else if (pandora::XML == fileReader.GetFileType())
     {
@@ -516,17 +357,6 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
                 hitScoreLabels.emplace_back(std::move(label));
             }
         }
-        if (m_version > 3)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("Plane", plane));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("WireID", wireId));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("Plane1", plane1));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("MinIntersectWire1", minIntersectWire1));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("MaxIntersectWire1", maxIntersectWire1));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("Plane2", plane2));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("MinIntersectWire2", minIntersectWire2));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("MaxIntersectWire2", maxIntersectWire2));
-        }
     }
     else
     {
@@ -538,14 +368,6 @@ inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pando
     larCaloHitParameters.m_daughterVolumeId = daughterVolumeId;
     larCaloHitParameters.m_hitScores = std::move(hitScores);
     larCaloHitParameters.m_hitScoreLabels = std::move(hitScoreLabels);
-    larCaloHitParameters.m_plane = plane;
-    larCaloHitParameters.m_wireId = wireId;
-    larCaloHitParameters.m_plane1 = plane1;
-    larCaloHitParameters.m_minIntersectWire1 = minIntersectWire1;
-    larCaloHitParameters.m_maxIntersectWire1 = maxIntersectWire1;
-    larCaloHitParameters.m_plane2 = plane2;
-    larCaloHitParameters.m_minIntersectWire2 = minIntersectWire2;
-    larCaloHitParameters.m_maxIntersectWire2 = maxIntersectWire2;    
 
     return pandora::STATUS_CODE_SUCCESS;
 }
@@ -578,17 +400,6 @@ inline pandora::StatusCode LArCaloHitFactory::Write(const Object *const pObject,
                 PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(hitScoreLabels.at(i)));
             }
         }
-        if (m_version > 3)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetPlane()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetWireId()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetPlane1()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetMinIntersectWire1()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetMaxIntersectWire1()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetPlane2()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetMinIntersectWire2()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetMaxIntersectWire2()));
-        }
     }
     else if (pandora::XML == fileWriter.GetFileType())
     {
@@ -608,17 +419,6 @@ inline pandora::StatusCode LArCaloHitFactory::Write(const Object *const pObject,
                 PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("HitScore", hitScores.at(i)));
                 PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("HitScoreLabel", hitScoreLabels.at(i)));
             }
-        }
-        if (m_version > 3)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("Plane", pLArCaloHit->GetPlane()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("WireId", pLArCaloHit->GetWireId()));
-             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("Plane1", pLArCaloHit->GetPlane1()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("MinIntersectWire1", pLArCaloHit->GetMinIntersectWire1()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("MaxIntersectWire1", pLArCaloHit->GetMaxIntersectWire1()));
-             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("Plane2", pLArCaloHit->GetPlane2()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("MinIntersectWire2", pLArCaloHit->GetMinIntersectWire2()));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("MaxIntersectWire2", pLArCaloHit->GetMaxIntersectWire2()));            
         }
     }
     else

--- a/larpandoradlcontent/LArDLContent.cc
+++ b/larpandoradlcontent/LArDLContent.cc
@@ -21,6 +21,11 @@
 #include "larpandoradlcontent/LArThreeDReco/LArEventBuilding/DLLaterTierHierarchyTool.h"
 #include "larpandoradlcontent/LArThreeDReco/LArEventBuilding/DLNeutrinoHierarchyAlgorithm.h"
 #include "larpandoradlcontent/LArThreeDReco/LArEventBuilding/DLPrimaryHierarchyTool.h"
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.h"
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.h"
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.h"
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.h"
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h"
 #include "larpandoradlcontent/LArTrackShowerId/DlClusterCharacterisationAlgorithm.h"
 #include "larpandoradlcontent/LArTrackShowerId/DlHitTrackShowerIdAlgorithm.h"
 #include "larpandoradlcontent/LArTrackShowerId/DlPfoCharacterisationAlgorithm.h"
@@ -43,6 +48,7 @@
     d("LArDLSecondaryVertexing",         DlSecondaryVertexingAlgorithm)                               \
     d("LArDLSNSignal",                   DlSNSignalAlgorithm)                                         \
     d("LArDLThreeDClusterSplitting",     DLThreeDClusterSplittingAlgorithm)                           \
+    d("LArDLMultiViewMatching",          DLMultiViewMatchingAlgorithm)                                \
     d("LArDLTrackCharacterisation",      DlTrackCharacterisationAlgorithm)                            \
     d("LArDLTrackShowerStreamSelection", DlTrackShowerStreamSelectionAlgorithm)                       \
     d("LArDLVertexing",                  DlVertexingAlgorithm)                                        \
@@ -51,7 +57,11 @@
 
 #define LAR_DL_ALGORITHM_TOOL_LIST(d)                                                                                                     \
     d("LArDLCheatHierarchy",                    DLCheatHierarchyTool)                                                                     \
-    d("LArDLLaterTierHierarchy",                DLLaterTierHierarchyTool)                                                                 \
+    d("LArDLThreeViewClearShowers",             DLThreeViewClearShowersTool)                                                              \
+    d("LArDLTwoViewClearShowers",               DLTwoViewClearShowersTool)                                                                \
+    d("LArDLThreeViewMergeAndCreateShowers",    DLThreeViewMergeAndCreateShowersTool)                                                     \
+    d("LArDLTwoViewMergeAndCreateShowers",      DLTwoViewMergeAndCreateShowersTool)                                                       \
+    d("LArDLLaterTierHierarchy",                DLLaterTierHierarchyTool) \
     d("LArDLPrimaryHierarchy",                  DLPrimaryHierarchyTool)
 
 #define DL_FACTORY Factory

--- a/larpandoradlcontent/LArDLContent.cc
+++ b/larpandoradlcontent/LArDLContent.cc
@@ -43,12 +43,12 @@
     d("LArDLClusterCharacterisation",    DlClusterCharacterisationAlgorithm)                          \
     d("LArDLHitTrackShowerId",           DlHitTrackShowerIdAlgorithm)                                 \
     d("LArDLHitValidation",              DlHitValidationAlgorithm)                                    \
+    d("LArDLMultiViewMatching",          DLMultiViewMatchingAlgorithm)                                \
     d("LArDLNeutrinoHierarchy",          DLNeutrinoHierarchyAlgorithm)                                \
     d("LArDLPfoCharacterisation",        DlPfoCharacterisationAlgorithm)                              \
     d("LArDLSecondaryVertexing",         DlSecondaryVertexingAlgorithm)                               \
     d("LArDLSNSignal",                   DlSNSignalAlgorithm)                                         \
     d("LArDLThreeDClusterSplitting",     DLThreeDClusterSplittingAlgorithm)                           \
-    d("LArDLMultiViewMatching",          DLMultiViewMatchingAlgorithm)                                \
     d("LArDLTrackCharacterisation",      DlTrackCharacterisationAlgorithm)                            \
     d("LArDLTrackShowerStreamSelection", DlTrackShowerStreamSelectionAlgorithm)                       \
     d("LArDLVertexing",                  DlVertexingAlgorithm)                                        \
@@ -57,12 +57,13 @@
 
 #define LAR_DL_ALGORITHM_TOOL_LIST(d)                                                                                                     \
     d("LArDLCheatHierarchy",                    DLCheatHierarchyTool)                                                                     \
+    d("LArDLLaterTierHierarchy",                DLLaterTierHierarchyTool)                                                                 \
+    d("LArDLPrimaryHierarchy",                  DLPrimaryHierarchyTool)                                                                   \
     d("LArDLThreeViewClearShowers",             DLThreeViewClearShowersTool)                                                              \
-    d("LArDLTwoViewClearShowers",               DLTwoViewClearShowersTool)                                                                \
     d("LArDLThreeViewMergeAndCreateShowers",    DLThreeViewMergeAndCreateShowersTool)                                                     \
-    d("LArDLTwoViewMergeAndCreateShowers",      DLTwoViewMergeAndCreateShowersTool)                                                       \
-    d("LArDLLaterTierHierarchy",                DLLaterTierHierarchyTool) \
-    d("LArDLPrimaryHierarchy",                  DLPrimaryHierarchyTool)
+    d("LArDLTwoViewClearShowers",               DLTwoViewClearShowersTool)                                                                \
+    d("LArDLTwoViewMergeAndCreateShowers",      DLTwoViewMergeAndCreateShowersTool)
+
 
 #define DL_FACTORY Factory
 

--- a/larpandoradlcontent/LArHelpers/LArDLShowerHelper.cc
+++ b/larpandoradlcontent/LArHelpers/LArDLShowerHelper.cc
@@ -1,0 +1,67 @@
+/**
+ *  @file   larpandoradlcontent/LArHelpers/LArDLShowerHelper.cc
+ *
+ *  @brief  Implementation of the lar deep learning helper helper class.
+ *
+ *  $Log: $
+ */
+
+#include "Objects/CaloHit.h"
+#include "Objects/CartesianVector.h"
+
+#include "larpandoradlcontent/LArHelpers/LArDLShowerHelper.h"
+
+#include <set>
+
+namespace lar_dl_content
+{
+
+using namespace pandora;
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
+
+LArDLShowerHelper::HitFeatures::HitFeatures() :
+    m_xRel{0.f},
+    m_zRel{0.f},
+    m_rRel{0.f},
+    m_cosThetaRel{0.f},
+    m_sinThetaRel{0.f},
+    m_distToXGap{0.f},
+    m_xWidth{0.f},
+    m_energy{0.f}
+{
+}
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
+
+void LArDLShowerHelper::CalculateHitFeatures(const CaloHit *const pCaloHit, const std::set<float> &detXGaps, CartesianVector vtxPos, HitFeatures &hitFeatures)
+{
+    const double x{static_cast<double>(pCaloHit->GetPositionVector().GetX())};
+    const double xRel{x - static_cast<double>(vtxPos.GetX())};
+    const double z{static_cast<double>(pCaloHit->GetPositionVector().GetZ())};
+    const double zRel{z - static_cast<double>(vtxPos.GetZ())};
+    const double rRel{std::sqrt(pow(xRel, 2.) + pow(zRel, 2.))};
+    const double cosThetaRel{rRel != 0. ? xRel / rRel : 0.};
+    const double sinThetaRel{rRel != 0. ? zRel / rRel : 0.};
+
+    double distToXGap{std::numeric_limits<double>::max()};
+    for (const double xGap : detXGaps)
+    {
+        const double dist{x - xGap};
+        if (std::abs(dist) < std::abs(distToXGap))
+        {
+                distToXGap = dist;
+        }
+    }
+
+    hitFeatures.m_xRel = static_cast<float>(xRel);
+    hitFeatures.m_zRel = static_cast<float>(zRel);
+    hitFeatures.m_rRel = static_cast<float>(rRel);
+    hitFeatures.m_cosThetaRel = static_cast<float>(cosThetaRel);
+    hitFeatures.m_sinThetaRel = static_cast<float>(sinThetaRel);
+    hitFeatures.m_distToXGap = static_cast<float>(distToXGap);
+    hitFeatures.m_xWidth = pCaloHit->GetCellSize1();
+    hitFeatures.m_energy = pCaloHit->GetMipEquivalentEnergy();
+}
+
+} // namespace lar_dl_content

--- a/larpandoradlcontent/LArHelpers/LArDLShowerHelper.cc
+++ b/larpandoradlcontent/LArHelpers/LArDLShowerHelper.cc
@@ -48,7 +48,7 @@ void LArDLShowerHelper::CalculateHitFeatures(const CaloHit *const pCaloHit, cons
     for (const double xGap : detXGaps)
     {
         const double dist(x - xGap);
-        if (std::abs(dist) < distToXGap)
+        if (std::abs(dist) < std::abs(distToXGap))
             distToXGap = dist;
     }
 

--- a/larpandoradlcontent/LArHelpers/LArDLShowerHelper.cc
+++ b/larpandoradlcontent/LArHelpers/LArDLShowerHelper.cc
@@ -34,24 +34,22 @@ LArDLShowerHelper::HitFeatures::HitFeatures() :
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 
-void LArDLShowerHelper::CalculateHitFeatures(const CaloHit *const pCaloHit, const std::set<float> &detXGaps, CartesianVector vtxPos, HitFeatures &hitFeatures)
+void LArDLShowerHelper::CalculateHitFeatures(const CaloHit *const pCaloHit, const std::set<float> &detXGaps, const CartesianVector &vtxPos, HitFeatures &hitFeatures)
 {
-    const double x{static_cast<double>(pCaloHit->GetPositionVector().GetX())};
-    const double xRel{x - static_cast<double>(vtxPos.GetX())};
-    const double z{static_cast<double>(pCaloHit->GetPositionVector().GetZ())};
-    const double zRel{z - static_cast<double>(vtxPos.GetZ())};
-    const double rRel{std::sqrt(pow(xRel, 2.) + pow(zRel, 2.))};
-    const double cosThetaRel{rRel != 0. ? xRel / rRel : 0.};
-    const double sinThetaRel{rRel != 0. ? zRel / rRel : 0.};
+    const double x(pCaloHit->GetPositionVector().GetX());
+    const double xRel(x - vtxPos.GetX());
+    const double z(pCaloHit->GetPositionVector().GetZ());
+    const double zRel(z - vtxPos.GetZ());
+    const double rRel(std::sqrt(std::pow(xRel, 2.) + std::pow(zRel, 2.)));
+    const double cosThetaRel(rRel != 0. ? xRel / rRel : 0.);
+    const double sinThetaRel(rRel != 0. ? zRel / rRel : 0.);
 
-    double distToXGap{std::numeric_limits<double>::max()};
+    double distToXGap(std::numeric_limits<double>::max());
     for (const double xGap : detXGaps)
     {
-        const double dist{x - xGap};
-        if (std::abs(dist) < std::abs(distToXGap))
-        {
-                distToXGap = dist;
-        }
+        const double dist(x - xGap);
+        if (std::abs(dist) < distToXGap)
+            distToXGap = dist;
     }
 
     hitFeatures.m_xRel = static_cast<float>(xRel);

--- a/larpandoradlcontent/LArHelpers/LArDLShowerHelper.h
+++ b/larpandoradlcontent/LArHelpers/LArDLShowerHelper.h
@@ -1,0 +1,55 @@
+/**
+ *  @file   larpandoradlcontent/LArHelpers/LArDLShowerHelper.h
+ *
+ *  @brief  Header file for the DL shower helper class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_DL_SHOWER_HELPER_H
+#define LAR_DL_SHOWER_HELPER_H 1
+
+#include "Pandora/StatusCodes.h"
+
+#include "Objects/CaloHit.h"
+
+#include <set>
+
+namespace lar_dl_content
+{
+
+/**
+ *  @brief  LArDLShowerHelper class
+ */
+class LArDLShowerHelper
+{
+public:
+    struct HitFeatures
+    {
+        HitFeatures();
+
+        float m_xRel;
+        float m_zRel;
+        float m_rRel;
+        float m_cosThetaRel;
+        float m_sinThetaRel;
+        float m_distToXGap;
+        float m_xWidth;
+        float m_energy;
+    };
+
+    /**
+     *  @brief Calculate all properties of a hit relevant for constructing the hit feature vector.
+     *         for use in the DLShowerGrowing and DLShowerMatching algorithm networks
+     *
+     *  @param pCaloHit the input hit
+     *  @param detXGaps the boundaries of the 'line gaps' within the detector i.e. those that span the drift coordinate
+     *  @param vtxPos the position of the 2D neutrino vertex associated with the hit
+     *  @param hitFeatures[out] struct to store calculated hit properties
+     */
+    static void CalculateHitFeatures(const pandora::CaloHit *const pCaloHit, const std::set<float> &detXGaps,
+        pandora::CartesianVector vtxPos, HitFeatures &hitFeatures);
+};
+
+} // namespace lar_dl_content
+
+#endif // #ifndef LAR_DL_SHOWER_HELPER_H

--- a/larpandoradlcontent/LArHelpers/LArDLShowerHelper.h
+++ b/larpandoradlcontent/LArHelpers/LArDLShowerHelper.h
@@ -47,7 +47,7 @@ public:
      *  @param hitFeatures[out] struct to store calculated hit properties
      */
     static void CalculateHitFeatures(const pandora::CaloHit *const pCaloHit, const std::set<float> &detXGaps,
-        pandora::CartesianVector vtxPos, HitFeatures &hitFeatures);
+        const pandora::CartesianVector &vtxPos, HitFeatures &hitFeatures);
 };
 
 } // namespace lar_dl_content

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.cc
@@ -1,0 +1,776 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArThreeDBase/MultiViewMatchingAlgorithm.cc
+ *
+ *  @brief  Implementation of the multi view matching algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArFileHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+
+#include "larpandoradlcontent/LArHelpers/LArDLHelper.h"
+#include "larpandoradlcontent/LArHelpers/LArDLShowerHelper.h"
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h"
+
+using namespace pandora;
+using namespace lar_content;
+
+namespace lar_dl_content
+{
+
+DLMultiViewMatchingAlgorithm::DLMultiViewMatchingAlgorithm() :
+    m_trainingMode(false),
+    m_trainingFileName("ShowerMatchingTraining.root"),
+    m_trainingTreeName("trainingTree"),
+    m_minNClusterHits(5),    
+    m_nMaxRepeats(2),
+    m_minWireOverlapFraction(0.8f),
+    m_hitFeatureDim(14),
+    m_polarRScaleFactor{1.f},
+    m_cartesianXScaleFactor{1.f},
+    m_cartesianZScaleFactor{1.f},
+    m_matchThreshold(0.5f)    
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+DLMultiViewMatchingAlgorithm::~DLMultiViewMatchingAlgorithm()
+{
+    if (m_trainingMode)
+    {
+        PANDORA_MONITORING_API(SaveTree(this->GetPandora(), m_trainingTreeName, m_trainingFileName, "UPDATE"));
+
+        for ([[maybe_unused]] const HitType &view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
+        {
+            PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName + "_view_data", "view", static_cast<int>(view)));
+            PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(),
+                m_trainingTreeName + "_view_data", "pitch", lar_content::LArGeometryHelper::GetWirePitch(this->GetPandora(), view)));
+            PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_trainingTreeName + "_view_data"));
+        }
+        PANDORA_MONITORING_API(SaveTree(this->GetPandora(), m_trainingTreeName + "_view_data", m_trainingFileName, "UPDATE"));
+    }
+}
+    
+//------------------------------------------------------------------------------------------------------------------------------------------    
+
+StatusCode DLMultiViewMatchingAlgorithm::Run()
+{
+    // Get lists
+    const ClusterList *pClusterListU(nullptr), *pClusterListV(nullptr), *pClusterListW(nullptr);
+    if (this->GetList(m_clusterListNameU, pClusterListU) != STATUS_CODE_SUCCESS)
+        return STATUS_CODE_NOT_FOUND;
+    if (this->GetList(m_clusterListNameV, pClusterListV) != STATUS_CODE_SUCCESS)
+        return STATUS_CODE_NOT_FOUND;
+    if (this->GetList(m_clusterListNameW, pClusterListW) != STATUS_CODE_SUCCESS)
+        return STATUS_CODE_NOT_FOUND;
+    
+    // Initialise
+    ClusterExtentMap clusterExtentMap;
+    this->PrepareClusters(pClusterListU, pClusterListV, pClusterListW, clusterExtentMap);
+
+    // Get navigation maps
+    this->FillNavigationMaps(clusterExtentMap);
+
+    // Get initial connected cluster groups (before applying score)
+    ClusterGroupVector clusterGroupVector;
+    this->GetConnectedGroups(clusterGroupVector);
+
+    if (m_trainingMode)
+    {
+        this->PrepareTrainingSample(clusterGroupVector);
+    }
+    else
+    {
+        // Calculate global sim matrix
+        SimilarityMatrix globalSimMatrix;
+        this->FillGlobalSimMatrix(clusterGroupVector, globalSimMatrix);
+        
+        // Update connected cluster groups
+        this->UpdateNavigationMaps(globalSimMatrix);
+    
+        // Run algorithms
+        bool repeat(true);        
+        unsigned int repeatCounter(0);
+        while (repeat && (repeatCounter < m_nMaxRepeats))
+        {
+            repeat = false;
+            ++repeatCounter;            
+            for (const auto &matchingTool : m_matchingToolVector)
+            {
+                const bool particlesMade(matchingTool->Run(this, globalSimMatrix));
+                repeat = repeat ? repeat : particlesMade;               
+            }
+        }
+    }
+
+    // Reset containers
+    this->CleanUp();
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------  
+
+template <typename T>
+StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string listName, const T *&pList)
+{
+    pList = nullptr;
+
+    if (PandoraContentApi::GetList(*this, listName, pList) != STATUS_CODE_SUCCESS)
+        return STATUS_CODE_NOT_FOUND;
+
+    if ((!pList) || pList->empty())
+        return STATUS_CODE_NOT_FOUND;
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------    
+
+void DLMultiViewMatchingAlgorithm::PrepareClusters(const ClusterList *const pClusterListU, const ClusterList *const pClusterListV,
+    const ClusterList *const pClusterListW, ClusterExtentMap &clusterExtentMap)
+{
+    for (const ClusterList *const pClusterList : {pClusterListU, pClusterListV, pClusterListW})
+    {
+        if (pClusterList->empty())
+            continue;
+
+        const HitType hitType(LArClusterHelper::GetClusterHitType(pClusterList->front()));
+        ClusterList &filteredClusters((hitType == TPC_VIEW_U) ? m_filteredU : (hitType == TPC_VIEW_V) ? m_filteredV : m_filteredW);
+        
+        for (const Cluster *const pCluster : *pClusterList)
+        {
+            if (!pCluster->IsAvailable())
+                continue;
+            
+            if (pCluster->GetNCaloHits() < m_minNClusterHits)
+                continue;
+
+            filteredClusters.emplace_back(pCluster);
+
+            // Get drift-extent
+            CartesianVector minCoord(0.f, 0.f, 0.f), maxCoord(0.f, 0.f, 0.f);
+            LArClusterHelper::GetClusterBoundingBox(pCluster, minCoord, maxCoord);
+
+            clusterExtentMap[pCluster] = std::pair(minCoord.GetX(), maxCoord.GetX());           
+        }
+    }    
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------    
+
+void DLMultiViewMatchingAlgorithm::FillNavigationMaps(const ClusterExtentMap &clusterExtentMap)
+{
+    std::vector<std::pair<HitType, HitType>> viewCombinations({{TPC_VIEW_U, TPC_VIEW_V}, {TPC_VIEW_U, TPC_VIEW_W}, {TPC_VIEW_V, TPC_VIEW_W}});
+    for (const auto& [hitType, projHitType] : viewCombinations)
+    {
+        const ClusterList &clusters((hitType == TPC_VIEW_U) ? m_filteredU : (hitType == TPC_VIEW_V) ? m_filteredV : m_filteredW);
+        const ClusterList &projClusters((projHitType == TPC_VIEW_U) ? m_filteredU : (projHitType == TPC_VIEW_V) ? m_filteredV : m_filteredW);        
+        NavigationMap &navigationMap((hitType == TPC_VIEW_U) ? m_navigationU : (hitType == TPC_VIEW_V) ? m_navigationV : m_navigationW);
+        NavigationMap &projNavigationMap((projHitType == TPC_VIEW_U) ? m_navigationU : (projHitType == TPC_VIEW_V) ? m_navigationV : m_navigationW);
+
+        for (const Cluster *const pCluster : clusters)
+        {
+            for (const Cluster *const pProjCluster : projClusters)
+            {
+                if (this->DoClustersOverlap(pCluster, pProjCluster, clusterExtentMap))
+                {
+                    navigationMap[pCluster].emplace_back(pProjCluster);
+                    projNavigationMap[pProjCluster].emplace_back(pCluster);
+                }
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------  
+    
+bool DLMultiViewMatchingAlgorithm::DoClustersOverlap(const Cluster *const pCluster1, const Cluster *const pCluster2, const ClusterExtentMap &clusterExtentMap)
+{
+    const std::pair<float, float> &driftExtent1(clusterExtentMap.at(pCluster1));
+    const std::pair<float, float> &driftExtent2(clusterExtentMap.at(pCluster2));
+    const float minX(std::max(driftExtent1.first, driftExtent2.first));
+    const float maxX(std::min(driftExtent1.second, driftExtent2.second));            
+    const float driftSpan(maxX - minX);
+            
+    if (driftSpan < std::numeric_limits<float>::epsilon())
+        return false;
+
+    return this->DoClustersOverlapInWire(pCluster1, pCluster2, minX, maxX);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------      
+
+bool DLMultiViewMatchingAlgorithm::DoClustersOverlapInWire(const Cluster *const pCluster1, const Cluster *const pCluster2, const float minX, const float maxX)
+{
+    CaloHitList caloHitList1, caloHitList2, filteredCaloHitList2;
+    LArClusterHelper::GetAllHits(pCluster1, caloHitList1);
+    LArClusterHelper::GetAllHits(pCluster2, caloHitList2);    
+    for (const CaloHit *const pCaloHit2 : caloHitList2)
+    {
+        if ((pCaloHit2->GetPositionVector().GetX() < minX) || (pCaloHit2->GetPositionVector().GetX() > maxX))
+            continue;
+
+        filteredCaloHitList2.emplace_back(pCaloHit2);
+    }
+
+    // Search for overlap
+    int overlapCount(0), nSamplingPoints1(0);
+    const int nSamplingPoints2(filteredCaloHitList2.size());    
+    for (const CaloHit *const pCaloHit1 : caloHitList1)
+    {
+        const LArCaloHit *const pLArHit1(dynamic_cast<const LArCaloHit *>(pCaloHit1));
+
+        if (!pLArHit1)
+            continue;
+        
+        if ((pCaloHit1->GetPositionVector().GetX() < minX) || (pCaloHit1->GetPositionVector().GetX() > maxX))
+            continue;
+
+        ++nSamplingPoints1;
+        
+        for (const CaloHit *const pCaloHit2 : caloHitList2)
+        {
+            const LArCaloHit *const pLArHit2(dynamic_cast<const LArCaloHit *>(pCaloHit2));
+
+            if (!pLArHit2)
+                continue;
+            
+            // tpc & child volume should be the same
+            if ((pLArHit1->GetLArTPCVolumeId() != pLArHit2->GetLArTPCVolumeId()) ||
+                (pLArHit1->GetDaughterVolumeId() != pLArHit2->GetDaughterVolumeId()))
+            {
+                continue;
+            }
+
+            const unsigned int wireId2(pLArHit2->GetWireId());
+            
+            // make sure wire intersects with proj planes
+            if (pLArHit2->GetPlane() == pLArHit1->GetPlane1())
+            {
+                const unsigned int minWireIntersect(pLArHit1->GetMinIntersectWire1());
+                const unsigned int maxWireIntersect(pLArHit1->GetMaxIntersectWire1());
+                
+                if ((minWireIntersect <= wireId2) && (maxWireIntersect >= wireId2))
+                {
+                    overlapCount++;
+                    break;
+                }
+            }
+            else
+            {
+                const unsigned int minWireIntersect(pLArHit1->GetMinIntersectWire2());
+                const unsigned int maxWireIntersect(pLArHit1->GetMaxIntersectWire2());
+                
+                if ((minWireIntersect <= wireId2) && (maxWireIntersect >= wireId2))
+                {
+                    overlapCount++;
+                    break;
+                }
+            }
+        }
+    }
+
+    const float overlapFraction1(nSamplingPoints1 == 0 ? 0.f : float(overlapCount) / float(nSamplingPoints1));
+    const float overlapFraction2(nSamplingPoints2 == 0 ? 0.f : float(overlapCount) / float(nSamplingPoints2));
+    return ((overlapFraction1 > m_minWireOverlapFraction) && (overlapFraction2 > m_minWireOverlapFraction));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------    
+
+void DLMultiViewMatchingAlgorithm::GetConnectedGroups(ClusterGroupVector &clusterGroupVector)
+{
+    ClusterList usedU, usedV, usedW;
+    
+    for (const ClusterList &clusterList : {m_filteredU, m_filteredV, m_filteredW})
+    {
+        for (const Cluster *const pCluster : clusterList)
+        {
+            ClusterGroup clusterGroup;
+            this->GetConnectedGroup(pCluster, clusterGroup, usedU, usedV, usedW);
+
+            int nU(clusterGroup.m_clustersU.size()), nV(clusterGroup.m_clustersV.size()), nW(clusterGroup.m_clustersW.size());
+            
+            if ((nU + nV + nW) <= 1)
+                continue;
+
+            clusterGroupVector.push_back(clusterGroup);  
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------    
+
+void DLMultiViewMatchingAlgorithm::GetConnectedGroup(const Cluster *const pCluster, ClusterGroup &clusterGroup, ClusterList &usedU, ClusterList &usedV, ClusterList &usedW)
+{
+    if (!pCluster->IsAvailable())
+        return;
+    
+    const HitType hitType(LArClusterHelper::GetClusterHitType(pCluster));
+    ClusterList &used((hitType == TPC_VIEW_U) ? usedU : (hitType == TPC_VIEW_V) ? usedV : usedW);
+        
+    if (std::find(used.begin(), used.end(), pCluster) != used.end())
+        return;
+
+    // Add cluster
+    ClusterList &clusterGroupList((hitType == TPC_VIEW_U) ? clusterGroup.m_clustersU : (hitType == TPC_VIEW_V) ? clusterGroup.m_clustersV : clusterGroup.m_clustersW);
+    clusterGroupList.emplace_back(pCluster);
+    used.emplace_back(pCluster);
+    
+    // Now find its connections and add those
+    const NavigationMap &navigation((hitType == TPC_VIEW_U) ? m_navigationU : (hitType == TPC_VIEW_V) ? m_navigationV : m_navigationW);
+    const auto navIter(navigation.find(pCluster));
+
+    if (navIter == navigation.end())
+        return;
+    
+    for (const Cluster *const pNavCluster : navIter->second)
+        this->GetConnectedGroup(pNavCluster, clusterGroup, usedU, usedV, usedW);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------     
+    
+void DLMultiViewMatchingAlgorithm::FillGlobalSimMatrix(const ClusterGroupVector &clusterGroupVector, SimilarityMatrix &globalSimMatrix)
+{
+    // Get nu vertex projections
+    const VertexList *pVertexList(nullptr);
+    if (this->GetList(m_nuVertexListName, pVertexList) != STATUS_CODE_SUCCESS)
+        return;
+    const Vertex *const pVertex(pVertexList->front());
+    PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, pVertex->GetVertexType() != VERTEX_3D);
+    const std::map<HitType, CartesianVector> viewToVtxPos(
+           {{TPC_VIEW_U, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U)},
+            {TPC_VIEW_V, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V)},
+            {TPC_VIEW_W, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W)}});
+
+    // Get detector x-gaps
+    std::set<float> detXGaps;
+    LArGeometryHelper::GetDetectorXGaps(this->GetPandora(), detXGaps);
+
+    // Add scores to the global similarity matrix
+    for (const ClusterGroup &clusterGroup : clusterGroupVector)
+    {
+        this->PredictClusterSimilarityMatrix(clusterGroup.m_clustersU, clusterGroup.m_clustersV, clusterGroup.m_clustersW,
+            viewToVtxPos, detXGaps, globalSimMatrix);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode DLMultiViewMatchingAlgorithm::PredictClusterSimilarityMatrix(const ClusterList &clusterListU, const ClusterList &clusterListV, const ClusterList &clusterListW, 
+    const std::map<HitType, CartesianVector> &viewToVtxPos, const std::set<float> &detXGaps, SimilarityMatrix &clusterSimMat)
+{
+    // First sort the lists
+    ClusterVector clusterVecU(clusterListU.begin(), clusterListU.end());
+    std::sort(clusterVecU.begin(), clusterVecU.end(), LArClusterHelper::SortByNHits);
+    ClusterVector clusterVecV(clusterListV.begin(), clusterListV.end());
+    std::sort(clusterVecV.begin(), clusterVecV.end(), LArClusterHelper::SortByNHits);
+    ClusterVector clusterVecW(clusterListW.begin(), clusterListW.end());
+    std::sort(clusterVecW.begin(), clusterVecW.end(), LArClusterHelper::SortByNHits);
+    int nClusters(clusterVecU.size() + clusterVecV.size() + clusterVecW.size());
+    ClusterVector clusterVec;
+    clusterVec.insert(clusterVec.end(), clusterVecU.begin(), clusterVecU.end());
+    clusterVec.insert(clusterVec.end(), clusterVecV.begin(), clusterVecV.end());
+    clusterVec.insert(clusterVec.end(), clusterVecW.begin(), clusterVecW.end());
+
+    // Get our similarity matrix
+    torch::InferenceMode guard;
+    std::vector<torch::Tensor> tensorEncodedClusters;
+
+    for (const Cluster *const pCluster : clusterVec)
+    {
+        CaloHitList clusterHits;
+        LArClusterHelper::GetAllHits(pCluster, clusterHits);
+
+        const HitType view(LArClusterHelper::GetClusterHitType(pCluster));
+
+        std::vector<LArDLShowerHelper::HitFeatures> clusterFeatures;
+        for (const CaloHit *const pCaloHit : clusterHits)
+        {
+            LArDLShowerHelper::HitFeatures hitFeatures;
+            LArDLShowerHelper::CalculateHitFeatures(pCaloHit, detXGaps, viewToVtxPos.at(view), hitFeatures);
+            clusterFeatures.emplace_back(hitFeatures);
+        }
+
+        torch::Tensor tensorCluster;
+        this->MakeClusterTensor(clusterFeatures, view, nClusters, tensorCluster);
+        torch::Tensor tensorEncodedCluster{m_modelEncoder.forward({tensorCluster}).toTensor()};
+        tensorEncodedClusters.emplace_back(tensorEncodedCluster);
+    }
+
+    torch::Tensor tensorEncodedEvent{torch::cat(tensorEncodedClusters, 1)};
+    tensorEncodedClusters.clear(); // Free memory
+    torch::Tensor tensorAttnEvent{m_modelAttn.forward({tensorEncodedEvent}).toTensor()};
+    tensorEncodedEvent = torch::Tensor(); // Free memory
+    torch::Tensor tensorSimMat{m_modelSim.forward({tensorAttnEvent}).toTensor()};
+    tensorAttnEvent = torch::Tensor();
+
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->PopulateClusterSimilarityMatrix(tensorSimMat, clusterVec, clusterSimMat));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void DLMultiViewMatchingAlgorithm::MakeClusterTensor(const std::vector<LArDLShowerHelper::HitFeatures> &clusterFeatures, const HitType view,
+    const int nClusters, torch::Tensor &tensorCluster) const
+{
+    // Global features
+    const int nHits{static_cast<int>(clusterFeatures.size())};
+    const float nHitsFeat{std::log(static_cast<float>(nHits))};
+    const float nClustersFeat{std::log(static_cast<float>(nClusters))};
+    const float zWidthFeat{LArGeometryHelper::GetWirePitch(this->GetPandora(), view) * m_cartesianZScaleFactor};
+
+    // Fill tensor
+    tensorCluster = torch::zeros({1, nHits, m_hitFeatureDim});
+    auto accessor = tensorCluster.accessor<float, 3>();
+    for (int i = 0; i < nHits; i++)
+    {
+        const LArDLShowerHelper::HitFeatures hitFeatures{clusterFeatures.at(i)};
+        accessor[0][i][0] = hitFeatures.m_rRel * m_polarRScaleFactor;
+        accessor[0][i][1] = hitFeatures.m_cosThetaRel;
+        accessor[0][i][2] = hitFeatures.m_sinThetaRel;
+        accessor[0][i][3] = hitFeatures.m_xRel * m_cartesianXScaleFactor;
+        accessor[0][i][4] = hitFeatures.m_zRel * m_cartesianZScaleFactor;
+        accessor[0][i][5] = hitFeatures.m_xWidth * m_cartesianXScaleFactor;
+        accessor[0][i][6] = zWidthFeat;
+        accessor[0][i][7] = hitFeatures.m_distToXGap * m_cartesianXScaleFactor;
+        accessor[0][i][8] = std::log(hitFeatures.m_energy);
+        accessor[0][i][9] = view == TPC_VIEW_U ? 1.f : 0.f;
+        accessor[0][i][10] = view == TPC_VIEW_V ? 1.f : 0.f;
+        accessor[0][i][11] = view == TPC_VIEW_W ? 1.f : 0.f;
+        accessor[0][i][12] = nHitsFeat;
+        accessor[0][i][13] = nClustersFeat;
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode DLMultiViewMatchingAlgorithm::PopulateClusterSimilarityMatrix(const torch::Tensor &tensorSimMat, const ClusterVector &clusterVector,
+    SimilarityMatrix &clusterSimMat) const
+{
+    // Check predicted sim matrics
+    const int64_t nClusters{static_cast<int64_t>(clusterVector.size())};
+    PANDORA_RETURN_IF(STATUS_CODE_NOT_ALLOWED, tensorSimMat.dim() != 3 || nClusters != tensorSimMat.size(-1) || nClusters != tensorSimMat.size(-2));
+    
+    // Populate SimilarityMatrix
+    auto accessor = tensorSimMat.accessor<float, 3>();
+    auto iterI{clusterVector.begin()};
+    for (int i = 0; i < nClusters; i++, iterI++)
+    {
+        auto iterJ{clusterVector.begin()};
+        for (int j = 0; j < nClusters; j++, iterJ++)
+            clusterSimMat[*iterI][*iterJ] = accessor[0][i][j];
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------    
+
+void DLMultiViewMatchingAlgorithm::UpdateNavigationMaps(const SimilarityMatrix &globalSimMatrix)
+{
+    for (const HitType &hitType : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
+    {
+        NavigationMap &navigationMap((hitType == TPC_VIEW_U) ? m_navigationU : (hitType == TPC_VIEW_V) ? m_navigationV : m_navigationW);
+
+        for (auto &[pCluster, clusterList] : navigationMap)
+        {
+            for (auto iter = clusterList.begin(); iter != clusterList.end(); )
+            {
+                auto simIter1(globalSimMatrix.find(pCluster));
+                if (simIter1 == globalSimMatrix.end()) {++iter; continue;}
+                auto simIter2(simIter1->second.find(*iter));
+                if (simIter2 == simIter1->second.end()) {++iter; continue;}                
+
+                if (simIter2->second < m_matchThreshold)
+                    iter = clusterList.erase(iter);
+                else
+                    ++iter;
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void DLMultiViewMatchingAlgorithm::CreatePfo(const ClusterList &clusters)
+{
+    const PfoList *pPfoList(nullptr);
+    std::string pfoListName;
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, pfoListName));
+
+    PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
+    pfoParameters.m_particleId = E_MINUS;
+    pfoParameters.m_charge = PdgTable::GetParticleCharge(pfoParameters.m_particleId.Get());
+    pfoParameters.m_mass = PdgTable::GetParticleMass(pfoParameters.m_particleId.Get());
+    pfoParameters.m_energy = 0.f;
+    pfoParameters.m_momentum = CartesianVector(0.f, 0.f, 0.f);
+    pfoParameters.m_clusterList = clusters;
+    
+    const ParticleFlowObject *pPfo(nullptr);
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pPfo));
+
+    if (!pPfoList->empty())
+    {
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, m_outputPfoListName));
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Pfo>(*this, m_outputPfoListName));
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void DLMultiViewMatchingAlgorithm::DeleteCluster(const Cluster *const pClusterToRemove)
+{
+    // Remove from filtered lists
+    const HitType hitType(LArClusterHelper::GetClusterHitType(pClusterToRemove));
+    ClusterList &filteredClusters((hitType == TPC_VIEW_U) ? m_filteredU : (hitType == TPC_VIEW_V) ? m_filteredV : m_filteredW);
+
+    auto iter(std::find(filteredClusters.begin(), filteredClusters.end(), pClusterToRemove));
+    if (iter != filteredClusters.end()) { filteredClusters.erase(iter); }
+
+    // Remove from navigation maps
+    NavigationMap &navigation((hitType == TPC_VIEW_U) ? m_navigationU : (hitType == TPC_VIEW_V) ? m_navigationV : m_navigationW);
+    auto iterNav(navigation.find(pClusterToRemove));
+
+    if (iterNav != navigation.end())
+    {
+        for (const Cluster *const pAssocCluster : iterNav->second)
+        {
+            const HitType assocHitType(LArClusterHelper::GetClusterHitType(pAssocCluster));
+            NavigationMap &assocNavigation((assocHitType == TPC_VIEW_U) ? m_navigationU : (assocHitType == TPC_VIEW_V) ? m_navigationV : m_navigationW);
+
+            auto iterAssoc(assocNavigation.find(pAssocCluster));
+            if (iterAssoc == assocNavigation.end()) { continue; }
+
+            auto iterRemove(std::find(iterAssoc->second.begin(), iterAssoc->second.end(), pClusterToRemove));
+            if (iterRemove != iterAssoc->second.end()) { iterAssoc->second.erase(iterRemove); }
+        }
+
+        navigation.erase(iterNav);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void DLMultiViewMatchingAlgorithm::PrepareTrainingSample(const ClusterGroupVector &clusterGroupVector)
+{
+    // Get nu vertex projections
+    const VertexList *pVertexList{nullptr};
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_nuVertexListName, pVertexList));
+    const Vertex *const pVertex{pVertexList->front()};
+    PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, pVertex->GetVertexType() != VERTEX_3D);
+    const std::map<HitType, CartesianVector> viewToVtxPos(
+           {{TPC_VIEW_U, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_U)},
+            {TPC_VIEW_V, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V)},
+            {TPC_VIEW_W, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W)}});
+
+    // Get detector x-gaps
+    std::set<float> detXGaps;
+    LArGeometryHelper::GetDetectorXGaps(this->GetPandora(), detXGaps);
+
+    // Fill tree for each isolated group
+    for (const ClusterGroup &clusterGroup : clusterGroupVector)
+    {
+        // The vectors to fill
+        int currClusterID{0}, currMCID{0};
+        std::map<const MCParticle *const, int> mcToID = {{nullptr, -1}}, mcToPDG = {{nullptr, 0}};
+        std::vector<int> clusterView, clusterID;
+        std::vector<int> mcID = {-1}, mcPDG = {0};
+        std::vector<int> hitClusterID;
+        std::vector<float> hitXRelPos, hitZRelPos;
+        std::vector<float> hitRRelPos, hitSinThetaRelPos, hitCosThetaRelPos; // Polar coordinates
+        std::vector<float> hitXWidth;
+        std::vector<float> hitDistToXGap;
+        std::vector<float> hitEnergy;
+        std::vector<int> hitMCID;
+
+        for (const ClusterList &clusterList : {clusterGroup.m_clustersU, clusterGroup.m_clustersV, clusterGroup.m_clustersW})
+        {
+            for (const Cluster *const pCluster : clusterList)
+            {
+                const HitType view{LArClusterHelper::GetClusterHitType(pCluster)};
+                bool filled(false);
+
+                CaloHitList clusterCaloHits;
+                LArClusterHelper::GetAllHits(pCluster, clusterCaloHits);
+                for (const CaloHit *const pCaloHit : clusterCaloHits)
+                {
+                    LArDLShowerHelper::HitFeatures hitFeatures;
+                    LArDLShowerHelper::CalculateHitFeatures(pCaloHit, detXGaps, viewToVtxPos.at(view), hitFeatures);
+
+                    try
+                    {
+                        // Get MC match
+                        const MCParticle *const pMainMC{MCParticleHelper::GetMainMCParticle(pCaloHit)};
+
+                        // Fill out MC info for event
+                        if (mcToID.find(pMainMC) == mcToID.end())
+                        {
+                            mcToID.insert({pMainMC, currMCID++});
+                            mcToPDG.insert({pMainMC, pMainMC->GetParticleId()});
+                            mcID.emplace_back(mcToID.at(pMainMC));
+                            mcPDG.emplace_back(mcToPDG.at(pMainMC));
+                        }
+
+                        // Fill out info for hit
+                        filled = true;
+                        hitClusterID.emplace_back(currClusterID);
+                        hitXRelPos.emplace_back(hitFeatures.m_xRel);
+                        hitZRelPos.emplace_back(hitFeatures.m_zRel);
+                        hitRRelPos.emplace_back(hitFeatures.m_rRel);
+                        hitCosThetaRelPos.emplace_back(hitFeatures.m_cosThetaRel);
+                        hitSinThetaRelPos.emplace_back(hitFeatures.m_sinThetaRel);
+                        hitXWidth.emplace_back(hitFeatures.m_xWidth);
+                        hitDistToXGap.emplace_back(hitFeatures.m_distToXGap);
+                        hitEnergy.emplace_back(hitFeatures.m_energy);
+                        hitMCID.emplace_back(mcToID.at(pMainMC));
+                    }
+                    catch(...) { continue; }
+                }
+
+                if (filled)
+                {
+                    clusterView.emplace_back(static_cast<int>(view));
+                    clusterID.emplace_back(currClusterID);
+
+                    currClusterID++;
+                }
+            }
+        }
+
+        // Fill tree
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "cluster_id", &clusterID));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "cluster_view", &clusterView));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "mc_id", &mcID));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "mc_pdg", &mcPDG));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_cluster_id", &hitClusterID));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_x_rel_pos", &hitXRelPos));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_z_rel_pos", &hitZRelPos));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_r_rel_pos", &hitRRelPos));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_ctheta_rel_pos", &hitCosThetaRelPos));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_stheta_rel_pos", &hitSinThetaRelPos));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_x_width", &hitXWidth));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_x_gap_dist", &hitDistToXGap));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_energy", &hitEnergy));
+        PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "hit_mc_id", &hitMCID));
+        PANDORA_MONITORING_API(FillTree(this->GetPandora(), m_trainingTreeName));
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------    
+
+void DLMultiViewMatchingAlgorithm::CleanUp()
+{
+    m_filteredU.clear();
+    m_filteredV.clear();
+    m_filteredW.clear();
+    m_navigationU.clear();
+    m_navigationV.clear();
+    m_navigationW.clear();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+    
+StatusCode DLMultiViewMatchingAlgorithm::ReadSettings([[maybe_unused]] const TiXmlHandle xmlHandle)
+{
+    AlgorithmToolVector algorithmToolVector;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, 
+        XmlHelper::ProcessAlgorithmToolList(*this, xmlHandle, "MatchingTools", algorithmToolVector));
+
+    for (AlgorithmToolVector::const_iterator iter = algorithmToolVector.begin(), iterEnd = algorithmToolVector.end(); iter != iterEnd; ++iter)
+    {
+        DLShowerMatchingTool *const pMatchingTool(dynamic_cast<DLShowerMatchingTool *>(*iter));
+
+        if (!pMatchingTool)
+            return STATUS_CODE_INVALID_PARAMETER;
+
+        m_matchingToolVector.push_back(pMatchingTool);
+    }
+    
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "NuVertexListName", m_nuVertexListName));
+    if (m_nuVertexListName.empty())
+        m_nuVertexListName = "NeutrinoVertices3D";
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameU", m_clusterListNameU));
+    if (m_clusterListNameU.empty())
+        m_clusterListNameU = "ClustersU";
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameV", m_clusterListNameV));
+    if (m_clusterListNameV.empty())
+        m_clusterListNameV = "ClustersV";
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameW", m_clusterListNameW));
+    if (m_clusterListNameW.empty())
+        m_clusterListNameW = "ClustersW";
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "OutputPfoListName", m_outputPfoListName));
+    if (m_outputPfoListName.empty())
+        m_outputPfoListName = "ShowerParticles3D";
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "TrainingMode", m_trainingMode));
+
+    if (m_trainingMode)
+    {
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, 
+            XmlHelper::ReadValue(xmlHandle, "TrainingFileName", m_trainingFileName));
+
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, 
+            XmlHelper::ReadValue(xmlHandle, "TrainingTreeName", m_trainingTreeName));
+    }
+    else
+    {
+        std::string modelEncoderName, modelAttnName, modelSimName;
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ModelEncoderFileName", modelEncoderName));
+        modelEncoderName = LArFileHelper::FindFileInPath(modelEncoderName, "FW_SEARCH_PATH");
+        LArDLHelper::LoadModel(modelEncoderName, m_modelEncoder);
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ModelAttnFileName", modelAttnName));
+        modelAttnName = LArFileHelper::FindFileInPath(modelAttnName, "FW_SEARCH_PATH");
+        LArDLHelper::LoadModel(modelAttnName, m_modelAttn);
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "ModelSimFileName", modelSimName));
+        modelSimName = LArFileHelper::FindFileInPath(modelSimName, "FW_SEARCH_PATH");
+        LArDLHelper::LoadModel(modelSimName, m_modelSim);                
+        
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, 
+            XmlHelper::ReadValue(xmlHandle, "NMaxRepeats", m_nMaxRepeats));
+               
+        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, 
+            XmlHelper::ReadValue(xmlHandle, "HitFeatureDim", m_hitFeatureDim));
+    }
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MinNClusterHits", m_minNClusterHits));
+
+     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, 
+        XmlHelper::ReadValue(xmlHandle, "MinWireOverlapFraction", m_minWireOverlapFraction));
+    
+    const LArGeometryHelper::DetectorBoundaries detBounds{LArGeometryHelper::GetDetectorBoundaries(this->GetPandora())};
+    double xLow{static_cast<double>(detBounds.m_xBoundaries.first)}, xHigh{static_cast<double>(detBounds.m_xBoundaries.second)};
+    double yLow{static_cast<double>(detBounds.m_yBoundaries.first)}, yHigh{static_cast<double>(detBounds.m_yBoundaries.second)};
+    double zLow{static_cast<double>(detBounds.m_zBoundaries.first)}, zHigh{static_cast<double>(detBounds.m_zBoundaries.second)};
+    m_polarRScaleFactor = static_cast<float>(1. / std::sqrt(std::pow(xHigh - xLow, 2.) + std::pow(yHigh - yLow, 2.) + std::pow(zHigh - zLow, 2.)));
+    m_cartesianXScaleFactor = static_cast<float>(1. / (xHigh - xLow));
+    m_cartesianZScaleFactor = static_cast<float>(1. / (zHigh - zLow));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "MatchThreshold", m_matchThreshold));
+    
+    return STATUS_CODE_SUCCESS;
+
+}   
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string, const ClusterList *&);
+template StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string, const VertexList *&);
+template StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string, const MCParticleList *&);
+
+} // namespace lar_dl_content

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.cc
@@ -8,6 +8,8 @@
 
 #include "Pandora/AlgorithmHeaders.h"
 
+#include "Geometry/LArReadoutChannel.h"
+
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArFileHelper.h"
@@ -120,7 +122,7 @@ StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string listName, con
     return STATUS_CODE_SUCCESS;
 }
 
-//------------------------------------------------------------------------------------------------------------------------------------------    
+// //------------------------------------------------------------------------------------------------------------------------------------------    
 
 void DLMultiViewMatchingAlgorithm::PrepareClusters(const ClusterList *const pClusterListU, const ClusterList *const pClusterListV,
     const ClusterList *const pClusterListW, ClusterExtentMap &clusterExtentMap)
@@ -152,7 +154,7 @@ void DLMultiViewMatchingAlgorithm::PrepareClusters(const ClusterList *const pClu
     }    
 }
 
-//------------------------------------------------------------------------------------------------------------------------------------------    
+// //------------------------------------------------------------------------------------------------------------------------------------------    
 
 void DLMultiViewMatchingAlgorithm::FillNavigationMaps(const ClusterExtentMap &clusterExtentMap)
 {
@@ -178,7 +180,7 @@ void DLMultiViewMatchingAlgorithm::FillNavigationMaps(const ClusterExtentMap &cl
     }
 }
 
-//------------------------------------------------------------------------------------------------------------------------------------------  
+// //------------------------------------------------------------------------------------------------------------------------------------------  
     
 bool DLMultiViewMatchingAlgorithm::DoClustersOverlap(const Cluster *const pCluster1, const Cluster *const pCluster2, const ClusterExtentMap &clusterExtentMap)
 {
@@ -194,7 +196,7 @@ bool DLMultiViewMatchingAlgorithm::DoClustersOverlap(const Cluster *const pClust
     return this->DoClustersOverlapInWire(pCluster1, pCluster2, minX, maxX);
 }
 
-//------------------------------------------------------------------------------------------------------------------------------------------      
+// //------------------------------------------------------------------------------------------------------------------------------------------      
 
 bool DLMultiViewMatchingAlgorithm::DoClustersOverlapInWire(const Cluster *const pCluster1, const Cluster *const pCluster2, const float minX, const float maxX)
 {
@@ -234,43 +236,31 @@ bool DLMultiViewMatchingAlgorithm::DoClustersOverlapInWire(const Cluster *const 
             if (!pLArHit2)
                 continue;
             
-            // tpc & child volume should be the same
-            if ((pLArHit1->GetLArTPCVolumeId() != pLArHit2->GetLArTPCVolumeId()) ||
-                (pLArHit1->GetDaughterVolumeId() != pLArHit2->GetDaughterVolumeId()))
+            // Readout volume should be the same
+            if (LArGeometryHelper::GetReadoutVolume(this->GetPandora(), *pLArHit1).GetId() !=
+                LArGeometryHelper::GetReadoutVolume(this->GetPandora(), *pLArHit2).GetId())
             {
                 continue;
             }
 
-            const unsigned int wireId2(pLArHit2->GetWireId());
+            // pLAr1 get overlap in pLAr2 hit type...
+            const LArReadoutChannel &readoutChannel1(LArGeometryHelper::GetReadoutChannel(this->GetPandora(), *pLArHit1));
+            const LArReadoutChannel &readoutChannel2(LArGeometryHelper::GetReadoutChannel(this->GetPandora(), *pLArHit2));         
+            const LArReadoutChannel::ChannelInterval &channelIntervalIn2(readoutChannel1.GetChannelInterval(pLArHit2->GetHitType()));
             
-            // make sure wire intersects with proj planes
-            if (pLArHit2->GetPlane() == pLArHit1->GetPlane1())
-            {
-                const unsigned int minWireIntersect(pLArHit1->GetMinIntersectWire1());
-                const unsigned int maxWireIntersect(pLArHit1->GetMaxIntersectWire1());
-                
-                if ((minWireIntersect <= wireId2) && (maxWireIntersect >= wireId2))
-                {
-                    overlapCount++;
-                    break;
-                }
-            }
-            else
-            {
-                const unsigned int minWireIntersect(pLArHit1->GetMinIntersectWire2());
-                const unsigned int maxWireIntersect(pLArHit1->GetMaxIntersectWire2());
-                
-                if ((minWireIntersect <= wireId2) && (maxWireIntersect >= wireId2))
-                {
-                    overlapCount++;
-                    break;
-                }
-            }
+            if ((readoutChannel2.GetId() < channelIntervalIn2.first) || (readoutChannel2.GetId() > channelIntervalIn2.second))
+                continue;
+
+            overlapCount++;
+            break;
         }
     }
 
     const float overlapFraction1(nSamplingPoints1 == 0 ? 0.f : float(overlapCount) / float(nSamplingPoints1));
     const float overlapFraction2(nSamplingPoints2 == 0 ? 0.f : float(overlapCount) / float(nSamplingPoints2));
+    std::cout << "overlapFraction1: " << overlapFraction1 << std::endl;
+    std::cout << "overlapFraction2: " << overlapFraction2 << std::endl;    
+    
     return ((overlapFraction1 > m_minWireOverlapFraction) && (overlapFraction2 > m_minWireOverlapFraction));
 }
 
@@ -512,7 +502,7 @@ void DLMultiViewMatchingAlgorithm::CreatePfo(const ClusterList &clusters)
     }
 }
 
-//------------------------------------------------------------------------------------------------------------------------------------------
+// //------------------------------------------------------------------------------------------------------------------------------------------
 
 void DLMultiViewMatchingAlgorithm::DeleteCluster(const Cluster *const pClusterToRemove)
 {
@@ -747,7 +737,7 @@ StatusCode DLMultiViewMatchingAlgorithm::ReadSettings([[maybe_unused]] const TiX
     return STATUS_CODE_SUCCESS;
 }   
 
-//------------------------------------------------------------------------------------------------------------------------------------------
+// //------------------------------------------------------------------------------------------------------------------------------------------
 
 template StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string, const ClusterList *&);
 template StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string, const VertexList *&);

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.cc
@@ -61,23 +61,16 @@ DLMultiViewMatchingAlgorithm::~DLMultiViewMatchingAlgorithm()
 
 StatusCode DLMultiViewMatchingAlgorithm::Run()
 {
-    // Get lists
     const ClusterList *pClusterListU(nullptr), *pClusterListV(nullptr), *pClusterListW(nullptr);
-    if (this->GetList(m_clusterListNameU, pClusterListU) != STATUS_CODE_SUCCESS)
-        return STATUS_CODE_NOT_FOUND;
-    if (this->GetList(m_clusterListNameV, pClusterListV) != STATUS_CODE_SUCCESS)
-        return STATUS_CODE_NOT_FOUND;
-    if (this->GetList(m_clusterListNameW, pClusterListW) != STATUS_CODE_SUCCESS)
-        return STATUS_CODE_NOT_FOUND;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetList(m_clusterListNameU, pClusterListU));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetList(m_clusterListNameV, pClusterListV));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetList(m_clusterListNameW, pClusterListW));
     
-    // Initialise
     ClusterExtentMap clusterExtentMap;
     this->PrepareClusters(pClusterListU, pClusterListV, pClusterListW, clusterExtentMap);
 
-    // Get navigation maps
     this->FillNavigationMaps(clusterExtentMap);
 
-    // Get initial connected cluster groups (before applying score)
     ClusterGroupVector clusterGroupVector;
     this->GetConnectedGroups(clusterGroupVector);
 
@@ -87,14 +80,11 @@ StatusCode DLMultiViewMatchingAlgorithm::Run()
     }
     else
     {
-        // Calculate global sim matrix
         SimilarityMatrix globalSimMatrix;
         this->FillGlobalSimMatrix(clusterGroupVector, globalSimMatrix);
         
-        // Update connected cluster groups
         this->UpdateNavigationMaps(globalSimMatrix);
     
-        // Run algorithms
         bool repeat(true);        
         unsigned int repeatCounter(0);
         while (repeat && (repeatCounter < m_nMaxRepeats))
@@ -104,12 +94,11 @@ StatusCode DLMultiViewMatchingAlgorithm::Run()
             for (const auto &matchingTool : m_matchingToolVector)
             {
                 const bool particlesMade(matchingTool->Run(this, globalSimMatrix));
-                repeat = repeat ? repeat : particlesMade;               
+                repeat = repeat || particlesMade;
             }
         }
     }
 
-    // Reset containers
     this->CleanUp();
 
     return STATUS_CODE_SUCCESS;
@@ -156,7 +145,7 @@ void DLMultiViewMatchingAlgorithm::PrepareClusters(const ClusterList *const pClu
 
             // Get drift-extent
             CartesianVector minCoord(0.f, 0.f, 0.f), maxCoord(0.f, 0.f, 0.f);
-            LArClusterHelper::GetClusterBoundingBox(pCluster, minCoord, maxCoord);
+            LArClusterHelper::GetClusterBoundingBox(pCluster, minCoord, maxCoord, true);
 
             clusterExtentMap[pCluster] = std::pair(minCoord.GetX(), maxCoord.GetX());           
         }
@@ -209,33 +198,36 @@ bool DLMultiViewMatchingAlgorithm::DoClustersOverlap(const Cluster *const pClust
 
 bool DLMultiViewMatchingAlgorithm::DoClustersOverlapInWire(const Cluster *const pCluster1, const Cluster *const pCluster2, const float minX, const float maxX)
 {
-    CaloHitList caloHitList1, caloHitList2, filteredCaloHitList2;
+    CaloHitList caloHitList1, caloHitList2, filteredCaloHitList1, filteredCaloHitList2;
     LArClusterHelper::GetAllHits(pCluster1, caloHitList1);
-    LArClusterHelper::GetAllHits(pCluster2, caloHitList2);    
-    for (const CaloHit *const pCaloHit2 : caloHitList2)
+    LArClusterHelper::GetAllHits(pCluster2, caloHitList2);
+    
+    for (unsigned int iList : {0, 1})
     {
-        if ((pCaloHit2->GetPositionVector().GetX() < minX) || (pCaloHit2->GetPositionVector().GetX() > maxX))
-            continue;
+        CaloHitList &caloHitList((iList == 0) ? caloHitList1 : caloHitList2);
+        CaloHitList &filteredCaloHitList((iList == 0) ? filteredCaloHitList1 : filteredCaloHitList2);
 
-        filteredCaloHitList2.emplace_back(pCaloHit2);
+        for (const CaloHit *const pCaloHit : caloHitList)
+        {
+            if ((pCaloHit->GetPositionVector().GetX() < minX) || (pCaloHit->GetPositionVector().GetX() > maxX))
+                continue;
+
+            filteredCaloHitList.emplace_back(pCaloHit);
+        }
     }
 
     // Search for overlap
-    int overlapCount(0), nSamplingPoints1(0);
+    int overlapCount(0);
+    const int nSamplingPoints1(filteredCaloHitList1.size());        
     const int nSamplingPoints2(filteredCaloHitList2.size());    
-    for (const CaloHit *const pCaloHit1 : caloHitList1)
+    for (const CaloHit *const pCaloHit1 : filteredCaloHitList1)
     {
         const LArCaloHit *const pLArHit1(dynamic_cast<const LArCaloHit *>(pCaloHit1));
 
         if (!pLArHit1)
             continue;
         
-        if ((pCaloHit1->GetPositionVector().GetX() < minX) || (pCaloHit1->GetPositionVector().GetX() > maxX))
-            continue;
-
-        ++nSamplingPoints1;
-        
-        for (const CaloHit *const pCaloHit2 : caloHitList2)
+        for (const CaloHit *const pCaloHit2 : filteredCaloHitList2)
         {
             const LArCaloHit *const pLArHit2(dynamic_cast<const LArCaloHit *>(pCaloHit2));
 
@@ -349,7 +341,6 @@ void DLMultiViewMatchingAlgorithm::FillGlobalSimMatrix(const ClusterGroupVector 
             {TPC_VIEW_V, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V)},
             {TPC_VIEW_W, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W)}});
 
-    // Get detector x-gaps
     std::set<float> detXGaps;
     LArGeometryHelper::GetDetectorXGaps(this->GetPandora(), detXGaps);
 
@@ -366,7 +357,6 @@ void DLMultiViewMatchingAlgorithm::FillGlobalSimMatrix(const ClusterGroupVector 
 StatusCode DLMultiViewMatchingAlgorithm::PredictClusterSimilarityMatrix(const ClusterList &clusterListU, const ClusterList &clusterListV, const ClusterList &clusterListW, 
     const std::map<HitType, CartesianVector> &viewToVtxPos, const std::set<float> &detXGaps, SimilarityMatrix &clusterSimMat)
 {
-    // First sort the lists
     ClusterVector clusterVecU(clusterListU.begin(), clusterListU.end());
     std::sort(clusterVecU.begin(), clusterVecU.end(), LArClusterHelper::SortByNHits);
     ClusterVector clusterVecV(clusterListV.begin(), clusterListV.end());
@@ -455,11 +445,9 @@ void DLMultiViewMatchingAlgorithm::MakeClusterTensor(const std::vector<LArDLShow
 StatusCode DLMultiViewMatchingAlgorithm::PopulateClusterSimilarityMatrix(const torch::Tensor &tensorSimMat, const ClusterVector &clusterVector,
     SimilarityMatrix &clusterSimMat) const
 {
-    // Check predicted sim matrics
     const int64_t nClusters{static_cast<int64_t>(clusterVector.size())};
     PANDORA_RETURN_IF(STATUS_CODE_NOT_ALLOWED, tensorSimMat.dim() != 3 || nClusters != tensorSimMat.size(-1) || nClusters != tensorSimMat.size(-2));
     
-    // Populate SimilarityMatrix
     auto accessor = tensorSimMat.accessor<float, 3>();
     auto iterI{clusterVector.begin()};
     for (int i = 0; i < nClusters; i++, iterI++)
@@ -508,8 +496,8 @@ void DLMultiViewMatchingAlgorithm::CreatePfo(const ClusterList &clusters)
 
     PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
     pfoParameters.m_particleId = E_MINUS;
-    pfoParameters.m_charge = PdgTable::GetParticleCharge(pfoParameters.m_particleId.Get());
-    pfoParameters.m_mass = PdgTable::GetParticleMass(pfoParameters.m_particleId.Get());
+    pfoParameters.m_charge = PdgTable::GetParticleCharge(E_MINUS);
+    pfoParameters.m_mass = PdgTable::GetParticleMass(E_MINUS);
     pfoParameters.m_energy = 0.f;
     pfoParameters.m_momentum = CartesianVector(0.f, 0.f, 0.f);
     pfoParameters.m_clusterList = clusters;
@@ -571,14 +559,12 @@ void DLMultiViewMatchingAlgorithm::PrepareTrainingSample(const ClusterGroupVecto
             {TPC_VIEW_V, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_V)},
             {TPC_VIEW_W, LArGeometryHelper::ProjectPosition(this->GetPandora(), pVertex->GetPosition(), TPC_VIEW_W)}});
 
-    // Get detector x-gaps
     std::set<float> detXGaps;
     LArGeometryHelper::GetDetectorXGaps(this->GetPandora(), detXGaps);
 
     // Fill tree for each isolated group
     for (const ClusterGroup &clusterGroup : clusterGroupVector)
     {
-        // The vectors to fill
         int currClusterID{0}, currMCID{0};
         std::map<const MCParticle *const, int> mcToID = {{nullptr, -1}}, mcToPDG = {{nullptr, 0}};
         std::vector<int> clusterView, clusterID;
@@ -607,10 +593,7 @@ void DLMultiViewMatchingAlgorithm::PrepareTrainingSample(const ClusterGroupVecto
 
                     try
                     {
-                        // Get MC match
                         const MCParticle *const pMainMC{MCParticleHelper::GetMainMCParticle(pCaloHit)};
-
-                        // Fill out MC info for event
                         if (mcToID.find(pMainMC) == mcToID.end())
                         {
                             mcToID.insert({pMainMC, currMCID++});
@@ -619,7 +602,6 @@ void DLMultiViewMatchingAlgorithm::PrepareTrainingSample(const ClusterGroupVecto
                             mcPDG.emplace_back(mcToPDG.at(pMainMC));
                         }
 
-                        // Fill out info for hit
                         filled = true;
                         hitClusterID.emplace_back(currClusterID);
                         hitXRelPos.emplace_back(hitFeatures.m_xRel);
@@ -645,7 +627,6 @@ void DLMultiViewMatchingAlgorithm::PrepareTrainingSample(const ClusterGroupVecto
             }
         }
 
-        // Fill tree
         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "cluster_id", &clusterID));
         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "cluster_view", &clusterView));
         PANDORA_MONITORING_API(SetTreeVariable(this->GetPandora(), m_trainingTreeName, "mc_id", &mcID));
@@ -764,7 +745,6 @@ StatusCode DLMultiViewMatchingAlgorithm::ReadSettings([[maybe_unused]] const TiX
         XmlHelper::ReadValue(xmlHandle, "MatchThreshold", m_matchThreshold));
     
     return STATUS_CODE_SUCCESS;
-
 }   
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -774,3 +754,4 @@ template StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string, con
 template StatusCode DLMultiViewMatchingAlgorithm::GetList(const std::string, const MCParticleList *&);
 
 } // namespace lar_dl_content
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h
@@ -1,0 +1,249 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArThreeDBase/DLMultiViewMatchingAlgorithm.h
+ *
+ *  @brief  Header file for the dl multi view matching algorithm class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_MULTI_VIEW_MATCHING_ALGORITHM_H
+#define LAR_MULTI_VIEW_MATCHING_ALGORITHM_H 1
+
+
+#include "Pandora/Algorithm.h"
+
+#include "larpandoradlcontent/LArHelpers/LArDLHelper.h"
+#include "larpandoradlcontent/LArHelpers/LArDLShowerHelper.h"
+
+namespace lar_dl_content
+{
+
+class DLShowerMatchingTool;    
+
+/**
+ *  @brief  DLMultiViewMatchingAlgorithm class
+ */
+class DLMultiViewMatchingAlgorithm : public pandora::Algorithm
+{
+public:
+    struct ClusterGroup
+    {
+        pandora::ClusterList m_clustersU; ///< clusters in the U-view
+        pandora::ClusterList m_clustersV; ///< clusters in the V-view
+        pandora::ClusterList m_clustersW; ///< clusters in the W-view        
+    };
+    typedef std::vector<ClusterGroup> ClusterGroupVector;
+    
+    typedef std::map<const pandora::Cluster*, std::map<const pandora::Cluster*, float>> SimilarityMatrix;      
+        
+    /**
+     *  @brief  Default constructor
+     */
+    DLMultiViewMatchingAlgorithm();
+
+    /**
+     *  @brief  Default destructor
+     */    
+    ~DLMultiViewMatchingAlgorithm();    
+
+    /**
+     *  @brief  Obtain groups of 'connected' clusters by following cluster navigations
+     *
+     *  @param[out] clusterGroupVector the output vector of ClusterGroups
+     */    
+    void GetConnectedGroups(ClusterGroupVector &clusterGroupVector);
+    
+    /**
+     *  @brief  Create a pfo from a list of input clusters
+     *
+     *  @param clusters the input list of clusters
+     */
+    void CreatePfo(const pandora::ClusterList &clusters);
+
+    /**
+     *  @brief  Delete a cluster from all algorithm containers
+     *
+     *  @param pClusterToRemove a pointer to the cluster to remove
+     */    
+    void DeleteCluster(const pandora::Cluster *const pClusterToRemove);    
+
+private:
+    pandora::StatusCode Run();
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    typedef std::map<const pandora::Cluster *, pandora::ClusterList> NavigationMap;
+    typedef std::map<const pandora::Cluster *, std::pair<float, float>> ClusterExtentMap;
+    typedef std::vector<DLShowerMatchingTool *> MatchingToolVector;     
+    
+    /**
+     *  @brief  Fill an algorithm list
+     *
+     *  @param listName the name of the internal pandora list     
+     *  @param[out] pList the algorithm list to fill
+     *
+     *  @return StatusCode whether the list has been filled
+     */
+    template <typename T>
+    pandora::StatusCode GetList(const std::string listName, const T *&pList);
+
+    /**
+     *  @brief  Filter input clusters and prepare algorithm containers
+     *
+     *  @param pClusterListU the input list of U-view clusters
+     *  @param pClusterListV the input list of V-view clusters
+     *  @param pClusterListW the input list of W-view clusters     
+     *  @param[out] clusterExtentMap the map of clusters->extremal drift coordinates
+     */
+    void PrepareClusters(const pandora::ClusterList *const pClusterListU, const pandora::ClusterList *const pClusterListV,
+        const pandora::ClusterList *const pClusterListW, ClusterExtentMap &clusterExtentMap);
+
+    /**
+     *  @brief  Fill the algorithm navigation maps
+     *
+     *  @param clusterExtentMap the map of clusters->extremal drift coordinates     
+     */
+    void FillNavigationMaps(const ClusterExtentMap &clusterExtentMap);
+
+    /**
+     *  @brief  Whether the input cluster pair overlap (at all) in the wire and drift plane
+     *
+     *  @param pCluster1 the first cluster in the cluster pair match
+     *  @param pCluster2 the second cluster in the cluster pair match
+     *  @param clusterExtentMap the map of clusters->extremal drift coordinates     
+     */
+    bool DoClustersOverlap(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const ClusterExtentMap &clusterExtentMap);
+
+    /**
+     *  @brief  Whether the input cluster pair overlap (to a defined extent) in the wire plane
+     *
+     *  @param pCluster1 the first cluster in the cluster pair match
+     *  @param pCluster2 the second cluster in the cluster pair match
+     *  @param minX the lower bound of the drift overlap region
+     *  @param maxX the upper bound of the drift overlap region     
+     */    
+    bool DoClustersOverlapInWire(const pandora::Cluster *const pCluster1, const pandora::Cluster *const pCluster2, const float minX, const float maxX);
+
+    /**
+     *  @brief  Obtain group of 'connected' clusters by following the cluster navigations of an initial input cluster
+     *
+     *  @param pCluster the initial input cluster
+     *  @param[out] clusterGroup the group of connected clusters
+     *  @param[in,out] usedU the list of U-view clusters already assigned to a cluster group
+     *  @param[in,out] usedV the list of V-view clusters already assigned to a cluster group
+     *  @param[in,out] usedW the list of W-view clusters already assigned to a cluster group
+     */    
+    void GetConnectedGroup(const pandora::Cluster *const pCluster, ClusterGroup &clusterGroup,
+        pandora::ClusterList &usedU, pandora::ClusterList &usedV, pandora::ClusterList &usedW);
+    
+    /**
+     *  @brief  Apply the matching model to obtain pairwise similarity scores between all UVW clusters considered by the algorithm
+     *
+     *  @param clusterGroupVector the vector of ClusterGroups
+     *  @param[out] globalSimMatrix the output cluster->cluster->score mapping
+     */    
+    void FillGlobalSimMatrix(const ClusterGroupVector &clusterGroupVector, SimilarityMatrix &globalSimMatrix);
+
+    /**
+     *  @brief  Apply the matching model to obtain pairwise similarity scores between UVW clusters within a common drift region
+     *
+     *  @param clusterListU the list of U clusters
+     *  @param clusterListV the list of V clusters
+     *  @param clusterListW the list of W clusters
+     *  @param viewToVtxPos the hit type -> 2D nu vertex map
+     *  @param detXGaps the container of drift-gaps within the detector
+     *  @param[out] clusterSimMat the output cluster->cluster->score mapping
+     */        
+    pandora::StatusCode PredictClusterSimilarityMatrix(const pandora::ClusterList &clusterListU, const pandora::ClusterList &clusterListV,
+        const pandora::ClusterList &clusterListW, const std::map<pandora::HitType, pandora::CartesianVector> &viewToVtxPos,
+        const std::set<float> &detXGaps, SimilarityMatrix &clusterSimMat);
+
+    /**
+     *  @brief  Construct the tensor that encodes a cluster.
+     *
+     *  @param clusterFeatures vector of hit properties for the hits of one 2D cluster
+     *  @param view the view of the 2D clusters
+     *  @param nClusters the total number of 2D clusters in the view
+     *  @param tensorCluster the tensor encoding the cluster as a sequence of hit feature vectors
+     */    
+    void MakeClusterTensor(const std::vector<LArDLShowerHelper::HitFeatures> &clusterFeatures, const pandora::HitType view,
+        const int nClusters, torch::Tensor &tensorCluster) const;
+
+    /**
+     *  @brief  Populates a SimilarityMatrix from the Tensor output of model inference.
+     *
+     *  @param tensorSimMat the predicted similarity matrix tensor, shape [1, N, N] where N is the number of 2D clusters
+     *  @param clusterList the list of 2D clusters
+     *  @param[out] clusterSimMat the cluster similarity matrix object
+     */    
+    pandora::StatusCode PopulateClusterSimilarityMatrix(const torch::Tensor &tensorSimMat, const pandora::ClusterVector &clusterVector,
+        SimilarityMatrix &clusterSimMat) const;
+
+    /**
+     *  @brief Update the algorithm's navigation maps, removing the links between clusters with poor similarity scores
+     *
+     *  @param globalSimMatrix the cluster->cluster->score mapping
+     */    
+    void UpdateNavigationMaps(const SimilarityMatrix &globalSimMatrix);
+
+    /**
+     *  @brief Reset algorithm containers
+     */     
+    void CleanUp();
+
+    /**
+     *  @brief Write, to a tree, the training dataset such that each entry in the tree corresponds to connected cluster group
+     *
+     *  @param clusterGroupVector the vector of ClusterGroups
+     */       
+    void PrepareTrainingSample(const ClusterGroupVector &clusterGroupVector);
+
+    std::string m_nuVertexListName;   ///< The neutrino vertex list name
+    std::string m_clusterListNameU;   ///< The input cluster list name for the U view
+    std::string m_clusterListNameV;   ///< The input cluster list name for the V view
+    std::string m_clusterListNameW;   ///< The input cluster list name for the W view
+    std::string m_outputPfoListName;  ///< The name of the list in which to store the created pfos
+    pandora::ClusterList m_filteredU; ///< The filtered list of U-view clusters to consider for matching
+    pandora::ClusterList m_filteredV; ///< The filtered list of V-view clusters to consider for matching
+    pandora::ClusterList m_filteredW; ///< The filtered list of W-view clusters to consider for matching
+    NavigationMap m_navigationU; ///< The mapping between U-view clusters and 'matched' V/W clusters
+    NavigationMap m_navigationV; ///< The mapping between V-view clusters and 'matched' U/W clusters
+    NavigationMap m_navigationW; ///< The mapping between W-view clusters and 'matched' U/V clusters
+    MatchingToolVector m_matchingToolVector; ///< The algorithm tool vector   
+    bool m_trainingMode;               ///< Whether to run the algorithm in training mode
+    std::string m_trainingFileName;    ///< The name of the produced training file
+    std::string m_trainingTreeName;    ///< The name of the produced training tree
+    unsigned int m_minNClusterHits;    ///< The threshold number of hits of a considered cluster
+    unsigned int m_nMaxRepeats;        ///< The maximum number of times to repeat the matching tools
+    float m_minWireOverlapFraction;    ///< The minimum required fraction of hits that exist on intersecting wires
+    int m_hitFeatureDim;               ///< The number of hit features 
+    float m_polarRScaleFactor;              ///< Scale factor for polar r coordinate input features
+    float m_cartesianXScaleFactor;          ///< Scale factor for cartesian x coordinate input features
+    float m_cartesianZScaleFactor;          ///< Scale factor for cartesian z coordinate input features
+    float m_matchThreshold;                 ///< The threshold on the predicted similarity for a match to be made
+    LArDLHelper::TorchModel m_modelEncoder; ///< TorchScript model for encoding hits in a cluster
+    LArDLHelper::TorchModel m_modelAttn;    ///< TorchScript model for attention over encoded clusters in a view
+    LArDLHelper::TorchModel m_modelSim;     ///< TorchScript model for pairwise similarities over clusters after attention    
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+/**
+ *  @brief  DLShowerTensorTool class
+ */
+class DLShowerMatchingTool : public pandora::AlgorithmTool
+{
+public:
+   
+    /**
+     *  @brief  Run the algorithm tool
+     *
+     *  @param  pAlgorithm address of the calling algorithm
+     *  @param globalSimMatrix the output cluster->cluster->score mapping
+     *
+     *  @return whether changes have been made by the tool
+     */
+    virtual bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix) = 0;
+};    
+    
+} // namespace lar_content
+
+#endif // #ifndef LAR_MULTI_VIEW_MATCHING_ALGORITHM_H

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h
@@ -8,7 +8,6 @@
 #ifndef LAR_MULTI_VIEW_MATCHING_ALGORITHM_H
 #define LAR_MULTI_VIEW_MATCHING_ALGORITHM_H 1
 
-
 #include "Pandora/Algorithm.h"
 
 #include "larpandoradlcontent/LArHelpers/LArDLHelper.h"
@@ -236,7 +235,7 @@ public:
     /**
      *  @brief  Run the algorithm tool
      *
-     *  @param  pAlgorithm address of the calling algorithm
+     *  @param pAlgorithm address of the calling algorithm
      *  @param globalSimMatrix the output cluster->cluster->score mapping
      *
      *  @return whether changes have been made by the tool
@@ -244,6 +243,7 @@ public:
     virtual bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix) = 0;
 };    
     
-} // namespace lar_content
+} // namespace lar_dl_content
 
 #endif // #ifndef LAR_MULTI_VIEW_MATCHING_ALGORITHM_H
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.cc
@@ -1,0 +1,69 @@
+/**
+ *  @file   larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.cc
+ *
+ *  @brief  Implementation of the three view clear showers tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.h"
+
+
+using namespace pandora;
+
+namespace lar_dl_content
+{
+
+DLThreeViewClearShowersTool::DLThreeViewClearShowersTool()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool DLThreeViewClearShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix)
+{
+    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    // Get connected clusters
+    DLMultiViewMatchingAlgorithm::ClusterGroupVector clusterGroupVector;
+    pAlgorithm->GetConnectedGroups(clusterGroupVector);    
+
+    // Loop over connected groups
+    bool madeParticles(false);
+    for (const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup : clusterGroupVector)
+    {
+        int nU(clusterGroup.m_clustersU.size()), nV(clusterGroup.m_clustersV.size()), nW(clusterGroup.m_clustersW.size());                
+        
+        // Look for 1:1:1 unambiguous match
+        if ((nU * nV * nW) != 1)
+            continue;
+            
+        this->CreateClearShowers(pAlgorithm, clusterGroup);
+        madeParticles = true;
+    }
+
+    return madeParticles;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void DLThreeViewClearShowersTool::CreateClearShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup)
+{
+    ClusterList pfoClusters({clusterGroup.m_clustersU.front()});
+    pfoClusters.push_back(clusterGroup.m_clustersV.front());
+    pfoClusters.push_back(clusterGroup.m_clustersW.front());
+            
+    pAlgorithm->CreatePfo(pfoClusters);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode DLThreeViewClearShowersTool::ReadSettings([[maybe_unused]] const TiXmlHandle xmlHandle)
+{
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_dl_content

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.cc
@@ -10,7 +10,6 @@
 
 #include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.h"
 
-
 using namespace pandora;
 
 namespace lar_dl_content
@@ -27,11 +26,9 @@ bool DLThreeViewClearShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgor
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    // Get connected clusters
     DLMultiViewMatchingAlgorithm::ClusterGroupVector clusterGroupVector;
     pAlgorithm->GetConnectedGroups(clusterGroupVector);    
 
-    // Loop over connected groups
     bool madeParticles(false);
     for (const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup : clusterGroupVector)
     {
@@ -41,7 +38,7 @@ bool DLThreeViewClearShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgor
         if ((nU * nV * nW) != 1)
             continue;
             
-        this->CreateClearShowers(pAlgorithm, clusterGroup);
+        this->CreateShowers(pAlgorithm, clusterGroup);
         madeParticles = true;
     }
 
@@ -50,13 +47,9 @@ bool DLThreeViewClearShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgor
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void DLThreeViewClearShowersTool::CreateClearShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup)
+void DLThreeViewClearShowersTool::CreateShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup)
 {
-    ClusterList pfoClusters({clusterGroup.m_clustersU.front()});
-    pfoClusters.push_back(clusterGroup.m_clustersV.front());
-    pfoClusters.push_back(clusterGroup.m_clustersW.front());
-            
-    pAlgorithm->CreatePfo(pfoClusters);
+    pAlgorithm->CreatePfo({clusterGroup.m_clustersU.front(), clusterGroup.m_clustersV.front(), clusterGroup.m_clustersW.front()});
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -67,3 +60,4 @@ StatusCode DLThreeViewClearShowersTool::ReadSettings([[maybe_unused]] const TiXm
 }
 
 } // namespace lar_dl_content
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.h
@@ -1,0 +1,43 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.h
+ *
+ *  @brief  Header file for the three view clear showers tool class.
+ *
+ *  $Log: $
+ */
+#ifndef DL_THREE_VIEW_CLEAR_SHOWERS_TOOL_H
+#define DL_THREE_VIEW_CLEAR_SHOWERS_TOOL_H 1
+
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h"
+
+namespace lar_dl_content
+{
+
+/**
+ *  @brief  DLThreeViewClearShowersTool class
+ */
+class DLThreeViewClearShowersTool : public DLShowerMatchingTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    DLThreeViewClearShowersTool();
+
+    bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
+
+private:
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief Create a shower-like particle from a 1:1:1 matched cluster group
+     *
+     *  @param pAlgorithm the calling algorithm
+     *  @param clusterGroup the input connected cluster group
+     */     
+    void CreateClearShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup);
+};
+
+} // namespace lar_dl_content
+
+#endif // #ifndef DL_THREE_VIEW_CLEAR_SHOWERS_TOOL_H

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewClearShowersTool.h
@@ -24,6 +24,14 @@ public:
      */
     DLThreeViewClearShowersTool();
 
+    /**
+     *  @brief  Create shower-like pfos from unambiguous 1:1:1 matched cluster groups
+     *
+     *  @param pAlgorithm address of the calling algorithm
+     *  @param globalSimMatrix the output cluster->cluster->score mapping
+     *
+     *  @return whether shower-like pfos have been created
+     */    
     bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
 
 private:
@@ -35,9 +43,10 @@ private:
      *  @param pAlgorithm the calling algorithm
      *  @param clusterGroup the input connected cluster group
      */     
-    void CreateClearShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup);
+    void CreateShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup);
 };
 
 } // namespace lar_dl_content
 
 #endif // #ifndef DL_THREE_VIEW_CLEAR_SHOWERS_TOOL_H
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.cc
@@ -1,0 +1,170 @@
+/**
+ *  @file   larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.cc
+ *
+ *  @brief  Implementation of the merge and create showers tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.h"
+
+using namespace pandora;
+
+namespace lar_dl_content
+{
+
+DLThreeViewMergeAndCreateShowersTool::DLThreeViewMergeAndCreateShowersTool() :
+    m_matchThreshold(0.5)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool DLThreeViewMergeAndCreateShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+    const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix)
+{
+    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    // Get connected clusters
+    DLMultiViewMatchingAlgorithm::ClusterGroupVector clusterGroupVector;
+    pAlgorithm->GetConnectedGroups(clusterGroupVector);  
+
+    // Loop over connected groups
+    bool madeParticles(false);
+    for (const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup : clusterGroupVector)
+    {
+        int nU(clusterGroup.m_clustersU.size()), nV(clusterGroup.m_clustersV.size()), nW(clusterGroup.m_clustersW.size());                
+            
+        if ((nU * nV * nW) <= 1)
+            continue;
+
+        // Deal with ambiguous showers
+        const bool thisMadeParticles(this->CreateAmbiguousShower(pAlgorithm, clusterGroup, globalSimMatrix));
+        madeParticles = madeParticles ? madeParticles : thisMadeParticles;
+    }
+
+    return madeParticles;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool DLThreeViewMergeAndCreateShowersTool::CreateAmbiguousShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+    const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix)
+{
+    // Find 'seed' element
+    const Cluster *pSeedU(nullptr), *pSeedV(nullptr), *pSeedW(nullptr);
+    if (!this->FindSeed(clusterGroup, globalSimMatrix, pSeedU, pSeedV, pSeedW)) { return false; }
+
+    // Merge into seed
+    this->MergeClusters(pAlgorithm, clusterGroup, globalSimMatrix, pSeedU, pSeedV, pSeedW);
+
+    // Create pfo
+    ClusterList pfoClusters({pSeedU});
+    pfoClusters.push_back(pSeedV);
+    pfoClusters.push_back(pSeedW);          
+    pAlgorithm->CreatePfo(pfoClusters);
+    return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool DLThreeViewMergeAndCreateShowersTool::FindSeed(const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+    const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix, const Cluster *&pSeedU, const Cluster *&pSeedV, const Cluster *&pSeedW)
+{
+    bool found(false);
+    int highestHits(0);
+    
+    for (const Cluster *const pClusterU : clusterGroup.m_clustersU)
+    {
+        const auto iterU(globalSimMatrix.find(pClusterU));
+        
+        for (const Cluster *const pClusterV : clusterGroup.m_clustersV)
+        {
+            const auto iterUV(iterU->second.find(pClusterV));
+            if (iterUV == iterU->second.end()) { continue; }
+            if (iterUV->second < m_matchThreshold) { continue; }
+            const auto iterV(globalSimMatrix.find(pClusterV));
+            
+            for (const Cluster *const pClusterW : clusterGroup.m_clustersW)
+            {
+                const auto iterUW(iterU->second.find(pClusterW));
+                if (iterUW == iterU->second.end()) { continue; }
+                if (iterUW->second < m_matchThreshold) { continue; }
+                const auto iterVW(iterV->second.find(pClusterW));
+                if (iterVW == iterV->second.end()) { continue; }
+                if (iterVW->second < m_matchThreshold) { continue; }                
+        
+                const int nHits(pClusterU->GetNCaloHits() + pClusterV->GetNCaloHits() + pClusterW->GetNCaloHits());
+
+                if (nHits > highestHits)
+                {
+                    found = true;
+                    highestHits = nHits;
+                    pSeedU = pClusterU;
+                    pSeedV = pClusterV;
+                    pSeedW = pClusterW;
+                }
+            }
+        } 
+    }
+
+    return found;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void DLThreeViewMergeAndCreateShowersTool::MergeClusters(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+    const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix, const Cluster *const pSeedU, const Cluster *const pSeedV, const Cluster *const pSeedW)
+{
+    for (const HitType hitType : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
+    {
+        const Cluster *const pSeed(hitType == TPC_VIEW_U ? pSeedU : hitType == TPC_VIEW_V ? pSeedV : pSeedW);
+        const ClusterList &clusterList(hitType == TPC_VIEW_U ? clusterGroup.m_clustersU : hitType == TPC_VIEW_V ? clusterGroup.m_clustersV : clusterGroup.m_clustersW);
+        const std::string clusterListName(hitType == TPC_VIEW_U ? m_clusterListNameU : hitType == TPC_VIEW_V ? m_clusterListNameV : m_clusterListNameW);
+        
+        for (const Cluster *const pClusterToMerge : clusterList)
+        {
+            if (pSeed == pClusterToMerge)
+                continue;
+            
+            const auto iter1(globalSimMatrix.find(pSeed));
+            if (iter1 == globalSimMatrix.end()) { continue; }
+            const auto iter2(iter1->second.find(pClusterToMerge));
+            if (iter2 == iter1->second.end()) { continue; }
+            if (iter2->second < m_matchThreshold) { continue; }
+
+            pAlgorithm->DeleteCluster(pClusterToMerge);            
+
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(
+                *pAlgorithm, pSeed, pClusterToMerge, clusterListName, clusterListName));
+        }
+    }
+}
+
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode DLThreeViewMergeAndCreateShowersTool::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameU", m_clusterListNameU));
+    if (m_clusterListNameU.empty())
+        m_clusterListNameU = "ClustersU";
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameV", m_clusterListNameV));
+    if (m_clusterListNameV.empty())
+        m_clusterListNameV = "ClustersV";
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameW", m_clusterListNameW));
+    if (m_clusterListNameW.empty())
+        m_clusterListNameW = "ClustersW";
+    
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MatchThreshold", m_matchThreshold));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_dl_content

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.cc
@@ -28,11 +28,9 @@ bool DLThreeViewMergeAndCreateShowersTool::Run(DLMultiViewMatchingAlgorithm *con
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    // Get connected clusters
     DLMultiViewMatchingAlgorithm::ClusterGroupVector clusterGroupVector;
     pAlgorithm->GetConnectedGroups(clusterGroupVector);  
 
-    // Loop over connected groups
     bool madeParticles(false);
     for (const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup : clusterGroupVector)
     {
@@ -41,9 +39,8 @@ bool DLThreeViewMergeAndCreateShowersTool::Run(DLMultiViewMatchingAlgorithm *con
         if ((nU * nV * nW) <= 1)
             continue;
 
-        // Deal with ambiguous showers
-        const bool thisMadeParticles(this->CreateAmbiguousShower(pAlgorithm, clusterGroup, globalSimMatrix));
-        madeParticles = madeParticles ? madeParticles : thisMadeParticles;
+        const bool thisMadeParticles(this->CreateShower(pAlgorithm, clusterGroup, globalSimMatrix));
+        madeParticles = madeParticles || thisMadeParticles;
     }
 
     return madeParticles;
@@ -51,21 +48,15 @@ bool DLThreeViewMergeAndCreateShowersTool::Run(DLMultiViewMatchingAlgorithm *con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool DLThreeViewMergeAndCreateShowersTool::CreateAmbiguousShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+bool DLThreeViewMergeAndCreateShowersTool::CreateShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
     const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix)
 {
-    // Find 'seed' element
     const Cluster *pSeedU(nullptr), *pSeedV(nullptr), *pSeedW(nullptr);
     if (!this->FindSeed(clusterGroup, globalSimMatrix, pSeedU, pSeedV, pSeedW)) { return false; }
 
-    // Merge into seed
     this->MergeClusters(pAlgorithm, clusterGroup, globalSimMatrix, pSeedU, pSeedV, pSeedW);
-
-    // Create pfo
-    ClusterList pfoClusters({pSeedU});
-    pfoClusters.push_back(pSeedV);
-    pfoClusters.push_back(pSeedW);          
-    pAlgorithm->CreatePfo(pfoClusters);
+    pAlgorithm->CreatePfo({pSeedU, pSeedV, pSeedW});
+    
     return true;
 }
 
@@ -80,6 +71,7 @@ bool DLThreeViewMergeAndCreateShowersTool::FindSeed(const DLMultiViewMatchingAlg
     for (const Cluster *const pClusterU : clusterGroup.m_clustersU)
     {
         const auto iterU(globalSimMatrix.find(pClusterU));
+        if (iterU == globalSimMatrix.end()) { continue; }
         
         for (const Cluster *const pClusterV : clusterGroup.m_clustersV)
         {
@@ -87,6 +79,7 @@ bool DLThreeViewMergeAndCreateShowersTool::FindSeed(const DLMultiViewMatchingAlg
             if (iterUV == iterU->second.end()) { continue; }
             if (iterUV->second < m_matchThreshold) { continue; }
             const auto iterV(globalSimMatrix.find(pClusterV));
+            if (iterV == globalSimMatrix.end()) { continue; }
             
             for (const Cluster *const pClusterW : clusterGroup.m_clustersW)
             {
@@ -144,7 +137,6 @@ void DLThreeViewMergeAndCreateShowersTool::MergeClusters(DLMultiViewMatchingAlgo
     }
 }
 
-
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode DLThreeViewMergeAndCreateShowersTool::ReadSettings(const TiXmlHandle xmlHandle)
@@ -168,3 +160,4 @@ StatusCode DLThreeViewMergeAndCreateShowersTool::ReadSettings(const TiXmlHandle 
 }
 
 } // namespace lar_dl_content
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.h
@@ -1,0 +1,83 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.h
+ *
+ *  @brief  Header file for the three view merge and create showers tool class.
+ *
+ *  $Log: $
+ */
+#ifndef DL_THREE_VIEW_MERGE_AND_CREATE_SHOWERS_TOOL_H
+#define DL_THREE_VIEW_MERGE_AND_CREATE_SHOWERS_TOOL_H 1
+
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h"
+
+namespace lar_dl_content
+{
+
+/**
+ *  @brief  DLThreeViewMergeAndCreateShowersTool class
+ */
+class DLThreeViewMergeAndCreateShowersTool : public DLShowerMatchingTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    DLThreeViewMergeAndCreateShowersTool();
+
+    bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+        const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
+
+private:
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief Create a shower-like particle from a L:M:N matched cluster group,
+     *         where L,M,N >= 1 and at least two of L,M,N are >1
+     *
+     *  @param pAlgorithm the calling algorithm
+     *  @param clusterGroup the input connected cluster group
+     *  @param globalSimMatrix the input cluster->cluster->score mapping
+     *
+     *  @return whether a particle was created
+     */  
+    bool CreateAmbiguousShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+        const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
+
+    /**
+     *  @brief Within the ambiguous cluster group, pick out the 'best' cluster triplet
+     *
+     *  @param clusterGroup the input connected cluster group
+     *  @param globalSimMatrix the input cluster->cluster->score mapping
+     *  @param[out] the U-view seed cluster
+     *  @param[out] the V-view seed cluster
+     *  @param[out] the W-view seed cluster      
+     *
+     *  @return whether a seed cluster triplet was found i.e. in which all pairwise cluster pairs are 'similar'
+     */      
+    bool FindSeed(const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+        const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix, const pandora::Cluster *&pSeedU,
+        const pandora::Cluster *&pSeedV, const pandora::Cluster *&pSeedW);
+
+    /**
+     *  @brief Grow the seed clusters by merging 'similar' same-view clusters within the connected group
+     *
+     *  @param pAlgorithm the calling algorithm
+     *  @param clusterGroup the input connected cluster group
+     *  @param globalSimMatrix the input cluster->cluster->score mapping
+     *  @param the U-view seed cluster
+     *  @param the V-view seed cluster
+     *  @param the W-view seed cluster      
+     */ 
+    void MergeClusters(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+        const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix, const pandora::Cluster *const pSeedU,
+        const pandora::Cluster *const pSeedV, const pandora::Cluster *const pSeedW);
+
+    std::string m_clusterListNameU; ///< The input cluster list name for the U view
+    std::string m_clusterListNameV; ///< The input cluster list name for the V view
+    std::string m_clusterListNameW; ///< The input cluster list name for the W view
+    float m_matchThreshold; ///< Threshold similarity score required for match
+};
+
+} // namespace lar_dl_content
+
+#endif // #ifndef DL_THREE_VIEW_MERGE_AND_CREATE_SHOWERS_TOOL_H

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLThreeViewMergeAndCreateShowersTool.h
@@ -24,6 +24,14 @@ public:
      */
     DLThreeViewMergeAndCreateShowersTool();
 
+    /**
+     *  @brief  Create shower-like pfos from ambiguous L:M:N matched cluster groups
+     *
+     *  @param pAlgorithm address of the calling algorithm
+     *  @param globalSimMatrix the output cluster->cluster->score mapping
+     *
+     *  @return whether shower-like pfos have been created
+     */
     bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm,
         const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
 
@@ -40,7 +48,7 @@ private:
      *
      *  @return whether a particle was created
      */  
-    bool CreateAmbiguousShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+    bool CreateShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
         const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
 
     /**
@@ -81,3 +89,4 @@ private:
 } // namespace lar_dl_content
 
 #endif // #ifndef DL_THREE_VIEW_MERGE_AND_CREATE_SHOWERS_TOOL_H
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.cc
@@ -1,0 +1,77 @@
+/**
+ *  @file   larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.cc
+ *
+ *  @brief  Implementation of the two view clear showers tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.h"
+
+using namespace pandora;
+
+namespace lar_dl_content
+{
+
+DLTwoViewClearShowersTool::DLTwoViewClearShowersTool()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool DLTwoViewClearShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix)
+{
+    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    // Get connected clusters
+    DLMultiViewMatchingAlgorithm::ClusterGroupVector clusterGroupVector;
+    pAlgorithm->GetConnectedGroups(clusterGroupVector);    
+
+    // Loop over connected groups
+    bool madeParticles(false);
+    for (const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup : clusterGroupVector)
+    {
+        int nView0(0), nView1(0);
+
+        for (const ClusterList &clusterList : {clusterGroup.m_clustersU, clusterGroup.m_clustersV, clusterGroup.m_clustersW})
+        {
+            if (clusterList.size() == 0)
+                ++nView0;
+            else if (clusterList.size() == 1)
+                ++nView1;
+        }
+
+        if ((nView0 == 1) && (nView1 == 2))
+        {
+            this->CreateClearShowers(pAlgorithm, clusterGroup);
+            madeParticles = true;
+        }
+    }
+
+    return madeParticles;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void DLTwoViewClearShowersTool::CreateClearShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup)
+{
+    ClusterList pfoClusters;
+
+    for (const ClusterList &clusterList : {clusterGroup.m_clustersU, clusterGroup.m_clustersV, clusterGroup.m_clustersW})
+        if (clusterList.size() == 1)
+            pfoClusters.push_back(clusterList.front());
+
+    pAlgorithm->CreatePfo(pfoClusters);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode DLTwoViewClearShowersTool::ReadSettings([[maybe_unused]] const TiXmlHandle xmlHandle)
+{
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_dl_content

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.cc
@@ -26,27 +26,24 @@ bool DLTwoViewClearShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgorit
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    // Get connected clusters
     DLMultiViewMatchingAlgorithm::ClusterGroupVector clusterGroupVector;
     pAlgorithm->GetConnectedGroups(clusterGroupVector);    
 
-    // Loop over connected groups
     bool madeParticles(false);
     for (const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup : clusterGroupVector)
     {
-        int nView0(0), nView1(0);
-
+        int nZeroClusterViews(0), nOneClusterViews(0);
         for (const ClusterList &clusterList : {clusterGroup.m_clustersU, clusterGroup.m_clustersV, clusterGroup.m_clustersW})
         {
-            if (clusterList.size() == 0)
-                ++nView0;
+            if (clusterList.empty())
+                ++nZeroClusterViews;
             else if (clusterList.size() == 1)
-                ++nView1;
+                ++nOneClusterViews;
         }
 
-        if ((nView0 == 1) && (nView1 == 2))
+        if ((nZeroClusterViews == 1) && (nOneClusterViews == 2))
         {
-            this->CreateClearShowers(pAlgorithm, clusterGroup);
+            this->CreateShowers(pAlgorithm, clusterGroup);
             madeParticles = true;
         }
     }
@@ -56,7 +53,7 @@ bool DLTwoViewClearShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgorit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void DLTwoViewClearShowersTool::CreateClearShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup)
+void DLTwoViewClearShowersTool::CreateShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup)
 {
     ClusterList pfoClusters;
 
@@ -75,3 +72,4 @@ StatusCode DLTwoViewClearShowersTool::ReadSettings([[maybe_unused]] const TiXmlH
 }
 
 } // namespace lar_dl_content
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.h
@@ -1,0 +1,43 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.h
+ *
+ *  @brief  Header file for the two view clear showers tool class.
+ *
+ *  $Log: $
+ */
+#ifndef DL_TWO_VIEW_CLEAR_SHOWERS_TOOL_H
+#define DL_TWO_VIEW_CLEAR_SHOWERS_TOOL_H 1
+
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h"
+
+namespace lar_dl_content
+{
+
+/**
+ *  @brief  DLTwoViewClearShowersTool class
+ */
+class DLTwoViewClearShowersTool : public DLShowerMatchingTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    DLTwoViewClearShowersTool();
+
+    bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
+
+private:
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief Create a shower-like particle from a 0:1:1/1:0:1/1:1:0 matched cluster group
+     *
+     *  @param pAlgorithm the calling algorithm
+     *  @param clusterGroup the input connected cluster group
+     */  
+    void CreateClearShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup);
+};
+
+} // namespace lar_dl_content
+
+#endif // #ifndef DL_TWO_VIEW_CLEAR_SHOWERS_TOOL_H

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewClearShowersTool.h
@@ -24,6 +24,14 @@ public:
      */
     DLTwoViewClearShowersTool();
 
+    /**
+     *  @brief  Create shower-like pfos from unambiguous 0:1:1/1:0:1/1:1:0 matched cluster groups
+     *
+     *  @param pAlgorithm address of the calling algorithm
+     *  @param globalSimMatrix the output cluster->cluster->score mapping
+     *
+     *  @return whether shower-like pfos have been created
+     */
     bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
 
 private:
@@ -35,9 +43,10 @@ private:
      *  @param pAlgorithm the calling algorithm
      *  @param clusterGroup the input connected cluster group
      */  
-    void CreateClearShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup);
+    void CreateShowers(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup);
 };
 
 } // namespace lar_dl_content
 
 #endif // #ifndef DL_TWO_VIEW_CLEAR_SHOWERS_TOOL_H
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.cc
@@ -1,0 +1,177 @@
+/**
+ *  @file   larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.cc
+ *
+ *  @brief  Implementation of the merge and create showers tool class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.h"
+
+using namespace pandora;
+using namespace lar_content;
+
+namespace lar_dl_content
+{
+
+DLTwoViewMergeAndCreateShowersTool::DLTwoViewMergeAndCreateShowersTool() :
+    m_matchThreshold(0.5)
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool DLTwoViewMergeAndCreateShowersTool::Run(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+    const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix)
+{
+    if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
+        std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
+
+    // Get connected clusters
+    DLMultiViewMatchingAlgorithm::ClusterGroupVector clusterGroupVector;
+    pAlgorithm->GetConnectedGroups(clusterGroupVector);  
+
+    // Loop over connected groups
+    bool madeParticles(false);
+    for (const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup : clusterGroupVector)
+    {
+        int nView0(0), nView1(0);
+
+        for (const ClusterList &clusterList : {clusterGroup.m_clustersU, clusterGroup.m_clustersV, clusterGroup.m_clustersW})
+        {
+            if (clusterList.size() == 0)
+                ++nView0;
+            else if (clusterList.size() == 1)
+                ++nView1;
+        }
+
+        if ((nView0 != 1) || (nView1 == 2))
+            continue;
+
+        // Identify hitTypes
+        const HitType ignoreHitType(clusterGroup.m_clustersU.size() == 0 ? TPC_VIEW_U : clusterGroup.m_clustersV.size() == 0 ? TPC_VIEW_V : TPC_VIEW_W);
+        const HitType hitType1(ignoreHitType == TPC_VIEW_U ? TPC_VIEW_V : ignoreHitType == TPC_VIEW_V ? TPC_VIEW_W : TPC_VIEW_U);
+        const HitType hitType2(ignoreHitType == TPC_VIEW_U ? TPC_VIEW_W : ignoreHitType == TPC_VIEW_V ? TPC_VIEW_U : TPC_VIEW_V);        
+
+        const bool thisMadeParticles(this->CreateAmbiguousShower(pAlgorithm, clusterGroup, globalSimMatrix, hitType1, hitType2));
+        madeParticles = madeParticles ? madeParticles : thisMadeParticles;
+    }
+
+    return madeParticles;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool DLTwoViewMergeAndCreateShowersTool::CreateAmbiguousShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+    const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix,
+    const HitType hitType1, const HitType hitType2)
+{
+    // Find 'seed' element
+    const Cluster *pSeed1(nullptr), *pSeed2(nullptr);
+    if (!this->FindSeed(clusterGroup, globalSimMatrix, hitType1, hitType2, pSeed1, pSeed2)) { return false; }
+
+    // Merge into seed
+    this->MergeClusters(pAlgorithm, clusterGroup, globalSimMatrix, pSeed1, pSeed2);
+
+    // Create pfo
+    ClusterList pfoClusters({pSeed1});
+    pfoClusters.push_back(pSeed2);
+    pAlgorithm->CreatePfo(pfoClusters);
+
+    return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool DLTwoViewMergeAndCreateShowersTool::FindSeed(const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+    const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix, const HitType hitType1, const HitType hitType2,
+    const Cluster *&pSeed1, const Cluster *&pSeed2)
+{
+    const ClusterList clusterList1(hitType1 == TPC_VIEW_U ? clusterGroup.m_clustersU : hitType1 == TPC_VIEW_V ? clusterGroup.m_clustersV : clusterGroup.m_clustersW);
+    const ClusterList clusterList2(hitType2 == TPC_VIEW_U ? clusterGroup.m_clustersU : hitType2 == TPC_VIEW_V ? clusterGroup.m_clustersV : clusterGroup.m_clustersW);
+    bool found(false);
+    int highestHits(0);    
+    
+    for (const Cluster *const pCluster1 : clusterList1)
+    {
+        const auto iter1(globalSimMatrix.find(pCluster1));
+        
+        for (const Cluster *const pCluster2 : clusterList2)
+        {
+            const auto iter12(iter1->second.find(pCluster2));
+            if (iter12 == iter1->second.end()) { continue; }
+            if (iter12->second < m_matchThreshold) { continue; }
+        
+            const int nHits(pCluster1->GetNCaloHits() + pCluster2->GetNCaloHits());
+
+            if (nHits > highestHits)
+            {
+                found = true;
+                highestHits = nHits;
+                pSeed1 = pCluster1;
+                pSeed2 = pCluster2;
+            }
+        } 
+    }
+
+    return found;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void DLTwoViewMergeAndCreateShowersTool::MergeClusters(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+    const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix, const Cluster *const pSeed1, const Cluster *const pSeed2)
+{
+    for (const Cluster *const pSeed : {pSeed1, pSeed2})
+    {
+        const HitType hitType(LArClusterHelper::GetClusterHitType(pSeed));            
+        const ClusterList &clusterList(hitType == TPC_VIEW_U ? clusterGroup.m_clustersU : hitType == TPC_VIEW_V ? clusterGroup.m_clustersV : clusterGroup.m_clustersW);
+        const std::string clusterListName(hitType == TPC_VIEW_U ? m_clusterListNameU : hitType == TPC_VIEW_V ? m_clusterListNameV :m_clusterListNameW);
+        
+        for (const Cluster *const pClusterToMerge : clusterList)
+        {
+            if (pSeed == pClusterToMerge)
+                continue;
+            
+            const auto iter1(globalSimMatrix.find(pSeed));
+            if (iter1 == globalSimMatrix.end()) { continue; }
+            const auto iter2(iter1->second.find(pClusterToMerge));
+            if (iter2 == iter1->second.end()) { continue; }
+            if (iter2->second < m_matchThreshold) { continue; }
+
+            pAlgorithm->DeleteCluster(pClusterToMerge);            
+
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(
+                *pAlgorithm, pSeed, pClusterToMerge, clusterListName, clusterListName));
+        }
+    }
+}
+
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode DLTwoViewMergeAndCreateShowersTool::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameU", m_clusterListNameU));
+    if (m_clusterListNameU.empty())
+        m_clusterListNameU = "ClustersU";
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameV", m_clusterListNameV));
+    if (m_clusterListNameV.empty())
+        m_clusterListNameV = "ClustersV";
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "ClusterListNameW", m_clusterListNameW));
+    if (m_clusterListNameW.empty())
+        m_clusterListNameW = "ClustersW";
+    
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MatchThreshold", m_matchThreshold));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_dl_content

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.cc
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.cc
@@ -31,33 +31,30 @@ bool DLTwoViewMergeAndCreateShowersTool::Run(DLMultiViewMatchingAlgorithm *const
     if (PandoraContentApi::GetSettings(*pAlgorithm)->ShouldDisplayAlgorithmInfo())
         std::cout << "----> Running Algorithm Tool: " << this->GetInstanceName() << ", " << this->GetType() << std::endl;
 
-    // Get connected clusters
     DLMultiViewMatchingAlgorithm::ClusterGroupVector clusterGroupVector;
     pAlgorithm->GetConnectedGroups(clusterGroupVector);  
 
-    // Loop over connected groups
     bool madeParticles(false);
     for (const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup : clusterGroupVector)
     {
-        int nView0(0), nView1(0);
+        int nZeroClusterViews(0), nOneClusterViews(0);
 
         for (const ClusterList &clusterList : {clusterGroup.m_clustersU, clusterGroup.m_clustersV, clusterGroup.m_clustersW})
         {
-            if (clusterList.size() == 0)
-                ++nView0;
+            if (clusterList.empty())
+                ++nZeroClusterViews;
             else if (clusterList.size() == 1)
-                ++nView1;
+                ++nOneClusterViews;
         }
 
-        if ((nView0 != 1) || (nView1 == 2))
+        if ((nZeroClusterViews != 1) || (nOneClusterViews == 2))
             continue;
 
-        // Identify hitTypes
         const HitType ignoreHitType(clusterGroup.m_clustersU.size() == 0 ? TPC_VIEW_U : clusterGroup.m_clustersV.size() == 0 ? TPC_VIEW_V : TPC_VIEW_W);
         const HitType hitType1(ignoreHitType == TPC_VIEW_U ? TPC_VIEW_V : ignoreHitType == TPC_VIEW_V ? TPC_VIEW_W : TPC_VIEW_U);
         const HitType hitType2(ignoreHitType == TPC_VIEW_U ? TPC_VIEW_W : ignoreHitType == TPC_VIEW_V ? TPC_VIEW_U : TPC_VIEW_V);        
 
-        const bool thisMadeParticles(this->CreateAmbiguousShower(pAlgorithm, clusterGroup, globalSimMatrix, hitType1, hitType2));
+        const bool thisMadeParticles(this->CreateShower(pAlgorithm, clusterGroup, globalSimMatrix, hitType1, hitType2));
         madeParticles = madeParticles ? madeParticles : thisMadeParticles;
     }
 
@@ -66,21 +63,15 @@ bool DLTwoViewMergeAndCreateShowersTool::Run(DLMultiViewMatchingAlgorithm *const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-bool DLTwoViewMergeAndCreateShowersTool::CreateAmbiguousShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+bool DLTwoViewMergeAndCreateShowersTool::CreateShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
     const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix,
     const HitType hitType1, const HitType hitType2)
 {
-    // Find 'seed' element
     const Cluster *pSeed1(nullptr), *pSeed2(nullptr);
     if (!this->FindSeed(clusterGroup, globalSimMatrix, hitType1, hitType2, pSeed1, pSeed2)) { return false; }
 
-    // Merge into seed
     this->MergeClusters(pAlgorithm, clusterGroup, globalSimMatrix, pSeed1, pSeed2);
-
-    // Create pfo
-    ClusterList pfoClusters({pSeed1});
-    pfoClusters.push_back(pSeed2);
-    pAlgorithm->CreatePfo(pfoClusters);
+    pAlgorithm->CreatePfo({pSeed1, pSeed2});
 
     return true;
 }
@@ -99,6 +90,7 @@ bool DLTwoViewMergeAndCreateShowersTool::FindSeed(const DLMultiViewMatchingAlgor
     for (const Cluster *const pCluster1 : clusterList1)
     {
         const auto iter1(globalSimMatrix.find(pCluster1));
+        if (iter1 == globalSimMatrix.end()) { continue; }
         
         for (const Cluster *const pCluster2 : clusterList2)
         {
@@ -151,7 +143,6 @@ void DLTwoViewMergeAndCreateShowersTool::MergeClusters(DLMultiViewMatchingAlgori
     }
 }
 
-
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode DLTwoViewMergeAndCreateShowersTool::ReadSettings(const TiXmlHandle xmlHandle)
@@ -175,3 +166,4 @@ StatusCode DLTwoViewMergeAndCreateShowersTool::ReadSettings(const TiXmlHandle xm
 }
 
 } // namespace lar_dl_content
+

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.h
@@ -1,0 +1,86 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.h
+ *
+ *  @brief  Header file for the two view merge and create showers tool class. 
+ *
+ *  $Log: $
+ */
+#ifndef DL_TWO_VIEW_MERGE_AND_CREATE_SHOWERS_TOOL_H
+#define DL_TWO_VIEW_MERGE_AND_CREATE_SHOWERS_TOOL_H 1
+
+#include "larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLMultiViewMatchingAlgorithm.h"
+
+namespace lar_dl_content
+{
+
+/**
+ *  @brief  DLTwoViewMergeAndCreateShowersTool class
+ */
+class DLTwoViewMergeAndCreateShowersTool : public DLShowerMatchingTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    DLTwoViewMergeAndCreateShowersTool();
+
+    bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+        const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
+
+private:
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief Create a shower-like particle from a L:M:N matched cluster group,
+     *         where exactly one of L,M,N is zero and the other two are >=1
+     *
+     *  @param pAlgorithm the calling algorithm
+     *  @param clusterGroup the input connected cluster group
+     *  @param globalSimMatrix the input cluster->cluster->score mapping
+     *  @param hitType1 the hit type of one of the two non-empty views
+     *  @param hitType2 the other hit type of the two non-empty views
+     *
+     *  @return whether a particle was created
+     */ 
+    bool CreateAmbiguousShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
+        const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix,
+        const pandora::HitType hitType1, const pandora::HitType hitType2);
+
+    /**
+     *  @brief Within the ambiguous cluster group, pick out the 'best' cluster pair
+     *
+     *  @param clusterGroup the input connected cluster group
+     *  @param globalSimMatrix the input cluster->cluster->score mapping
+     *  @param hitType1 the hit type of one of the two non-empty views
+     *  @param hitType2 the other hit type of the two non-empty views
+     *  @param[out] the seed cluster in the first view
+     *  @param[out] the seed cluster in the second view    
+     *
+     *  @return whether a seed cluster pair was found
+     */      
+    bool FindSeed(const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+        const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix, const pandora::HitType hitType1,
+        const pandora::HitType hitType2, const pandora::Cluster *&pSeed1, const pandora::Cluster *&pSeed2);
+
+    /**
+     *  @brief Grow the seed clusters by merging 'similar' same-view clusters within the connected group
+     *
+     *  @param pAlgorithm the calling algorithm
+     *  @param clusterGroup the input connected cluster group
+     *  @param globalSimMatrix the input cluster->cluster->score mapping
+     *  @param the seed cluster in the first view
+     *  @param the seed cluster in the second view     
+     */ 
+    void MergeClusters(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+        const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix, const pandora::Cluster *const pSeed1,
+        const pandora::Cluster *const pSeed2);
+
+    std::string m_clusterListNameU; ///< The input cluster list name for the U view
+    std::string m_clusterListNameV; ///< The input cluster list name for the V view
+    std::string m_clusterListNameW; ///< The input cluster list name for the W view      
+    float m_matchThreshold; ///< Threshold similarity score required for match
+};
+
+} // namespace lar_dl_content
+
+#endif // #ifndef DL_TWO_VIEW_MERGE_AND_CREATE_SHOWERS_TOOL_H

--- a/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.h
+++ b/larpandoradlcontent/LArThreeDReco/LArShowerMatching/DLTwoViewMergeAndCreateShowersTool.h
@@ -24,6 +24,15 @@ public:
      */
     DLTwoViewMergeAndCreateShowersTool();
 
+    /**
+     *  @brief  Create shower-like pfos from ambiguous L:M:N matched cluster groups,
+     *          where exactly one of L,M,N is zero and the other two are >=1
+     *
+     *  @param pAlgorithm address of the calling algorithm
+     *  @param globalSimMatrix the output cluster->cluster->score mapping
+     *
+     *  @return whether shower-like pfos have been created
+     */
     bool Run(DLMultiViewMatchingAlgorithm *const pAlgorithm,
         const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix);
 
@@ -42,8 +51,8 @@ private:
      *
      *  @return whether a particle was created
      */ 
-    bool CreateAmbiguousShower(DLMultiViewMatchingAlgorithm *const pAlgorithm,
-        const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup, const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix,
+    bool CreateShower(DLMultiViewMatchingAlgorithm *const pAlgorithm, const DLMultiViewMatchingAlgorithm::ClusterGroup &clusterGroup,
+        const DLMultiViewMatchingAlgorithm::SimilarityMatrix &globalSimMatrix,
         const pandora::HitType hitType1, const pandora::HitType hitType2);
 
     /**
@@ -84,3 +93,4 @@ private:
 } // namespace lar_dl_content
 
 #endif // #ifndef DL_TWO_VIEW_MERGE_AND_CREATE_SHOWERS_TOOL_H
+


### PR DESCRIPTION
Hello again,

This PR introduces the DLShowerMatching. The DLShowerMatching is called the DLMultiViewMatchingAlgorithm (it's not actually specific to showers). The algorithm works as follows:

1. Topological information is used to identify pairs of clusters (each in a different view) which may belong to the same pfo. These matches are stored in the 'navigation maps' which record the associated cluster pairs.
2. Connected groups of clusters are identified by following the identified cluster navigations (akin to the Pandora matching Tensor/Matrix logic)
3. The cluster similarity network (trained on all U/V/W clusters) is ran on each connected group.
4. The navigations are revised, and those that have low similarity scores are removed.
5. The connected groups are once again found, and for each group several tools are ran in order to extract the pfos.

These tools are:
- DLThreeViewClearShowersTool: Forms pfos from 1:1:1 matches
- DLThreeViewMergeAndCreateShowersTool: forms pfos from N:N:N matches. This tool will form a pfo from the cluster triplet that has the highest number of hits (and in which each cluster pair has an above threshold similarity score). Remaining clusters can be merged into the pfo if the similarity score with the cluster in their view exceeds some threshold.
- DLTwoViewClearShowersTool: two view equivalent of DLThreeViewClearShowersTool
- DLTwoViewMergeAndCreateShowersTool: two view equivalent of DLThreeViewMergeAndCreateShowersTool

Okay so, there is a spicy element to the PR - the LArCaloHit updates. I think we need to read in more information about the geometry into pandora. I 100% agree that this is not the best way to do it. Ideally we'd want to pass in a mapping between wires->overlapping wire range for each wire, in each plane, in each daughter volume. But I don't see how that's possible with the current SDK. I am very happy to discuss other approaches. 