### PR TITLE
feature/milestone_1_4

### DIFF
--- a/cmake/LArContent_sources.cmake
+++ b/cmake/LArContent_sources.cmake
@@ -90,6 +90,7 @@ set(LAR_CONTENT_SRCS
     larpandoracontent/LArObjects/LArOverlapMatrix.cc
     larpandoracontent/LArObjects/LArOverlapTensor.cc
     larpandoracontent/LArObjects/LArPfoObjects.cc
+    larpandoracontent/LArObjects/LArPlaneContextObject.cc
     larpandoracontent/LArObjects/LArPointingCluster.cc
     larpandoracontent/LArObjects/LArShowerOverlapResult.cc
     larpandoracontent/LArObjects/LArSupportVectorMachine.cc
@@ -108,6 +109,7 @@ set(LAR_CONTENT_SRCS
     larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.cc
     larpandoracontent/LArReclustering/LArExample/RandomClusteringAlgorithm.cc
     larpandoracontent/LArReclustering/LArExample/RandomFigureOfMeritTool.cc
+    larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
     larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.cc
     larpandoracontent/LArReclustering/ThreeDMultiReclusteringAlgorithm.cc
     larpandoracontent/LArReclustering/ThreeDReclusteringAlgorithm.cc
@@ -155,6 +157,7 @@ set(LAR_CONTENT_SRCS
     larpandoracontent/LArThreeDReco/LArHitCreation/LongitudinalTrackHitsBaseTool.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedLongitudinalTrackHitsTool.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedTransverseTrackHitsTool.cc
+    larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/ShowerHitsBaseTool.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.cc
@@ -171,6 +174,7 @@ set(LAR_CONTENT_SRCS
     larpandoracontent/LArThreeDReco/LArPfoMopUp/SlidingConePfoMopUpAlgorithm.cc
     larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.cc
     larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.cc
+    larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
     larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.cc
     larpandoracontent/LArThreeDReco/LArShowerFragments/ClearRemnantsTool.cc
     larpandoracontent/LArThreeDReco/LArShowerFragments/ConnectedRemnantsTool.cc

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -122,6 +122,7 @@
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/DeltaRayShowerHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedLongitudinalTrackHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedTransverseTrackHitsTool.h"
+#include "larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/TwoViewShowerHitsTool.h"
@@ -292,6 +293,7 @@
     d("LArTwoViewDeltaRayMatching",             TwoViewDeltaRayMatchingAlgorithm)                                               \
     d("LArOneViewDeltaRayMatching",             OneViewDeltaRayMatchingAlgorithm)                                               \
     d("LArUnattachedDeltaRays",                 UnattachedDeltaRaysAlgorithm)                                                   \
+    d("LArPlaneSolver",                         PlaneSolverAlgorithm)                                                           \
     d("LArThreeDHitCreation",                   ThreeDHitCreationAlgorithm)                                                     \
     d("LArThreeDLongitudinalTracks",            ThreeViewLongitudinalTracksAlgorithm)                                           \
     d("LArRecursivePfoMopUp",                   RecursivePfoMopUpAlgorithm)                                                     \

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -79,6 +79,7 @@
 #include "larpandoracontent/LArReclustering/CheatedThreeDClusteringTool.h"
 #include "larpandoracontent/LArReclustering/LArExample/RandomClusteringAlgorithm.h"
 #include "larpandoracontent/LArReclustering/LArExample/RandomFigureOfMeritTool.h"
+#include "larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h"
 #include "larpandoracontent/LArReclustering/SimplePCAThreeDClusteringTool.h"
 
 #include "larpandoracontent/LArShowerRefinement/ConnectionPathwayFeatureTool.h"
@@ -357,6 +358,7 @@
     d("LArThreeDReclustering",                  ThreeDReclusteringAlgorithm)                                                    \
     d("LArThreeDMultiReclustering",             ThreeDMultiReclusteringAlgorithm)                                               \
     d("LArRandomClustering",                    RandomClusteringAlgorithm)                                                      \
+    d("LArShortTrackReclustering",              ShortTrackReclusteringAlgorithm)                                                \
     d("LArCandidateVertexCreation",             CandidateVertexCreationAlgorithm)                                               \
     d("LArEnergyKickVertexSelection",           EnergyKickVertexSelectionAlgorithm)                                             \
     d("LArHitAngleVertexSelection",             HitAngleVertexSelectionAlgorithm)                                               \

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -140,6 +140,7 @@
 #include "larpandoracontent/LArThreeDReco/LArPfoMopUp/VertexBasedPfoMopUpAlgorithm.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoRecovery/ParticleRecoveryAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArPfoRecovery/VertexBasedPfoRecoveryAlgorithm.h"
 
 #include "larpandoracontent/LArThreeDReco/LArShowerFragments/ClearRemnantsTool.h"
@@ -304,6 +305,7 @@
     d("LArShowerMergingPfoMopUp",               ShowerMergingPfoMopUpAlgorithm)                                                 \
     d("LArVertexBasedPfoMopUp",                 VertexBasedPfoMopUpAlgorithm)                                                   \
     d("LArParticleRecovery",                    ParticleRecoveryAlgorithm)                                                      \
+    d("LArTrackRecovery",                       TrackRecoveryAlgorithm)                                                         \
     d("LArVertexBasedPfoRecovery",              VertexBasedPfoRecoveryAlgorithm)                                                \
     d("LArThreeDRemnants",                      ThreeViewRemnantsAlgorithm)                                                     \
     d("LArThreeDShowers",                       ThreeViewShowersAlgorithm)                                                      \

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -8,6 +8,7 @@
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
+#include "larpandoracontent/LArUtility/KDTreeLinkerAlgoT.h"
 
 #include <algorithm>
 #include <cmath>
@@ -688,6 +689,135 @@ bool LArClusterHelper::HasBlockedPath(const CaloHitVector &caloHits, const CaloH
     }
 
     return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArClusterHelper::OrderHitsAlongTrajectory(const Cluster *const pCluster, const TwoDSlidingFitResult &sfr, CaloHitList &orderedHits)
+{
+    CaloHitList clusterHits;
+    pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterHits);
+
+    if (clusterHits.size() < 3)
+    {
+        orderedHits = clusterHits;
+        return;
+    }
+
+    // Build a KD tree to allow quick identification of hits in the vicinity of a given position along the trajectory
+    typedef KDTreeLinkerAlgo<const pandora::CaloHit *, 2> HitKDTree2D;
+    typedef KDTreeNodeInfoT<const pandora::CaloHit *, 2> HitKDNode2D;
+    typedef std::vector<HitKDNode2D> HitKDNode2DList;
+
+    float r{2.f};
+    HitKDTree2D kdTree;
+    HitKDNode2DList nodes;
+    KDTreeBox boundingRegion{fill_and_bound_2d_kd_tree(clusterHits, nodes)};
+    kdTree.build(nodes, boundingRegion);
+
+    // We'll compare the size of the number of used hits to the number of hits in the cluster to determine when we're done
+    const size_t nHits(clusterHits.size());
+    CaloHitSet usedHits, skippedHits;
+    // Start with the first hit in the list
+    const CaloHit *pSeedHit{clusterHits.front()};
+    bool seedIdentified{false};
+    // Check that no other hit precedes this in the sliding fit trajectory, and if it does, update the seed hit until we find the true seed
+    while (!seedIdentified)
+    {
+        seedIdentified = true;
+        // Get sliding fit trajectory for the seed
+        const CartesianVector &seedPos{pSeedHit->GetPositionVector()};
+        float rL{0.f}, rT{0.f};
+        CartesianVector fitDir(0, 0, 0);
+        sfr.GetLocalPosition(seedPos, rL, rT);
+        sfr.GetGlobalFitDirection(rL, fitDir);
+
+        for (const CaloHit *pTestHit : clusterHits)
+        {
+            const CartesianVector &testPos{pTestHit->GetPositionVector()};
+            const CartesianVector testDir{testPos - seedPos};
+            const float lPos{testDir.GetDotProduct(fitDir)};
+
+            // Check for upstream hit, and if found, select as new seed and repeat the process
+            if (lPos < 0)
+            {
+                pSeedHit = pTestHit;
+                seedIdentified = false;
+                break;
+            }
+        }
+    }
+    orderedHits.push_back(pSeedHit);
+    usedHits.insert(pSeedHit);
+
+    // Add hits along the trajectory
+    while (usedHits.size() < nHits)
+    {
+        // Get the local sliding fit trajectory
+        const CartesianVector &seedPos{pSeedHit->GetPositionVector()};
+        float rL{0.f}, rT{0.f};
+        CartesianVector fitDir(0, 0, 0);
+        sfr.GetLocalPosition(seedPos, rL, rT);
+        sfr.GetGlobalFitDirection(rL, fitDir);
+
+        // Find the nearby hits
+        HitKDNode2DList found;
+        bool ok{false};
+        unsigned int nExpansions{0};
+        do
+        {
+            // If we've failed to find usable hits after three expansions, just include all hits
+            if (nExpansions > 2)
+                r = std::numeric_limits<float>::max();
+            KDTreeBox searchRegion(build_2d_kd_search_region(pSeedHit, r, r));
+            kdTree.search(searchRegion, found);
+            // Check if we found something other than the seed
+            if (found.size() < 2)
+            {
+                r *= 2.f;
+                ++nExpansions;
+            }
+            else
+            {
+                for (const auto &node : found)
+                {
+                    const CaloHit *const pTestHit{node.data};
+                    // Ensure our hit region has usable hits
+                    if (!usedHits.count(pTestHit))
+                    {
+                        ok = true;
+                        break;
+                    }
+                }
+                if (!ok)
+                {
+                    found.clear();
+                    r *= 2.f;
+                    ++nExpansions;
+                }
+            }
+        }
+        while (!ok);
+
+        // Find the most upstream unused hit relative to the seed hit, and set this to be the new seed
+        float minLPos(std::numeric_limits<float>::max());
+        for (const auto &node : found)
+        {
+            const CaloHit *const pTestHit{node.data};
+            if (usedHits.count(pTestHit))
+                continue;
+            const CartesianVector &testPos{pTestHit->GetPositionVector()};
+            const CartesianVector testDir{testPos - seedPos};
+            const float lPos{testDir.GetDotProduct(fitDir)};
+            if (lPos < minLPos)
+            {
+                minLPos = lPos;
+                pSeedHit = pTestHit;
+            }
+        }
+        usedHits.insert(pSeedHit);
+        orderedHits.emplace_back(pSeedHit);
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -717,7 +717,7 @@ void LArClusterHelper::OrderHitsAlongTrajectory(const Cluster *const pCluster, c
 
     // We'll compare the size of the number of used hits to the number of hits in the cluster to determine when we're done
     const size_t nHits(clusterHits.size());
-    CaloHitSet usedHits, skippedHits;
+    CaloHitSet usedHits, skippedHits, prevSeed;
     // Start with the first hit in the list
     const CaloHit *pSeedHit{clusterHits.front()};
     bool seedIdentified{false};
@@ -739,8 +739,9 @@ void LArClusterHelper::OrderHitsAlongTrajectory(const Cluster *const pCluster, c
             const float lPos{testDir.GetDotProduct(fitDir)};
 
             // Check for upstream hit, and if found, select as new seed and repeat the process
-            if (lPos < 0)
+            if (lPos < 0.f && !prevSeed.count(pTestHit))
             {
+                prevSeed.insert(pSeedHit);
                 pSeedHit = pTestHit;
                 seedIdentified = false;
                 break;

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -717,7 +717,7 @@ void LArClusterHelper::OrderHitsAlongTrajectory(const Cluster *const pCluster, c
 
     // We'll compare the size of the number of used hits to the number of hits in the cluster to determine when we're done
     const size_t nHits(clusterHits.size());
-    CaloHitSet usedHits, skippedHits, prevSeed;
+    CaloHitSet usedHits, prevSeed;
     // Start with the first hit in the list
     const CaloHit *pSeedHit{clusterHits.front()};
     bool seedIdentified{false};

--- a/larpandoracontent/LArHelpers/LArClusterHelper.cc
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.cc
@@ -754,6 +754,7 @@ void LArClusterHelper::OrderHitsAlongTrajectory(const Cluster *const pCluster, c
     // Add hits along the trajectory
     while (usedHits.size() < nHits)
     {
+        r = 2.f;
         // Get the local sliding fit trajectory
         const CartesianVector &seedPos{pSeedHit->GetPositionVector()};
         float rL{0.f}, rT{0.f};

--- a/larpandoracontent/LArHelpers/LArClusterHelper.h
+++ b/larpandoracontent/LArHelpers/LArClusterHelper.h
@@ -9,6 +9,7 @@
 #define LAR_CLUSTER_HELPER_H 1
 
 #include "Objects/Cluster.h"
+#include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
 
 namespace lar_content
 {
@@ -323,6 +324,15 @@ public:
      *  @return true if there is a hit between the two hits, false otherwise
      */
     static bool HasBlockedPath(const pandora::CaloHitVector &caloHits, const pandora::CaloHit *const pCaloHit1, const pandora::CaloHit *const pCaloHit2);
+
+    /**
+     *  @brief  Constructs a list of hits from a cluster ordered along a sliding fit trajectory.
+     *
+     *  @param  pCluster the cluster whose hits are to be ordered
+     *  @param  sfr the result of the sliding linear fit of the clusters
+     *  @param  orderedHits the list in which to store the ordered hits
+     */
+    static void OrderHitsAlongTrajectory(const pandora::Cluster *const pCluster, const TwoDSlidingFitResult &sfr, pandora::CaloHitList &orderedHits);
 
     /**
      *  @brief  Sort clusters by number of occupied layers, and by inner layer, then energy in event of a tie

--- a/larpandoracontent/LArHelpers/LArEigenHelper.cc
+++ b/larpandoracontent/LArHelpers/LArEigenHelper.cc
@@ -55,6 +55,22 @@ void LArEigenHelper::Vectorize(const T &caloHitContainer, Eigen::MatrixXf &centr
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+template <class T>
+void LArEigenHelper::Vectorize3D(const T &caloHitContainer, Eigen::MatrixXf &hitMatrix)
+{
+    int i{0};
+    for (const CaloHit *const pCaloHit : caloHitContainer)
+    {
+        const CartesianVector &pos{pCaloHit->GetPositionVector()};
+        hitMatrix(i, 0) = pos.GetX();
+        hitMatrix(i, 1) = pos.GetY();
+        hitMatrix(i, 2) = pos.GetZ();
+        ++i;
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void LArEigenHelper::GetAngles(const Eigen::MatrixXf &hitMatrix, const Eigen::RowVectorXf &origin, Eigen::RowVectorXf &phis)
 {
     const float pi{static_cast<float>(M_PI)};
@@ -72,7 +88,12 @@ void LArEigenHelper::GetAngles(const Eigen::MatrixXf &hitMatrix, const Eigen::Ro
 
 template void LArEigenHelper::Vectorize(const CaloHitList &, Eigen::MatrixXf &);
 template void LArEigenHelper::Vectorize(const CaloHitVector &, Eigen::MatrixXf &);
+template void LArEigenHelper::Vectorize(const CaloHitSet &, Eigen::MatrixXf &);
+template void LArEigenHelper::Vectorize3D(const CaloHitList &, Eigen::MatrixXf &);
+template void LArEigenHelper::Vectorize3D(const CaloHitVector &, Eigen::MatrixXf &);
+template void LArEigenHelper::Vectorize3D(const CaloHitSet &, Eigen::MatrixXf &);
 template void LArEigenHelper::Vectorize(const CaloHitList &, Eigen::MatrixXf &, Eigen::MatrixXf &, Eigen::MatrixXf &);
 template void LArEigenHelper::Vectorize(const CaloHitVector &, Eigen::MatrixXf &, Eigen::MatrixXf &, Eigen::MatrixXf &);
+template void LArEigenHelper::Vectorize(const CaloHitSet &, Eigen::MatrixXf &, Eigen::MatrixXf &, Eigen::MatrixXf &);
 
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArEigenHelper.h
+++ b/larpandoracontent/LArHelpers/LArEigenHelper.h
@@ -44,6 +44,15 @@ public:
     static void Vectorize(const T &caloHitContainer, Eigen::MatrixXf &centre, Eigen::MatrixXf &low, Eigen::MatrixXf &high);
 
     /**
+     *  @brief  Convert a container of 3D calo hits into an Eigen matrix.
+     *
+     *  @param  caloHitContainer the calo hit list containing the hits from which to construct a maxtrix
+     *  @param  hitMatrix the output Eigen matrix
+     */
+    template <class T>
+    static void Vectorize3D(const T &caloHitContainer, Eigen::MatrixXf &hitMatrix);
+
+    /**
      *  @brief  Retrieve the angle, coutner-clockwise relative to the x axis, between all hits in a matrix and a specified origin.
      *
      *  @param  hitMatrix the input collection of hits

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -666,7 +666,7 @@ float LArGeometryHelper::CalculateChiSquared(const Pandora &pandora, const CaloH
     const float w(pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(y, z));
 
     const float sigma2_uvw{static_cast<float>(std::pow(LArGeometryHelper::GetSigmaUVW(pandora), 2))};
-    const float sigma2_x_u{static_cast<float>(std::pow(0.5f *pCaloHitU->GetCellSize1(), 2))};
+    const float sigma2_x_u{static_cast<float>(std::pow(0.5f * pCaloHitU->GetCellSize1(), 2))};
     const float sigma2_x_v{static_cast<float>(std::pow(0.5f * pCaloHitV->GetCellSize1(), 2))};
     const float sigma2_x_w{static_cast<float>(std::pow(0.5f * pCaloHitW->GetCellSize1(), 2))};
 

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -640,4 +640,40 @@ bool LArGeometryHelper::IsInDetector(const DetectorBoundaries &detectorBoundarie
     return true;
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LArGeometryHelper::CalculateChiSquared(const Pandora &pandora, const CaloHit *const pCaloHitU, const CaloHit *const pCaloHitV,
+    const CaloHit *const pCaloHitW)
+{
+    const CartesianVector posU(pCaloHitU->GetPositionVector());
+    const CartesianVector posV(pCaloHitV->GetPositionVector());
+    const CartesianVector posW(pCaloHitW->GetPositionVector());
+
+    const float y_uv(pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoY(posU.GetZ(), posV.GetZ()));
+    const float y_uw(pandora.GetPlugins()->GetLArTransformationPlugin()->UWtoY(posU.GetZ(), posW.GetZ()));
+    const float y_vw(pandora.GetPlugins()->GetLArTransformationPlugin()->VWtoY(posV.GetZ(), posW.GetZ()));
+
+    const float z_uv(pandora.GetPlugins()->GetLArTransformationPlugin()->UVtoZ(posU.GetZ(), posV.GetZ()));
+    const float z_uw(pandora.GetPlugins()->GetLArTransformationPlugin()->UWtoZ(posU.GetZ(), posW.GetZ()));
+    const float z_vw(pandora.GetPlugins()->GetLArTransformationPlugin()->VWtoZ(posV.GetZ(), posW.GetZ()));
+
+    const float x((posU.GetX() + posV.GetX() + posW.GetX()) / 3.f);
+    const float y((y_uv + y_uw + y_vw) / 3.f);
+    const float z((z_uv + z_uw + z_vw) / 3.f);
+
+    const float u(pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoU(y, z));
+    const float v(pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoV(y, z));
+    const float w(pandora.GetPlugins()->GetLArTransformationPlugin()->YZtoW(y, z));
+
+    const float sigma2_uvw{static_cast<float>(std::pow(LArGeometryHelper::GetSigmaUVW(pandora), 2))};
+    const float sigma2_x_u{static_cast<float>(std::pow(0.5f *pCaloHitU->GetCellSize1(), 2))};
+    const float sigma2_x_v{static_cast<float>(std::pow(0.5f * pCaloHitV->GetCellSize1(), 2))};
+    const float sigma2_x_w{static_cast<float>(std::pow(0.5f * pCaloHitW->GetCellSize1(), 2))};
+
+    float chiSquared = std::pow(x - posU.GetX(), 2) / sigma2_x_u + std::pow(x - posV.GetX(), 2) / sigma2_x_v + std::pow(x - posW.GetX(), 2) / sigma2_x_w;
+    chiSquared += (std::pow(u - posU.GetZ(), 2) + std::pow(v - posV.GetZ(), 2) + std::pow(w - posW.GetZ(), 2)) / sigma2_uvw;
+
+    return chiSquared;
+}
+
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -304,6 +304,17 @@ public:
      *  @return Whether the input position is within the detector
      */
     static bool IsInDetector(const DetectorBoundaries &detectorBoundaries, const pandora::CartesianVector &position);
+
+    /**
+     *  @brief  Calculate a chi-squared value (including hit width) for a triplet of hits
+     *
+     *  @param  pandora the associated pandora instance
+     *  @param  pCaloHitU the calo hit in the U view
+     *  @param  pCaloHitV the calo hit in the V view
+     *  @param  pCaloHitW the calo hit in the W view
+     */
+    static float CalculateChiSquared(const pandora::Pandora &pandora, const pandora::CaloHit *const pCaloHitU,
+        const pandora::CaloHit *const pCaloHitV, const pandora::CaloHit *const pCaloHitW);
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
+++ b/larpandoracontent/LArHelpers/LArHierarchyHelper.cc
@@ -856,7 +856,7 @@ void LArHierarchyHelper::RecoHierarchy::FillHierarchy(const PfoList &pfoList, co
                 LArPfoHelper::GetAllDownstreamPfos(pPrimary, allParticles);
                 CaloHitList allHits;
                 for (const ParticleFlowObject *pPfo : allParticles)
-                    LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+                    LArPfoHelper::GetAllCaloHits2D(pPfo, allHits);
                 m_interactions[pRoot].emplace_back(new Node(*this, allParticles, allHits));
             }
         }
@@ -875,7 +875,7 @@ void LArHierarchyHelper::RecoHierarchy::FillHierarchy(const PfoList &pfoList, co
 
                 CaloHitList allHits;
                 for (const ParticleFlowObject *pPfo : allParticles)
-                    LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+                    LArPfoHelper::GetAllCaloHits2D(pPfo, allHits);
                 Node *pNode{new Node(*this, allParticles, allHits)};
                 m_interactions[pRoot].emplace_back(pNode);
                 if (!isShower)
@@ -895,7 +895,7 @@ void LArHierarchyHelper::RecoHierarchy::FillHierarchy(const PfoList &pfoList, co
                 PfoList allParticles{pPrimary};
                 CaloHitList allHits;
                 for (const ParticleFlowObject *pPfo : allParticles)
-                    LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+                    LArPfoHelper::GetAllCaloHits2D(pPfo, allHits);
                 Node *pNode{new Node(*this, allParticles, allHits)};
                 m_interactions[pRoot].emplace_back(pNode);
                 // Find the children of this particle and recursively add them to the hierarchy
@@ -1024,7 +1024,7 @@ void LArHierarchyHelper::RecoHierarchy::Node::FillHierarchy(const ParticleFlowOb
 
     CaloHitList allHits;
     for (const ParticleFlowObject *pPfo : allParticles)
-        LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+        LArPfoHelper::GetAllCaloHits2D(pPfo, allHits);
     const bool hasChildren{(foldParameters.m_foldToTier && LArPfoHelper::GetHierarchyTier(pRoot) < foldParameters.m_tier) ||
         (!foldParameters.m_foldToTier && !foldParameters.m_foldToLeadingShowers) || (foldParameters.m_foldToLeadingShowers && !isShower)};
 
@@ -1050,7 +1050,7 @@ void LArHierarchyHelper::RecoHierarchy::Node::FillFlat(const ParticleFlowObject 
     LArPfoHelper::GetAllDownstreamPfos(pRoot, allParticles);
     CaloHitList allHits;
     for (const ParticleFlowObject *pPfo : allParticles)
-        LArPfoHelper::GetAllCaloHits(pPfo, allHits);
+        LArPfoHelper::GetAllCaloHits2D(pPfo, allHits);
     Node *pNode{new Node(m_hierarchy, allParticles, allHits, m_tier + 1)};
     m_children.emplace_back(pNode);
 }

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.cc
@@ -528,6 +528,33 @@ void LArMCParticleHelper::GetMCToSelfMap(const MCParticleList *const pMCParticle
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 
+void LArMCParticleHelper::GetMCToHitsMap(const CaloHitList &caloHitList2D, MCContributionMap &mcToHitsMap, const bool allowSharing)
+{
+    for (const CaloHit *const pCaloHit : caloHitList2D)
+    {
+        try
+        {
+            if (!allowSharing)
+            {
+                const MCParticle *const pMC{MCParticleHelper::GetMainMCParticle(pCaloHit)};
+                mcToHitsMap[pMC].emplace_back(pCaloHit);
+            }
+            else
+            {
+                const MCParticleWeightMap &mcWeightMap{pCaloHit->GetMCParticleWeightMap()};
+
+                for (const auto &[pMC, _] : mcWeightMap)
+                    mcToHitsMap[pMC].emplace_back(pCaloHit);
+            }
+        }
+        catch (StatusCodeException &)
+        {
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------------------------------------------------------------------
+
 void LArMCParticleHelper::GetMCToHitsMap(const CaloHitList *const pCaloHitList2D, const MCParticleList *const pMCParticleList,
     LArMCParticleHelper::MCContributionMap &mcToHitsMap)
 {

--- a/larpandoracontent/LArHelpers/LArMCParticleHelper.h
+++ b/larpandoracontent/LArHelpers/LArMCParticleHelper.h
@@ -316,6 +316,15 @@ public:
     static void GetMCToSelfMap(const pandora::MCParticleList *const pMCParticleList, MCRelationMap &mcToSelfMap);
 
     /*
+     *  @brief  Retrieve the map from MC to calo hits for all particles
+     *
+     *  @param  caloHitList The calo hit list for which MC particle matches are to be determined
+     *  @param  mcToHitsMap The map to populate
+     *  @param  allowSharing Whether to allow hits to be shared between multiple MC particles
+     **/
+    static void GetMCToHitsMap(const pandora::CaloHitList &caloHitList, MCContributionMap &mcToHitsMap, const bool allowSharing = false);
+
+    /*
      *  @brief  Retrieve the map from MC to calo hits for reconstructable particles
      *
      *  @param  pCaloHitList2D The calo hit list for which MC particle matches are to be determined

--- a/larpandoracontent/LArHelpers/LArPfoHelper.cc
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.cc
@@ -73,7 +73,7 @@ void LArPfoHelper::GetIsolatedCaloHits(const ParticleFlowObject *const pPfo, con
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void LArPfoHelper::GetAllCaloHits(const ParticleFlowObject *const pPfo, CaloHitList &caloHitList)
+void LArPfoHelper::GetAllCaloHits2D(const ParticleFlowObject *const pPfo, CaloHitList &caloHitList)
 {
     LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_U, caloHitList);
     LArPfoHelper::GetCaloHits(pPfo, TPC_VIEW_V, caloHitList);

--- a/larpandoracontent/LArHelpers/LArPfoHelper.h
+++ b/larpandoracontent/LArHelpers/LArPfoHelper.h
@@ -70,12 +70,12 @@ public:
     static void GetIsolatedCaloHits(const pandora::ParticleFlowObject *const pPfo, const pandora::HitType &hitType, pandora::CaloHitList &caloHitList);
 
     /**
-     *  @brief  Get a list of all calo hits (including isolated) of all types from a given pfo
+     *  @brief  Get a list of all 2D calo hits (including isolated) of all types from a given pfo
      *
      *  @param  pPfo the input Pfo
      *  @param  caloHitList the output list of calo hits
      */
-    static void GetAllCaloHits(const pandora::ParticleFlowObject *pPfo, pandora::CaloHitList &caloHitList);
+    static void GetAllCaloHits2D(const pandora::ParticleFlowObject *pPfo, pandora::CaloHitList &caloHitList);
 
     /**
      *  @brief  Get a list of clusters of a particular hit type from a list of pfos

--- a/larpandoracontent/LArObjects/LArPlaneContextObject.cc
+++ b/larpandoracontent/LArObjects/LArPlaneContextObject.cc
@@ -1,0 +1,71 @@
+/**
+ *  @file   larpandoracontent/LArHelpers/LArPlaneContextObject.cc
+ *
+ *  @brief  Implementation of the cluster helper class.
+ *
+ *  $Log: $
+ */
+
+#include "larpandoracontent/LArObjects/LArPlaneContextObject.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+bool LArPlaneContextObject::AddHitTriplet(const CaloHit *const pHitU, const CaloHit *const pHitV, const CaloHit *const pHitW)
+{
+    const int nValidHits{(pHitU ? 1 : 0) + (pHitV ? 1 : 0) + (pHitW ? 1 : 0)};
+    if (nValidHits < 2)
+        return false;
+
+    auto hitTriplet(std::make_unique<HitTriplet>(HitTriplet{pHitU, pHitV, pHitW}));
+    HitTriplet* raw = hitTriplet.get();
+    m_hitTriplets.emplace_back(std::move(hitTriplet));
+
+    if (pHitU)
+        m_uIndex[pHitU] = raw;
+    if (pHitV)
+        m_vIndex[pHitV] = raw;
+    if (pHitW)
+        m_wIndex[pHitW] = raw;
+
+    return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const LArPlaneContextObject::HitTriplet *LArPlaneContextObject::GetHitTriplet(const CaloHit *const pCaloHit) const
+{
+    if (m_uIndex.count(pCaloHit))
+        return m_uIndex.at(pCaloHit);
+    if (m_vIndex.count(pCaloHit))
+        return m_vIndex.at(pCaloHit);
+    if (m_wIndex.count(pCaloHit))
+        return m_wIndex.at(pCaloHit);
+
+    return nullptr;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArPlaneContextObject::HitTripletIterator LArPlaneContextObject::begin() const
+{
+    return HitTripletIterator(m_hitTriplets.begin());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArPlaneContextObject::HitTripletIterator LArPlaneContextObject::end() const
+{
+    return HitTripletIterator(m_hitTriplets.end());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+size_t LArPlaneContextObject::Size() const
+{
+    return m_hitTriplets.size();
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArObjects/LArPlaneContextObject.cc
+++ b/larpandoracontent/LArObjects/LArPlaneContextObject.cc
@@ -24,11 +24,20 @@ bool LArPlaneContextObject::AddHitTriplet(const CaloHit *const pHitU, const Calo
     m_hitTriplets.emplace_back(std::move(hitTriplet));
 
     if (pHitU)
+    {
+        PANDORA_THROW_IF(STATUS_CODE_ALREADY_PRESENT, m_uIndex.find(pHitU) != m_uIndex.end());
         m_uIndex[pHitU] = raw;
+    }
     if (pHitV)
+    {
+        PANDORA_THROW_IF(STATUS_CODE_ALREADY_PRESENT, m_vIndex.find(pHitV) != m_vIndex.end());
         m_vIndex[pHitV] = raw;
+    }
     if (pHitW)
+    {
+        PANDORA_THROW_IF(STATUS_CODE_ALREADY_PRESENT, m_wIndex.find(pHitW) != m_wIndex.end());
         m_wIndex[pHitW] = raw;
+    }
 
     return true;
 }

--- a/larpandoracontent/LArObjects/LArPlaneContextObject.cc
+++ b/larpandoracontent/LArObjects/LArPlaneContextObject.cc
@@ -1,5 +1,5 @@
 /**
- *  @file   larpandoracontent/LArHelpers/LArPlaneContextObject.cc
+ *  @file   larpandoracontent/LArObjects/LArPlaneContextObject.cc
  *
  *  @brief  Implementation of the cluster helper class.
  *

--- a/larpandoracontent/LArObjects/LArPlaneContextObject.h
+++ b/larpandoracontent/LArObjects/LArPlaneContextObject.h
@@ -1,0 +1,109 @@
+/**
+ *  @file   larpandoracontent/LArHelpers/LArPlaneContextObject.h
+ *
+ *  @brief  Header file for the LArPlaneContextObject class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_PLANE_CONTEXT_OBJECT_H
+#define LAR_PLANE_CONTEXT_OBJECT_H 1
+
+#include "Objects/CaloHit.h"
+#include "Objects/EventContext.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  LArPlaneContextObject class
+ */
+class LArPlaneContextObject : public pandora::EventContextObject
+{
+public:
+    struct HitTriplet
+    {
+        const pandora::CaloHit *m_uHit;
+        const pandora::CaloHit *m_vHit;
+        const pandora::CaloHit *m_wHit;
+    };
+
+    class HitTripletIterator
+    {
+    public:
+        using InnerIterator = std::vector<std::unique_ptr<HitTriplet>>::const_iterator;
+
+        explicit HitTripletIterator(InnerIterator it) : m_it(it) {}
+
+        const HitTriplet* operator*() const
+        {
+            return m_it->get();
+        }
+
+        HitTripletIterator& operator++()
+        {
+            ++m_it;
+            return *this;
+        }
+
+        bool operator!=(const HitTripletIterator& other) const
+        {
+            return m_it != other.m_it;
+        }
+
+    private:
+        InnerIterator m_it;
+    };
+
+    /**
+     *  @brief Adds a triplet of hits to the context object, where any one of the hits in this triplet could be null.
+     *         The triplet is indexed by each of the hits it contains (if non-null) for retrieval. If more than one hit is null, the triplet
+     *         is not added to the context object, as it cannot be valid.
+     *
+     *  @param  pUHit the U view hit in the triplet (can be null)
+     *  @param  pVHit the V view hit in the triplet (can be null)
+     *  @param  pWHit the W view hit in the triplet (can be null)
+     *
+     *  @return boolean indicating whether the triplet was successfully added to the context object (i.e. at most one hit is null)
+     */
+    bool AddHitTriplet(const pandora::CaloHit *const pUHit, const pandora::CaloHit *const pVHit, const pandora::CaloHit *const pWHit);
+
+    /**
+     *  @brief  Retrieve the triplet of hits associated with the specified hit. Note that any or all of the hits in this triplet could be null.
+     *
+     *  @param  pCaloHit the hit for which to retrieve the associated triplet
+     *
+     *  @return The triplet of hits associated with the specified hit.
+     */
+    const HitTriplet *GetHitTriplet(const pandora::CaloHit *const pCaloHit) const;
+
+    /**
+     *  @brief  Provides access to an iterator at the beginning of the hit triplets to allow iteration over the hit triplets in the context object.
+     *
+     *  @return A const iterator at the beginning of the triplets that can be used to iterate over the hit triplets in the context object.
+     */
+    HitTripletIterator begin() const;
+
+    /**
+     *  @brief  Provides access to an iterator at the end of the hit triplets to allow iteration over the hit triplets in the context object.
+     *
+     *  @return A const iterator at the end of the triplets that can be used to iterate over the hit triplets in the context object.
+     */
+    HitTripletIterator end() const;
+
+    /**
+     *  @brief  Retrieve the number of hit triplets.
+     *
+     *  @return The number of hit triplets.
+     */
+    size_t Size() const;
+
+private:
+    std::vector<std::unique_ptr<HitTriplet>> m_hitTriplets; ///< Storage for all of the triplets of hits
+    std::unordered_map<const pandora::CaloHit *, HitTriplet *> m_uIndex; ///< A map from each U hit to the triplet of hits associated with it
+    std::unordered_map<const pandora::CaloHit *, HitTriplet *> m_vIndex; ///< A map from each V hit to the triplet of hits associated with it
+    std::unordered_map<const pandora::CaloHit *, HitTriplet *> m_wIndex; ///< A map from each W hit to the triplet of hits associated with it
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_PLANE_CONTEXT_OBJECT_H

--- a/larpandoracontent/LArObjects/LArPlaneContextObject.h
+++ b/larpandoracontent/LArObjects/LArPlaneContextObject.h
@@ -11,6 +11,8 @@
 #include "Objects/CaloHit.h"
 #include "Objects/EventContext.h"
 
+#include <memory>
+
 namespace lar_content
 {
 

--- a/larpandoracontent/LArObjects/LArPlaneContextObject.h
+++ b/larpandoracontent/LArObjects/LArPlaneContextObject.h
@@ -1,5 +1,5 @@
 /**
- *  @file   larpandoracontent/LArHelpers/LArPlaneContextObject.h
+ *  @file   larpandoracontent/LArObjects/LArPlaneContextObject.h
  *
  *  @brief  Header file for the LArPlaneContextObject class.
  *

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -1,0 +1,245 @@
+/**
+ *  @file   larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+ *
+ *  @brief  Tries to identify short tracks that are either lost, or under-clustered and recover missing hits.
+ *          This algorithm looks at all three views of a PFO to try to identify if one or more views exhibit step changes in ADC values that
+ *          might be indicative of a decay or intelastic interaction. If such a change occurs it looks for consistency across views and also
+ *          examines nearby unclustered hits, or hits in nearby clusters to see if a more cohenrent clustering can be identified.
+ *          If these various conditions are met, then reclustering is performed.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+
+#include "larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h"
+
+#include <numeric>
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+ShortTrackReclusteringAlgorithm::ShortTrackReclusteringAlgorithm()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ShortTrackReclusteringAlgorithm::Run()
+{
+    // Note: This may become a tool within the reclustering paradigm, but I'll need to chat with Alex about that
+
+    const CaloHitList *pCaloHitList(nullptr);
+    PANDORA_RETURN_IF(STATUS_CODE_SUCCESS, !this->GetList(m_caloHitListName, pCaloHitList));
+
+    ViewToHitsMap viewToUnclusteredHitsMap;
+    this->CollectUnclusteredHits(*pCaloHitList, viewToUnclusteredHitsMap);
+
+    const PfoList *pPfoList{nullptr};
+    PANDORA_RETURN_IF(STATUS_CODE_SUCCESS, !this->GetList(m_pfoListName, pPfoList));
+
+    ViewToClustersMap viewToClustersMap;
+    ClusterToPfoMap clusterToPfoMap;
+    this->CollectClusters(*pPfoList, viewToClustersMap, clusterToPfoMap);
+
+    // Identify the end points of clusters in PFOs
+    for (const auto &[pCluster, pPfo] : clusterToPfoMap)
+    {
+        CaloHitList clusterHitList;
+        pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterHitList);
+        if (clusterHitList.empty())
+            continue;
+
+        CaloHitVector clusterHits(clusterHitList.begin(), clusterHitList.end());
+        HitType view{LArClusterHelper::GetClusterHitType(pCluster)};
+        const float nHalfWindow{2};
+        const float pitch{LArGeometryHelper::GetWirePitch(this->GetPandora(), view)};
+        LArPointingCluster pointingCluster(pCluster, nHalfWindow, pitch);
+
+        CaloHitVector forwardHits, backwardHits;
+        this->OrderHitsRelativeToVertex(clusterHits, pointingCluster.GetInnerVertex(), forwardHits);
+        this->OrderHitsRelativeToVertex(clusterHits, pointingCluster.GetOuterVertex(), backwardHits);
+
+        IntVector discontinuities;
+        this->GetStableAdcDiscontinuities(forwardHits, discontinuities);
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+template <typename T>
+bool ShortTrackReclusteringAlgorithm::GetList(const std::string &listName, const T *&pList) const
+{
+    PandoraContentApi::GetList(*this, listName, pList);
+    return pList && !pList->empty();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::CollectUnclusteredHits(const CaloHitList &caloHitList, ViewToHitsMap &viewToUnclusteredHitsMap) const
+{
+    for (const CaloHit *const pCaloHit : caloHitList)
+    {
+        if (!PandoraContentApi::IsAvailable(*this, pCaloHit))
+            viewToUnclusteredHitsMap[pCaloHit->GetHitType()].insert(pCaloHit);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::CollectClusters(const PfoList &pfoList, ViewToClustersMap &viewToClustersMap, ClusterToPfoMap &clusterToPfoMap) const
+{
+    for (const Pfo *const pPfo : pfoList)
+    {
+        for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
+        {
+            ClusterList pfoClusterList;
+            LArPfoHelper::GetClusters(pPfo, view, pfoClusterList);
+            for (const Cluster *const pCluster : pfoClusterList)
+            {
+                viewToClustersMap[view].emplace_back(pCluster);
+                clusterToPfoMap[pCluster] = pPfo;
+            }
+        }
+    }
+}
+
+void ShortTrackReclusteringAlgorithm::OrderHitsRelativeToVertex(const CaloHitVector &clusterHits, const LArPointingCluster::Vertex &vertex,
+    CaloHitVector &orderedHits) const
+{
+    const CartesianVector &position(vertex.GetPosition());
+    const CartesianVector &direction(vertex.GetDirection());
+
+    // Get the hit-vertex vector and project it onto the pointing cluster vector
+    FloatVector projections;
+    for (const CaloHit *const pCaloHit : clusterHits)
+    {
+        const CartesianVector hitDirection(pCaloHit->GetPositionVector() - position);
+        projections.emplace_back(direction.GetDotProduct(hitDirection));
+    }
+
+    // Sort the hits according to their projections
+    std::vector<size_t> hitIndices(clusterHits.size());
+    std::iota(hitIndices.begin(), hitIndices.end(), 0);
+    std::sort(hitIndices.begin(), hitIndices.end(), [&projections](size_t i, size_t j) { return projections[i] < projections[j]; });
+
+    for (size_t i = 0; i < hitIndices.size(); ++i)
+        orderedHits.emplace_back(clusterHits[hitIndices[i]]);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::GetAdcMovingAverage(const FloatVector &adcs, FloatVector &movingAverage, FloatVector &movingVariance,
+    const size_t window) const
+{
+    // Compute backward looking moving average and variance. Peforms rolling update for efficiency
+    PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, window == 0);
+    const size_t nHits{adcs.size()};
+    movingAverage.resize(nHits);
+    movingVariance.resize(nHits);
+
+    float S{0.f}, V{0.f};
+    size_t count{0};
+    // initial window
+    for (size_t i = 0; i < std::min(nHits, window); ++i)
+    {
+        S += adcs[i];
+        V += adcs[i] * adcs[i];
+        ++count;
+
+        movingAverage[i] = S / count;
+        movingVariance[i] = count > 1 ? (V - S*S / count) / (count - 1) : 0.0; // sample variance
+    }
+    // rolling update
+    for (size_t i = window; i < nHits; ++i)
+    {
+        const float o{adcs[i - window]};
+        const float n{adcs[i]};
+
+        S += n - o;
+        V += n*n - o*o;
+
+        movingAverage[i] = S / count;
+        movingVariance[i] = (V - S*S / count) / (count - 1); // sample variance
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::GetStableAdcDiscontinuities(const pandora::CaloHitVector &hits, pandora::IntVector &discontinuities,
+    const size_t window) const
+{
+    PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, window == 0);
+    FloatVector normalizedAdc, movingAverage, movingVariance;
+    this->NormalizeAdc(hits, normalizedAdc);
+    this->GetAdcMovingAverage(normalizedAdc, movingAverage, movingVariance, window);
+    (void)discontinuities;
+
+    /*
+    // Look for step changes in ADC
+    std::cout << "Cluster with " << clusterHits.size() << std::endl;
+    int i{0};
+    for (const CaloHit *const pCaloHit : hits)
+    {
+        const CartesianVector position(pCaloHit->GetPositionVector());
+        const float adc{pCaloHit->GetInputEnergy()};
+        std::cout << "Hit (" << position.GetX() << ", " << position.GetZ() << ") = " << adc << "(" << forwardAdcs[i] << ")" << std::endl;
+        if (i >= 3 && (forwardAdcs[i] > 2 * forwardAdcs[i - 3] || forwardAdcs[i] < 0.5f * forwardAdcs[i - 3]))
+            std::cout << "  Potential step change in ADC values!" << std::endl;
+        ++i;
+    }
+    */
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::NormalizeAdc(const pandora::CaloHitVector &hits, pandora::FloatVector &normalizedAdc) const
+{
+    normalizedAdc.clear();
+    const size_t mid{hits.size() / 2};
+
+    FloatVector adcs;
+    for (const CaloHit *const pCaloHit : hits)
+        adcs.emplace_back(pCaloHit->GetInputEnergy());
+    // Find median via nth_element - generally faster than sorting (O(n) vs O(n log n))
+    float median{0.f};
+    if (mid % 2 == 0)
+    {
+        std::nth_element(adcs.begin(), adcs.begin() + mid, adcs.end());
+        const float upper{adcs[mid]};
+        std::nth_element(adcs.begin(), adcs.begin() + mid - 1, adcs.end());
+        const float lower{adcs[mid - 1]};
+        median = 0.5f * (lower + upper);
+    }
+    else
+    {
+        std::nth_element(adcs.begin(), adcs.begin() + mid, adcs.end());
+        median = adcs[mid];
+    }
+
+    // This shouldn't be an issue, but just in case
+    if (median < 1.f)
+        median = 1.f;
+    for (const CaloHit *const pCaloHit : hits)
+        normalizedAdc.emplace_back(pCaloHit->GetInputEnergy() / median);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode ShortTrackReclusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -34,15 +34,12 @@ ShortTrackReclusteringAlgorithm::ShortTrackReclusteringAlgorithm()
 
 StatusCode ShortTrackReclusteringAlgorithm::Run()
 {
-    // Note: This may become a tool within the reclustering paradigm, but I'll need to chat with Alex about that
     const CaloHitList *pCaloHitList(nullptr);
     PANDORA_RETURN_IF(STATUS_CODE_SUCCESS, !this->GetList(m_caloHitListName, pCaloHitList));
 
-    ViewToHitsMap viewToUnclusteredHitsMap;
-    this->CollectUnclusteredHits(*pCaloHitList, viewToUnclusteredHitsMap);
-
     const PfoList *pPfoList{nullptr};
-    PANDORA_RETURN_IF(STATUS_CODE_SUCCESS, !this->GetList(m_pfoListName, pPfoList));
+    if (!this->GetList(m_pfoListName, pPfoList))
+        return STATUS_CODE_SUCCESS;
 
     ViewToClustersMap viewToClustersMap;
     ClusterToPfoMap clusterToPfoMap;
@@ -59,7 +56,7 @@ StatusCode ShortTrackReclusteringAlgorithm::Run()
     this->MatchAdcDiscontinuities(clusterToHitsMap, clusterToPfoMap, pfoToHitTripletsMap);
 
     PartitionVector partitions;
-    this->PartitionDiscontinuities(pfoToHitTripletsMap, viewToUnclusteredHitsMap, partitions);
+    this->PartitionDiscontinuities(pfoToHitTripletsMap, partitions);
 
     if (!partitions.empty())
         this->Recluster(partitions);
@@ -74,17 +71,6 @@ bool ShortTrackReclusteringAlgorithm::GetList(const std::string &listName, const
 {
     PandoraContentApi::GetList(*this, listName, pList);
     return pList && !pList->empty();
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-void ShortTrackReclusteringAlgorithm::CollectUnclusteredHits(const CaloHitList &caloHitList, ViewToHitsMap &viewToUnclusteredHitsMap) const
-{
-    for (const CaloHit *const pCaloHit : caloHitList)
-    {
-        if (!PandoraContentApi::IsAvailable(*this, pCaloHit))
-            viewToUnclusteredHitsMap[pCaloHit->GetHitType()].insert(pCaloHit);
-    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -311,10 +297,8 @@ void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHit
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTripletsMap &pfoToHitTripletsMap,
-    const ViewToHitsMap &viewToUnclusteredHitsMap, PartitionVector &partitions) const
+void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTripletsMap &pfoToHitTripletsMap, PartitionVector &partitions) const
 {
-    (void)viewToUnclusteredHitsMap;
     for (const auto &[pPfo, hitTriplets] : pfoToHitTripletsMap)
     {
         ClusterList pfoClusterList;
@@ -431,27 +415,54 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
     std::string tempPfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, tempPfoListName));
 
+    std::unordered_map<const CaloHit *, int> hitCount;
+    ProtoPfoVector protoPfos;
     for (const auto &[pPfo, hitTriplet, hitsU, hitsV, hitsW] : partitions)
     {
-        CaloHitList pfoHits3D;
-        LArPfoHelper::GetCaloHits(pPfo, TPC_3D, pfoHits3D);
+        ProtoPfo protoPfo;
+        protoPfo.m_pfoParameters.m_particleId = pPfo->GetParticleId();
+        protoPfo.m_pfoParameters.m_charge = PdgTable::GetParticleCharge(pPfo->GetParticleId());
+        protoPfo.m_pfoParameters.m_mass = PdgTable::GetParticleMass(pPfo->GetParticleId());
+        protoPfo.m_pfoParameters.m_energy = 0.f;
+        protoPfo.m_pfoParameters.m_momentum = CartesianVector(0.f, 0.f, 0.f);
+        protoPfo.m_pOldPfo = pPfo;
 
-        PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
-        pfoParameters.m_particleId = pPfo->GetParticleId();
-        pfoParameters.m_charge = PdgTable::GetParticleCharge(pfoParameters.m_particleId.Get());
-        pfoParameters.m_mass = PdgTable::GetParticleMass(pfoParameters.m_particleId.Get());
-        pfoParameters.m_energy = 0.f;
-        pfoParameters.m_momentum = CartesianVector(0.f, 0.f, 0.f);
         for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
         {
             const CaloHitList &hits{view == TPC_VIEW_U ? hitsU : (view == TPC_VIEW_V ? hitsV : hitsW)};
             const CaloHit *hit{view == TPC_VIEW_U ? std::get<0>(hitTriplet) : (view == TPC_VIEW_V ? std::get<1>(hitTriplet) : std::get<2>(hitTriplet))};
             CaloHitList cluster1Hits, cluster2Hits;
             this->PartitionHits(hits, hit, cluster1Hits, cluster2Hits);
+            protoPfo.m_viewToHitsMap[view] = std::move(cluster2Hits);
+            for (const CaloHit *const pCaloHit : protoPfo.m_viewToHitsMap[view])
+                if (hitCount.find(pCaloHit) == hitCount.end())
+                    hitCount[pCaloHit] = 1;
+                else
+                    ++hitCount[pCaloHit];
+        }
+        protoPfos.emplace_back(std::move(protoPfo));
+    }
 
+    for (const auto &[pCaloHit, count] : hitCount)
+    {
+        if (count > 1)
+            std::cout << "Hit " << pCaloHit << " is shared " << count << " times across partitions" << std::endl;
+    }
+
+    // Remove merge hits from their original PFOs, along with associated 3D hits
+    for (auto &protoPfo : protoPfos)
+    {
+        const Pfo *const pPfo{protoPfo.m_pOldPfo};
+        CaloHitList pfoHits3D;
+        LArPfoHelper::GetCaloHits(pPfo, TPC_3D, pfoHits3D);
+
+        for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
+        {
+            const CaloHitList &clusterHits{protoPfo.m_viewToHitsMap[view]};
             ClusterList clusterList;
             LArPfoHelper::GetClusters(pPfo, view, clusterList);
-            for (const CaloHit *const pCaloHit : cluster2Hits)
+            std::cout << "Removing view " << view << " hits" << std::endl;
+            for (const CaloHit *const pCaloHit : clusterHits)
                 PandoraContentApi::RemoveFromCluster(*this, clusterList.front(), pCaloHit);
 
             ClusterList clusterList3D;
@@ -459,25 +470,37 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
             for (const CaloHit *const pCaloHit : pfoHits3D)
             {
                 const CaloHit *pParent{static_cast<const CaloHit *>(pCaloHit->GetParentAddress())};
-                if (std::find(cluster2Hits.begin(), cluster2Hits.end(), pParent) != cluster2Hits.end())
+                if (std::find(clusterHits.begin(), clusterHits.end(), pParent) != clusterHits.end())
                     PandoraContentApi::RemoveFromCluster(*this, clusterList3D.front(), pCaloHit);
             }
+        }
+    }
+    std::cout << "Creating new clusters" << std::endl;
 
-            std::string newClusterListName;
-            const ClusterList *pClusterList{nullptr};
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, newClusterListName));
+    // Create the new clusters and associate to the proto PFOs
+    for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
+    {
+        std::string newClusterListName;
+        const ClusterList *pClusterList{nullptr};
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, newClusterListName));
+
+        for (auto &protoPfo : protoPfos)
+        {
             PandoraContentApi::Cluster::Parameters parameters;
-            parameters.m_caloHitList = std::move(cluster2Hits);
+            parameters.m_caloHitList = std::move(protoPfo.m_viewToHitsMap[view]);
 
             const Cluster *pNewCluster(nullptr);
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, parameters, pNewCluster));
-            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, viewToClusterListNameMap.at(view)));
-
-            pfoParameters.m_clusterList.emplace_back(pNewCluster);
+            protoPfo.m_pfoParameters.m_clusterList.emplace_back(pNewCluster);
         }
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, viewToClusterListNameMap.at(view)));
+    }
 
-        const Pfo *pNewPfo(nullptr);
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pNewPfo));
+    // Create the new PFOs
+    for (auto &protoPfo : protoPfos)
+    {
+        const Pfo *pNewPfo{nullptr};
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, protoPfo.m_pfoParameters, pNewPfo));
     }
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, tempPfoListName, m_pfoListName));
 

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -57,6 +57,7 @@ StatusCode ShortTrackReclusteringAlgorithm::Run()
 
     PartitionVector partitions;
     this->PartitionDiscontinuities(pfoToHitTripletsMap, partitions);
+    this->FilterPartitions(partitions);
 
     if (!partitions.empty())
         this->Recluster(partitions);
@@ -386,6 +387,24 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void ShortTrackReclusteringAlgorithm::FilterPartitions(PartitionVector &partitions) const
+{
+    for (auto iter1 = partitions.begin(); iter1 != partitions.end(); ++iter1)
+    {
+        const Pfo *const pPfo1{iter1->m_pCurrentPfo};
+        for (auto iter2 = std::next(iter1); iter2 != partitions.end();)
+        {
+            const Pfo *const pPfo2{iter2->m_pCurrentPfo};
+            if (pPfo2 == pPfo1)
+                iter2 = partitions.erase(iter2);
+            else
+                ++iter2;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partitions) const
 {
     std::string initialPfoListName;
@@ -416,6 +435,7 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, tempPfoListName));
 
     std::unordered_map<const CaloHit *, int> hitCount;
+    std::unordered_map<const Pfo *, int> pfoCount;
     ProtoPfoVector protoPfos;
     for (const auto &[pPfo, hitTriplet, hitsU, hitsV, hitsW] : partitions)
     {
@@ -434,19 +454,8 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
             CaloHitList cluster1Hits, cluster2Hits;
             this->PartitionHits(hits, hit, cluster1Hits, cluster2Hits);
             protoPfo.m_viewToHitsMap[view] = std::move(cluster2Hits);
-            for (const CaloHit *const pCaloHit : protoPfo.m_viewToHitsMap[view])
-                if (hitCount.find(pCaloHit) == hitCount.end())
-                    hitCount[pCaloHit] = 1;
-                else
-                    ++hitCount[pCaloHit];
         }
         protoPfos.emplace_back(std::move(protoPfo));
-    }
-
-    for (const auto &[pCaloHit, count] : hitCount)
-    {
-        if (count > 1)
-            std::cout << "Hit " << pCaloHit << " is shared " << count << " times across partitions" << std::endl;
     }
 
     // Remove merge hits from their original PFOs, along with associated 3D hits
@@ -461,7 +470,6 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
             const CaloHitList &clusterHits{protoPfo.m_viewToHitsMap[view]};
             ClusterList clusterList;
             LArPfoHelper::GetClusters(pPfo, view, clusterList);
-            std::cout << "Removing view " << view << " hits" << std::endl;
             for (const CaloHit *const pCaloHit : clusterHits)
                 PandoraContentApi::RemoveFromCluster(*this, clusterList.front(), pCaloHit);
 
@@ -475,7 +483,6 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
             }
         }
     }
-    std::cout << "Creating new clusters" << std::endl;
 
     // Create the new clusters and associate to the proto PFOs
     for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -86,6 +86,7 @@ void ShortTrackReclusteringAlgorithm::CollectUnclusteredHits(const CaloHitList &
 
 void ShortTrackReclusteringAlgorithm::CollectClusters(const PfoList &pfoList, ViewToClustersMap &viewToClustersMap, ClusterToPfoMap &clusterToPfoMap) const
 {
+    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1, -1, 1));
     for (const Pfo *const pPfo : pfoList)
     {
         for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
@@ -96,6 +97,20 @@ void ShortTrackReclusteringAlgorithm::CollectClusters(const PfoList &pfoList, Vi
             {
                 viewToClustersMap[view].emplace_back(pCluster);
                 clusterToPfoMap[pCluster] = pPfo;
+
+                /////////
+                const TwoDSlidingFitResult sfr(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), view));
+                CaloHitList clusterHits;
+                LArClusterHelper::OrderHitsAlongTrajectory(pCluster, sfr, clusterHits);
+                int i{1};
+                for (const CaloHit *const pCaloHit : clusterHits)
+                {
+                    const CartesianVector &position(pCaloHit->GetPositionVector());
+                    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, std::to_string(i), BLUE, 2));
+                    ++i;
+                }
+                PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+                /////////
             }
         }
     }

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -240,6 +240,8 @@ void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHit
                 *pBestW{view == TPC_VIEW_W ? pCaloHit : nullptr};
             if (view == TPC_VIEW_U || view == TPC_VIEW_V)
             {
+                if (filteredHits3Dw.empty())
+                    continue;
                 Eigen::MatrixXf norms((hitMatrixW.rowwise() - row).array().pow(2).rowwise().sum());
                 Eigen::Index index;
                 norms.col(0).minCoeff(&index);
@@ -247,6 +249,8 @@ void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHit
             }
             if (view == TPC_VIEW_U || view == TPC_VIEW_W)
             {
+                if (filteredHits3Dv.empty())
+                    continue;
                 Eigen::MatrixXf norms((hitMatrixV.rowwise() - row).array().pow(2).rowwise().sum());
                 Eigen::Index index;
                 norms.col(0).minCoeff(&index);
@@ -254,6 +258,8 @@ void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHit
             }
             if (view == TPC_VIEW_V || view == TPC_VIEW_W)
             {
+                if (filteredHits3Du.empty())
+                    continue;
                 Eigen::MatrixXf norms((hitMatrixU.rowwise() - row).array().pow(2).rowwise().sum());
                 Eigen::Index index;
                 norms.col(0).minCoeff(&index);
@@ -293,11 +299,7 @@ void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHit
 void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTripletsMap &pfoToHitTripletsMap,
     const ViewToHitsMap &viewToUnclusteredHitsMap, PartitionVector &partitions) const
 {
-    (void)viewToUnclusteredHitsMap; (void)partitions;
-    // Iterate over each PFO and get its respective discontinuities. Perform sliding linear fits on each of its clusters and use the
-    // discontinuities to focus on the relevant part of the sliding fit. Walk from just before that point of the fit to just after
-    // in all available views to see if a coherent picture emerges. If so, propose a new partition.
-    // Once partitions have been identified, examine the unclustered hits to see if they can be added to the partition.
+    (void)viewToUnclusteredHitsMap;
     for (const auto &[pPfo, hitTriplets] : pfoToHitTripletsMap)
     {
         ClusterList pfoClusterList;
@@ -324,54 +326,62 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
         const TwoDSlidingFitResult sfrV(pClusterV, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V));
         const TwoDSlidingFitResult sfrW(pClusterW, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W));
 
-        const std::streamsize originalPrecision{std::cout.precision()};
-        const std::ios_base::fmtflags originalFormat{std::cout.flags()};
         for (const auto &[hitU, hitV, hitW] : hitTriplets)
         {
-            std::cout << "Cluster" << std::endl;
-            std::cout << std::fixed << std::setprecision(1);
             CaloHitVector orderedHitsU, orderedHitsV, orderedHitsW;
             size_t indexU{0}, indexV{0}, indexW{0};
             if (hitU && pClusterU)
                 indexU = this->OrderHitsAlongTrajectory(pClusterU, hitU, sfrU, 5.f, orderedHitsU);
-                // We now have a logically ordered list of hits in the cluster around the discontinuity
-                // Once we have a similarly ordered list in the other views, we can look for consistent patterns
-                // Ideally we'd like to correlate these hits so that we can start and stop in the same place in each view
-                // A quick Hungarian algorithm style matching of the hits may be useful here
-                // More generally however, just explore the changes either side of the discontinuity, and look to see if
-                // at least two of the views agree
             if (hitV && pClusterV)
                 indexV = this->OrderHitsAlongTrajectory(pClusterV, hitV, sfrV, 5.f, orderedHitsV);
             if (hitW && pClusterW)
                 indexW = this->OrderHitsAlongTrajectory(pClusterW, hitW, sfrW, 5.f, orderedHitsW);
 
-            for (size_t i = 0; i < std::max({orderedHitsU.size(), orderedHitsV.size(), orderedHitsW.size()}); ++i)
-            {
-                if (orderedHitsU.size() > i)
-                    std::cout << "(" << (i == indexU) << ") " << orderedHitsU.at(i)->GetInputEnergy();
-                else
-                    std::cout << "         ";
-                std::cout << " | ";
-                if (orderedHitsV.size() > i)
-                    std::cout << "(" << (i == indexV) << ") " << orderedHitsV.at(i)->GetInputEnergy();
-                else
-                    std::cout << "         ";
-                std::cout << " | ";
-                if (orderedHitsW.size() > i)
-                    std::cout << "(" << (i == indexW) << ") " << orderedHitsW.at(i)->GetInputEnergy();
-                else
-                    std::cout << "         ";
-                std::cout << std::endl;
-            }
-            std::cout << "========================" << std::endl;
+            // Don't split when clusters are too small
+            int nSmall{0};
+            nSmall += ((orderedHitsU.size() - indexU) < 3) || indexU < 3;
+            nSmall += ((orderedHitsV.size() - indexV) < 3) || indexV < 3;
+            nSmall += ((orderedHitsW.size() - indexW) < 3) || indexW < 3;
+            if (nSmall >= 2)
+                continue;
+
             const float balanceU{this->GetBalance(orderedHitsU, indexU)};
             const float balanceV{this->GetBalance(orderedHitsV, indexV)};
             const float balanceW{this->GetBalance(orderedHitsW, indexW)};
-            std::cout << "Balance: " << std::endl;
-            std::cout << "U: " << balanceU << " V: " << balanceV << " W: " << balanceW << std::endl;
+            int nStepUp{0}, nStepDown{0}, nMissing{0};
+            nStepUp += balanceU > 1.5f;
+            nStepDown += balanceU && balanceU < 0.67f;
+            nMissing += !balanceU;
+            nStepUp += balanceV > 1.5f;
+            nStepDown += balanceV && balanceV < 0.67f;
+            nMissing += !balanceV;
+            nStepUp += balanceW > 1.5f;
+            nStepDown += balanceW &&balanceW < 0.67f;
+            nMissing += !balanceW;
+            if (nStepUp >= 3 || nStepDown >= 3 || (nStepUp == 2 && nMissing == 1) || (nStepDown == 2 && nMissing == 1))
+            {
+                // We have a consistent discontinuous change in ADC across at least two views
+                std::cout << "Balance: " << "U: " << balanceU << " V: " << balanceV << " W: " << balanceW << std::endl;
+                partitions.emplace_back(Partition(pPfo, std::make_tuple(hitU, hitV, hitW), sfrU, sfrV, sfrW));
+                PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1, -1, 1));
+                if (hitU)
+                {
+                    const CartesianVector &pos(hitU->GetPositionVector());
+                    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &pos, "U", RED, 2));
+                }
+                if (hitV)
+                {
+                    const CartesianVector &pos(hitV->GetPositionVector());
+                    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &pos, "V", RED, 2));
+                }
+                if (hitW)
+                {
+                    const CartesianVector &pos(hitW->GetPositionVector());
+                    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &pos, "W", RED, 2));
+                }
+                PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+            }
         }
-        std::cout.precision(originalPrecision);
-        std::cout.flags(originalFormat);
     }
 }
 

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -855,6 +855,9 @@ float ShortTrackReclusteringAlgorithm::GetMonotonicityScore(const pandora::CaloH
 
 float ShortTrackReclusteringAlgorithm::GetBalance(const pandora::CaloHitList &hits, const size_t pivot) const
 {
+    if (hits.empty() || pivot == 0 || pivot >= hits.size())
+        return 0.f;
+
     FloatVector adcs;
     // Get pre-pivot median
     size_t i{0};

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -61,6 +61,9 @@ StatusCode ShortTrackReclusteringAlgorithm::Run()
     PartitionVector partitions;
     this->PartitionDiscontinuities(pfoToHitTripletsMap, viewToUnclusteredHitsMap, partitions);
 
+    if (!partitions.empty())
+        this->Recluster(partitions);
+
     return STATUS_CODE_SUCCESS;
 }
 
@@ -397,6 +400,128 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
             }
         }
     }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partitions) const
+{
+    std::string pfoListName{"TrackParticles3D"};
+    std::string initialPfoListName;
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentListName<Pfo>(*this, initialPfoListName));
+
+    const PfoList *pPfoList{nullptr};
+    std::string tempPfoListName;
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, tempPfoListName));
+
+    std::map<HitType, std::string> viewToClusterListNameMap{{TPC_VIEW_U, "ClustersU"}, {TPC_VIEW_V, "ClustersV"}, {TPC_VIEW_W, "ClustersW"}};
+    std::map<HitType, int> viewToIndexMap{{TPC_VIEW_U, 0}, {TPC_VIEW_V, 1}, {TPC_VIEW_W, 2}};
+    for (const auto &[pPfo, hitTriplet, hitsU, hitsV, hitsW] : partitions)
+    {
+        CaloHitList pfoHits3D, newPfoHits3D;
+        LArPfoHelper::GetCaloHits(pPfo, TPC_3D, pfoHits3D);
+
+        // Need to get the cluster lists from XML and properly associated those.
+        // Similarly need to get the PFO list
+        // Need to remove the 3D hits from the current PFO and remake those
+        // Need to create a new PFO from the new clusters and add the 3D hits to that
+        // Need to change the hierarchy so that the new PFO is a child of the old one, and potentially associate any child PFOs from the original
+        // PFO to the new one - that's more complex, may want to just redo hierarchy building afterwards, or ensure this runs before
+        PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
+        pfoParameters.m_particleId = pPfo->GetParticleId();
+        pfoParameters.m_charge = PdgTable::GetParticleCharge(pfoParameters.m_particleId.Get());
+        pfoParameters.m_mass = PdgTable::GetParticleMass(pfoParameters.m_particleId.Get());
+        pfoParameters.m_energy = 0.f;
+        pfoParameters.m_momentum = CartesianVector(0.f, 0.f, 0.f);
+        for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
+        {
+            const CaloHitList &hits{view == TPC_VIEW_U ? hitsU : (view == TPC_VIEW_V ? hitsV : hitsW)};
+            const CaloHit *hit{view == TPC_VIEW_U ? std::get<0>(hitTriplet) : (view == TPC_VIEW_V ? std::get<1>(hitTriplet) : std::get<2>(hitTriplet))};
+            CaloHitList cluster1Hits, cluster2Hits;
+            this->PartitionHits(hits, hit, cluster1Hits, cluster2Hits);
+
+            ClusterList clusterList;
+            LArPfoHelper::GetClusters(pPfo, view, clusterList);
+            for (const CaloHit *const pCaloHit : cluster2Hits)
+                PandoraContentApi::RemoveFromCluster(*this, clusterList.front(), pCaloHit);
+
+            ClusterList clusterList3D;
+            LArPfoHelper::GetClusters(pPfo, TPC_3D, clusterList3D);
+            for (const CaloHit *const pCaloHit : pfoHits3D)
+            {
+                const CaloHit *pParent{static_cast<const CaloHit *>(pCaloHit->GetParentAddress())};
+                if (std::find(cluster2Hits.begin(), cluster2Hits.end(), pParent) != cluster2Hits.end())
+                {
+                    newPfoHits3D.emplace_back(pCaloHit);
+                    PandoraContentApi::RemoveFromCluster(*this, clusterList3D.front(), pCaloHit);
+                }
+            }
+
+            std::string newClusterListName;
+            const ClusterList *pClusterList{nullptr};
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, newClusterListName));
+            PandoraContentApi::Cluster::Parameters parameters;
+            parameters.m_caloHitList = std::move(cluster2Hits);
+
+            const Cluster *pNewCluster(nullptr);
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, parameters, pNewCluster));
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, viewToClusterListNameMap.at(view)));
+
+            pfoParameters.m_clusterList.emplace_back(pNewCluster);
+        }
+
+        std::string newCluster3DListName;
+        const ClusterList *pClusterList3D{nullptr};
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList3D, newCluster3DListName));
+        PandoraContentApi::Cluster::Parameters clusterParameters3D;
+        clusterParameters3D.m_caloHitList = std::move(newPfoHits3D);
+
+        const Cluster *pNewCluster3D(nullptr);
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, clusterParameters3D, pNewCluster3D));
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, "TrackClusters3D"));
+
+        pfoParameters.m_clusterList.emplace_back(pNewCluster3D);
+        std::cout << "Making new PFO with " << pfoParameters.m_clusterList.size() << " clusters" << std::endl;
+        const Pfo *pNewPfo(nullptr);
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pNewPfo));
+    }
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, tempPfoListName, pfoListName));
+
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Pfo>(*this, initialPfoListName));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::PartitionHits(const CaloHitList &caloHits, const CaloHit *const pSplitHit, CaloHitList &cluster1Hits, CaloHitList &cluster2Hits) const
+{
+    bool passedSplit{false};
+    for (const CaloHit *const pCaloHit : caloHits)
+    {
+        if (pCaloHit == pSplitHit)
+        {
+            passedSplit = true;
+            continue;
+        }
+        if (!passedSplit)
+            cluster1Hits.emplace_back(pCaloHit);
+        else
+            cluster2Hits.emplace_back(pCaloHit);
+    }
+    FloatVector adcs1;
+    for (const CaloHit *const pCaloHit : cluster1Hits)
+        adcs1.emplace_back(pCaloHit->GetInputEnergy());
+    const float median1{static_cast<float>(this->GetMedian(adcs1))};
+    FloatVector adcs2;
+    for (const CaloHit *const pCaloHit : cluster2Hits)
+        adcs2.emplace_back(pCaloHit->GetInputEnergy());
+    const float median2{static_cast<float>(this->GetMedian(adcs2))};
+    const float splitAdc{pSplitHit->GetInputEnergy()};
+    const float da1{std::abs(splitAdc - median1)}, da2{std::abs(splitAdc - median2)};
+    // Add the split point hit to the cluster most consistent with its ADC
+    if (da1 < da2)
+        cluster1Hits.emplace_back(pSplitHit);
+    else
+        cluster2Hits.emplace_back(pSplitHit);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -48,6 +48,8 @@ StatusCode ShortTrackReclusteringAlgorithm::Run()
     ClusterToPfoMap clusterToPfoMap;
     this->CollectClusters(*pPfoList, viewToClustersMap, clusterToPfoMap);
 
+    this->FitAndOrderClusters(viewToClustersMap);
+
     // Loop over clusters, and look for evidence of discontinuous changes in ADC deposition and collect the corresponding hits.
     ClusterToHitsMap clusterToHitsMap;
     this->FindAdcDiscontinuities(clusterToPfoMap, clusterToHitsMap);
@@ -97,20 +99,37 @@ void ShortTrackReclusteringAlgorithm::CollectClusters(const PfoList &pfoList, Vi
             {
                 viewToClustersMap[view].emplace_back(pCluster);
                 clusterToPfoMap[pCluster] = pPfo;
+            }
+        }
+    }
+}
 
-                /////////
-                const TwoDSlidingFitResult sfr(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), view));
-                CaloHitList clusterHits;
-                LArClusterHelper::OrderHitsAlongTrajectory(pCluster, sfr, clusterHits);
-                int i{1};
-                for (const CaloHit *const pCaloHit : clusterHits)
-                {
-                    const CartesianVector &position(pCaloHit->GetPositionVector());
-                    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, std::to_string(i), BLUE, 2));
-                    ++i;
-                }
-                PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
-                /////////
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::FitAndOrderClusters(const ViewToClustersMap &viewToClustersMap)
+{
+    for (const auto &[view, clusters] : viewToClustersMap)
+    {
+        for (const Cluster *const pCluster : clusters)
+        {
+            if (pCluster->GetNCaloHits() < 3)
+                continue;
+            switch (view)
+            {
+                case TPC_VIEW_U:
+                    m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U)));
+                    LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    break;
+                case TPC_VIEW_V:
+                    m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V)));
+                    LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    break;
+                case TPC_VIEW_W:
+                    m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W)));
+                    LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    break;
+                default:
+                    break;
             }
         }
     }
@@ -122,38 +141,16 @@ void ShortTrackReclusteringAlgorithm::FindAdcDiscontinuities(const ClusterToPfoM
 {
     for (const auto &[pCluster, pPfo] : clusterToPfoMap)
     {
-        CaloHitList clusterHitList;
-        pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterHitList);
+        CaloHitList clusterHitList{m_clusterToOrderedHitsMap.at(pCluster)};
         // Can't perform the pointing cluster's sliding linear fit without at least 3 hits
         if (clusterHitList.size() < 3)
             continue;
 
         CaloHitVector clusterHits(clusterHitList.begin(), clusterHitList.end());
-        HitType view{LArClusterHelper::GetClusterHitType(pCluster)};
-        const float nHalfWindow{2};
-        const float pitch{LArGeometryHelper::GetWirePitch(this->GetPandora(), view)};
-        try
-        {
-            LArPointingCluster pointingCluster(pCluster, nHalfWindow, pitch);
-
-            CaloHitVector forwardHits, backwardHits;
-            this->OrderHitsRelativeToVertex(clusterHits, pointingCluster.GetInnerVertex(), forwardHits);
-            this->OrderHitsRelativeToVertex(clusterHits, pointingCluster.GetOuterVertex(), backwardHits);
-
-            IntVector discontinuities;
-            this->GetStableAdcDiscontinuities(forwardHits, discontinuities);
-            for (const int index : discontinuities)
-                clusterToHitsMap[pCluster].insert(forwardHits.at(index));
-            IntVector backwardDiscontinuities;
-            this->GetStableAdcDiscontinuities(backwardHits, backwardDiscontinuities);
-            for (const int index : backwardDiscontinuities)
-                clusterToHitsMap[pCluster].insert(backwardHits.at(index));
-        }
-        catch (const StatusCodeException &)
-        {
-            // Couldn't construct a pointing cluster, so skip this cluster
-            continue;
-        }
+        IntVector discontinuities;
+        this->GetStableAdcDiscontinuities(clusterHits, discontinuities);
+        for (const int index : discontinuities)
+            clusterToHitsMap[pCluster].insert(clusterHits.at(index));
     }
 }
 
@@ -325,32 +322,49 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
             switch (LArClusterHelper::GetClusterHitType(pCluster))
             {
                 case TPC_VIEW_U:
+                {
                     pClusterU = pCluster;
                     break;
+                }
                 case TPC_VIEW_V:
+                {
                     pClusterV = pCluster;
                     break;
+                }
                 case TPC_VIEW_W:
+                {
                     pClusterW = pCluster;
                     break;
+                }
                 default:
                     break;
             }
         }
-        const TwoDSlidingFitResult sfrU(pClusterU, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U));
-        const TwoDSlidingFitResult sfrV(pClusterV, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V));
-        const TwoDSlidingFitResult sfrW(pClusterW, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W));
 
         for (const auto &[hitU, hitV, hitW] : hitTriplets)
         {
-            CaloHitVector orderedHitsU, orderedHitsV, orderedHitsW;
+            const CaloHitList &orderedHitsU{pClusterU ? m_clusterToOrderedHitsMap.at(pClusterU) : CaloHitList()},
+                &orderedHitsV{pClusterV ? m_clusterToOrderedHitsMap.at(pClusterV) : CaloHitList()},
+                &orderedHitsW{pClusterW ? m_clusterToOrderedHitsMap.at(pClusterW) : CaloHitList()};
             size_t indexU{0}, indexV{0}, indexW{0};
             if (hitU && pClusterU)
-                indexU = this->OrderHitsAlongTrajectory(pClusterU, hitU, sfrU, 5.f, orderedHitsU);
+            {
+                auto it = std::find(orderedHitsU.begin(), orderedHitsU.end(), hitU);
+                if (it != orderedHitsU.end())
+                    indexU = std::distance(orderedHitsU.begin(), it);
+            }
             if (hitV && pClusterV)
-                indexV = this->OrderHitsAlongTrajectory(pClusterV, hitV, sfrV, 5.f, orderedHitsV);
+            {
+                auto it = std::find(orderedHitsV.begin(), orderedHitsV.end(), hitV);
+                if (it != orderedHitsV.end())
+                    indexV = std::distance(orderedHitsV.begin(), it);
+            }
             if (hitW && pClusterW)
-                indexW = this->OrderHitsAlongTrajectory(pClusterW, hitW, sfrW, 5.f, orderedHitsW);
+            {
+                auto it = std::find(orderedHitsW.begin(), orderedHitsW.end(), hitW);
+                if (it != orderedHitsW.end())
+                    indexW = std::distance(orderedHitsW.begin(), it);
+            }
 
             // Don't split when clusters are too small
             int nSmall{0};
@@ -373,28 +387,13 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
             nStepUp += balanceW > 1.5f;
             nStepDown += balanceW &&balanceW < 0.67f;
             nMissing += !balanceW;
+            if (nStepUp >= 2 || nStepDown >= 2)
+                std::cout << "Balances: " << balanceU << " " << balanceV << " " << balanceW << std::endl;
+
             if (nStepUp >= 3 || nStepDown >= 3 || (nStepUp == 2 && nMissing == 1) || (nStepDown == 2 && nMissing == 1))
             {
                 // We have a consistent discontinuous change in ADC across at least two views
-                std::cout << "Balance: " << "U: " << balanceU << " V: " << balanceV << " W: " << balanceW << std::endl;
-                partitions.emplace_back(Partition(pPfo, std::make_tuple(hitU, hitV, hitW), sfrU, sfrV, sfrW));
-                PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1, -1, 1));
-                if (hitU)
-                {
-                    const CartesianVector &pos(hitU->GetPositionVector());
-                    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &pos, "U", RED, 2));
-                }
-                if (hitV)
-                {
-                    const CartesianVector &pos(hitV->GetPositionVector());
-                    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &pos, "V", RED, 2));
-                }
-                if (hitW)
-                {
-                    const CartesianVector &pos(hitW->GetPositionVector());
-                    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &pos, "W", RED, 2));
-                }
-                PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+                partitions.emplace_back(Partition(pPfo, std::make_tuple(hitU, hitV, hitW), orderedHitsU, orderedHitsV, orderedHitsW));
             }
         }
     }
@@ -494,7 +493,6 @@ double ShortTrackReclusteringAlgorithm::GetMedian(const std::vector<T> &values) 
 void ShortTrackReclusteringAlgorithm::GetStableAdcDiscontinuities(const pandora::CaloHitVector &hits, pandora::IntVector &discontinuities,
     const size_t window) const
 {
-    //PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1, -1, 1));
     PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, window == 0);
     FloatVector normalizedAdc, movingAverage, movingVariance;
     this->NormalizeAdc(hits, normalizedAdc);
@@ -531,13 +529,6 @@ void ShortTrackReclusteringAlgorithm::GetStableAdcDiscontinuities(const pandora:
             continue;
         }
     }
-/*    for (const int index : discontinuities)
-    {
-        const CartesianVector &position(hits[index]->GetPositionVector());
-        PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "d", RED, 2));
-    }
-    if (!discontinuities.empty())
-        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));*/
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -653,12 +644,18 @@ float ShortTrackReclusteringAlgorithm::GetMonotonicityScore(const pandora::CaloH
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-float ShortTrackReclusteringAlgorithm::GetBalance(const pandora::CaloHitVector &hits, const size_t pivot) const
+float ShortTrackReclusteringAlgorithm::GetBalance(const pandora::CaloHitList &hits, const size_t pivot) const
 {
     FloatVector adcs;
     // Get pre-pivot median
-    for (size_t i = 0; i < pivot; ++i)
-        adcs.emplace_back(hits[i]->GetInputEnergy());
+    size_t i{0};
+    for (const CaloHit *const pCaloHit : hits)
+    {
+        if (i >= pivot)
+            break;
+        adcs.emplace_back(pCaloHit->GetInputEnergy());
+        ++i;
+    }
     size_t mid{adcs.size() / 2};
     std::nth_element(adcs.begin(), adcs.begin() + mid, adcs.end());
     const float medianDenom{!adcs.empty() ? adcs[mid] : 0.f};
@@ -666,8 +663,17 @@ float ShortTrackReclusteringAlgorithm::GetBalance(const pandora::CaloHitVector &
     adcs.clear();
 
     // Get post-pivot median
-    for (size_t i = pivot + 1; i < hits.size(); ++i)
-        adcs.emplace_back(hits[i]->GetInputEnergy());
+    i = 0;
+    for (const CaloHit *const pCaloHit : hits)
+    {
+        if (i < pivot)
+        {
+            ++i;
+            continue;
+        }
+        adcs.emplace_back(pCaloHit->GetInputEnergy());
+        ++i;
+    }
     mid = adcs.size() / 2;
     std::nth_element(adcs.begin(), adcs.begin() + mid, adcs.end());
     const float medianNum{!adcs.empty() ? adcs[mid] : 0.f};

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -127,7 +127,8 @@ void ShortTrackReclusteringAlgorithm::FitAndOrderClusters(const ViewToClustersMa
                 case TPC_VIEW_V:
                     try
                     {
-                        m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V)));
+                        m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(),
+                            TPC_VIEW_V)));
                         LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
                     }
                     catch (const StatusCodeException &)
@@ -542,6 +543,7 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
         const ClusterList *pClusterList{nullptr};
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList, newClusterListName));
 
+        bool madeClusters{false};
         for (auto &protoPfo : protoPfos)
         {
             PandoraContentApi::Cluster::Parameters parameters;
@@ -553,8 +555,10 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
             const Cluster *pNewCluster(nullptr);
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, parameters, pNewCluster));
             protoPfo.m_pfoParameters.m_clusterList.emplace_back(pNewCluster);
+            madeClusters = true;
         }
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, viewToClusterListNameMap.at(view)));
+        if (madeClusters)
+            PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, viewToClusterListNameMap.at(view)));
     }
 
     // Create the new PFOs

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -13,6 +13,7 @@
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArEigenHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
 
@@ -34,7 +35,6 @@ ShortTrackReclusteringAlgorithm::ShortTrackReclusteringAlgorithm()
 StatusCode ShortTrackReclusteringAlgorithm::Run()
 {
     // Note: This may become a tool within the reclustering paradigm, but I'll need to chat with Alex about that
-
     const CaloHitList *pCaloHitList(nullptr);
     PANDORA_RETURN_IF(STATUS_CODE_SUCCESS, !this->GetList(m_caloHitListName, pCaloHitList));
 
@@ -48,27 +48,30 @@ StatusCode ShortTrackReclusteringAlgorithm::Run()
     ClusterToPfoMap clusterToPfoMap;
     this->CollectClusters(*pPfoList, viewToClustersMap, clusterToPfoMap);
 
-    // Identify the end points of clusters in PFOs
-    for (const auto &[pCluster, pPfo] : clusterToPfoMap)
+    // Loop over clusters, and look for evidence of discontinuous changes in ADC deposition and collect the corresponding hits.
+    ClusterToHitsMap clusterToHitsMap;
+    this->FindAdcDiscontinuities(clusterToPfoMap, clusterToHitsMap);
+
+    // Find corresponding hits for discontinuity hits in other views.
+    PfoToHitTripletsMap pfoToHitTripletsMap;
+    this->MatchAdcDiscontinuities(clusterToHitsMap, clusterToPfoMap, pfoToHitTripletsMap);
+
+/*    for (const auto &[pPfo, hitTriplets] : pfoToHitTripletsMap)
     {
-        CaloHitList clusterHitList;
-        pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterHitList);
-        if (clusterHitList.empty())
-            continue;
-
-        CaloHitVector clusterHits(clusterHitList.begin(), clusterHitList.end());
-        HitType view{LArClusterHelper::GetClusterHitType(pCluster)};
-        const float nHalfWindow{2};
-        const float pitch{LArGeometryHelper::GetWirePitch(this->GetPandora(), view)};
-        LArPointingCluster pointingCluster(pCluster, nHalfWindow, pitch);
-
-        CaloHitVector forwardHits, backwardHits;
-        this->OrderHitsRelativeToVertex(clusterHits, pointingCluster.GetInnerVertex(), forwardHits);
-        this->OrderHitsRelativeToVertex(clusterHits, pointingCluster.GetOuterVertex(), backwardHits);
-
-        IntVector discontinuities;
-        this->GetStableAdcDiscontinuities(forwardHits, discontinuities);
-    }
+        std::cout << "PFO " << pPfo << ":" << std::endl;
+        for (const auto &[hitU, hitV, hitW] : hitTriplets)
+        {
+            const CartesianVector &posU{hitU->GetPositionVector()}, &posV{hitV->GetPositionVector()}, &posW{hitW->GetPositionVector()};
+            std::cout << "   ";
+            if (hitU)
+                std::cout << "U(" << posU.GetX() << "," << posU.GetZ() << ")";
+            if (hitV)
+                std::cout << " V(" << posV.GetX() << "," << posV.GetZ() << ")";
+            if (hitW)
+                std::cout << " W(" << posW.GetX() << "," << posW.GetZ() << ")";
+            std::cout << std::endl;
+        }
+    }*/
 
     return STATUS_CODE_SUCCESS;
 }
@@ -111,6 +114,156 @@ void ShortTrackReclusteringAlgorithm::CollectClusters(const PfoList &pfoList, Vi
         }
     }
 }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::FindAdcDiscontinuities(const ClusterToPfoMap &clusterToPfoMap, ClusterToHitsMap &clusterToHitsMap) const
+{
+    for (const auto &[pCluster, pPfo] : clusterToPfoMap)
+    {
+        CaloHitList clusterHitList;
+        pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterHitList);
+        // Can't perform the pointing cluster's sliding linear fit without at least 3 hits
+        if (clusterHitList.size() < 3)
+            continue;
+
+        CaloHitVector clusterHits(clusterHitList.begin(), clusterHitList.end());
+        HitType view{LArClusterHelper::GetClusterHitType(pCluster)};
+        const float nHalfWindow{2};
+        const float pitch{LArGeometryHelper::GetWirePitch(this->GetPandora(), view)};
+        try
+        {
+            LArPointingCluster pointingCluster(pCluster, nHalfWindow, pitch);
+
+            CaloHitVector forwardHits, backwardHits;
+            this->OrderHitsRelativeToVertex(clusterHits, pointingCluster.GetInnerVertex(), forwardHits);
+            this->OrderHitsRelativeToVertex(clusterHits, pointingCluster.GetOuterVertex(), backwardHits);
+
+            IntVector discontinuities;
+            this->GetStableAdcDiscontinuities(forwardHits, discontinuities);
+            for (const int index : discontinuities)
+                clusterToHitsMap[pCluster].insert(forwardHits.at(index));
+            IntVector backwardDiscontinuities;
+            this->GetStableAdcDiscontinuities(backwardHits, backwardDiscontinuities);
+            for (const int index : backwardDiscontinuities)
+                clusterToHitsMap[pCluster].insert(backwardHits.at(index));
+        }
+        catch (const StatusCodeException &)
+        {
+            // Couldn't construct a pointing cluster, so skip this cluster
+            continue;
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHitsMap &clusterToHitsMap, const ClusterToPfoMap &clusterToPfoMap,
+    PfoToHitTripletsMap &pfoToHitTripletsMap) const
+{
+    for (const auto &[pCluster, discontinuityHits] : clusterToHitsMap)
+    {
+        const Pfo *const pPfo{clusterToPfoMap.at(pCluster)};
+        CaloHitList caloHits3D;
+        CaloHitVector caloHits3Du, caloHits3Dv, caloHits3Dw;
+        LArPfoHelper::GetCaloHits(pPfo, TPC_3D, caloHits3D);
+        // Split 3D hits according to which 2D view their parent belongs
+        for (const CaloHit *const pCaloHit : caloHits3D)
+        {
+            const CaloHit *pParent{static_cast<const CaloHit *>(pCaloHit->GetParentAddress())};
+            if (!pParent)
+                continue;
+            switch (pParent->GetHitType())
+            {
+                case TPC_VIEW_U:
+                    caloHits3Du.emplace_back(pCaloHit);
+                    break;
+                case TPC_VIEW_V:
+                    caloHits3Dv.emplace_back(pCaloHit);
+                    break;
+                case TPC_VIEW_W:
+                    caloHits3Dw.emplace_back(pCaloHit);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        // Find the closest matching 3D hit in each view for each discontinuity hit
+        Eigen::MatrixXf hitMatrixU(caloHits3Du.size(), 3);
+        LArEigenHelper::Vectorize3D(caloHits3Du, hitMatrixU);
+        Eigen::MatrixXf hitMatrixV(caloHits3Dv.size(), 3);
+        LArEigenHelper::Vectorize3D(caloHits3Dv, hitMatrixV);
+        Eigen::MatrixXf hitMatrixW(caloHits3Dw.size(), 3);
+        LArEigenHelper::Vectorize3D(caloHits3Dw, hitMatrixW);
+
+        for (const CaloHit *const pCaloHit : caloHits3D)
+        {
+            const CaloHit *pParent{static_cast<const CaloHit *>(pCaloHit->GetParentAddress())};
+            if (!pParent)
+                continue;
+
+            if (discontinuityHits.find(pParent) == discontinuityHits.end())
+                continue;
+
+            const CartesianVector &pos{pCaloHit->GetPositionVector()};
+            Eigen::RowVectorXf row(3);
+            row << pos.GetX(), pos.GetY(), pos.GetZ();
+
+            const HitType view{pParent->GetHitType()};
+            const CaloHit *pBestU{view == TPC_VIEW_U ? pCaloHit : nullptr}, *pBestV{view == TPC_VIEW_V ? pCaloHit : nullptr},
+                *pBestW{view == TPC_VIEW_W ? pCaloHit : nullptr};
+            if (view == TPC_VIEW_U || view == TPC_VIEW_V)
+            {
+                Eigen::MatrixXf norms((hitMatrixW.rowwise() - row).array().pow(2).rowwise().sum());
+                Eigen::Index index;
+                norms.col(0).minCoeff(&index);
+                pBestW = caloHits3Dw.at(index);
+            }
+            if (view == TPC_VIEW_U || view == TPC_VIEW_W)
+            {
+                Eigen::MatrixXf norms((hitMatrixV.rowwise() - row).array().pow(2).rowwise().sum());
+                Eigen::Index index;
+                norms.col(0).minCoeff(&index);
+                pBestV = caloHits3Dv.at(index);
+            }
+            if (view == TPC_VIEW_V || view == TPC_VIEW_W)
+            {
+                Eigen::MatrixXf norms((hitMatrixU.rowwise() - row).array().pow(2).rowwise().sum());
+                Eigen::Index index;
+                norms.col(0).minCoeff(&index);
+                pBestU = caloHits3Du.at(index);
+            }
+
+            // Calculate the distances between the found 3D hits and reject if the distances are too large
+            const CartesianVector &posU{pBestU->GetPositionVector()}, &posV{pBestV->GetPositionVector()}, &posW{pBestW->GetPositionVector()};
+            const float duv{(posU - posV).GetMagnitudeSquared()}, duw{(posU - posW).GetMagnitudeSquared()}, dvw{(posV - posW).GetMagnitudeSquared()};
+            const CaloHit *selectedU{static_cast<const CaloHit *>(pBestU->GetParentAddress())}, *selectedV{static_cast<const CaloHit *>(pBestV->GetParentAddress())}, *selectedW{static_cast<const CaloHit *>(pBestW->GetParentAddress())};
+            if (duv > 4.f && duw > 4.f)
+                selectedU = nullptr;
+            if (duv > 4.f && dvw > 4.f)
+                selectedV = nullptr;
+            if (duw > 4.f && dvw > 4.f)
+                selectedW = nullptr;
+
+            if (selectedU || selectedV || selectedW)
+            {
+                // We found candidates
+                pfoToHitTripletsMap[pPfo].emplace_back(std::make_tuple(selectedU, selectedV, selectedW));
+            }
+            else
+            {
+                // We found no matches, but retain the single 2D discontinuity hit to see if we can recover something later
+                selectedU = view == TPC_VIEW_U ? pParent : nullptr;
+                selectedV = view == TPC_VIEW_V ? pParent : nullptr;
+                selectedW = view == TPC_VIEW_W ? pParent : nullptr;
+                pfoToHitTripletsMap[pPfo].emplace_back(std::make_tuple(selectedU, selectedV, selectedW));
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
 
 void ShortTrackReclusteringAlgorithm::OrderHitsRelativeToVertex(const CaloHitVector &clusterHits, const LArPointingCluster::Vertex &vertex,
     CaloHitVector &orderedHits) const
@@ -204,7 +357,7 @@ double ShortTrackReclusteringAlgorithm::GetMedian(const std::vector<T> &values) 
 void ShortTrackReclusteringAlgorithm::GetStableAdcDiscontinuities(const pandora::CaloHitVector &hits, pandora::IntVector &discontinuities,
     const size_t window) const
 {
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1, -1, 1));
+    //PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1, -1, 1));
     PANDORA_THROW_IF(STATUS_CODE_INVALID_PARAMETER, window == 0);
     FloatVector normalizedAdc, movingAverage, movingVariance;
     this->NormalizeAdc(hits, normalizedAdc);
@@ -241,14 +394,13 @@ void ShortTrackReclusteringAlgorithm::GetStableAdcDiscontinuities(const pandora:
             continue;
         }
     }
-    std::cout << "Found " << discontinuities.size() << " discontinuities" << std::endl;
-    for (const int index : discontinuities)
+/*    for (const int index : discontinuities)
     {
         const CartesianVector &position(hits[index]->GetPositionVector());
         PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "d", RED, 2));
     }
     if (!discontinuities.empty())
-        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));*/
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -78,7 +78,6 @@ bool ShortTrackReclusteringAlgorithm::GetList(const std::string &listName, const
 
 void ShortTrackReclusteringAlgorithm::CollectClusters(const PfoList &pfoList, ViewToClustersMap &viewToClustersMap, ClusterToPfoMap &clusterToPfoMap) const
 {
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1, -1, 1));
     for (const Pfo *const pPfo : pfoList)
     {
         for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -103,20 +103,50 @@ void ShortTrackReclusteringAlgorithm::FitAndOrderClusters(const ViewToClustersMa
         for (const Cluster *const pCluster : clusters)
         {
             if (pCluster->GetNCaloHits() < 3)
+            {
+                m_clusterToOrderedHitsMap[pCluster] = CaloHitList();
+                pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
                 continue;
+            }
             switch (view)
             {
                 case TPC_VIEW_U:
-                    m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U)));
-                    LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    try
+                    {
+                        m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(),
+                            TPC_VIEW_U)));
+                        LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    }
+                    catch (const StatusCodeException &)
+                    {
+                        m_clusterToOrderedHitsMap[pCluster] = CaloHitList();
+                        pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
+                    }
                     break;
+
                 case TPC_VIEW_V:
-                    m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V)));
-                    LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    try
+                    {
+                        m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V)));
+                        LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    }
+                    catch (const StatusCodeException &)
+                    {
+                        m_clusterToOrderedHitsMap[pCluster] = CaloHitList();
+                        pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
+                    }
                     break;
                 case TPC_VIEW_W:
-                    m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W)));
-                    LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    try
+                    {
+                        m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W)));
+                        LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+                    }
+                    catch (const StatusCodeException &)
+                    {
+                        m_clusterToOrderedHitsMap[pCluster] = CaloHitList();
+                        pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
+                    }
                     break;
                 default:
                     break;
@@ -450,9 +480,16 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
         for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W})
         {
             const CaloHitList &hits{view == TPC_VIEW_U ? hitsU : (view == TPC_VIEW_V ? hitsV : hitsW)};
-            const CaloHit *hit{view == TPC_VIEW_U ? std::get<0>(hitTriplet) : (view == TPC_VIEW_V ? std::get<1>(hitTriplet) : std::get<2>(hitTriplet))};
+            const CaloHit *pHit{view == TPC_VIEW_U ? std::get<0>(hitTriplet) : (view == TPC_VIEW_V ? std::get<1>(hitTriplet) : std::get<2>(hitTriplet))};
             CaloHitList cluster1Hits, cluster2Hits;
-            this->PartitionHits(hits, hit, cluster1Hits, cluster2Hits);
+            // Not all triplets are complete, so we need to check for nullptrs
+            if (pHit)
+            {
+                const auto offset{std::distance(hits.begin(), std::find(hits.begin(), hits.end(), pHit))};
+                // Only split the hits if the discontinuity hit is not at the start or end of the cluster
+                if (offset != 0 && offset != hits.size() - 1)
+                    this->PartitionHits(hits, pHit, cluster1Hits, cluster2Hits);
+            }
             protoPfo.m_viewToHitsMap[view] = std::move(cluster2Hits);
         }
         protoPfos.emplace_back(std::move(protoPfo));
@@ -495,6 +532,9 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
         {
             PandoraContentApi::Cluster::Parameters parameters;
             parameters.m_caloHitList = std::move(protoPfo.m_viewToHitsMap[view]);
+            // Due to extremal split points, it's possible to have an empty list here
+            if (parameters.m_caloHitList.empty())
+                continue;
 
             const Cluster *pNewCluster(nullptr);
             PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, parameters, pNewCluster));
@@ -506,6 +546,9 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
     // Create the new PFOs
     for (auto &protoPfo : protoPfos)
     {
+        // Due to extremal split points, it's possible to have an empty list here
+        if (protoPfo.m_pfoParameters.m_clusterList.empty())
+            continue;
         const Pfo *pNewPfo{nullptr};
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, protoPfo.m_pfoParameters, pNewPfo));
     }
@@ -531,6 +574,7 @@ void ShortTrackReclusteringAlgorithm::PartitionHits(const CaloHitList &caloHits,
         else
             cluster2Hits.emplace_back(pCaloHit);
     }
+
     FloatVector adcs1;
     for (const CaloHit *const pCaloHit : cluster1Hits)
         adcs1.emplace_back(pCaloHit->GetInputEnergy());

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -294,7 +294,6 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
     const ViewToHitsMap &viewToUnclusteredHitsMap, PartitionVector &partitions) const
 {
     (void)viewToUnclusteredHitsMap; (void)partitions;
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), false, DETECTOR_VIEW_XZ, -1, -1, 1));
     // Iterate over each PFO and get its respective discontinuities. Perform sliding linear fits on each of its clusters and use the
     // discontinuities to focus on the relevant part of the sliding fit. Walk from just before that point of the fit to just after
     // in all available views to see if a coherent picture emerges. If so, propose a new partition.
@@ -321,17 +320,58 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
                     break;
             }
         }
-        (void)pClusterU; (void)pClusterV; (void)pClusterW;
+        const TwoDSlidingFitResult sfrU(pClusterU, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U));
+        const TwoDSlidingFitResult sfrV(pClusterV, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V));
+        const TwoDSlidingFitResult sfrW(pClusterW, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W));
+
+        const std::streamsize originalPrecision{std::cout.precision()};
+        const std::ios_base::fmtflags originalFormat{std::cout.flags()};
         for (const auto &[hitU, hitV, hitW] : hitTriplets)
         {
-            if (hitU)
-                PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &hitU->GetPositionVector(), "u", RED, 2));
-            if (hitV)
-                PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &hitV->GetPositionVector(), "v", GREEN, 2));
-            if (hitW)
-                PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &hitW->GetPositionVector(), "w", BLUE, 2));
-            PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+            std::cout << "Cluster" << std::endl;
+            std::cout << std::fixed << std::setprecision(1);
+            CaloHitVector orderedHitsU, orderedHitsV, orderedHitsW;
+            size_t indexU{0}, indexV{0}, indexW{0};
+            if (hitU && pClusterU)
+                indexU = this->OrderHitsAlongTrajectory(pClusterU, hitU, sfrU, 5.f, orderedHitsU);
+                // We now have a logically ordered list of hits in the cluster around the discontinuity
+                // Once we have a similarly ordered list in the other views, we can look for consistent patterns
+                // Ideally we'd like to correlate these hits so that we can start and stop in the same place in each view
+                // A quick Hungarian algorithm style matching of the hits may be useful here
+                // More generally however, just explore the changes either side of the discontinuity, and look to see if
+                // at least two of the views agree
+            if (hitV && pClusterV)
+                indexV = this->OrderHitsAlongTrajectory(pClusterV, hitV, sfrV, 5.f, orderedHitsV);
+            if (hitW && pClusterW)
+                indexW = this->OrderHitsAlongTrajectory(pClusterW, hitW, sfrW, 5.f, orderedHitsW);
+
+            for (size_t i = 0; i < std::max({orderedHitsU.size(), orderedHitsV.size(), orderedHitsW.size()}); ++i)
+            {
+                if (orderedHitsU.size() > i)
+                    std::cout << "(" << (i == indexU) << ") " << orderedHitsU.at(i)->GetInputEnergy();
+                else
+                    std::cout << "         ";
+                std::cout << " | ";
+                if (orderedHitsV.size() > i)
+                    std::cout << "(" << (i == indexV) << ") " << orderedHitsV.at(i)->GetInputEnergy();
+                else
+                    std::cout << "         ";
+                std::cout << " | ";
+                if (orderedHitsW.size() > i)
+                    std::cout << "(" << (i == indexW) << ") " << orderedHitsW.at(i)->GetInputEnergy();
+                else
+                    std::cout << "         ";
+                std::cout << std::endl;
+            }
+            std::cout << "========================" << std::endl;
+            const float balanceU{this->GetBalance(orderedHitsU, indexU)};
+            const float balanceV{this->GetBalance(orderedHitsV, indexV)};
+            const float balanceW{this->GetBalance(orderedHitsW, indexW)};
+            std::cout << "Balance: " << std::endl;
+            std::cout << "U: " << balanceU << " V: " << balanceV << " W: " << balanceW << std::endl;
         }
+        std::cout.precision(originalPrecision);
+        std::cout.flags(originalFormat);
     }
 }
 
@@ -584,6 +624,72 @@ float ShortTrackReclusteringAlgorithm::GetMonotonicityScore(const pandora::CaloH
     }
     
     return monotonicity / (end - start);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float ShortTrackReclusteringAlgorithm::GetBalance(const pandora::CaloHitVector &hits, const size_t pivot) const
+{
+    FloatVector adcs;
+    // Get pre-pivot median
+    for (size_t i = 0; i < pivot; ++i)
+        adcs.emplace_back(hits[i]->GetInputEnergy());
+    size_t mid{adcs.size() / 2};
+    std::nth_element(adcs.begin(), adcs.begin() + mid, adcs.end());
+    const float medianDenom{!adcs.empty() ? adcs[mid] : 0.f};
+
+    adcs.clear();
+
+    // Get post-pivot median
+    for (size_t i = pivot + 1; i < hits.size(); ++i)
+        adcs.emplace_back(hits[i]->GetInputEnergy());
+    mid = adcs.size() / 2;
+    std::nth_element(adcs.begin(), adcs.begin() + mid, adcs.end());
+    const float medianNum{!adcs.empty() ? adcs[mid] : 0.f};
+
+    return medianDenom > 0 ? medianNum / medianDenom : 0.f;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+size_t ShortTrackReclusteringAlgorithm::OrderHitsAlongTrajectory(const Cluster *const pCluster, const CaloHit *const pDiscontinuityHit,
+    const TwoDSlidingFitResult &sfr, const float window, CaloHitVector &orderedHits) const
+{
+    // Get the linear region around the discontinuity
+    float rL{0.f}, rT{0.f};
+    CartesianVector fitDir(0, 0, 0);
+    const CartesianVector &pos{pDiscontinuityHit->GetPositionVector()};
+    sfr.GetLocalPosition(pos, rL, rT);
+    sfr.GetGlobalFitDirection(rL, fitDir);
+    const CartesianVector start{pos - fitDir * window}, end{pos + fitDir * window};
+
+    // Collect the hits that project into the linear region and sort
+    CaloHitList clusterHitList;
+    pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterHitList);
+    CaloHitVector clusterHits(clusterHitList.begin(), clusterHitList.end());
+    FloatVector projections;
+    std::vector<std::pair<float, const CaloHit*>> hitProjectionPairs;
+    for (const CaloHit *const pCaloHit : clusterHits)
+    {
+        const CartesianVector &hitPos{pCaloHit->GetPositionVector()};
+        const CartesianVector hitDir{hitPos - pos};
+        const float lPos{hitDir.GetDotProduct(fitDir)};
+
+        if (std::abs(lPos) <= window)
+            hitProjectionPairs.emplace_back(lPos, pCaloHit);
+    }
+    std::sort(hitProjectionPairs.begin(), hitProjectionPairs.end(), [](const auto a, const auto b) { return a.first < b.first; });
+
+    size_t localIndex{0}, pivot{0};
+    for (const auto &[_, pCaloHit] : hitProjectionPairs)
+    {
+        orderedHits.emplace_back(pCaloHit);
+        if (pCaloHit == pDiscontinuityHit)
+            pivot = localIndex;
+        ++localIndex;
+    }
+
+    return pivot;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -160,7 +160,7 @@ void ShortTrackReclusteringAlgorithm::FitAndOrderClusters(const ViewToClustersMa
 
 void ShortTrackReclusteringAlgorithm::FindAdcDiscontinuities(const ClusterToPfoMap &clusterToPfoMap, ClusterToHitsMap &clusterToHitsMap) const
 {
-    for (const auto &[pCluster, pPfo] : clusterToPfoMap)
+    for (const auto &[pCluster, _] : clusterToPfoMap)
     {
         CaloHitList clusterHitList{m_clusterToOrderedHitsMap.at(pCluster)};
         // Can't perform the pointing cluster's sliding linear fit without at least 3 hits
@@ -479,8 +479,6 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
     std::string tempPfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, tempPfoListName));
 
-    std::unordered_map<const CaloHit *, int> hitCount;
-    std::unordered_map<const Pfo *, int> pfoCount;
     ProtoPfoVector protoPfos;
     for (const auto &[pPfo, hitTriplet, hitsU, hitsV, hitsW] : partitions)
     {

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -390,8 +390,6 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
             nStepUp += balanceW > 1.5f;
             nStepDown += balanceW &&balanceW < 0.67f;
             nMissing += !balanceW;
-            if (nStepUp >= 2 || nStepDown >= 2)
-                std::cout << "Balances: " << balanceU << " " << balanceV << " " << balanceW << std::endl;
 
             if (nStepUp >= 3 || nStepDown >= 3 || (nStepUp == 2 && nMissing == 1) || (nStepDown == 2 && nMissing == 1))
             {
@@ -406,27 +404,38 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
 
 void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partitions) const
 {
-    std::string pfoListName{"TrackParticles3D"};
     std::string initialPfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentListName<Pfo>(*this, initialPfoListName));
+    std::map<HitType, std::string> viewToClusterListNameMap;
+    for (const std::string &clusterListName : m_clusterListNames)
+    {
+        const ClusterList *pClusterList{nullptr};
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
+        for (const Cluster *const pCluster : *pClusterList)
+        {
+            if (pCluster)
+            {
+                try
+                {
+                    viewToClusterListNameMap[LArClusterHelper::GetClusterHitType(pCluster)] = clusterListName;
+                }
+                catch (const StatusCodeException &)
+                {
+                    continue;
+                }
+            }
+        }
+    }
 
     const PfoList *pPfoList{nullptr};
     std::string tempPfoListName;
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pPfoList, tempPfoListName));
 
-    std::map<HitType, std::string> viewToClusterListNameMap{{TPC_VIEW_U, "ClustersU"}, {TPC_VIEW_V, "ClustersV"}, {TPC_VIEW_W, "ClustersW"}};
-    std::map<HitType, int> viewToIndexMap{{TPC_VIEW_U, 0}, {TPC_VIEW_V, 1}, {TPC_VIEW_W, 2}};
     for (const auto &[pPfo, hitTriplet, hitsU, hitsV, hitsW] : partitions)
     {
-        CaloHitList pfoHits3D, newPfoHits3D;
+        CaloHitList pfoHits3D;
         LArPfoHelper::GetCaloHits(pPfo, TPC_3D, pfoHits3D);
 
-        // Need to get the cluster lists from XML and properly associated those.
-        // Similarly need to get the PFO list
-        // Need to remove the 3D hits from the current PFO and remake those
-        // Need to create a new PFO from the new clusters and add the 3D hits to that
-        // Need to change the hierarchy so that the new PFO is a child of the old one, and potentially associate any child PFOs from the original
-        // PFO to the new one - that's more complex, may want to just redo hierarchy building afterwards, or ensure this runs before
         PandoraContentApi::ParticleFlowObject::Parameters pfoParameters;
         pfoParameters.m_particleId = pPfo->GetParticleId();
         pfoParameters.m_charge = PdgTable::GetParticleCharge(pfoParameters.m_particleId.Get());
@@ -451,10 +460,7 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
             {
                 const CaloHit *pParent{static_cast<const CaloHit *>(pCaloHit->GetParentAddress())};
                 if (std::find(cluster2Hits.begin(), cluster2Hits.end(), pParent) != cluster2Hits.end())
-                {
-                    newPfoHits3D.emplace_back(pCaloHit);
                     PandoraContentApi::RemoveFromCluster(*this, clusterList3D.front(), pCaloHit);
-                }
             }
 
             std::string newClusterListName;
@@ -470,22 +476,10 @@ void ShortTrackReclusteringAlgorithm::Recluster(const PartitionVector &partition
             pfoParameters.m_clusterList.emplace_back(pNewCluster);
         }
 
-        std::string newCluster3DListName;
-        const ClusterList *pClusterList3D{nullptr};
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CreateTemporaryListAndSetCurrent(*this, pClusterList3D, newCluster3DListName));
-        PandoraContentApi::Cluster::Parameters clusterParameters3D;
-        clusterParameters3D.m_caloHitList = std::move(newPfoHits3D);
-
-        const Cluster *pNewCluster3D(nullptr);
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::Cluster::Create(*this, clusterParameters3D, pNewCluster3D));
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Cluster>(*this, "TrackClusters3D"));
-
-        pfoParameters.m_clusterList.emplace_back(pNewCluster3D);
-        std::cout << "Making new PFO with " << pfoParameters.m_clusterList.size() << " clusters" << std::endl;
         const Pfo *pNewPfo(nullptr);
         PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ParticleFlowObject::Create(*this, pfoParameters, pNewPfo));
     }
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, tempPfoListName, pfoListName));
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList<Pfo>(*this, tempPfoListName, m_pfoListName));
 
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::ReplaceCurrentList<Pfo>(*this, initialPfoListName));
 }
@@ -808,52 +802,11 @@ float ShortTrackReclusteringAlgorithm::GetBalance(const pandora::CaloHitList &hi
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-size_t ShortTrackReclusteringAlgorithm::OrderHitsAlongTrajectory(const Cluster *const pCluster, const CaloHit *const pDiscontinuityHit,
-    const TwoDSlidingFitResult &sfr, const float window, CaloHitVector &orderedHits) const
-{
-    // Get the linear region around the discontinuity
-    float rL{0.f}, rT{0.f};
-    CartesianVector fitDir(0, 0, 0);
-    const CartesianVector &pos{pDiscontinuityHit->GetPositionVector()};
-    sfr.GetLocalPosition(pos, rL, rT);
-    sfr.GetGlobalFitDirection(rL, fitDir);
-    const CartesianVector start{pos - fitDir * window}, end{pos + fitDir * window};
-
-    // Collect the hits that project into the linear region and sort
-    CaloHitList clusterHitList;
-    pCluster->GetOrderedCaloHitList().FillCaloHitList(clusterHitList);
-    CaloHitVector clusterHits(clusterHitList.begin(), clusterHitList.end());
-    FloatVector projections;
-    std::vector<std::pair<float, const CaloHit*>> hitProjectionPairs;
-    for (const CaloHit *const pCaloHit : clusterHits)
-    {
-        const CartesianVector &hitPos{pCaloHit->GetPositionVector()};
-        const CartesianVector hitDir{hitPos - pos};
-        const float lPos{hitDir.GetDotProduct(fitDir)};
-
-        if (std::abs(lPos) <= window)
-            hitProjectionPairs.emplace_back(lPos, pCaloHit);
-    }
-    std::sort(hitProjectionPairs.begin(), hitProjectionPairs.end(), [](const auto a, const auto b) { return a.first < b.first; });
-
-    size_t localIndex{0}, pivot{0};
-    for (const auto &[_, pCaloHit] : hitProjectionPairs)
-    {
-        orderedHits.emplace_back(pCaloHit);
-        if (pCaloHit == pDiscontinuityHit)
-            pivot = localIndex;
-        ++localIndex;
-    }
-
-    return pivot;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
 StatusCode ShortTrackReclusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -26,7 +26,15 @@ using namespace pandora;
 namespace lar_content
 {
 
-ShortTrackReclusteringAlgorithm::ShortTrackReclusteringAlgorithm()
+ShortTrackReclusteringAlgorithm::ShortTrackReclusteringAlgorithm() :
+    m_maxHitDiscrepancy{3.f},
+    m_maxHitDiscrepancySquared{m_maxHitDiscrepancy * m_maxHitDiscrepancy},
+    m_balanceThresholdLow{0.67f},
+    m_balanceThresholdHigh{1.5f},
+    m_braggLinearSlopeThreshold{0.16f},
+    m_braggCurvatureThreshold{0.f},
+    m_braggContrastThreshold{1.4f},
+    m_braggMonotonicityThreshold{0.5f}
 {
 }
 
@@ -107,49 +115,15 @@ void ShortTrackReclusteringAlgorithm::FitAndOrderClusters(const ViewToClustersMa
                 pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
                 continue;
             }
-            switch (view)
+            try
             {
-                case TPC_VIEW_U:
-                    try
-                    {
-                        m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(),
-                            TPC_VIEW_U)));
-                        LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
-                    }
-                    catch (const StatusCodeException &)
-                    {
-                        m_clusterToOrderedHitsMap[pCluster] = CaloHitList();
-                        pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
-                    }
-                    break;
-
-                case TPC_VIEW_V:
-                    try
-                    {
-                        m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(),
-                            TPC_VIEW_V)));
-                        LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
-                    }
-                    catch (const StatusCodeException &)
-                    {
-                        m_clusterToOrderedHitsMap[pCluster] = CaloHitList();
-                        pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
-                    }
-                    break;
-                case TPC_VIEW_W:
-                    try
-                    {
-                        m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W)));
-                        LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
-                    }
-                    catch (const StatusCodeException &)
-                    {
-                        m_clusterToOrderedHitsMap[pCluster] = CaloHitList();
-                        pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
-                    }
-                    break;
-                default:
-                    break;
+                m_clusterToSFRMap.emplace(pCluster, TwoDSlidingFitResult(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), view)));
+                LArClusterHelper::OrderHitsAlongTrajectory(pCluster, m_clusterToSFRMap.at(pCluster), m_clusterToOrderedHitsMap[pCluster]);
+            }
+            catch (const StatusCodeException &)
+            {
+                m_clusterToOrderedHitsMap[pCluster] = CaloHitList();
+                pCluster->GetOrderedCaloHitList().FillCaloHitList(m_clusterToOrderedHitsMap[pCluster]);
             }
         }
     }
@@ -181,7 +155,7 @@ void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHit
 {
     ClusterVector sortedClusters;
     sortedClusters.reserve(clusterToHitsMap.size());
-    for (const auto &[pCluster, discontinuityHits] : clusterToHitsMap)
+    for (const auto &[pCluster, _] : clusterToHitsMap)
         sortedClusters.emplace_back(pCluster);
     std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
 
@@ -309,11 +283,11 @@ void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHit
             const CartesianVector &posU{pBestU->GetPositionVector()}, &posV{pBestV->GetPositionVector()}, &posW{pBestW->GetPositionVector()};
             const float duv{(posU - posV).GetMagnitudeSquared()}, duw{(posU - posW).GetMagnitudeSquared()}, dvw{(posV - posW).GetMagnitudeSquared()};
             const CaloHit *selectedU{static_cast<const CaloHit *>(pBestU->GetParentAddress())}, *selectedV{static_cast<const CaloHit *>(pBestV->GetParentAddress())}, *selectedW{static_cast<const CaloHit *>(pBestW->GetParentAddress())};
-            if (duv > 9.f && duw > 9.f)
+            if (duv > m_maxHitDiscrepancySquared && duw > m_maxHitDiscrepancySquared)
                 selectedU = nullptr;
-            if (duv > 9.f && dvw > 9.f)
+            if (duv > m_maxHitDiscrepancySquared && dvw > m_maxHitDiscrepancySquared)
                 selectedV = nullptr;
-            if (duw > 9.f && dvw > 9.f)
+            if (duw > m_maxHitDiscrepancySquared && dvw > m_maxHitDiscrepancySquared)
                 selectedW = nullptr;
 
             if (selectedU || selectedV || selectedW)
@@ -339,7 +313,7 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
 {
     PfoVector sortedPfos;
     sortedPfos.reserve(pfoToHitTripletsMap.size());
-    for (const auto &[pPfo, hitTriplets] : pfoToHitTripletsMap)
+    for (const auto &[pPfo, _] : pfoToHitTripletsMap)
         sortedPfos.emplace_back(pPfo);
     std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
 
@@ -410,14 +384,14 @@ void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTri
             const float balanceV{this->GetBalance(orderedHitsV, indexV)};
             const float balanceW{this->GetBalance(orderedHitsW, indexW)};
             int nStepUp{0}, nStepDown{0}, nMissing{0};
-            nStepUp += balanceU > 1.5f;
-            nStepDown += balanceU && balanceU < 0.67f;
+            nStepUp += balanceU > m_balanceThresholdHigh;
+            nStepDown += balanceU && balanceU < m_balanceThresholdLow;
             nMissing += !balanceU;
-            nStepUp += balanceV > 1.5f;
-            nStepDown += balanceV && balanceV < 0.67f;
+            nStepUp += balanceV > m_balanceThresholdHigh;
+            nStepDown += balanceV && balanceV < m_balanceThresholdLow;
             nMissing += !balanceV;
-            nStepUp += balanceW > 1.5f;
-            nStepDown += balanceW &&balanceW < 0.67f;
+            nStepUp += balanceW > m_balanceThresholdHigh;
+            nStepDown += balanceW && balanceW < m_balanceThresholdLow;
             nMissing += !balanceW;
 
             if (nStepUp >= 3 || nStepDown >= 3 || (nStepUp == 2 && nMissing == 1) || (nStepDown == 2 && nMissing == 1))
@@ -757,6 +731,8 @@ void ShortTrackReclusteringAlgorithm::NormalizeAdc(const pandora::CaloHitVector 
         normalizedAdc.emplace_back(pCaloHit->GetInputEnergy() / median);
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 bool ShortTrackReclusteringAlgorithm::IsBraggPeak(const pandora::CaloHitVector &hits, const size_t start, const size_t end) const
 {
     const float linearSlopeScore{this->GetLinearSlopeScore(hits, start, end)};
@@ -860,13 +836,9 @@ float ShortTrackReclusteringAlgorithm::GetBalance(const pandora::CaloHitList &hi
     FloatVector adcs;
     // Get pre-pivot median
     size_t i{0};
-    for (const CaloHit *const pCaloHit : hits)
-    {
-        if (i >= pivot)
-            break;
-        adcs.emplace_back(pCaloHit->GetInputEnergy());
-        ++i;
-    }
+    auto it{hits.begin()};
+    for (auto end = hits.end(); it != end && i < pivot; ++it, ++i)
+        adcs.emplace_back((*it)->GetInputEnergy());
     size_t mid{adcs.size() / 2};
     std::nth_element(adcs.begin(), adcs.begin() + mid, adcs.end());
     const float medianDenom{!adcs.empty() ? adcs[mid] : 0.f};
@@ -874,17 +846,8 @@ float ShortTrackReclusteringAlgorithm::GetBalance(const pandora::CaloHitList &hi
     adcs.clear();
 
     // Get post-pivot median
-    i = 0;
-    for (const CaloHit *const pCaloHit : hits)
-    {
-        if (i < pivot)
-        {
-            ++i;
-            continue;
-        }
-        adcs.emplace_back(pCaloHit->GetInputEnergy());
-        ++i;
-    }
+    for (; it != hits.end(); ++it)
+        adcs.emplace_back((*it)->GetInputEnergy());
     mid = adcs.size() / 2;
     std::nth_element(adcs.begin(), adcs.begin() + mid, adcs.end());
     const float medianNum{!adcs.empty() ? adcs[mid] : 0.f};
@@ -899,6 +862,21 @@ StatusCode ShortTrackReclusteringAlgorithm::ReadSettings(const TiXmlHandle xmlHa
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "PfoListName", m_pfoListName));
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "ClusterListNames", m_clusterListNames));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "MaxHitDiscrepancy",
+        m_maxHitDiscrepancy));
+    m_maxHitDiscrepancySquared = m_maxHitDiscrepancy * m_maxHitDiscrepancy;
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BalanceThresholdLow",
+        m_balanceThresholdLow));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BalanceThresholdHigh",
+        m_balanceThresholdHigh));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BraggLinearSlopeThreshold",
+        m_braggLinearSlopeThreshold));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BraggCurvatureThreshold",
+        m_braggCurvatureThreshold));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BraggContrastThreshold",
+        m_braggContrastThreshold));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "BraggMonotonicityThreshold",
+        m_braggMonotonicityThreshold));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.cc
@@ -179,8 +179,15 @@ void ShortTrackReclusteringAlgorithm::FindAdcDiscontinuities(const ClusterToPfoM
 void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHitsMap &clusterToHitsMap, const ClusterToPfoMap &clusterToPfoMap,
     PfoToHitTripletsMap &pfoToHitTripletsMap) const
 {
+    ClusterVector sortedClusters;
+    sortedClusters.reserve(clusterToHitsMap.size());
     for (const auto &[pCluster, discontinuityHits] : clusterToHitsMap)
+        sortedClusters.emplace_back(pCluster);
+    std::sort(sortedClusters.begin(), sortedClusters.end(), LArClusterHelper::SortByNHits);
+
+    for (const Cluster *const pCluster : sortedClusters)
     {
+        const auto &discontinuityHits{clusterToHitsMap.at(pCluster)};
         const Pfo *const pPfo{clusterToPfoMap.at(pCluster)};
         CaloHitList caloHits3D;
         CaloHitVector caloHits3Du, caloHits3Dv, caloHits3Dw;
@@ -330,8 +337,15 @@ void ShortTrackReclusteringAlgorithm::MatchAdcDiscontinuities(const ClusterToHit
 
 void ShortTrackReclusteringAlgorithm::PartitionDiscontinuities(const PfoToHitTripletsMap &pfoToHitTripletsMap, PartitionVector &partitions) const
 {
+    PfoVector sortedPfos;
+    sortedPfos.reserve(pfoToHitTripletsMap.size());
     for (const auto &[pPfo, hitTriplets] : pfoToHitTripletsMap)
+        sortedPfos.emplace_back(pPfo);
+    std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
+
+    for (const Pfo *const pPfo : sortedPfos)
     {
+        const auto &hitTriplets{pfoToHitTripletsMap.at(pPfo)};
         ClusterList pfoClusterList;
         LArPfoHelper::GetTwoDClusterList(pPfo, pfoClusterList);
         const Cluster *pClusterU{nullptr}, *pClusterV{nullptr}, *pClusterW{nullptr};
@@ -666,7 +680,7 @@ double ShortTrackReclusteringAlgorithm::GetMedian(const std::vector<T> &values) 
     std::vector<T> copy(values);
     const size_t mid{copy.size() / 2};
 
-    if (mid % 2 == 0)
+    if (copy.size() % 2 == 0)
     {
         std::nth_element(copy.begin(), copy.begin() + mid, copy.end());
         const double upper{copy[mid]};

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -1,0 +1,127 @@
+/**
+ *  @file   larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+ *
+ *  @brief  Tries to identify short tracks that are either lost, or under-clustered and recover missing hits.
+ *          This algorithm looks at all three views of a PFO to try to identify if one or more views exhibit step changes in ADC values that
+ *          might be indicative of a decay or intelastic interaction. If such a change occurs it looks for consistency across views and also
+ *          examines nearby unclustered hits, or hits in nearby clusters to see if a more cohenrent clustering can be identified.
+ *          If these various conditions are met, then reclustering is performed.
+ *
+ *  $Log: $
+ */
+
+#ifndef LAR_SHORT_TRACK_RECLUSTERING_ALGORITHM_H
+#define LAR_SHORT_TRACK_RECLUSTERING_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+#include "Pandora/PandoraInternal.h"
+
+#include "larpandoracontent/LArObjects/LArPointingCluster.h"
+
+#include "larpandoracontent/LArReclustering/ThreeDReclusteringFigureOfMeritBaseTool.h"
+
+namespace lar_content
+{
+
+/**
+  *  @brief  ShortTrackReclusteringAlgorithm class
+  */
+class ShortTrackReclusteringAlgorithm : public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    ShortTrackReclusteringAlgorithm();
+
+    /**
+    *  @brief  Default destructor
+    */
+    ~ShortTrackReclusteringAlgorithm() = default;
+
+private:
+    typedef std::unordered_map<pandora::HitType, pandora::CaloHitSet> ViewToHitsMap;
+    typedef std::unordered_map<pandora::HitType, pandora::ClusterList> ViewToClustersMap;
+    typedef std::unordered_map<const pandora::Cluster *, const pandora::Pfo *> ClusterToPfoMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::FloatVector> ClusterToAdcMap;
+
+    pandora::StatusCode Run();
+
+    /**
+     *  @brief  Helper function to get a list from Pandora content, and check that it is valid
+     *
+     *  @param  listName the name of the list to retrieve
+     *  @param  pList the pointer to the list to be retrieved
+     *
+     *  @return true if the list is successfully retrieved and valid, false otherwise
+     */
+    template <typename T>
+    bool GetList(const std::string &listName, const T *&pList) const;
+
+    /**
+     *  @brief  Collects the hits not currently assigned to a PFO, and maps them by view
+     *
+     *  @param  caloHitList the list of calo hits to consider
+     *  @param  viewToUnclusteredHitsMap the map in which to store the unclustered hits, mapped by view
+     */
+    void CollectUnclusteredHits(const pandora::CaloHitList &caloHitList, ViewToHitsMap &viewToUnclusteredHitsMap) const;
+
+    /**
+     *  @brief  Collects the clusters currently assigned to PFOs, and maps them by view, and also maps clusters to their parent PFO
+     *
+     *  @param  pfoList the list of pfos to consider
+     *  @param  viewToClustersMap the map in which to store the clusters, mapped by view
+     *  @param  clusterToPfoMap the map in which to store the mapping of clusters to their parent PFO
+     */
+    void CollectClusters(const pandora::PfoList &pfoList, ViewToClustersMap &viewToClustersMap, ClusterToPfoMap &clusterToPfoMap) const;
+
+    /**
+     *  @brief  Gets the hits associated with a cluster, ordered relative to a specified vertex
+     *
+     *  @param  clusterHits the hits associated with the cluster for which to retrieve the ordered hits
+     *  @param  vertex the vertex relative to which to order the hits
+     *  @param  orderedHits the vector in which to store the ordered hits
+     */
+    void OrderHitsRelativeToVertex(const pandora::CaloHitVector &clusterHits, const LArPointingCluster::Vertex &vertex,
+        pandora::CaloHitVector &orderedHits) const;
+
+    /**
+     *  @brief  Gets the moving average of the ADC values for ordered sets of hits, window is backward looking, so considers the "current"i
+     *          hit and the previous (window-1) hits.
+     *
+     *  @param  adcs an ordered set of ADC values for which to calculate the moving average
+     *  @param  movingAdc the vector in which to store the moving average of the ADC values for the hits
+     *  @param  movingVariance the vector in which to store the moving variance of the ADC values for the hits
+     *  @param  window the size of the window over which to calculate the moving average
+     */
+    void GetAdcMovingAverage(const pandora::FloatVector &adcs, pandora::FloatVector &movingAdc, pandora::FloatVector &movingVariance,
+        const size_t window = 3) const;
+
+    /**
+     *  @brief  Gets the indices of hits in an ordered set of hits for which there is a step change in ADC values. This function looks for step changes in
+     *          ADC, but with relatively stable ADC either side of the discontinuity, indicative of a decay or inelastic interaction. This method attempts
+     *          to filter out Bragg peaks or regions of high volatility.
+     *
+     *  @param  hits an ordered set of hits for which to identify stable ADC discontinuities
+     *  @param  discontinuities the vector in which to store the indices of hits for which there is a stable ADC discontinuity
+     *  @param  window the size of the window over which to calculate the moving average and identify step changes
+     */
+    void GetStableAdcDiscontinuities(const pandora::CaloHitVector &hits, pandora::IntVector &discontinuities, const size_t window = 3) const;
+
+    /**
+     *  @brief  Gets the ADC values for a set of hits and normalizes relative to the median ADC
+     *
+     *  @param  hits a set of hits for which to get the normalized ADC values
+     *  @param  normalizedAdc the vector in which to store the normalized ADC values for the hits
+     */
+    void NormalizeAdc(const pandora::CaloHitVector &hits, pandora::FloatVector &normalizedAdc) const;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    std::string m_caloHitListName; ///< Name of list of calo hits to consider during reclustering
+    std::string m_pfoListName; ///< Name of list of track-like pfos to consider for reclustering
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_SHORT_TRACK_RECLUSTERING_ALGORITHM_H

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -98,6 +98,15 @@ private:
         const size_t window = 3) const;
 
     /**
+     *  @brief  Gets the median value for a vector. The input vector need not be sorted.
+     *
+     *  @param  values a set of values for which to calculate the median
+     *  @return the median value for the input set of values
+     */
+    template <typename T>
+    double GetMedian(const std::vector<T> &values) const;
+
+    /**
      *  @brief  Gets the indices of hits in an ordered set of hits for which there is a step change in ADC values. This function looks for step changes in
      *          ADC, but with relatively stable ADC either side of the discontinuity, indicative of a decay or inelastic interaction. This method attempts
      *          to filter out Bragg peaks or regions of high volatility.
@@ -115,6 +124,62 @@ private:
      *  @param  normalizedAdc the vector in which to store the normalized ADC values for the hits
      */
     void NormalizeAdc(const pandora::CaloHitVector &hits, pandora::FloatVector &normalizedAdc) const;
+
+    /**
+     *  @brief  Identifies whether a set of hits exhibits a Bragg peak. This method considers the consensus view from computation of the linear slope,
+     *          quadratic curvature, contrast ratio and monotonicity.
+     *
+     *  @param  hits the set of hits for which to identify whether there is a Bragg peak
+     *  @param  start the index of the first hit in the set of hits to consider when looking for a Bragg peak
+     *  @param  end the index of the last hit in the set of hits to consider when looking for a Bragg peak
+     *
+     *  @return true if there is evidence for a Bragg peak in the specified range of hits, false otherwise
+     */
+    bool IsBraggPeak(const pandora::CaloHitVector &hits, const size_t start, const size_t end) const;
+
+    /**
+     *  @brief  Gets a score indicative of the linear slope of the ADC values for a set of hits
+     *
+     *  @param  hits the set of hits for which to calculate the linear slope score
+     *  @param  start the index of the first hit in the set of hits to consider when calculating the linear slope score
+     *  @param  end the index of the last hit in the set of hits to consider when calculating the linear slope score
+     *
+     *  @return a score indicative of the linear slope of the ADC values for the specified range of hits
+     */
+    float GetLinearSlopeScore(const pandora::CaloHitVector &hits, const size_t start, const size_t end) const;
+
+    /**
+     *  @brief  Gets a score indicative of the quadratic curvature of the ADC values for a set of hits
+     *
+     *  @param  hits the set of hits for which to calculate the quadratic curvature score
+     *  @param  start the index of the first hit in the set of hits to consider when calculating the quadratic curvature score
+     *  @param  end the index of the last hit in the set of hits to consider when calculating the quadratic curvature score
+     *
+     *  @return a score indicative of the quadratic curvature of the ADC values for the specified range of hits
+     */
+    float GetQuadraticCurvatureScore(const pandora::CaloHitVector &hits, const size_t start, const size_t end) const;
+
+    /**
+     *  @brief  Gets a score indicative of the contrast in ADC values for a set of hits
+     *
+     *  @param  hits the set of hits for which to calculate the contrast score
+     *  @param  start the index of the first hit in the set of hits to consider when calculating the contrast score
+     *  @param  end the index of the last hit in the set of hits to consider when calculating the contrast score
+     *
+     *  @return a score indicative of the contrast in ADC values for the specified range of hits
+     */
+    float GetContrastScore(const pandora::CaloHitVector &hits, const size_t start, const size_t end) const;
+
+    /**
+     *  @brief  Gets a score indicative of the monotonicity of the ADC values for a set of hits
+     *
+     *  @param  hits the set of hits for which to calculate the monotonicity score
+     *  @param  start the index of the first hit in the set of hits to consider when calculating the monotonicity score
+     *  @param  end the index of the last hit in the set of hits to consider when calculating the monotonicity score
+     *
+     *  @return a score indicative of the monotonicity of the ADC values for the specified range of hits
+     */
+    float GetMonotonicityScore(const pandora::CaloHitVector &hits, const size_t start, const size_t end) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -48,6 +48,14 @@ private:
     typedef std::unordered_map<const pandora::Cluster *, pandora::CaloHitSet> ClusterToHitsMap;
     typedef std::unordered_map<const pandora::Pfo *, std::vector<HitTriplet>> PfoToHitTripletsMap;
 
+    // Need to decide exactly what this is, but basically we want an object that can tell us which hits from which views belong together,
+    // and we want a way of knowing which PFO will become the owner, which PFO (if any) previously owned the hits, and which hits were
+    // formerly unclustered. We likely want a vector of these objects to describe the complete picture
+    struct Partition
+    {
+    };
+    typedef std::vector<Partition> PartitionVector;
+
     pandora::StatusCode Run();
 
     /**
@@ -97,6 +105,16 @@ private:
      */
     void MatchAdcDiscontinuities(const ClusterToHitsMap &clusterToHitsMap, const ClusterToPfoMap &clusterToPfoMap,
         PfoToHitTripletsMap &pfoToHitTripletsMap) const;
+
+    /**
+     *  @brief  Uses the identified discontinuity triplets to find coherent changes across all three views and proposes new partitions.
+     *
+     *  @param  pfoToHitTripletsMap the map of PFOs to triplets of hits across views that are consistent with a common 3D position
+     *  @param  viewToUnclusteredHitsMap the map of unclustered hits, mapped by view
+     *  @param  partitions the proposed partitions if coherent alternatives can be found
+     */
+    void PartitionDiscontinuities(const PfoToHitTripletsMap &pfoToHitTripletsMap, const ViewToHitsMap &viewToUnclusteredHitsMap,
+        PartitionVector &partitions) const;
 
     /**
      *  @brief  Gets the hits associated with a cluster, ordered relative to a specified vertex

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -67,6 +67,15 @@ private:
     };
     typedef std::vector<Partition> PartitionVector;
 
+    struct ProtoPfo
+    {
+        PandoraContentApi::ParticleFlowObject::Parameters m_pfoParameters;
+        const pandora::Pfo *m_pOldPfo;
+        std::unordered_map<pandora::HitType, const pandora::Cluster *> m_viewToClusterMap;
+        std::unordered_map<pandora::HitType, pandora::CaloHitList> m_viewToHitsMap;
+    };
+    typedef std::vector<ProtoPfo> ProtoPfoVector;
+
     pandora::StatusCode Run();
 
     /**
@@ -79,14 +88,6 @@ private:
      */
     template <typename T>
     bool GetList(const std::string &listName, const T *&pList) const;
-
-    /**
-     *  @brief  Collects the hits not currently assigned to a PFO, and maps them by view
-     *
-     *  @param  caloHitList the list of calo hits to consider
-     *  @param  viewToUnclusteredHitsMap the map in which to store the unclustered hits, mapped by view
-     */
-    void CollectUnclusteredHits(const pandora::CaloHitList &caloHitList, ViewToHitsMap &viewToUnclusteredHitsMap) const;
 
     /**
      *  @brief  Collects the clusters currently assigned to PFOs, and maps them by view, and also maps clusters to their parent PFO
@@ -129,11 +130,9 @@ private:
      *  @brief  Uses the identified discontinuity triplets to find coherent changes across all three views and proposes new partitions.
      *
      *  @param  pfoToHitTripletsMap the map of PFOs to triplets of hits across views that are consistent with a common 3D position
-     *  @param  viewToUnclusteredHitsMap the map of unclustered hits, mapped by view
      *  @param  partitions the proposed partitions if coherent alternatives can be found
      */
-    void PartitionDiscontinuities(const PfoToHitTripletsMap &pfoToHitTripletsMap, const ViewToHitsMap &viewToUnclusteredHitsMap,
-        PartitionVector &partitions) const;
+    void PartitionDiscontinuities(const PfoToHitTripletsMap &pfoToHitTripletsMap, PartitionVector &partitions) const;
 
     /**
      *  @brief  Applies the reclustering described by a given partition vector

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -61,9 +61,9 @@ private:
         {
         }
 
-        const pandora::Pfo *const m_pCurrentPfo;
-        const HitTriplet m_hitTriplet;
-        const pandora::CaloHitList m_hitsU, m_hitsV, m_hitsW;
+        const pandora::Pfo * m_pCurrentPfo;
+        HitTriplet m_hitTriplet;
+        pandora::CaloHitList m_hitsU, m_hitsV, m_hitsW;
     };
     typedef std::vector<Partition> PartitionVector;
 
@@ -133,6 +133,13 @@ private:
      *  @param  partitions the proposed partitions if coherent alternatives can be found
      */
     void PartitionDiscontinuities(const PfoToHitTripletsMap &pfoToHitTripletsMap, PartitionVector &partitions) const;
+
+    /**
+     *  @brief  Different partitions can have overlap. This function throws filters out the smaller partitions
+     *  
+     *  @param[in,out]  partitions the proposed partitions, which are filtered in place
+     */
+    void FilterPartitions(PartitionVector &partitions) const;
 
     /**
      *  @brief  Applies the reclustering described by a given partition vector

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -17,6 +17,7 @@
 #include "Pandora/PandoraInternal.h"
 
 #include "larpandoracontent/LArObjects/LArPointingCluster.h"
+#include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
 
 #include "larpandoracontent/LArReclustering/ThreeDReclusteringFigureOfMeritBaseTool.h"
 
@@ -221,6 +222,29 @@ private:
      *  @return a score indicative of the monotonicity of the ADC values for the specified range of hits
      */
     float GetMonotonicityScore(const pandora::CaloHitVector &hits, const size_t start, const size_t end) const;
+
+    /**
+     *  @brief  Gets the ratio of the median ADC value either side of the pivot.
+     *
+     *  @param  hits the set of hits for which to calculate the balance
+     *  @param  pivot the index of the hit about which to calculate the balance
+     *
+     *  @return the ratio of the median ADC value either side of the pivot
+     */
+    float GetBalance(const pandora::CaloHitVector &hits, const size_t pivot) const;
+
+    /**
+     *  @brief  Gets a windowed, ordered vector of hits along the direction of a sliding linear fit about the discontinuity hit.
+     *
+     *  @param  pCluster the cluster for which to retrieve the ordered hits
+     *  @param  pDiscontinuityHit the hit associated with the identified discontinuity
+     *  @param  sfr the result of the sliding linear fit to the cluster
+     *  @param  window the size of the window, in each direction, over which to retrieve hits, in cm
+     *  @param  orderedHits the vector in which to store the ordered hits
+     *
+     *  @return The index of the discontinuity hit in the ordered vector of hits
+     */
+    size_t OrderHitsAlongTrajectory(const pandora::Cluster *const pCluster, const pandora::CaloHit *const pDiscontinuityHit, const TwoDSlidingFitResult &sfr, const float window, pandora::CaloHitVector &orderedHits) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -136,6 +136,25 @@ private:
         PartitionVector &partitions) const;
 
     /**
+     *  @brief  Applies the reclustering described by a given partition vector
+     *
+     *  @param  partitions the proposed reclustering partitions
+     */
+    void Recluster(const PartitionVector &partitions) const;
+
+    /**
+     *  @brief  Utility function that performs the partitioning of a given set of hits according to a provided hit about which the split
+     *          should be performed. The split hit is then allocated to the partition that is most consistent with its ADC
+     *
+     *  @param  caloHits the set of hits to partition
+     *  @param  pSplitHit the hit about which to partition the set of hits
+     *  @param  cluster1Hits the vector in which to store the first set of partitioned hits
+     *  @param  cluster2Hits the vector in which to store the second set of partitioned hits
+     */
+    void PartitionHits(const pandora::CaloHitList &caloHits, const pandora::CaloHit *const pSplitHit, pandora::CaloHitList &cluster1Hits,
+        pandora::CaloHitList &cluster2Hits) const;
+
+    /**
      *  @brief  Gets the hits associated with a cluster, ordered relative to a specified vertex
      *
      *  @param  clusterHits the hits associated with the cluster for which to retrieve the ordered hits

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -49,11 +49,21 @@ private:
     typedef std::unordered_map<const pandora::Cluster *, pandora::CaloHitSet> ClusterToHitsMap;
     typedef std::unordered_map<const pandora::Pfo *, std::vector<HitTriplet>> PfoToHitTripletsMap;
 
-    // Need to decide exactly what this is, but basically we want an object that can tell us which hits from which views belong together,
-    // and we want a way of knowing which PFO will become the owner, which PFO (if any) previously owned the hits, and which hits were
-    // formerly unclustered. We likely want a vector of these objects to describe the complete picture
     struct Partition
     {
+        Partition(const pandora::Pfo *const pCurrentPfo, const HitTriplet &hitTriplet, const TwoDSlidingFitResult &sfrU,
+            const TwoDSlidingFitResult &sfrV, const TwoDSlidingFitResult &sfrW) :
+            m_pCurrentPfo(pCurrentPfo),
+            m_hitTriplet(hitTriplet),
+            m_sfrU(sfrU),
+            m_sfrV(sfrV),
+            m_sfrW(sfrW)
+        {
+        }
+
+        const pandora::Pfo *const m_pCurrentPfo;
+        const HitTriplet m_hitTriplet;
+        const TwoDSlidingFitResult m_sfrU, m_sfrV, m_sfrW;
     };
     typedef std::vector<Partition> PartitionVector;
 

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -281,6 +281,14 @@ private:
     std::string m_caloHitListName; ///< Name of list of calo hits to consider during reclustering
     std::string m_pfoListName; ///< Name of list of track-like pfos to consider for reclustering
     pandora::StringVector m_clusterListNames; ///< Names of lists of clusters to consider during reclustering
+    float m_maxHitDiscrepancy; ///< Maximum allowed discrepancy between 2D hit positions and triplet projections
+    float m_maxHitDiscrepancySquared; ///< Square of m_maxHitDiscrepancy, cached for efficiency
+    float m_balanceThresholdLow; ///< Threshold for the balance ratio below which a discontinuity is considered to be present
+    float m_balanceThresholdHigh; ///< Threshold for the balance ratio above which a discontinuity is considered to be present
+    float m_braggLinearSlopeThreshold; ///< Threshold for the linear slope score above which a Bragg peak is considered to be present
+    float m_braggCurvatureThreshold; ///< Threshold for the quadratic curvature score above which a Bragg peak is considered to be present
+    float m_braggContrastThreshold; ///< Threshold for the contrast score above which a Bragg peak is considered to be present
+    float m_braggMonotonicityThreshold; ///< Threshold for the monotonicity score above which a Bragg peak is considered to be present
     std::unordered_map<const pandora::Cluster *, TwoDSlidingFitResult> m_clusterToSFRMap;
     std::unordered_map<const pandora::Cluster *, pandora::CaloHitList> m_clusterToOrderedHitsMap;
 };

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -51,19 +51,19 @@ private:
 
     struct Partition
     {
-        Partition(const pandora::Pfo *const pCurrentPfo, const HitTriplet &hitTriplet, const TwoDSlidingFitResult &sfrU,
-            const TwoDSlidingFitResult &sfrV, const TwoDSlidingFitResult &sfrW) :
+        Partition(const pandora::Pfo *const pCurrentPfo, const HitTriplet &hitTriplet, const pandora::CaloHitList &hitsU,
+            const pandora::CaloHitList &hitsV, const pandora::CaloHitList &hitsW) :
             m_pCurrentPfo(pCurrentPfo),
             m_hitTriplet(hitTriplet),
-            m_sfrU(sfrU),
-            m_sfrV(sfrV),
-            m_sfrW(sfrW)
+            m_hitsU(hitsU),
+            m_hitsV(hitsV),
+            m_hitsW(hitsW)
         {
         }
 
         const pandora::Pfo *const m_pCurrentPfo;
         const HitTriplet m_hitTriplet;
-        const TwoDSlidingFitResult m_sfrU, m_sfrV, m_sfrW;
+        const pandora::CaloHitList m_hitsU, m_hitsV, m_hitsW;
     };
     typedef std::vector<Partition> PartitionVector;
 
@@ -96,6 +96,14 @@ private:
      *  @param  clusterToPfoMap the map in which to store the mapping of clusters to their parent PFO
      */
     void CollectClusters(const pandora::PfoList &pfoList, ViewToClustersMap &viewToClustersMap, ClusterToPfoMap &clusterToPfoMap) const;
+
+    /**
+     *  @brief  Loops over clusters and performs a sliding linear fit to get an ordered set of hits along the cluster trajectory, and the
+     *          corresponding fit result, which are stored in maps for later use.
+     *
+     *  @param  viewToClustersMap the map of clusters mapped by view
+     */
+    void FitAndOrderClusters(const ViewToClustersMap &viewToClustersMap);
 
     /**
      *  @brief  Loops over clusters and looks for evidence of discontinuous changes in ADC values, and collects the corresponding hits
@@ -241,7 +249,7 @@ private:
      *
      *  @return the ratio of the median ADC value either side of the pivot
      */
-    float GetBalance(const pandora::CaloHitVector &hits, const size_t pivot) const;
+    float GetBalance(const pandora::CaloHitList &hits, const size_t pivot) const;
 
     /**
      *  @brief  Gets a windowed, ordered vector of hits along the direction of a sliding linear fit about the discontinuity hit.
@@ -260,6 +268,8 @@ private:
 
     std::string m_caloHitListName; ///< Name of list of calo hits to consider during reclustering
     std::string m_pfoListName; ///< Name of list of track-like pfos to consider for reclustering
+    std::unordered_map<const pandora::Cluster *, TwoDSlidingFitResult> m_clusterToSFRMap;
+    std::unordered_map<const pandora::Cluster *, pandora::CaloHitList> m_clusterToOrderedHitsMap;
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -40,10 +40,13 @@ public:
     ~ShortTrackReclusteringAlgorithm() = default;
 
 private:
+    typedef std::tuple<const pandora::CaloHit *, const pandora::CaloHit *, const pandora::CaloHit *> HitTriplet;
     typedef std::unordered_map<pandora::HitType, pandora::CaloHitSet> ViewToHitsMap;
     typedef std::unordered_map<pandora::HitType, pandora::ClusterList> ViewToClustersMap;
     typedef std::unordered_map<const pandora::Cluster *, const pandora::Pfo *> ClusterToPfoMap;
     typedef std::unordered_map<const pandora::Cluster *, pandora::FloatVector> ClusterToAdcMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::CaloHitSet> ClusterToHitsMap;
+    typedef std::unordered_map<const pandora::Pfo *, std::vector<HitTriplet>> PfoToHitTripletsMap;
 
     pandora::StatusCode Run();
 
@@ -74,6 +77,26 @@ private:
      *  @param  clusterToPfoMap the map in which to store the mapping of clusters to their parent PFO
      */
     void CollectClusters(const pandora::PfoList &pfoList, ViewToClustersMap &viewToClustersMap, ClusterToPfoMap &clusterToPfoMap) const;
+
+    /**
+     *  @brief  Loops over clusters and looks for evidence of discontinuous changes in ADC values, and collects the corresponding hits
+     *
+     *  @param  clusterToPfoMap the map of clusters to their parent PFO
+     *  @param  clusterToHitsMap the map in which to store the mapping of clusters to the hits associated with any identified ADC discontinuities
+     */
+    void FindAdcDiscontinuities(const ClusterToPfoMap &clusterToPfoMap, ClusterToHitsMap &clusterToHitsMap) const;
+
+    /**
+     *  @brief  Loops over the hits associated with identified ADC discontinuities and looks for corresponding hits in other views, to identify
+     *  potential triplets of hits across views that are consistent with a common 3D position
+     *
+     *  @param  clusterToHitsMap the map of clusters to the hits associated with any identified ADC discontinuities
+     *  @param  clusterToPfoMap the map of clusters to their parent PFO
+     *  @param  pfoToHitTripletsMap the map in which to store the mapping of PFOs to triplets of hits across views that are consistent with
+     *          a common 3D position
+     */
+    void MatchAdcDiscontinuities(const ClusterToHitsMap &clusterToHitsMap, const ClusterToPfoMap &clusterToPfoMap,
+        PfoToHitTripletsMap &pfoToHitTripletsMap) const;
 
     /**
      *  @brief  Gets the hits associated with a cluster, ordered relative to a specified vertex

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -3,8 +3,8 @@
  *
  *  @brief  Tries to identify short tracks that are either lost, or under-clustered and recover missing hits.
  *          This algorithm looks at all three views of a PFO to try to identify if one or more views exhibit step changes in ADC values that
- *          might be indicative of a decay or intelastic interaction. If such a change occurs it looks for consistency across views and also
- *          examines nearby unclustered hits, or hits in nearby clusters to see if a more cohenrent clustering can be identified.
+ *          might be indicative of a decay or inelastic interaction. If such a change occurs it looks for consistency across views and also
+ *          examines nearby unclustered hits, or hits in nearby clusters to see if a more coherent clustering can be identified.
  *          If these various conditions are met, then reclustering is performed.
  *
  *  $Log: $

--- a/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
+++ b/larpandoracontent/LArReclustering/ShortTrackReclusteringAlgorithm.h
@@ -270,23 +270,11 @@ private:
      */
     float GetBalance(const pandora::CaloHitList &hits, const size_t pivot) const;
 
-    /**
-     *  @brief  Gets a windowed, ordered vector of hits along the direction of a sliding linear fit about the discontinuity hit.
-     *
-     *  @param  pCluster the cluster for which to retrieve the ordered hits
-     *  @param  pDiscontinuityHit the hit associated with the identified discontinuity
-     *  @param  sfr the result of the sliding linear fit to the cluster
-     *  @param  window the size of the window, in each direction, over which to retrieve hits, in cm
-     *  @param  orderedHits the vector in which to store the ordered hits
-     *
-     *  @return The index of the discontinuity hit in the ordered vector of hits
-     */
-    size_t OrderHitsAlongTrajectory(const pandora::Cluster *const pCluster, const pandora::CaloHit *const pDiscontinuityHit, const TwoDSlidingFitResult &sfr, const float window, pandora::CaloHitVector &orderedHits) const;
-
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     std::string m_caloHitListName; ///< Name of list of calo hits to consider during reclustering
     std::string m_pfoListName; ///< Name of list of track-like pfos to consider for reclustering
+    pandora::StringVector m_clusterListNames; ///< Names of lists of clusters to consider during reclustering
     std::unordered_map<const pandora::Cluster *, TwoDSlidingFitResult> m_clusterToSFRMap;
     std::unordered_map<const pandora::Cluster *, pandora::CaloHitList> m_clusterToOrderedHitsMap;
 };

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -62,15 +62,15 @@ void PlaneSolverAlgorithm::FillHitMap(const CaloHitList &caloHitList)
 
 void PlaneSolverAlgorithm::Solve() const
 {
-    // STATUS: Seems like lot so pairs/triplets can be found in pass 2, but not actually added to the 3D hits, investigate.
-
     const float chi2Threshold{6.f};
     CaloHitList hits3D;
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
+    //PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
     // Loop over each read out volume (e.g. an APA in a horizontal drift detector) and solve for the optimal set of triplet and doublet
     // relationships between the 2D hits in each unit.
     for (const auto &[_, readout] : m_planeToReadoutMap)
     {
+        if (readout.size() < 3)
+            continue;
         // Set the used view to an "invalid" type for the first pass
         HitType usedView{HIT_CUSTOM};
         CaloHitSet usedHits;
@@ -204,11 +204,10 @@ void PlaneSolverAlgorithm::Solve() const
             if (pHit3D)
                 hits3D.emplace_back(pHit3D);
         }
-        std::cout << "Number of 3D hits: " << hits3D.size() << std::endl;
     }
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, hits3D, "KMHitList"));
-    PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hits3D, "3D", BLACK));
-    PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+    //PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hits3D, "3D", BLACK));
+    //PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -218,7 +217,6 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
 {
     HitType viewA, viewB;
     this->SelectViewPair(constraintView, viewA, viewB);
-    std::cout << "View A: " << viewA << ", View B: " << viewB << ", Constraint view: " << constraintView << std::endl;
     const CaloHitVector &aHits(planeToHitsMap.at(viewA));
     const CaloHitVector &bHits(planeToHitsMap.at(viewB));
     const CaloHitVector &cHits(planeToHitsMap.at(constraintView));

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -1,0 +1,321 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+ *
+ *  @brief  Implementation of the three dimensional hit creation algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
+
+#include "larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+PlaneSolverAlgorithm::PlaneSolverAlgorithm() :
+    m_caloHitListName{"CaloHitList2D"}
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PlaneSolverAlgorithm::Run()
+{
+    const CaloHitList *pCaloHitList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_caloHitListName, pCaloHitList));
+
+    this->FillHitMap(*pCaloHitList);
+    this->Solve();
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void PlaneSolverAlgorithm::FillHitMap(const CaloHitList &caloHitList)
+{
+    for (const auto *pCaloHit : caloHitList)
+    {
+        const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pCaloHit));
+        if (!pLArCaloHit)
+        {
+            std::cout << "PlaneSolverAlgorithm - non LArCaloHit found in calo hit list: " << m_caloHitListName << std::endl;
+            throw StatusCodeException(STATUS_CODE_FAILURE);
+        }
+        const unsigned int tpc{pLArCaloHit->GetLArTPCVolumeId()};
+        const unsigned int childVolume{pLArCaloHit->GetDaughterVolumeId()};
+        const Volume volume{tpc, childVolume};
+
+        const HitType view(pLArCaloHit->GetHitType());
+        m_planeToReadoutMap[volume][view].emplace_back(pLArCaloHit);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void PlaneSolverAlgorithm::Solve() const
+{
+    CaloHitList hits3D;
+    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
+    // Loop over each read out volume (e.g. an APA in a horizontal drift detector) and solve for the optimal set of triplet and doublet
+    // relationships between the 2D hits in each unit.
+    for (const auto &[_, readout] : m_planeToReadoutMap)
+    {
+        IndexMatrix bestK;
+        CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f, bestK)};
+        const IntVector assignment{this->KuhneMunkres(costMatrix)};
+        //CaloHitList hitsU{readout.at(TPC_VIEW_U).begin(), readout.at(TPC_VIEW_U).end()};
+        //CaloHitList hitsV{readout.at(TPC_VIEW_V).begin(), readout.at(TPC_VIEW_V).end()};
+        //PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsU, "U", RED));
+        //PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsV, "V", GREEN));
+        int nHitsU{static_cast<int>(readout.at(TPC_VIEW_U).size())};
+        int nHitsV{static_cast<int>(readout.at(TPC_VIEW_V).size())};
+        int nHitsW{static_cast<int>(readout.at(TPC_VIEW_W).size())};
+        int nMatchedU{0}, nMatchedV{0};
+        for (size_t i = 0; i < assignment.size(); ++i)
+        {
+            if (assignment[i] < 0)
+                continue;
+            const size_t j{static_cast<size_t>(assignment[i])};
+            //if (i < hitsU.size())
+            //{
+            //    const CartesianVector u(readout.at(TPC_VIEW_U)[i]->GetPositionVector());
+            //    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &u, "U", RED, 2));
+            //}
+            //if (j < hitsV.size())
+            //{
+            //    const CartesianVector v(readout.at(TPC_VIEW_V)[j]->GetPositionVector());
+            //    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &v, "V", GREEN, 2));
+            //}
+            //PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+
+            if (i < readout.at(TPC_VIEW_U).size() && j < readout.at(TPC_VIEW_V).size())
+            {
+                ++nMatchedU;
+                ++nMatchedV;
+                std::cout << "Assignment: i = " << i << "(" << readout.at(TPC_VIEW_U).size() << "), j = " << j << " (" <<
+                    readout.at(TPC_VIEW_V).size() << ")" << std::endl;
+
+                const CaloHit *pHit3D{nullptr};
+                this->CreateThreeDHit(readout.at(TPC_VIEW_U)[i], readout.at(TPC_VIEW_V)[j], pHit3D);
+                hits3D.emplace_back(pHit3D);
+            }
+        }
+        std::cout << "Matched " << nMatchedU << " out of " << nHitsU << " U hits, and " << nMatchedV << " out of " << nHitsV << " V hits. " <<
+            "The W view has " << nHitsW << std::endl;
+    }
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, hits3D, "KMHitList"));
+    PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hits3D, "3D", BLACK));
+    PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost,
+    IndexMatrix &bestW) const
+{
+    const CaloHitVector &uHits(planeToHitsMap.at(TPC_VIEW_U));
+    const CaloHitVector &vHits(planeToHitsMap.at(TPC_VIEW_V));
+    const CaloHitVector &wHits(planeToHitsMap.at(TPC_VIEW_W));
+    const int nU{static_cast<int>(uHits.size())};
+    const int nV{static_cast<int>(vHits.size())};
+    const int nW{static_cast<int>(wHits.size())};
+    const int N{std::max(nU, nV)};
+
+    // Initialize the cost matrix with the cost for unmatched hits, and the best k matrix with -1 (indicating no match).
+    CostMatrix C(N, FloatVector(N, unmatchedCost));
+    bestW.assign(nU, std::vector<int>(nV, -1));
+
+    // Compute all chi-squared values
+    for (int i = 0; i < nU; ++i)
+    {
+        const CartesianVector u(uHits[i]->GetPositionVector());
+        const float dx_u(0.5f * uHits[i]->GetCellSize1());
+        const float xMin_u(u.GetX() - dx_u);
+        const float xMax_u(u.GetX() + dx_u);
+        
+        for (int j = 0; j < nV; ++j)
+        {
+            const CartesianVector v(vHits[j]->GetPositionVector());
+            const float dx_v(0.5f * vHits[j]->GetCellSize1());
+            const float xMin_v(v.GetX() - dx_v);
+            const float xMax_v(v.GetX() + dx_v);
+            // Check that the U and V views are compatible in x, otherwise skip the chi-squared calculation
+            if ((xMax_u < xMin_v) || (xMin_u > xMax_v))
+                continue;
+            
+            float bestChi2 = std::numeric_limits<float>::max();
+            int bestK{-1};
+
+            for (int k = 0; k < nW; ++k)
+            {
+                const CartesianVector w(wHits[k]->GetPositionVector());
+                const float dx_w(0.5f * wHits[k]->GetCellSize1());
+                const float xMin_w(w.GetX() - dx_w);
+                const float xMax_w(w.GetX() + dx_w);
+                // Check that W view is compatible with U and V in x, otherwise skip the chi-squared calculation
+                if ((xMax_u < xMin_w) || (xMin_u > xMax_w) || (xMax_v < xMin_w) || (xMin_v > xMax_w))
+                    continue;
+
+                float chi2{LArGeometryHelper::CalculateChiSquared(this->GetPandora(), uHits[i], vHits[j], wHits[k])};
+                if (chi2 < bestChi2)
+                {
+                    bestChi2 = chi2;
+                    bestK = k;
+                }
+            }
+
+            if (bestK >= 0)
+            {
+                C[i][j] = bestChi2;
+                bestW[i][j] = bestK;
+            }
+        }
+    }
+
+    return C;
+}
+
+IntVector PlaneSolverAlgorithm::KuhneMunkres(const CostMatrix& cost) const
+{
+    const int N{static_cast<int>(cost.size())};
+    // Define the dual variables for rows (u) and columns (v), enforcing u[i] + v[j] <= cost[i][j]
+    // We are essentially trying to maximise the sum of the duals over all rows/columns, while enforcing the constraint above
+    FloatVector u(N + 1), v(N + 1);
+    // Define the matching from a row to a column (p[col] = row) and the way matrix to reconstruct the augmenting path - indexing is
+    // 1-based, zero is a dummy node
+    IntVector p(N + 1), way(N + 1);
+
+    // Iterate over the rows
+    for (int i = 1; i <= N; ++i)
+    {
+        // Start from the dummy column zero and initialise lowest cost and element usage
+        int j0 = 0;
+        p[j0] = i;
+        FloatVector minReducedCost(N + 1, std::numeric_limits<float>::max());
+        IntVector used(N + 1, 0);
+
+        // Build the augmenting path (Dijkstra-like)
+        do
+        {
+            // Mark the current column (j0) and the current row (i0)
+            used[j0] = 1;
+            int i0{p[j0]}, j1{0};
+            float delta{std::numeric_limits<float>::max()};
+
+            // Evaluate all possible assignments - trying to find a path from the current row to the best column with the minimum reduced cost
+            for (int j = 1; j <= N; ++j)
+            {
+                if (used[j])
+                    continue;
+                // Key step, computing the reduced cost to maintain feasibility
+                // When an optimal edge between hits is found, the reduced cost will be zero
+                float reducedCost{cost[i0 - 1][j - 1] - u[i0] - v[j]};
+                if (reducedCost < minReducedCost[j])
+                {
+                    // Keep track of the best cost for reaching column j so far
+                    minReducedCost[j] = reducedCost;
+                    // ... and how we got there. We reach column j via column j0
+                    way[j] = j0;
+                }
+                if (minReducedCost[j] < delta)
+                {
+                    // Keep track of the best column to expand to
+                    delta = minReducedCost[j];
+                    j1 = j;
+                }
+            }
+
+            // Update the potentials (ensures reduced cost of zero for at least one edge)
+            // Opposing deltas also ensure that u_i + v_j = (u_i + delta) + (v_j - delta), so the constraint still holds
+            for (int j = 0; j <= N; ++j)
+            {
+                if (used[j])
+                {
+                    u[p[j]] += delta;
+                    v[j] -= delta;
+                }
+                else
+                {
+                    // Reduce the slack for unmatched columns
+                    minReducedCost[j] -= delta;
+                }
+            }
+
+            // Step j0 forward - continue the search
+            j0 = j1;
+            // Stop when we get to an unmatched column, implying we've found an augmenting path. Otherwise, we have a clash and should look
+            // to reassign the previous row (which happens because we've now set j0 to j1 for the next loop iteration)
+        }
+        while (p[j0] != 0);
+
+        // Walk back through way to update the matching along the augmenting path
+        do
+        {
+            int j1 = way[j0];
+            p[j0] = p[j1];
+            j0 = j1;
+        }
+        while (j0);
+    }
+
+    // p[j] = i means row i is matched to column j, so we need to invert this to get the assignment of columns to rows.
+    // Unmatched columns will have p[j] = 0, so we assign -1 in the output.
+    IntVector assignment(N, -1);
+    for (int j = 1; j <= N; ++j)
+        if (p[j] != 0)
+            assignment[p[j] - 1] = j - 1;
+
+    return assignment;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const CaloHit *const pCaloHitV, const CaloHit *&pCaloHit3D) const
+{
+    float chi2{0.f};
+    CartesianVector pos3D(0, 0, 0);
+    PandoraContentApi::CaloHit::Parameters parameters;
+    LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, pCaloHitU->GetPositionVector(), pCaloHitV->GetPositionVector(),
+        pos3D, chi2);
+    parameters.m_positionVector = pos3D;
+    parameters.m_hitType = TPC_3D;
+
+    const CaloHit *const pCaloHit2D(pCaloHitU);
+    parameters.m_pParentAddress = static_cast<const void *>(pCaloHit2D);
+    parameters.m_cellThickness = pCaloHit2D->GetCellThickness();
+    parameters.m_cellGeometry = RECTANGULAR;
+    parameters.m_cellSize0 = pCaloHit2D->GetCellLengthScale();
+    parameters.m_cellSize1 = pCaloHit2D->GetCellLengthScale();
+    parameters.m_cellNormalVector = pCaloHit2D->GetCellNormalVector();
+    parameters.m_expectedDirection = pCaloHit2D->GetExpectedDirection();
+    parameters.m_nCellRadiationLengths = pCaloHit2D->GetNCellRadiationLengths();
+    parameters.m_nCellInteractionLengths = pCaloHit2D->GetNCellInteractionLengths();
+    parameters.m_time = pCaloHit2D->GetTime();
+    parameters.m_inputEnergy = pCaloHit2D->GetInputEnergy();
+    parameters.m_mipEquivalentEnergy = pCaloHit2D->GetMipEquivalentEnergy();
+    parameters.m_electromagneticEnergy = pCaloHit2D->GetElectromagneticEnergy();
+    parameters.m_hadronicEnergy = pCaloHit2D->GetHadronicEnergy();
+    parameters.m_isDigital = pCaloHit2D->IsDigital();
+    parameters.m_hitRegion = pCaloHit2D->GetHitRegion();
+    parameters.m_layer = pCaloHit2D->GetLayer();
+    parameters.m_isInOuterSamplingLayer = pCaloHit2D->IsInOuterSamplingLayer();
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PlaneSolverAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -67,17 +67,22 @@ void PlaneSolverAlgorithm::Solve() const
     // relationships between the 2D hits in each unit.
     for (const auto &[_, readout] : m_planeToReadoutMap)
     {
-        IndexMatrix bestK;
-        CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f, bestK)};
+        CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f)};
         const IntVector assignment{this->KuhneMunkres(costMatrix)};
+        int nHitsU{static_cast<int>(readout.at(TPC_VIEW_U).size())};
+        int nHitsV{static_cast<int>(readout.at(TPC_VIEW_V).size())};
+        const PairVector pairs{this->BuildUVPairs(assignment, nHitsU, nHitsV)};
+        CostMatrix tripletCostMatrix{this->ComputeTripletCostMatrix(pairs, readout, 100.f)};
+        const IntVector tripletAssignment{this->KuhneMunkres(tripletCostMatrix)};
+        int nHitsW{static_cast<int>(readout.at(TPC_VIEW_W).size())};
+        const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsW)};
         //CaloHitList hitsU{readout.at(TPC_VIEW_U).begin(), readout.at(TPC_VIEW_U).end()};
         //CaloHitList hitsV{readout.at(TPC_VIEW_V).begin(), readout.at(TPC_VIEW_V).end()};
         //PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsU, "U", RED));
         //PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsV, "V", GREEN));
-        int nHitsU{static_cast<int>(readout.at(TPC_VIEW_U).size())};
-        int nHitsV{static_cast<int>(readout.at(TPC_VIEW_V).size())};
-        int nHitsW{static_cast<int>(readout.at(TPC_VIEW_W).size())};
         int nMatchedU{0}, nMatchedV{0};
+        std::cout << "UV pairs with non-unique W" << std::endl;
+        std::cout << "-----------------------------" << std::endl;
         for (size_t i = 0; i < assignment.size(); ++i)
         {
             if (assignment[i] < 0)
@@ -102,13 +107,29 @@ void PlaneSolverAlgorithm::Solve() const
                 std::cout << "Assignment: i = " << i << "(" << readout.at(TPC_VIEW_U).size() << "), j = " << j << " (" <<
                     readout.at(TPC_VIEW_V).size() << ")" << std::endl;
 
-                const CaloHit *pHit3D{nullptr};
-                this->CreateThreeDHit(readout.at(TPC_VIEW_U)[i], readout.at(TPC_VIEW_V)[j], pHit3D);
-                hits3D.emplace_back(pHit3D);
+                //const CaloHit *pHit3D{nullptr};
+                //this->CreateThreeDHit(readout.at(TPC_VIEW_U)[i], readout.at(TPC_VIEW_V)[j], pHit3D);
+                //hits3D.emplace_back(pHit3D);
             }
         }
         std::cout << "Matched " << nMatchedU << " out of " << nHitsU << " U hits, and " << nMatchedV << " out of " << nHitsV << " V hits. " <<
             "The W view has " << nHitsW << std::endl;
+        std::cout << "-----------------------------" << std::endl;
+        std::cout << "Triplets" << std::endl;
+        std::cout << "-----------------------------" << std::endl;
+        for (size_t i = 0; i < triplets.size(); ++i)
+        {
+            std::cout << "Triplet: i = " << triplets[i].m_uIndex << ", j = " << triplets[i].m_vIndex << ", k = " << triplets[i].m_wIndex << std::endl;
+            const CaloHit *pHit3D{nullptr};
+            if (triplets[i].m_wIndex >= 0)
+                this->CreateThreeDHit(readout.at(TPC_VIEW_U)[triplets[i].m_uIndex], readout.at(TPC_VIEW_V)[triplets[i].m_vIndex],
+                    readout.at(TPC_VIEW_W)[triplets[i].m_wIndex], pHit3D);
+            else
+                this->CreateThreeDHit(readout.at(TPC_VIEW_U)[triplets[i].m_uIndex], readout.at(TPC_VIEW_V)[triplets[i].m_vIndex], pHit3D);
+            hits3D.emplace_back(pHit3D);
+        }
+        std::cout << "-----------------------------" << std::endl;
+        std::cout << "Number of triplets: " << triplets.size() << std::endl;
     }
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, hits3D, "KMHitList"));
     PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hits3D, "3D", BLACK));
@@ -117,8 +138,7 @@ void PlaneSolverAlgorithm::Solve() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost,
-    IndexMatrix &bestW) const
+PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost) const
 {
     const CaloHitVector &uHits(planeToHitsMap.at(TPC_VIEW_U));
     const CaloHitVector &vHits(planeToHitsMap.at(TPC_VIEW_V));
@@ -128,9 +148,8 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
     const int nW{static_cast<int>(wHits.size())};
     const int N{std::max(nU, nV)};
 
-    // Initialize the cost matrix with the cost for unmatched hits, and the best k matrix with -1 (indicating no match).
+    // Initialize the cost matrix with the cost for unmatched hits.
     CostMatrix C(N, FloatVector(N, unmatchedCost));
-    bestW.assign(nU, std::vector<int>(nV, -1));
 
     // Compute all chi-squared values
     for (int i = 0; i < nU; ++i)
@@ -172,15 +191,42 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
             }
 
             if (bestK >= 0)
-            {
                 C[i][j] = bestChi2;
-                bestW[i][j] = bestK;
-            }
         }
     }
 
     return C;
 }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeTripletCostMatrix(const PairVector &uvPairs, const PlaneToHitsMap &planeToHitsMap,
+    const float unmatchedCost) const
+{
+    const CaloHitVector &uHits(planeToHitsMap.at(TPC_VIEW_U));
+    const CaloHitVector &vHits(planeToHitsMap.at(TPC_VIEW_V));
+    const CaloHitVector &wHits(planeToHitsMap.at(TPC_VIEW_W));
+    int nPairs{static_cast<int>(uvPairs.size())};
+    int nW{static_cast<int>(wHits.size())};
+    int N{std::max(nPairs, nW)};
+
+    CostMatrix C(N, FloatVector(N, unmatchedCost));
+    for (int p = 0; p < nPairs; ++p)
+    {
+        int i{uvPairs[p].m_uIndex};
+        int j{uvPairs[p].m_vIndex};
+
+        for (int k = 0; k < nW; ++k)
+        {
+            float chi2{LArGeometryHelper::CalculateChiSquared(this->GetPandora(), uHits[i], vHits[j], wHits[k])};
+            C[p][k] = chi2;
+        }
+    }
+
+    return C;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
 
 IntVector PlaneSolverAlgorithm::KuhneMunkres(const CostMatrix& cost) const
 {
@@ -277,6 +323,43 @@ IntVector PlaneSolverAlgorithm::KuhneMunkres(const CostMatrix& cost) const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildUVPairs(const IntVector &assignment, int nU, int nV) const
+{
+    PairVector pairs;
+
+    for (int i = 0; i < nU; ++i)
+    {
+        int j{assignment[i]};
+
+        if (j < nV)
+            pairs.push_back({i, j});
+    }
+
+    return pairs;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const PairVector& uvPairs, const IntVector& assignment, int nW) const
+{
+    TripletVector result;
+    const int nPairs{static_cast<int>(uvPairs.size())};
+
+    for (int p = 0; p < nPairs; ++p)
+    {
+        int k{assignment[p]};
+
+        if (k < nW)
+            result.push_back({uvPairs[p].m_uIndex, uvPairs[p].m_vIndex, k});
+        else
+            result.push_back({uvPairs[p].m_uIndex, uvPairs[p].m_vIndex, -1});
+    }
+
+    return result;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const CaloHit *const pCaloHitV, const CaloHit *&pCaloHit3D) const
 {
     float chi2{0.f};
@@ -308,6 +391,42 @@ void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const
     parameters.m_isInOuterSamplingLayer = pCaloHit2D->IsInOuterSamplingLayer();
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
 }
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const CaloHit *const pCaloHitV, const CaloHit *const pCaloHitW,
+    const CaloHit *&pCaloHit3D) const
+{
+    float chi2{0.f};
+    CartesianVector pos3D(0, 0, 0);
+    PandoraContentApi::CaloHit::Parameters parameters;
+    LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, pCaloHitU->GetPositionVector(),
+        pCaloHitV->GetPositionVector(), pCaloHitW->GetPositionVector(), pos3D, chi2);
+    parameters.m_positionVector = pos3D;
+    parameters.m_hitType = TPC_3D;
+
+    const CaloHit *const pCaloHit2D(pCaloHitU);
+    parameters.m_pParentAddress = static_cast<const void *>(pCaloHit2D);
+    parameters.m_cellThickness = pCaloHit2D->GetCellThickness();
+    parameters.m_cellGeometry = RECTANGULAR;
+    parameters.m_cellSize0 = pCaloHit2D->GetCellLengthScale();
+    parameters.m_cellSize1 = pCaloHit2D->GetCellLengthScale();
+    parameters.m_cellNormalVector = pCaloHit2D->GetCellNormalVector();
+    parameters.m_expectedDirection = pCaloHit2D->GetExpectedDirection();
+    parameters.m_nCellRadiationLengths = pCaloHit2D->GetNCellRadiationLengths();
+    parameters.m_nCellInteractionLengths = pCaloHit2D->GetNCellInteractionLengths();
+    parameters.m_time = pCaloHit2D->GetTime();
+    parameters.m_inputEnergy = pCaloHit2D->GetInputEnergy();
+    parameters.m_mipEquivalentEnergy = pCaloHit2D->GetMipEquivalentEnergy();
+    parameters.m_electromagneticEnergy = pCaloHit2D->GetElectromagneticEnergy();
+    parameters.m_hadronicEnergy = pCaloHit2D->GetHadronicEnergy();
+    parameters.m_isDigital = pCaloHit2D->IsDigital();
+    parameters.m_hitRegion = pCaloHit2D->GetHitRegion();
+    parameters.m_layer = pCaloHit2D->GetLayer();
+    parameters.m_isInOuterSamplingLayer = pCaloHit2D->IsInOuterSamplingLayer();
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
+}
+
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -10,8 +10,11 @@
 
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArObjects/LArCaloHit.h"
+#include "larpandoracontent/LArObjects/LArPlaneContextObject.h"
 
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h"
+
+#include <ranges>
 
 using namespace pandora;
 
@@ -19,7 +22,9 @@ namespace lar_content
 {
 
 PlaneSolverAlgorithm::PlaneSolverAlgorithm() :
-    m_caloHitListName{"CaloHitList2D"}
+    m_chi2Threshold(6.f),
+    m_caloHitListName{"CaloHitList2D"},
+    m_eventContextName{"PlaneContext"}
 {
 }
 
@@ -62,9 +67,7 @@ void PlaneSolverAlgorithm::FillHitMap(const CaloHitList &caloHitList)
 
 void PlaneSolverAlgorithm::Solve() const
 {
-    const float chi2Threshold{6.f};
-    CaloHitList hits3D;
-    //PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
+    LArPlaneContextObject *pPlaneContextObject{new LArPlaneContextObject()};
     // Loop over each read out volume (e.g. an APA in a horizontal drift detector) and solve for the optimal set of triplet and doublet
     // relationships between the 2D hits in each unit.
     for (const auto &[_, readout] : m_planeToReadoutMap)
@@ -114,7 +117,7 @@ void PlaneSolverAlgorithm::Solve() const
                     constraintView = nHitsV <= nHitsU ? TPC_VIEW_V : TPC_VIEW_U;
             }
             CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f, constraintView, usedHits)};
-            const IntVector assignment{this->KuhneMunkres(costMatrix)};
+            const IntVector assignment{this->KuhnMunkres(costMatrix)};
             HitType viewA, viewB;
             this->SelectViewPair(constraintView, viewA, viewB);
             int nHitsA{static_cast<int>(readout.at(viewA).size())};
@@ -128,14 +131,13 @@ void PlaneSolverAlgorithm::Solve() const
             }
             if (nHitsA == 0 || nHitsB == 0)
                 continue;
-            const PairVector pairs{this->BuildPairs(assignment, nHitsA, nHitsB, costMatrix, chi2Threshold)};
+            const PairVector pairs{this->BuildPairs(assignment, nHitsA, nHitsB, costMatrix, m_chi2Threshold)};
             CostMatrix tripletCostMatrix{this->ComputeTripletCostMatrix(pairs, readout, 100.f, constraintView, usedHits)};
-            const IntVector tripletAssignment{this->KuhneMunkres(tripletCostMatrix)};
+            const IntVector tripletAssignment{this->KuhnMunkres(tripletCostMatrix)};
             int nHitsC{static_cast<int>(readout.at(constraintView).size())};
-            const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsC, tripletCostMatrix, constraintView, chi2Threshold)};
+            const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsC, tripletCostMatrix, constraintView, m_chi2Threshold)};
             for (size_t i = 0; i < triplets.size(); ++i)
             {
-                const CaloHit *pHit3D{nullptr};
                 if (triplets[i].m_uIndex >= 0 && triplets[i].m_vIndex >= 0 && triplets[i].m_wIndex >= 0)
                 {
                     const CaloHit *pHitU{readout.at(TPC_VIEW_U)[triplets[i].m_uIndex]};
@@ -157,15 +159,12 @@ void PlaneSolverAlgorithm::Solve() const
                         if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
                             continue;
                     }
-                    this->CreateThreeDHit(pHitU, pHitV, pHitW, pHit3D);
-                    if (pass == 1)
+                    if (pass == 1 && pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW))
                     {
                         usedHits.insert(pHitU);
                         usedHits.insert(pHitV);
                         usedHits.insert(pHitW);
                     }
-                    if (pHit3D)
-                        hits3D.emplace_back(pHit3D);
                 }
                 else
                 {
@@ -174,17 +173,13 @@ void PlaneSolverAlgorithm::Solve() const
                     const CaloHit *pHitW{(triplets[i].m_wIndex >= 0) ? readout.at(TPC_VIEW_W)[triplets[i].m_wIndex] : nullptr};
                     if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
                         continue;
-                    this->CreateThreeDHit(pHitU, pHitV, pHitW, pHit3D);
                     if (pass == 1)
-                    {
                         fallbackTriplets.push_back({triplets[i].m_uIndex, triplets[i].m_vIndex, triplets[i].m_wIndex, triplets[i].m_cost});
-                    }
-                    if (pass == 2 && pHit3D)
+                    if (pass == 2 && pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW))
                     {
                         usedHits.insert(pHitU);
                         usedHits.insert(pHitV);
                         usedHits.insert(pHitW);
-                        hits3D.emplace_back(pHit3D);
                     }
                 }
             }
@@ -193,21 +188,16 @@ void PlaneSolverAlgorithm::Solve() const
         // Add in the fallback triplets that were not picked up in the second pass
         for (const auto& triplet : fallbackTriplets)
         {
-            const CaloHit *pHit3D{nullptr};
             const CaloHit *pHitU{(triplet.m_uIndex >= 0) ? readout.at(TPC_VIEW_U)[triplet.m_uIndex] : nullptr};
             const CaloHit *pHitV{(triplet.m_vIndex >= 0) ? readout.at(TPC_VIEW_V)[triplet.m_vIndex] : nullptr};
             const CaloHit *pHitW{(triplet.m_wIndex >= 0) ? readout.at(TPC_VIEW_W)[triplet.m_wIndex] : nullptr};
             if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
                 continue;
 
-            this->CreateThreeDHit(pHitU, pHitV, pHitW, pHit3D);
-            if (pHit3D)
-                hits3D.emplace_back(pHit3D);
+            pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW);
         }
     }
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, hits3D, "KMHitList"));
-    //PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hits3D, "3D", BLACK));
-    //PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+    PandoraContentApi::AddEventContextObject(*this, m_eventContextName, pPlaneContextObject);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -343,7 +333,7 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeTripletCostMatrix(
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-IntVector PlaneSolverAlgorithm::KuhneMunkres(const CostMatrix& cost) const
+IntVector PlaneSolverAlgorithm::KuhnMunkres(const CostMatrix& cost) const
 {
     const int N{static_cast<int>(cost.size())};
     // Define the dual variables for rows (u) and columns (v), enforcing u[i] + v[j] <= cost[i][j]
@@ -554,16 +544,7 @@ void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const
     parameters.m_hitRegion = pCaloHit2D->GetHitRegion();
     parameters.m_layer = pCaloHit2D->GetLayer();
     parameters.m_isInOuterSamplingLayer = pCaloHit2D->IsInOuterSamplingLayer();
-    try
-    {
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
-    }
-    catch (const StatusCodeException &e)
-    {
-        std::cout << "Failed to create 3D hit from U: " << (pCaloHitU ? pCaloHitU->GetPositionVector().GetX() : -1) << ", V: "
-            << (pCaloHitV ? pCaloHitV->GetPositionVector().GetX() : -1) << ", W: " << (pCaloHitW ? pCaloHitW->GetPositionVector().GetX() : -1)
-            << " with chi2: " << chi2 << std::endl;
-    }
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -593,7 +574,9 @@ void PlaneSolverAlgorithm::SelectViewPair(const HitType constraintView, HitType 
 
 StatusCode PlaneSolverAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
 {
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "Chi2Threshold", m_chi2Threshold));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EventContextName", m_eventContextName));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -27,6 +27,7 @@ PlaneSolverAlgorithm::PlaneSolverAlgorithm() :
 
 StatusCode PlaneSolverAlgorithm::Run()
 {
+    m_planeToReadoutMap.clear();
     const CaloHitList *pCaloHitList(nullptr);
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_caloHitListName, pCaloHitList));
 
@@ -61,68 +62,149 @@ void PlaneSolverAlgorithm::FillHitMap(const CaloHitList &caloHitList)
 
 void PlaneSolverAlgorithm::Solve() const
 {
+    // STATUS: Seems like lot so pairs/triplets can be found in pass 2, but not actually added to the 3D hits, investigate.
+
+    const float chi2Threshold{6.f};
     CaloHitList hits3D;
     PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
     // Loop over each read out volume (e.g. an APA in a horizontal drift detector) and solve for the optimal set of triplet and doublet
     // relationships between the 2D hits in each unit.
     for (const auto &[_, readout] : m_planeToReadoutMap)
     {
-        int nHitsU{static_cast<int>(readout.at(TPC_VIEW_U).size())};
-        int nHitsV{static_cast<int>(readout.at(TPC_VIEW_V).size())};
-        int nHitsW{static_cast<int>(readout.at(TPC_VIEW_W).size())};
+        // Set the used view to an "invalid" type for the first pass
+        HitType usedView{HIT_CUSTOM};
+        CaloHitSet usedHits;
+        TripletVector fallbackTriplets;
+        for (int pass = 1; pass <= 2; ++pass)
+        {
+            int nHitsU{static_cast<int>(usedView != TPC_VIEW_U ? readout.at(TPC_VIEW_U).size() : 0)};
+            int nHitsV{static_cast<int>(usedView != TPC_VIEW_V ? readout.at(TPC_VIEW_V).size() : 0)};
+            int nHitsW{static_cast<int>(usedView != TPC_VIEW_W ? readout.at(TPC_VIEW_W).size() : 0)};
+            if (pass == 2 && nHitsU != 0)
+            {
+                nHitsU = 0;
+                for (const auto *pHit : readout.at(TPC_VIEW_U))
+                    nHitsU += !usedHits.count(pHit);
+            }
+            if (pass == 2 && nHitsV != 0)
+            {
+                nHitsV = 0;
+                for (const auto *pHit : readout.at(TPC_VIEW_V))
+                    nHitsV += !usedHits.count(pHit);
+            }
+            if (pass == 2 && nHitsW != 0)
+            {
+                nHitsW = 0;
+                for (const auto *pHit : readout.at(TPC_VIEW_W))
+                    nHitsW += !usedHits.count(pHit);
+            }
 
-        HitType constraintView{nHitsW >= nHitsV && nHitsW >= nHitsU ? TPC_VIEW_W : nHitsV >= nHitsU ? TPC_VIEW_V : TPC_VIEW_U};
-        std::cout << "Constraint view: " << constraintView << " with nHitsW = " << nHitsW << ", nHitsV = " << nHitsV << ", nHitsU = " << nHitsU << std::endl;
-        CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f, constraintView)};
-        const IntVector assignment{this->KuhneMunkres(costMatrix)};
-        HitType viewA, viewB;
-        this->SelectViewPair(constraintView, viewA, viewB);
-        int nHitsA{static_cast<int>(readout.at(viewA).size())};
-        int nHitsB{static_cast<int>(readout.at(viewB).size())};
-        const PairVector pairs{this->BuildPairs(assignment, nHitsA, nHitsB, costMatrix)};
-        std::cout << "-----------------------------" << std::endl;
-        std::cout << "Pairs" << std::endl;
-        std::cout << "-----------------------------" << std::endl;
-        for (size_t i = 0; i < pairs.size(); ++i)
-        {
-            std::cout << "Pair: i = " << pairs[i].m_aIndex << ", j = " << pairs[i].m_bIndex << ", cost = " << pairs[i].m_cost << std::endl;
-        }
-        CostMatrix tripletCostMatrix{this->ComputeTripletCostMatrix(pairs, readout, 100.f, constraintView)};
-        const IntVector tripletAssignment{this->KuhneMunkres(tripletCostMatrix)};
-        int nHitsC{static_cast<int>(readout.at(constraintView).size())};
-        const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsC, tripletCostMatrix, constraintView)};
-        std::cout << "-----------------------------" << std::endl;
-        std::cout << "Triplets" << std::endl;
-        std::cout << "-----------------------------" << std::endl;
-        for (size_t i = 0; i < triplets.size(); ++i)
-        {
-            std::cout << "Triplet: i = " << triplets[i].m_uIndex << ", j = " << triplets[i].m_vIndex << ", k = " << triplets[i].m_wIndex <<
-                ", cost = " << triplets[i].m_cost << std::endl;
-            const CaloHit *pHit3D{nullptr};
-            try
+            HitType constraintView{HIT_CUSTOM};
+            if (pass == 1)
             {
-            if (triplets[i].m_uIndex >= 0 && triplets[i].m_vIndex >= 0 && triplets[i].m_wIndex >= 0)
-            {
-                this->CreateThreeDHit(readout.at(TPC_VIEW_U)[triplets[i].m_uIndex], readout.at(TPC_VIEW_V)[triplets[i].m_vIndex],
-                    readout.at(TPC_VIEW_W)[triplets[i].m_wIndex], pHit3D);
+                constraintView = nHitsW >= nHitsV && nHitsW >= nHitsU ? TPC_VIEW_W : nHitsV >= nHitsU ? TPC_VIEW_V : TPC_VIEW_U;
             }
             else
             {
-                const CaloHit *pHitU{(triplets[i].m_uIndex >= 0) ? readout.at(TPC_VIEW_U)[triplets[i].m_uIndex] : nullptr};
-                const CaloHit *pHitV{(triplets[i].m_vIndex >= 0) ? readout.at(TPC_VIEW_V)[triplets[i].m_vIndex] : nullptr};
-                const CaloHit *pHitW{(triplets[i].m_wIndex >= 0) ? readout.at(TPC_VIEW_W)[triplets[i].m_wIndex] : nullptr};
-                this->CreateThreeDHit(pHitU, pHitV, pHitW, pHit3D);
+                if (usedView == TPC_VIEW_U)
+                    constraintView = nHitsW <= nHitsV ? TPC_VIEW_W : TPC_VIEW_V;
+                else if (usedView == TPC_VIEW_V)
+                    constraintView = nHitsW <= nHitsU ? TPC_VIEW_W : TPC_VIEW_U;
+                else if (usedView == TPC_VIEW_W)
+                    constraintView = nHitsV <= nHitsU ? TPC_VIEW_V : TPC_VIEW_U;
             }
-            }
-            catch (const StatusCodeException &e)
+            CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f, constraintView, usedHits)};
+            const IntVector assignment{this->KuhneMunkres(costMatrix)};
+            HitType viewA, viewB;
+            this->SelectViewPair(constraintView, viewA, viewB);
+            int nHitsA{static_cast<int>(readout.at(viewA).size())};
+            int nHitsB{static_cast<int>(readout.at(viewB).size())};
             {
-                std::cout << "Complaint" << std::endl;
+                int nActualA{0}, nActualB{0};
+                for (const auto *pHit : readout.at(viewA))
+                    nActualA += !usedHits.count(pHit);
+                for (const auto *pHit : readout.at(viewB))
+                    nActualB += !usedHits.count(pHit);
             }
+            if (nHitsA == 0 || nHitsB == 0)
+                continue;
+            const PairVector pairs{this->BuildPairs(assignment, nHitsA, nHitsB, costMatrix, chi2Threshold)};
+            CostMatrix tripletCostMatrix{this->ComputeTripletCostMatrix(pairs, readout, 100.f, constraintView, usedHits)};
+            const IntVector tripletAssignment{this->KuhneMunkres(tripletCostMatrix)};
+            int nHitsC{static_cast<int>(readout.at(constraintView).size())};
+            const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsC, tripletCostMatrix, constraintView, chi2Threshold)};
+            for (size_t i = 0; i < triplets.size(); ++i)
+            {
+                const CaloHit *pHit3D{nullptr};
+                if (triplets[i].m_uIndex >= 0 && triplets[i].m_vIndex >= 0 && triplets[i].m_wIndex >= 0)
+                {
+                    const CaloHit *pHitU{readout.at(TPC_VIEW_U)[triplets[i].m_uIndex]};
+                    const CaloHit *pHitV{readout.at(TPC_VIEW_V)[triplets[i].m_vIndex]};
+                    const CaloHit *pHitW{readout.at(TPC_VIEW_W)[triplets[i].m_wIndex]};
+
+                    if (pass == 1 && (usedHits.count(pHitU) || usedHits.count(pHitV) || usedHits.count(pHitW)))
+                        continue;
+                    if (pass == 2)
+                    {
+                        // If the matched constraint hit is already used, we can still use the triplet if the other two hits are unused
+                        if (constraintView == TPC_VIEW_U && usedHits.count(pHitU))
+                            pHitU = nullptr;
+                        else if (constraintView == TPC_VIEW_V && usedHits.count(pHitV))
+                            pHitV = nullptr;
+                        else if (constraintView == TPC_VIEW_W && usedHits.count(pHitW))
+                            pHitW = nullptr;
+
+                        if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
+                            continue;
+                    }
+                    this->CreateThreeDHit(pHitU, pHitV, pHitW, pHit3D);
+                    if (pass == 1)
+                    {
+                        usedHits.insert(pHitU);
+                        usedHits.insert(pHitV);
+                        usedHits.insert(pHitW);
+                    }
+                    if (pHit3D)
+                        hits3D.emplace_back(pHit3D);
+                }
+                else
+                {
+                    const CaloHit *pHitU{(triplets[i].m_uIndex >= 0) ? readout.at(TPC_VIEW_U)[triplets[i].m_uIndex] : nullptr};
+                    const CaloHit *pHitV{(triplets[i].m_vIndex >= 0) ? readout.at(TPC_VIEW_V)[triplets[i].m_vIndex] : nullptr};
+                    const CaloHit *pHitW{(triplets[i].m_wIndex >= 0) ? readout.at(TPC_VIEW_W)[triplets[i].m_wIndex] : nullptr};
+                    if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
+                        continue;
+                    this->CreateThreeDHit(pHitU, pHitV, pHitW, pHit3D);
+                    if (pass == 1)
+                    {
+                        fallbackTriplets.push_back({triplets[i].m_uIndex, triplets[i].m_vIndex, triplets[i].m_wIndex, triplets[i].m_cost});
+                    }
+                    if (pass == 2 && pHit3D)
+                    {
+                        usedHits.insert(pHitU);
+                        usedHits.insert(pHitV);
+                        usedHits.insert(pHitW);
+                        hits3D.emplace_back(pHit3D);
+                    }
+                }
+            }
+            usedView = constraintView;
+        }
+        // Add in the fallback triplets that were not picked up in the second pass
+        for (const auto& triplet : fallbackTriplets)
+        {
+            const CaloHit *pHit3D{nullptr};
+            const CaloHit *pHitU{(triplet.m_uIndex >= 0) ? readout.at(TPC_VIEW_U)[triplet.m_uIndex] : nullptr};
+            const CaloHit *pHitV{(triplet.m_vIndex >= 0) ? readout.at(TPC_VIEW_V)[triplet.m_vIndex] : nullptr};
+            const CaloHit *pHitW{(triplet.m_wIndex >= 0) ? readout.at(TPC_VIEW_W)[triplet.m_wIndex] : nullptr};
+            if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
+                continue;
+
+            this->CreateThreeDHit(pHitU, pHitV, pHitW, pHit3D);
             if (pHit3D)
                 hits3D.emplace_back(pHit3D);
         }
-        std::cout << "-----------------------------" << std::endl;
-        std::cout << "Number of triplets: " << triplets.size() << std::endl;
+        std::cout << "Number of 3D hits: " << hits3D.size() << std::endl;
     }
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::SaveList(*this, hits3D, "KMHitList"));
     PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hits3D, "3D", BLACK));
@@ -132,7 +214,7 @@ void PlaneSolverAlgorithm::Solve() const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost,
-    const HitType constraintView) const
+    const HitType constraintView, const CaloHitSet &usedHits) const
 {
     HitType viewA, viewB;
     this->SelectViewPair(constraintView, viewA, viewB);
@@ -151,6 +233,8 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
     // Compute all chi-squared values
     for (int i = 0; i < nA; ++i)
     {
+        if (usedHits.count(aHits[i]))
+            continue;
         const CartesianVector a(aHits[i]->GetPositionVector());
         const float dx_a(0.5f * aHits[i]->GetCellSize1());
         const float xMin_a(a.GetX() - dx_a);
@@ -158,6 +242,8 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
         
         for (int j = 0; j < nB; ++j)
         {
+            if (usedHits.count(bHits[j]))
+                continue;
             const CartesianVector b(bHits[j]->GetPositionVector());
             const float dx_b(0.5f * bHits[j]->GetCellSize1());
             const float xMin_b(b.GetX() - dx_b);
@@ -171,6 +257,7 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
 
             for (int k = 0; k < nC; ++k)
             {
+                // We allow the constraint hit to be used for cost calculation even if it's already used (it can validate a doublet match)
                 const CartesianVector c(cHits[k]->GetPositionVector());
                 const float dx_c(0.5f * cHits[k]->GetCellSize1());
                 const float xMin_c(c.GetX() - dx_c);
@@ -192,7 +279,7 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
                         chi2 = LArGeometryHelper::CalculateChiSquared(this->GetPandora(), aHits[i], cHits[k], bHits[j]);
                         break;
                     default:
-                        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+                        PANDORA_THROW(STATUS_CODE_INVALID_PARAMETER);
                 }
                 if (chi2 < bestChi2)
                 {
@@ -212,7 +299,7 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeTripletCostMatrix(const PairVector &pairs, const PlaneToHitsMap &planeToHitsMap,
-    const float unmatchedCost, const HitType constraintView) const
+    const float unmatchedCost, const HitType constraintView, const CaloHitSet &usedHits) const
 {
     HitType viewA, viewB;
     this->SelectViewPair(constraintView, viewA, viewB);
@@ -228,6 +315,8 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeTripletCostMatrix(
     {
         int i{pairs[p].m_aIndex};
         int j{pairs[p].m_bIndex};
+        if (usedHits.count(aHits[i]) || usedHits.count(bHits[j]))
+            continue;
 
         for (int k = 0; k < nC; ++k)
         {
@@ -244,7 +333,7 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeTripletCostMatrix(
                     chi2 = LArGeometryHelper::CalculateChiSquared(this->GetPandora(), aHits[i], cHits[k], bHits[j]);
                     break;
                 default:
-                    throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+                    PANDORA_THROW(STATUS_CODE_INVALID_PARAMETER);
             }
 
             C[p][k] = chi2;
@@ -351,7 +440,8 @@ IntVector PlaneSolverAlgorithm::KuhneMunkres(const CostMatrix& cost) const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildPairs(const IntVector &assignment, int nA, int nB, const CostMatrix& costMatrix) const
+PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildPairs(const IntVector &assignment, int nA, int nB, const CostMatrix& costMatrix,
+    float chi2Threshold) const
 {
     PairVector pairs;
 
@@ -359,7 +449,7 @@ PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildPairs(const IntVecto
     {
         int j{assignment[i]};
 
-        if (j < nB && costMatrix[i][j] < 100.f)
+        if (j < nB && costMatrix[i][j] < chi2Threshold)
             pairs.push_back({i, j, costMatrix[i][j]});
     }
 
@@ -369,7 +459,7 @@ PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildPairs(const IntVecto
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const PairVector& pairs, const IntVector& assignment, int nC,
-    const CostMatrix& costMatrix, const HitType constraintView) const
+    const CostMatrix& costMatrix, const HitType constraintView, float chi2Threshold) const
 {
     TripletVector result;
     const int nPairs{static_cast<int>(pairs.size())};
@@ -378,7 +468,7 @@ PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const Pa
     {
         int k{assignment[p]};
 
-        if (k < nC && costMatrix[p][k] < 100.f)
+        if (k < nC && costMatrix[p][k] < chi2Threshold)
         {
             switch (constraintView)
             {
@@ -392,10 +482,10 @@ PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const Pa
                     result.push_back({pairs[p].m_aIndex, pairs[p].m_bIndex, k, costMatrix[p][k]});
                     break;
                 default:
-                    throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+                    PANDORA_THROW(STATUS_CODE_INVALID_PARAMETER);
             }
         }
-        else if (costMatrix[p][k] < 100.f)
+        else if (costMatrix[p][k] < chi2Threshold)
         {
             switch (constraintView)
             {
@@ -409,7 +499,7 @@ PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const Pa
                     result.push_back({pairs[p].m_aIndex, pairs[p].m_bIndex, -1, pairs[p].m_cost});
                     break;
                 default:
-                    throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+                    PANDORA_THROW(STATUS_CODE_INVALID_PARAMETER);
             }
         }
     }
@@ -422,6 +512,12 @@ PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const Pa
 void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const CaloHit *const pCaloHitV, const CaloHit *const pCaloHitW,
     const CaloHit *&pCaloHit3D) const
 {
+    const int nValidHits = (pCaloHitU ? 1 : 0) + (pCaloHitV ? 1 : 0) + (pCaloHitW ? 1 : 0);
+    if (nValidHits < 2)
+    {
+        pCaloHit3D = nullptr;
+        return;
+    }
     float chi2{0.f};
     CartesianVector pos3D(0, 0, 0);
     PandoraContentApi::CaloHit::Parameters parameters;
@@ -460,7 +556,16 @@ void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const
     parameters.m_hitRegion = pCaloHit2D->GetHitRegion();
     parameters.m_layer = pCaloHit2D->GetLayer();
     parameters.m_isInOuterSamplingLayer = pCaloHit2D->IsInOuterSamplingLayer();
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
+    try
+    {
+        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
+    }
+    catch (const StatusCodeException &e)
+    {
+        std::cout << "Failed to create 3D hit from U: " << (pCaloHitU ? pCaloHitU->GetPositionVector().GetX() : -1) << ", V: "
+            << (pCaloHitV ? pCaloHitV->GetPositionVector().GetX() : -1) << ", W: " << (pCaloHitW ? pCaloHitW->GetPositionVector().GetX() : -1)
+            << " with chi2: " << chi2 << std::endl;
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -482,7 +587,7 @@ void PlaneSolverAlgorithm::SelectViewPair(const HitType constraintView, HitType 
             viewB = TPC_VIEW_V;
             break;
         default:
-            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+            PANDORA_THROW(STATUS_CODE_INVALID_PARAMETER);
     }
 }
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -24,7 +24,8 @@ namespace lar_content
 PlaneSolverAlgorithm::PlaneSolverAlgorithm() :
     m_chi2Threshold(6.f),
     m_caloHitListName{"CaloHitList2D"},
-    m_eventContextName{"PlaneContext"}
+    m_eventContextName{"PlaneContext"},
+    m_visualize(false)
 {
 }
 
@@ -65,8 +66,50 @@ void PlaneSolverAlgorithm::FillHitMap(const CaloHitList &caloHitList)
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
+void PlaneSolverAlgorithm::BinHitsByDrift(const PlaneToHitsMap &hitsByPlane, DriftBinToHitsMap &driftBinToHitsMap) const
+{
+    driftBinToHitsMap.clear();
+    float xMin{std::numeric_limits<float>::max()}, xMax{std::numeric_limits<float>::lowest()};
+    for (const auto &[view, hits] : hitsByPlane)
+    {
+        for (const auto *pHit : hits)
+        {
+            const float x{pHit->GetPositionVector().GetX()};
+            xMin = std::min(xMin, x);
+            xMax = std::max(xMax, x);
+        }
+    }
+
+    // Adjust the minimum and maximum to sit on 0.5 cm boundaries, and ensure that the bin region extends beyond the range of hits
+    float xLowBin{std::floor(xMin * 2.f) / 2.f};
+    float xHighBin{std::ceil(xMax * 2.f) / 2.f};
+    xHighBin = xHighBin == xMax ? xHighBin + 0.5f : xHighBin;
+    const int N{static_cast<int>((xHighBin - xLowBin) * 2.f)};
+
+    for (int i = 0, b = 0; i < N; i += 3, ++b)
+    {
+        const float xBinLow{xLowBin + 0.5f * i};
+        const float xBinHigh{xLowBin + 0.5f * (i + 3)};
+        for (const auto &[view, hits] : hitsByPlane)
+        {
+            for (const auto *pHit : hits)
+            {
+                const float x{pHit->GetPositionVector().GetX()};
+                if (x >= xBinLow && x < xBinHigh)
+                    driftBinToHitsMap[b][view].emplace_back(pHit);
+            }
+        }
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
 void PlaneSolverAlgorithm::Solve() const
 {
+    if (m_visualize)
+    {
+        PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
+    }
     LArPlaneContextObject *pPlaneContextObject{new LArPlaneContextObject()};
     // Loop over each read out volume (e.g. an APA in a horizontal drift detector) and solve for the optimal set of triplet and doublet
     // relationships between the 2D hits in each unit.
@@ -74,130 +117,158 @@ void PlaneSolverAlgorithm::Solve() const
     {
         if (readout.size() < 3)
             continue;
-        // Set the used view to an "invalid" type for the first pass
-        HitType usedView{HIT_CUSTOM};
-        CaloHitSet usedHits;
-        TripletVector fallbackTriplets;
-        for (int pass = 1; pass <= 2; ++pass)
+
+        DriftBinToHitsMap driftBinToHitsMap;
+        this->BinHitsByDrift(readout, driftBinToHitsMap);
+        for (const auto &[_, driftBinHits] : driftBinToHitsMap)
         {
-            int nHitsU{static_cast<int>(usedView != TPC_VIEW_U ? readout.at(TPC_VIEW_U).size() : 0)};
-            int nHitsV{static_cast<int>(usedView != TPC_VIEW_V ? readout.at(TPC_VIEW_V).size() : 0)};
-            int nHitsW{static_cast<int>(usedView != TPC_VIEW_W ? readout.at(TPC_VIEW_W).size() : 0)};
-            if (pass == 2 && nHitsU != 0)
-            {
-                nHitsU = 0;
-                for (const auto *pHit : readout.at(TPC_VIEW_U))
-                    nHitsU += !usedHits.count(pHit);
-            }
-            if (pass == 2 && nHitsV != 0)
-            {
-                nHitsV = 0;
-                for (const auto *pHit : readout.at(TPC_VIEW_V))
-                    nHitsV += !usedHits.count(pHit);
-            }
-            if (pass == 2 && nHitsW != 0)
-            {
-                nHitsW = 0;
-                for (const auto *pHit : readout.at(TPC_VIEW_W))
-                    nHitsW += !usedHits.count(pHit);
-            }
-
-            HitType constraintView{HIT_CUSTOM};
-            if (pass == 1)
-            {
-                constraintView = nHitsW >= nHitsV && nHitsW >= nHitsU ? TPC_VIEW_W : nHitsV >= nHitsU ? TPC_VIEW_V : TPC_VIEW_U;
-            }
-            else
-            {
-                if (usedView == TPC_VIEW_U)
-                    constraintView = nHitsW <= nHitsV ? TPC_VIEW_W : TPC_VIEW_V;
-                else if (usedView == TPC_VIEW_V)
-                    constraintView = nHitsW <= nHitsU ? TPC_VIEW_W : TPC_VIEW_U;
-                else if (usedView == TPC_VIEW_W)
-                    constraintView = nHitsV <= nHitsU ? TPC_VIEW_V : TPC_VIEW_U;
-            }
-            CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f, constraintView, usedHits)};
-            const IntVector assignment{this->KuhnMunkres(costMatrix)};
-            HitType viewA, viewB;
-            this->SelectViewPair(constraintView, viewA, viewB);
-            int nHitsA{static_cast<int>(readout.at(viewA).size())};
-            int nHitsB{static_cast<int>(readout.at(viewB).size())};
-            {
-                int nActualA{0}, nActualB{0};
-                for (const auto *pHit : readout.at(viewA))
-                    nActualA += !usedHits.count(pHit);
-                for (const auto *pHit : readout.at(viewB))
-                    nActualB += !usedHits.count(pHit);
-            }
-            if (nHitsA == 0 || nHitsB == 0)
+            if (driftBinHits.size() < 3)
                 continue;
-            const PairVector pairs{this->BuildPairs(assignment, nHitsA, nHitsB, costMatrix, m_chi2Threshold)};
-            CostMatrix tripletCostMatrix{this->ComputeTripletCostMatrix(pairs, readout, 100.f, constraintView, usedHits)};
-            const IntVector tripletAssignment{this->KuhnMunkres(tripletCostMatrix)};
-            int nHitsC{static_cast<int>(readout.at(constraintView).size())};
-            const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsC, tripletCostMatrix, constraintView, m_chi2Threshold)};
-            for (size_t i = 0; i < triplets.size(); ++i)
+
+            // Set the used view to an "invalid" type for the first pass
+            HitType usedView{HIT_CUSTOM};
+            CaloHitSet usedHits;
+            TripletVector fallbackTriplets;
+            for (int pass = 1; pass <= 2; ++pass)
             {
-                if (triplets[i].m_uIndex >= 0 && triplets[i].m_vIndex >= 0 && triplets[i].m_wIndex >= 0)
+                int nHitsU{static_cast<int>(usedView != TPC_VIEW_U ? driftBinHits.at(TPC_VIEW_U).size() : 0)};
+                int nHitsV{static_cast<int>(usedView != TPC_VIEW_V ? driftBinHits.at(TPC_VIEW_V).size() : 0)};
+                int nHitsW{static_cast<int>(usedView != TPC_VIEW_W ? driftBinHits.at(TPC_VIEW_W).size() : 0)};
+                if (pass == 2 && nHitsU != 0)
                 {
-                    const CaloHit *pHitU{readout.at(TPC_VIEW_U)[triplets[i].m_uIndex]};
-                    const CaloHit *pHitV{readout.at(TPC_VIEW_V)[triplets[i].m_vIndex]};
-                    const CaloHit *pHitW{readout.at(TPC_VIEW_W)[triplets[i].m_wIndex]};
+                    nHitsU = 0;
+                    for (const auto *pHit : driftBinHits.at(TPC_VIEW_U))
+                        nHitsU += !usedHits.count(pHit);
+                }
+                if (pass == 2 && nHitsV != 0)
+                {
+                    nHitsV = 0;
+                    for (const auto *pHit : driftBinHits.at(TPC_VIEW_V))
+                        nHitsV += !usedHits.count(pHit);
+                }
+                if (pass == 2 && nHitsW != 0)
+                {
+                    nHitsW = 0;
+                    for (const auto *pHit : driftBinHits.at(TPC_VIEW_W))
+                        nHitsW += !usedHits.count(pHit);
+                }
 
-                    if (pass == 1 && (usedHits.count(pHitU) || usedHits.count(pHitV) || usedHits.count(pHitW)))
-                        continue;
-                    if (pass == 2)
-                    {
-                        // If the matched constraint hit is already used, we can still use the triplet if the other two hits are unused
-                        if (constraintView == TPC_VIEW_U && usedHits.count(pHitU))
-                            pHitU = nullptr;
-                        else if (constraintView == TPC_VIEW_V && usedHits.count(pHitV))
-                            pHitV = nullptr;
-                        else if (constraintView == TPC_VIEW_W && usedHits.count(pHitW))
-                            pHitW = nullptr;
-
-                        if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
-                            continue;
-                    }
-                    if (pass == 1 && pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW))
-                    {
-                        usedHits.insert(pHitU);
-                        usedHits.insert(pHitV);
-                        usedHits.insert(pHitW);
-                    }
+                HitType constraintView{HIT_CUSTOM};
+                if (pass == 1)
+                {
+                    constraintView = nHitsW >= nHitsV && nHitsW >= nHitsU ? TPC_VIEW_W : nHitsV >= nHitsU ? TPC_VIEW_V : TPC_VIEW_U;
                 }
                 else
                 {
-                    const CaloHit *pHitU{(triplets[i].m_uIndex >= 0) ? readout.at(TPC_VIEW_U)[triplets[i].m_uIndex] : nullptr};
-                    const CaloHit *pHitV{(triplets[i].m_vIndex >= 0) ? readout.at(TPC_VIEW_V)[triplets[i].m_vIndex] : nullptr};
-                    const CaloHit *pHitW{(triplets[i].m_wIndex >= 0) ? readout.at(TPC_VIEW_W)[triplets[i].m_wIndex] : nullptr};
-                    if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
-                        continue;
-                    if (pass == 1)
-                        fallbackTriplets.push_back({triplets[i].m_uIndex, triplets[i].m_vIndex, triplets[i].m_wIndex, triplets[i].m_cost});
-                    if (pass == 2 && pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW))
+                    if (usedView == TPC_VIEW_U)
+                        constraintView = nHitsW <= nHitsV ? TPC_VIEW_W : TPC_VIEW_V;
+                    else if (usedView == TPC_VIEW_V)
+                        constraintView = nHitsW <= nHitsU ? TPC_VIEW_W : TPC_VIEW_U;
+                    else if (usedView == TPC_VIEW_W)
+                        constraintView = nHitsV <= nHitsU ? TPC_VIEW_V : TPC_VIEW_U;
+                }
+
+                CostMatrix costMatrix{this->ComputeCostMatrix(driftBinHits, 100.f, constraintView, usedHits)};
+                const IntVector assignment{this->KuhnMunkres(costMatrix)};
+                HitType viewA, viewB;
+                this->SelectViewPair(constraintView, viewA, viewB);
+                int nHitsA{static_cast<int>(driftBinHits.at(viewA).size())};
+                int nHitsB{static_cast<int>(driftBinHits.at(viewB).size())};
+                {
+                    int nActualA{0}, nActualB{0};
+                    for (const auto *pHit : driftBinHits.at(viewA))
+                        nActualA += !usedHits.count(pHit);
+                    for (const auto *pHit : driftBinHits.at(viewB))
+                        nActualB += !usedHits.count(pHit);
+                }
+                if (nHitsA == 0 || nHitsB == 0)
+                    continue;
+                const PairVector pairs{this->BuildPairs(assignment, nHitsA, nHitsB, costMatrix, m_chi2Threshold)};
+                CostMatrix tripletCostMatrix{this->ComputeTripletCostMatrix(pairs, driftBinHits, 100.f, constraintView, usedHits)};
+                const IntVector tripletAssignment{this->KuhnMunkres(tripletCostMatrix)};
+                int nHitsC{static_cast<int>(driftBinHits.at(constraintView).size())};
+                const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsC, tripletCostMatrix, constraintView, m_chi2Threshold)};
+                for (size_t i = 0; i < triplets.size(); ++i)
+                {
+                    if (triplets[i].m_uIndex >= 0 && triplets[i].m_vIndex >= 0 && triplets[i].m_wIndex >= 0)
                     {
-                        usedHits.insert(pHitU);
-                        usedHits.insert(pHitV);
-                        usedHits.insert(pHitW);
+                        const CaloHit *pHitU{driftBinHits.at(TPC_VIEW_U)[triplets[i].m_uIndex]};
+                        const CaloHit *pHitV{driftBinHits.at(TPC_VIEW_V)[triplets[i].m_vIndex]};
+                        const CaloHit *pHitW{driftBinHits.at(TPC_VIEW_W)[triplets[i].m_wIndex]};
+
+                        if (pass == 1 && (usedHits.count(pHitU) || usedHits.count(pHitV) || usedHits.count(pHitW)))
+                            continue;
+                        if (pass == 2)
+                        {
+                            // If the matched constraint hit is already used, we can still use the triplet if the other two hits are unused
+                            if (constraintView == TPC_VIEW_U && usedHits.count(pHitU))
+                                pHitU = nullptr;
+                            else if (constraintView == TPC_VIEW_V && usedHits.count(pHitV))
+                                pHitV = nullptr;
+                            else if (constraintView == TPC_VIEW_W && usedHits.count(pHitW))
+                                pHitW = nullptr;
+
+                            if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
+                                continue;
+                        }
+                        if (pass == 1 && pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW))
+                        {
+                            usedHits.insert(pHitU);
+                            usedHits.insert(pHitV);
+                            usedHits.insert(pHitW);
+                        }
+                    }
+                    else
+                    {
+                        const CaloHit *pHitU{(triplets[i].m_uIndex >= 0) ? driftBinHits.at(TPC_VIEW_U)[triplets[i].m_uIndex] : nullptr};
+                        const CaloHit *pHitV{(triplets[i].m_vIndex >= 0) ? driftBinHits.at(TPC_VIEW_V)[triplets[i].m_vIndex] : nullptr};
+                        const CaloHit *pHitW{(triplets[i].m_wIndex >= 0) ? driftBinHits.at(TPC_VIEW_W)[triplets[i].m_wIndex] : nullptr};
+                        if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
+                            continue;
+                        if (pass == 1)
+                            fallbackTriplets.push_back({triplets[i].m_uIndex, triplets[i].m_vIndex, triplets[i].m_wIndex, triplets[i].m_cost});
+                        if (pass == 2 && pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW))
+                        {
+                            usedHits.insert(pHitU);
+                            usedHits.insert(pHitV);
+                            usedHits.insert(pHitW);
+                        }
                     }
                 }
+                usedView = constraintView;
             }
-            usedView = constraintView;
-        }
-        // Add in the fallback triplets that were not picked up in the second pass
-        for (const auto& triplet : fallbackTriplets)
-        {
-            const CaloHit *pHitU{(triplet.m_uIndex >= 0) ? readout.at(TPC_VIEW_U)[triplet.m_uIndex] : nullptr};
-            const CaloHit *pHitV{(triplet.m_vIndex >= 0) ? readout.at(TPC_VIEW_V)[triplet.m_vIndex] : nullptr};
-            const CaloHit *pHitW{(triplet.m_wIndex >= 0) ? readout.at(TPC_VIEW_W)[triplet.m_wIndex] : nullptr};
-            if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
-                continue;
+            // Add in the fallback triplets that were not picked up in the second pass
+            for (const auto& triplet : fallbackTriplets)
+            {
+                const CaloHit *pHitU{(triplet.m_uIndex >= 0) ? driftBinHits.at(TPC_VIEW_U)[triplet.m_uIndex] : nullptr};
+                const CaloHit *pHitV{(triplet.m_vIndex >= 0) ? driftBinHits.at(TPC_VIEW_V)[triplet.m_vIndex] : nullptr};
+                const CaloHit *pHitW{(triplet.m_wIndex >= 0) ? driftBinHits.at(TPC_VIEW_W)[triplet.m_wIndex] : nullptr};
+                if ((pHitU && usedHits.count(pHitU)) || (pHitV && usedHits.count(pHitV)) || (pHitW && usedHits.count(pHitW)))
+                    continue;
 
-            pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW);
+                pPlaneContextObject->AddHitTriplet(pHitU, pHitV, pHitW);
+            }
         }
     }
     PandoraContentApi::AddEventContextObject(*this, m_eventContextName, pPlaneContextObject);
+
+    if (m_visualize)
+    {
+        CaloHitList hits3D;
+        for (const LArPlaneContextObject::HitTriplet *pHitTriplet : *pPlaneContextObject)
+        {
+            const CaloHit *pHitU{pHitTriplet->m_uHit};
+            const CaloHit *pHitV{pHitTriplet->m_vHit};
+            const CaloHit *pHitW{pHitTriplet->m_wHit};
+            const CaloHit *pCaloHit3D{nullptr};
+            this->CreateThreeDHit(pHitU, pHitV, pHitW, pCaloHit3D);
+            if (pCaloHit3D)
+                hits3D.push_back(pCaloHit3D);
+        }
+
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hits3D, "3D", BLACK));
+        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -223,21 +294,10 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
     {
         if (usedHits.count(aHits[i]))
             continue;
-        const CartesianVector a(aHits[i]->GetPositionVector());
-        const float dx_a(0.5f * aHits[i]->GetCellSize1());
-        const float xMin_a(a.GetX() - dx_a);
-        const float xMax_a(a.GetX() + dx_a);
         
         for (int j = 0; j < nB; ++j)
         {
             if (usedHits.count(bHits[j]))
-                continue;
-            const CartesianVector b(bHits[j]->GetPositionVector());
-            const float dx_b(0.5f * bHits[j]->GetCellSize1());
-            const float xMin_b(b.GetX() - dx_b);
-            const float xMax_b(b.GetX() + dx_b);
-            // Check that the A and B views are compatible in x, otherwise skip the chi-squared calculation
-            if ((xMax_a < xMin_b) || (xMin_a > xMax_b))
                 continue;
             
             float bestChi2 = std::numeric_limits<float>::max();
@@ -246,14 +306,6 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
             for (int k = 0; k < nC; ++k)
             {
                 // We allow the constraint hit to be used for cost calculation even if it's already used (it can validate a doublet match)
-                const CartesianVector c(cHits[k]->GetPositionVector());
-                const float dx_c(0.5f * cHits[k]->GetCellSize1());
-                const float xMin_c(c.GetX() - dx_c);
-                const float xMax_c(c.GetX() + dx_c);
-                // Check that constraint view is compatible with A and V in x, otherwise skip the chi-squared calculation
-                if ((xMax_a < xMin_c) || (xMin_a > xMax_c) || (xMax_b < xMin_c) || (xMin_b > xMax_c))
-                    continue;
-
                 float chi2{std::numeric_limits<float>::max()};
                 switch (constraintView)
                 {
@@ -577,6 +629,7 @@ StatusCode PlaneSolverAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "Chi2Threshold", m_chi2Threshold));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "CaloHitListName", m_caloHitListName));
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "EventContextName", m_eventContextName));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "Visualize", m_visualize));
 
     return STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -67,66 +67,59 @@ void PlaneSolverAlgorithm::Solve() const
     // relationships between the 2D hits in each unit.
     for (const auto &[_, readout] : m_planeToReadoutMap)
     {
-        CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f)};
-        const IntVector assignment{this->KuhneMunkres(costMatrix)};
         int nHitsU{static_cast<int>(readout.at(TPC_VIEW_U).size())};
         int nHitsV{static_cast<int>(readout.at(TPC_VIEW_V).size())};
-        const PairVector pairs{this->BuildUVPairs(assignment, nHitsU, nHitsV)};
-        CostMatrix tripletCostMatrix{this->ComputeTripletCostMatrix(pairs, readout, 100.f)};
-        const IntVector tripletAssignment{this->KuhneMunkres(tripletCostMatrix)};
         int nHitsW{static_cast<int>(readout.at(TPC_VIEW_W).size())};
-        const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsW)};
-        //CaloHitList hitsU{readout.at(TPC_VIEW_U).begin(), readout.at(TPC_VIEW_U).end()};
-        //CaloHitList hitsV{readout.at(TPC_VIEW_V).begin(), readout.at(TPC_VIEW_V).end()};
-        //PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsU, "U", RED));
-        //PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsV, "V", GREEN));
-        int nMatchedU{0}, nMatchedV{0};
-        std::cout << "UV pairs with non-unique W" << std::endl;
+
+        HitType constraintView{nHitsW >= nHitsV && nHitsW >= nHitsU ? TPC_VIEW_W : nHitsV >= nHitsU ? TPC_VIEW_V : TPC_VIEW_U};
+        std::cout << "Constraint view: " << constraintView << " with nHitsW = " << nHitsW << ", nHitsV = " << nHitsV << ", nHitsU = " << nHitsU << std::endl;
+        CostMatrix costMatrix{this->ComputeCostMatrix(readout, 100.f, constraintView)};
+        const IntVector assignment{this->KuhneMunkres(costMatrix)};
+        HitType viewA, viewB;
+        this->SelectViewPair(constraintView, viewA, viewB);
+        int nHitsA{static_cast<int>(readout.at(viewA).size())};
+        int nHitsB{static_cast<int>(readout.at(viewB).size())};
+        const PairVector pairs{this->BuildPairs(assignment, nHitsA, nHitsB, costMatrix)};
         std::cout << "-----------------------------" << std::endl;
-        for (size_t i = 0; i < assignment.size(); ++i)
+        std::cout << "Pairs" << std::endl;
+        std::cout << "-----------------------------" << std::endl;
+        for (size_t i = 0; i < pairs.size(); ++i)
         {
-            if (assignment[i] < 0)
-                continue;
-            const size_t j{static_cast<size_t>(assignment[i])};
-            //if (i < hitsU.size())
-            //{
-            //    const CartesianVector u(readout.at(TPC_VIEW_U)[i]->GetPositionVector());
-            //    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &u, "U", RED, 2));
-            //}
-            //if (j < hitsV.size())
-            //{
-            //    const CartesianVector v(readout.at(TPC_VIEW_V)[j]->GetPositionVector());
-            //    PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &v, "V", GREEN, 2));
-            //}
-            //PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
-
-            if (i < readout.at(TPC_VIEW_U).size() && j < readout.at(TPC_VIEW_V).size())
-            {
-                ++nMatchedU;
-                ++nMatchedV;
-                std::cout << "Assignment: i = " << i << "(" << readout.at(TPC_VIEW_U).size() << "), j = " << j << " (" <<
-                    readout.at(TPC_VIEW_V).size() << ")" << std::endl;
-
-                //const CaloHit *pHit3D{nullptr};
-                //this->CreateThreeDHit(readout.at(TPC_VIEW_U)[i], readout.at(TPC_VIEW_V)[j], pHit3D);
-                //hits3D.emplace_back(pHit3D);
-            }
+            std::cout << "Pair: i = " << pairs[i].m_aIndex << ", j = " << pairs[i].m_bIndex << ", cost = " << pairs[i].m_cost << std::endl;
         }
-        std::cout << "Matched " << nMatchedU << " out of " << nHitsU << " U hits, and " << nMatchedV << " out of " << nHitsV << " V hits. " <<
-            "The W view has " << nHitsW << std::endl;
+        CostMatrix tripletCostMatrix{this->ComputeTripletCostMatrix(pairs, readout, 100.f, constraintView)};
+        const IntVector tripletAssignment{this->KuhneMunkres(tripletCostMatrix)};
+        int nHitsC{static_cast<int>(readout.at(constraintView).size())};
+        const TripletVector triplets{this->BuildTriplets(pairs, tripletAssignment, nHitsC, tripletCostMatrix, constraintView)};
         std::cout << "-----------------------------" << std::endl;
         std::cout << "Triplets" << std::endl;
         std::cout << "-----------------------------" << std::endl;
         for (size_t i = 0; i < triplets.size(); ++i)
         {
-            std::cout << "Triplet: i = " << triplets[i].m_uIndex << ", j = " << triplets[i].m_vIndex << ", k = " << triplets[i].m_wIndex << std::endl;
+            std::cout << "Triplet: i = " << triplets[i].m_uIndex << ", j = " << triplets[i].m_vIndex << ", k = " << triplets[i].m_wIndex <<
+                ", cost = " << triplets[i].m_cost << std::endl;
             const CaloHit *pHit3D{nullptr};
-            if (triplets[i].m_wIndex >= 0)
+            try
+            {
+            if (triplets[i].m_uIndex >= 0 && triplets[i].m_vIndex >= 0 && triplets[i].m_wIndex >= 0)
+            {
                 this->CreateThreeDHit(readout.at(TPC_VIEW_U)[triplets[i].m_uIndex], readout.at(TPC_VIEW_V)[triplets[i].m_vIndex],
                     readout.at(TPC_VIEW_W)[triplets[i].m_wIndex], pHit3D);
+            }
             else
-                this->CreateThreeDHit(readout.at(TPC_VIEW_U)[triplets[i].m_uIndex], readout.at(TPC_VIEW_V)[triplets[i].m_vIndex], pHit3D);
-            hits3D.emplace_back(pHit3D);
+            {
+                const CaloHit *pHitU{(triplets[i].m_uIndex >= 0) ? readout.at(TPC_VIEW_U)[triplets[i].m_uIndex] : nullptr};
+                const CaloHit *pHitV{(triplets[i].m_vIndex >= 0) ? readout.at(TPC_VIEW_V)[triplets[i].m_vIndex] : nullptr};
+                const CaloHit *pHitW{(triplets[i].m_wIndex >= 0) ? readout.at(TPC_VIEW_W)[triplets[i].m_wIndex] : nullptr};
+                this->CreateThreeDHit(pHitU, pHitV, pHitW, pHit3D);
+            }
+            }
+            catch (const StatusCodeException &e)
+            {
+                std::cout << "Complaint" << std::endl;
+            }
+            if (pHit3D)
+                hits3D.emplace_back(pHit3D);
         }
         std::cout << "-----------------------------" << std::endl;
         std::cout << "Number of triplets: " << triplets.size() << std::endl;
@@ -138,51 +131,69 @@ void PlaneSolverAlgorithm::Solve() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost) const
+PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost,
+    const HitType constraintView) const
 {
-    const CaloHitVector &uHits(planeToHitsMap.at(TPC_VIEW_U));
-    const CaloHitVector &vHits(planeToHitsMap.at(TPC_VIEW_V));
-    const CaloHitVector &wHits(planeToHitsMap.at(TPC_VIEW_W));
-    const int nU{static_cast<int>(uHits.size())};
-    const int nV{static_cast<int>(vHits.size())};
-    const int nW{static_cast<int>(wHits.size())};
-    const int N{std::max(nU, nV)};
+    HitType viewA, viewB;
+    this->SelectViewPair(constraintView, viewA, viewB);
+    std::cout << "View A: " << viewA << ", View B: " << viewB << ", Constraint view: " << constraintView << std::endl;
+    const CaloHitVector &aHits(planeToHitsMap.at(viewA));
+    const CaloHitVector &bHits(planeToHitsMap.at(viewB));
+    const CaloHitVector &cHits(planeToHitsMap.at(constraintView));
+    const int nA{static_cast<int>(aHits.size())};
+    const int nB{static_cast<int>(bHits.size())};
+    const int nC{static_cast<int>(cHits.size())};
+    const int N{std::max(nA, nB)};
 
     // Initialize the cost matrix with the cost for unmatched hits.
     CostMatrix C(N, FloatVector(N, unmatchedCost));
 
     // Compute all chi-squared values
-    for (int i = 0; i < nU; ++i)
+    for (int i = 0; i < nA; ++i)
     {
-        const CartesianVector u(uHits[i]->GetPositionVector());
-        const float dx_u(0.5f * uHits[i]->GetCellSize1());
-        const float xMin_u(u.GetX() - dx_u);
-        const float xMax_u(u.GetX() + dx_u);
+        const CartesianVector a(aHits[i]->GetPositionVector());
+        const float dx_a(0.5f * aHits[i]->GetCellSize1());
+        const float xMin_a(a.GetX() - dx_a);
+        const float xMax_a(a.GetX() + dx_a);
         
-        for (int j = 0; j < nV; ++j)
+        for (int j = 0; j < nB; ++j)
         {
-            const CartesianVector v(vHits[j]->GetPositionVector());
-            const float dx_v(0.5f * vHits[j]->GetCellSize1());
-            const float xMin_v(v.GetX() - dx_v);
-            const float xMax_v(v.GetX() + dx_v);
-            // Check that the U and V views are compatible in x, otherwise skip the chi-squared calculation
-            if ((xMax_u < xMin_v) || (xMin_u > xMax_v))
+            const CartesianVector b(bHits[j]->GetPositionVector());
+            const float dx_b(0.5f * bHits[j]->GetCellSize1());
+            const float xMin_b(b.GetX() - dx_b);
+            const float xMax_b(b.GetX() + dx_b);
+            // Check that the A and B views are compatible in x, otherwise skip the chi-squared calculation
+            if ((xMax_a < xMin_b) || (xMin_a > xMax_b))
                 continue;
             
             float bestChi2 = std::numeric_limits<float>::max();
             int bestK{-1};
 
-            for (int k = 0; k < nW; ++k)
+            for (int k = 0; k < nC; ++k)
             {
-                const CartesianVector w(wHits[k]->GetPositionVector());
-                const float dx_w(0.5f * wHits[k]->GetCellSize1());
-                const float xMin_w(w.GetX() - dx_w);
-                const float xMax_w(w.GetX() + dx_w);
-                // Check that W view is compatible with U and V in x, otherwise skip the chi-squared calculation
-                if ((xMax_u < xMin_w) || (xMin_u > xMax_w) || (xMax_v < xMin_w) || (xMin_v > xMax_w))
+                const CartesianVector c(cHits[k]->GetPositionVector());
+                const float dx_c(0.5f * cHits[k]->GetCellSize1());
+                const float xMin_c(c.GetX() - dx_c);
+                const float xMax_c(c.GetX() + dx_c);
+                // Check that constraint view is compatible with A and V in x, otherwise skip the chi-squared calculation
+                if ((xMax_a < xMin_c) || (xMin_a > xMax_c) || (xMax_b < xMin_c) || (xMin_b > xMax_c))
                     continue;
 
-                float chi2{LArGeometryHelper::CalculateChiSquared(this->GetPandora(), uHits[i], vHits[j], wHits[k])};
+                float chi2{std::numeric_limits<float>::max()};
+                switch (constraintView)
+                {
+                    case TPC_VIEW_W:
+                        chi2 = LArGeometryHelper::CalculateChiSquared(this->GetPandora(), aHits[i], bHits[j], cHits[k]);
+                        break;
+                    case TPC_VIEW_U:
+                        chi2 = LArGeometryHelper::CalculateChiSquared(this->GetPandora(), cHits[k], aHits[i], bHits[j]);
+                        break;
+                    case TPC_VIEW_V:
+                        chi2 = LArGeometryHelper::CalculateChiSquared(this->GetPandora(), aHits[i], cHits[k], bHits[j]);
+                        break;
+                    default:
+                        throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+                }
                 if (chi2 < bestChi2)
                 {
                     bestChi2 = chi2;
@@ -200,25 +211,42 @@ PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeCostMatrix(const P
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeTripletCostMatrix(const PairVector &uvPairs, const PlaneToHitsMap &planeToHitsMap,
-    const float unmatchedCost) const
+PlaneSolverAlgorithm::CostMatrix PlaneSolverAlgorithm::ComputeTripletCostMatrix(const PairVector &pairs, const PlaneToHitsMap &planeToHitsMap,
+    const float unmatchedCost, const HitType constraintView) const
 {
-    const CaloHitVector &uHits(planeToHitsMap.at(TPC_VIEW_U));
-    const CaloHitVector &vHits(planeToHitsMap.at(TPC_VIEW_V));
-    const CaloHitVector &wHits(planeToHitsMap.at(TPC_VIEW_W));
-    int nPairs{static_cast<int>(uvPairs.size())};
-    int nW{static_cast<int>(wHits.size())};
-    int N{std::max(nPairs, nW)};
+    HitType viewA, viewB;
+    this->SelectViewPair(constraintView, viewA, viewB);
+    const CaloHitVector &aHits{planeToHitsMap.at(viewA)};
+    const CaloHitVector &bHits{planeToHitsMap.at(viewB)};
+    const CaloHitVector &cHits{planeToHitsMap.at(constraintView)};
+    int nPairs{static_cast<int>(pairs.size())};
+    int nC{static_cast<int>(cHits.size())};
+    int N{std::max(nPairs, nC)};
 
     CostMatrix C(N, FloatVector(N, unmatchedCost));
     for (int p = 0; p < nPairs; ++p)
     {
-        int i{uvPairs[p].m_uIndex};
-        int j{uvPairs[p].m_vIndex};
+        int i{pairs[p].m_aIndex};
+        int j{pairs[p].m_bIndex};
 
-        for (int k = 0; k < nW; ++k)
+        for (int k = 0; k < nC; ++k)
         {
-            float chi2{LArGeometryHelper::CalculateChiSquared(this->GetPandora(), uHits[i], vHits[j], wHits[k])};
+            float chi2{std::numeric_limits<float>::max()};
+            switch (constraintView)
+            {
+                case TPC_VIEW_W:
+                    chi2 = LArGeometryHelper::CalculateChiSquared(this->GetPandora(), aHits[i], bHits[j], cHits[k]);
+                    break;
+                case TPC_VIEW_U:
+                    chi2 = LArGeometryHelper::CalculateChiSquared(this->GetPandora(), cHits[k], aHits[i], bHits[j]);
+                    break;
+                case TPC_VIEW_V:
+                    chi2 = LArGeometryHelper::CalculateChiSquared(this->GetPandora(), aHits[i], cHits[k], bHits[j]);
+                    break;
+                default:
+                    throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+            }
+
             C[p][k] = chi2;
         }
     }
@@ -323,16 +351,16 @@ IntVector PlaneSolverAlgorithm::KuhneMunkres(const CostMatrix& cost) const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildUVPairs(const IntVector &assignment, int nU, int nV) const
+PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildPairs(const IntVector &assignment, int nA, int nB, const CostMatrix& costMatrix) const
 {
     PairVector pairs;
 
-    for (int i = 0; i < nU; ++i)
+    for (int i = 0; i < nA; ++i)
     {
         int j{assignment[i]};
 
-        if (j < nV)
-            pairs.push_back({i, j});
+        if (j < nB && costMatrix[i][j] < 100.f)
+            pairs.push_back({i, j, costMatrix[i][j]});
     }
 
     return pairs;
@@ -340,56 +368,53 @@ PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildUVPairs(const IntVec
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const PairVector& uvPairs, const IntVector& assignment, int nW) const
+PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const PairVector& pairs, const IntVector& assignment, int nC,
+    const CostMatrix& costMatrix, const HitType constraintView) const
 {
     TripletVector result;
-    const int nPairs{static_cast<int>(uvPairs.size())};
+    const int nPairs{static_cast<int>(pairs.size())};
 
     for (int p = 0; p < nPairs; ++p)
     {
         int k{assignment[p]};
 
-        if (k < nW)
-            result.push_back({uvPairs[p].m_uIndex, uvPairs[p].m_vIndex, k});
-        else
-            result.push_back({uvPairs[p].m_uIndex, uvPairs[p].m_vIndex, -1});
+        if (k < nC && costMatrix[p][k] < 100.f)
+        {
+            switch (constraintView)
+            {
+                case TPC_VIEW_U:
+                    result.push_back({k, pairs[p].m_aIndex, pairs[p].m_bIndex, costMatrix[p][k]});
+                    break;
+                case TPC_VIEW_V:
+                    result.push_back({pairs[p].m_aIndex, k, pairs[p].m_bIndex, costMatrix[p][k]});
+                    break;
+                case TPC_VIEW_W:
+                    result.push_back({pairs[p].m_aIndex, pairs[p].m_bIndex, k, costMatrix[p][k]});
+                    break;
+                default:
+                    throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+            }
+        }
+        else if (costMatrix[p][k] < 100.f)
+        {
+            switch (constraintView)
+            {
+                case TPC_VIEW_U:
+                    result.push_back({-1, pairs[p].m_aIndex, pairs[p].m_bIndex, pairs[p].m_cost});
+                    break;
+                case TPC_VIEW_V:
+                    result.push_back({pairs[p].m_aIndex, -1, pairs[p].m_bIndex, pairs[p].m_cost});
+                    break;
+                case TPC_VIEW_W:
+                    result.push_back({pairs[p].m_aIndex, pairs[p].m_bIndex, -1, pairs[p].m_cost});
+                    break;
+                default:
+                    throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+            }
+        }
     }
 
     return result;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const CaloHit *const pCaloHitV, const CaloHit *&pCaloHit3D) const
-{
-    float chi2{0.f};
-    CartesianVector pos3D(0, 0, 0);
-    PandoraContentApi::CaloHit::Parameters parameters;
-    LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, pCaloHitU->GetPositionVector(), pCaloHitV->GetPositionVector(),
-        pos3D, chi2);
-    parameters.m_positionVector = pos3D;
-    parameters.m_hitType = TPC_3D;
-
-    const CaloHit *const pCaloHit2D(pCaloHitU);
-    parameters.m_pParentAddress = static_cast<const void *>(pCaloHit2D);
-    parameters.m_cellThickness = pCaloHit2D->GetCellThickness();
-    parameters.m_cellGeometry = RECTANGULAR;
-    parameters.m_cellSize0 = pCaloHit2D->GetCellLengthScale();
-    parameters.m_cellSize1 = pCaloHit2D->GetCellLengthScale();
-    parameters.m_cellNormalVector = pCaloHit2D->GetCellNormalVector();
-    parameters.m_expectedDirection = pCaloHit2D->GetExpectedDirection();
-    parameters.m_nCellRadiationLengths = pCaloHit2D->GetNCellRadiationLengths();
-    parameters.m_nCellInteractionLengths = pCaloHit2D->GetNCellInteractionLengths();
-    parameters.m_time = pCaloHit2D->GetTime();
-    parameters.m_inputEnergy = pCaloHit2D->GetInputEnergy();
-    parameters.m_mipEquivalentEnergy = pCaloHit2D->GetMipEquivalentEnergy();
-    parameters.m_electromagneticEnergy = pCaloHit2D->GetElectromagneticEnergy();
-    parameters.m_hadronicEnergy = pCaloHit2D->GetHadronicEnergy();
-    parameters.m_isDigital = pCaloHit2D->IsDigital();
-    parameters.m_hitRegion = pCaloHit2D->GetHitRegion();
-    parameters.m_layer = pCaloHit2D->GetLayer();
-    parameters.m_isInOuterSamplingLayer = pCaloHit2D->IsInOuterSamplingLayer();
-    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -400,12 +425,23 @@ void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const
     float chi2{0.f};
     CartesianVector pos3D(0, 0, 0);
     PandoraContentApi::CaloHit::Parameters parameters;
-    LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, pCaloHitU->GetPositionVector(),
-        pCaloHitV->GetPositionVector(), pCaloHitW->GetPositionVector(), pos3D, chi2);
+    if (pCaloHitU && pCaloHitV && pCaloHitW)
+    {
+        LArGeometryHelper::MergeThreePositions3D(this->GetPandora(), TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, pCaloHitU->GetPositionVector(),
+            pCaloHitV->GetPositionVector(), pCaloHitW->GetPositionVector(), pos3D, chi2);
+    }
+    else
+    {
+        const CaloHit *const pHitA(pCaloHitU ? pCaloHitU : pCaloHitV);
+        const CaloHit *const pHitB(pCaloHitW ? pCaloHitW : pCaloHitV);
+        LArGeometryHelper::MergeTwoPositions3D(this->GetPandora(), pHitA->GetHitType(), pHitB->GetHitType(), pHitA->GetPositionVector(),
+            pHitB->GetPositionVector(), pos3D, chi2);
+    }
+
     parameters.m_positionVector = pos3D;
     parameters.m_hitType = TPC_3D;
 
-    const CaloHit *const pCaloHit2D(pCaloHitU);
+    const CaloHit *const pCaloHit2D(pCaloHitW ? pCaloHitW : pCaloHitU ? pCaloHitU : pCaloHitV);
     parameters.m_pParentAddress = static_cast<const void *>(pCaloHit2D);
     parameters.m_cellThickness = pCaloHit2D->GetCellThickness();
     parameters.m_cellGeometry = RECTANGULAR;
@@ -427,6 +463,28 @@ void PlaneSolverAlgorithm::CreateThreeDHit(const CaloHit *const pCaloHitU, const
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::CaloHit::Create(*this, parameters, pCaloHit3D));
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void PlaneSolverAlgorithm::SelectViewPair(const HitType constraintView, HitType &viewA, HitType &viewB) const
+{
+    switch (constraintView)
+    {
+        case TPC_VIEW_U:
+            viewA = TPC_VIEW_V;
+            viewB = TPC_VIEW_W;
+            break;
+        case TPC_VIEW_V:
+            viewA = TPC_VIEW_U;
+            viewB = TPC_VIEW_W;
+            break;
+        case TPC_VIEW_W:
+            viewA = TPC_VIEW_U;
+            viewB = TPC_VIEW_V;
+            break;
+        default:
+            throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
+    }
+}
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -174,13 +174,6 @@ void PlaneSolverAlgorithm::Solve() const
                 this->SelectViewPair(constraintView, viewA, viewB);
                 int nHitsA{static_cast<int>(driftBinHits.at(viewA).size())};
                 int nHitsB{static_cast<int>(driftBinHits.at(viewB).size())};
-                {
-                    int nActualA{0}, nActualB{0};
-                    for (const auto *pHit : driftBinHits.at(viewA))
-                        nActualA += !usedHits.count(pHit);
-                    for (const auto *pHit : driftBinHits.at(viewB))
-                        nActualB += !usedHits.count(pHit);
-                }
                 if (nHitsA == 0 || nHitsB == 0)
                     continue;
                 const PairVector pairs{this->BuildPairs(assignment, nHitsA, nHitsB, costMatrix, m_chi2Threshold)};

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
@@ -480,9 +480,9 @@ PlaneSolverAlgorithm::PairVector PlaneSolverAlgorithm::BuildPairs(const IntVecto
 
     for (int i = 0; i < nA; ++i)
     {
-        int j{assignment[i]};
+        const int j{assignment[i]};
 
-        if (j < nB && costMatrix[i][j] < chi2Threshold)
+        if (j >= 0 && j < nB && costMatrix[i][j] < chi2Threshold)
             pairs.push_back({i, j, costMatrix[i][j]});
     }
 
@@ -499,9 +499,9 @@ PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const Pa
 
     for (int p = 0; p < nPairs; ++p)
     {
-        int k{assignment[p]};
+        const int k{assignment[p]};
 
-        if (k < nC && costMatrix[p][k] < chi2Threshold)
+        if (k >= 0 && k < nC && costMatrix[p][k] < chi2Threshold)
         {
             switch (constraintView)
             {
@@ -518,7 +518,7 @@ PlaneSolverAlgorithm::TripletVector PlaneSolverAlgorithm::BuildTriplets(const Pa
                     PANDORA_THROW(STATUS_CODE_INVALID_PARAMETER);
             }
         }
-        else if (costMatrix[p][k] < chi2Threshold)
+        else if (pairs[p].m_cost < chi2Threshold)
         {
             switch (constraintView)
             {

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
@@ -1,0 +1,110 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
+ *
+ *  @brief  The Plane Solver algorithm takes the collection of 2D hits across all planes and constructs an optimal set of triplet and doublet
+ *          relationships between them. These relationships are persisted via the EventContext object so that they are available to subsequent
+ *          algorithms.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_PLANE_SOLVER_ALGORITHM_H
+#define LAR_PLANE_SOLVER_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+#include "Pandora/AlgorithmTool.h"
+
+#include <unordered_map>
+
+namespace lar_content
+{
+
+/**
+ *  @brief  An algorithm to construct hit triplets and doublets representing candidate 3D hits
+ */
+class PlaneSolverAlgorithm : public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    PlaneSolverAlgorithm();
+
+private:
+    struct Volume
+    {
+        unsigned int m_tpc;
+        unsigned int m_childVolume;
+
+        bool operator==(const Volume& other) const
+        {
+            return m_tpc == other.m_tpc && m_childVolume == other.m_childVolume;
+        }
+    };
+
+    struct VolumeHash
+    {
+        std::size_t operator()(const Volume& v) const noexcept
+        {
+            return std::hash<int>{}(v.m_tpc) ^ (std::hash<int>{}(v.m_childVolume) << 1);
+        }
+    };
+
+    typedef std::unordered_map<pandora::HitType, pandora::CaloHitVector> PlaneToHitsMap;
+    typedef std::unordered_map<Volume, PlaneToHitsMap, VolumeHash> VolumeToReadoutMap;
+    typedef std::vector<std::vector<int>> IndexMatrix;
+    typedef std::vector<std::vector<float>> CostMatrix;
+
+    pandora::StatusCode Run();
+
+    /**
+     *  @brief  Fills the map of the 2D hits, keyed by volume
+     *
+     *  @param  caloHitList the list of 2D hits to be mapped
+     */
+    void FillHitMap(const pandora::CaloHitList &caloHitList);
+
+    /**
+     *  @brief  Solve for the optimal set of triplet and doublet relationships between the 2D hits
+     */
+    void Solve() const;
+
+    /**
+     *  @brief  Compute the cost matrix for the hits in a given slice, where the cost is based on the chi-squared value for triplets and doublets of hits
+     *
+     *  @param  planetoHitsMap the map of the 2D hits in the slice, keyed by view
+     *  @param  unmatchedCost the cost to be assigned to unmatched hits
+     *  @param  bestK the matrix to be filled with the index of the best matching hit in the W view for each UV pair
+     *
+     *  @return The cost matrix for the hits in the slice
+     */
+    CostMatrix ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost, IndexMatrix &bestK) const;
+
+    /**
+     *  @brief  Implementation of the Kunhne-Munkres (aka Hungarian) algorithm to solve the optimal matching between UV pairs and W hits.
+     *          For each row, attempt to assign it and if there is a conflict, reroute via an augmenting path.
+     *
+     *  @param  cost the cost matrix for the hits in a volume
+     *
+     *  @return The optimal matching between UV pairs and W hits, where the vector elements align with the U hits and indicate matched index
+     *          in the V hits (or -1 if unmatched)
+     */
+    pandora::IntVector KuhneMunkres(const CostMatrix& cost) const;
+
+    /**
+     *  @brief  Create a 3D hit from a double of U and V hits
+     *
+     *  @param  pCaloHitU the U view hit
+     *  @param  pCaloHitV the V view hit
+     *  @param[out] pCaloHit3D the 3D hit to be created
+     */
+    void CreateThreeDHit(const pandora::CaloHit *const pCaloHitU, const pandora::CaloHit *const pCaloHitV, const pandora::CaloHit *&pCaloHit3D) const;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    std::string m_caloHitListName; ///< The name of the calo hit list containing all of the 2D hits
+    VolumeToReadoutMap m_planeToReadoutMap; ///< A map from volume, to readout plane, to the 2D hits in that plane
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_PLANE_SOLVER_ALGORITHM_H

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
@@ -49,10 +49,25 @@ private:
         }
     };
 
+    struct UVPair
+    {
+        int m_uIndex;
+        int m_vIndex;
+    };
+
+    struct Triplet
+    {
+        int m_uIndex;
+        int m_vIndex;
+        int m_wIndex;
+    };
+
     typedef std::unordered_map<pandora::HitType, pandora::CaloHitVector> PlaneToHitsMap;
     typedef std::unordered_map<Volume, PlaneToHitsMap, VolumeHash> VolumeToReadoutMap;
     typedef std::vector<std::vector<int>> IndexMatrix;
     typedef std::vector<std::vector<float>> CostMatrix;
+    typedef std::vector<UVPair> PairVector;
+    typedef std::vector<Triplet> TripletVector;
 
     pandora::StatusCode Run();
 
@@ -69,15 +84,29 @@ private:
     void Solve() const;
 
     /**
-     *  @brief  Compute the cost matrix for the hits in a given slice, where the cost is based on the chi-squared value for triplets and doublets of hits
+     *  @brief  Compute the cost matrix for the hits, where the cost is based on the chi-squared value for hit triplets.
+     *          This function computes the cost of matching a UV pair, using the W hits to provide a constraint, but allows for the W hits
+     *          to be used more than once.
      *
-     *  @param  planetoHitsMap the map of the 2D hits in the slice, keyed by view
+     *  @param  planetoHitsMap the map of the 2D hits, keyed by view
      *  @param  unmatchedCost the cost to be assigned to unmatched hits
-     *  @param  bestK the matrix to be filled with the index of the best matching hit in the W view for each UV pair
      *
      *  @return The cost matrix for the hits in the slice
      */
-    CostMatrix ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost, IndexMatrix &bestK) const;
+    CostMatrix ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost) const;
+
+    /**
+     *  @brief  Compute the cost matrix for the hits, where the cost is based on the chi-squared value for hit triplets.
+     *          This function starts with the UV pairs from the first pass of the Kuhne-Munkres algorithm, and computes the cost of matching
+     *          each UV pair to a unique W hit, constructing triplet matches where possible, but retaining the doublet matches otherwise.
+     *
+     *  @param  uVPairs the list of UV pairs to be considered for triplet matching
+     *  @param  planetoHitsMap the map of the 2D hits, keyed by view
+     *  @param  unmatchedCost the cost to be assigned to unmatched hits
+     *
+     *  @return The cost matrix for the hits in the slice
+     */
+    CostMatrix ComputeTripletCostMatrix(const PairVector &uvPairs, const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost) const;
 
     /**
      *  @brief  Implementation of the Kunhne-Munkres (aka Hungarian) algorithm to solve the optimal matching between UV pairs and W hits.
@@ -91,6 +120,28 @@ private:
     pandora::IntVector KuhneMunkres(const CostMatrix& cost) const;
 
     /**
+     *  @brief  Build the list of UV pairs based on the assignment of V hits to U hits from the Kuhne-Munkres algorithm
+     *
+     *  @param  assignment the output of the Kuhne-Munkres algorithm, indicating the index of the assigned V hit for each U hit (or -1 if unmatched)
+     *  @param  nU the number of U hits
+     *  @param  nV the number of V hits
+     *
+     *  @return The list of UV pairs
+     */
+    PairVector BuildUVPairs(const pandora::IntVector &assignment, int nU, int nV) const;
+
+    /**
+     *  @brief  Build the list of triplets based on the assignment of W hits to UV pairs from the second pass of the Kuhne-Munkres algorithm
+     *
+     *  @param  uvPairs the list of UV pairs to be considered for triplet matching
+     *  @param  assignment the output of the Kuhne-Munkres algorithm, indicating the index of the assigned W hit for each UV pair (or -1 if unmatched)
+     *  @param  nW the number of W hits
+     *
+     *  @return The list of triplets, where unmatched UV pairs are indicated with a W index of -1
+     */
+    TripletVector BuildTriplets(const PairVector& uvPairs, const pandora::IntVector& assignment, int nW) const;
+
+    /**
      *  @brief  Create a 3D hit from a double of U and V hits
      *
      *  @param  pCaloHitU the U view hit
@@ -98,6 +149,17 @@ private:
      *  @param[out] pCaloHit3D the 3D hit to be created
      */
     void CreateThreeDHit(const pandora::CaloHit *const pCaloHitU, const pandora::CaloHit *const pCaloHitV, const pandora::CaloHit *&pCaloHit3D) const;
+
+    /**
+     *  @brief  Create a 3D hit from a triplet of U, V and W hits
+     *
+     *  @param  pCaloHitU the U view hit
+     *  @param  pCaloHitV the V view hit
+     *  @param  pCaloHitW the W view hit
+     *  @param[out] pCaloHit3D the 3D hit to be created
+     */
+    void CreateThreeDHit(const pandora::CaloHit *const pCaloHitU, const pandora::CaloHit *const pCaloHitV, const pandora::CaloHit *const pCaloHitW,
+        const pandora::CaloHit *&pCaloHit3D) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
@@ -102,7 +102,7 @@ private:
 
     /**
      *  @brief  Compute the cost matrix for the hits, where the cost is based on the chi-squared value for hit triplets.
-     *          This function starts with the pairs from the first pass of the Kuhne-Munkres algorithm, and computes the cost of matching
+     *          This function starts with the pairs from the first pass of the Kuhn-Munkres algorithm, and computes the cost of matching
      *          each pair to a unique constraint hit, constructing triplet matches where possible, but retaining the doublet matches otherwise.
      *
      *  @param  pairs the list of pairs to be considered for triplet matching
@@ -120,20 +120,25 @@ private:
      *  @brief  Implementation of the Kunhne-Munkres (aka Hungarian) algorithm to solve the optimal matching between UV pairs and W hits.
      *          For each row, attempt to assign it and if there is a conflict, reroute via an augmenting path.
      *
+     *          Based on Andrey Lopatin's implementation as described at https://cp-algorithms.com/graph/hungarian-algorithm.html
+     *
+     *          H. W. Kuhn, “The Hungarian Method for the Assignment Problem,” Naval Research Logistics Quarterly, 1955.
+     *          J. Munkres, “Algorithms for the Assignment and Transportation Problems,” 1957.
+     *
      *  @param  cost the cost matrix for the hits in a volume
      *
      *  @return The optimal matching between UV pairs and W hits, where the vector elements align with the U hits and indicate matched index
      *          in the V hits (or -1 if unmatched)
      */
-    pandora::IntVector KuhneMunkres(const CostMatrix& cost) const;
+    pandora::IntVector KuhnMunkres(const CostMatrix& cost) const;
 
     /**
-     *  @brief  Build the list of AB pairs based on the assignment of B hits to A hits from the Kuhne-Munkres algorithm
+     *  @brief  Build the list of AB pairs based on the assignment of B hits to A hits from the Kuhn-Munkres algorithm
      *
-     *  @param  assignment the output of the Kuhne-Munkres algorithm, indicating the index of the assigned B hit for each A hit (or -1 if unmatched)
+     *  @param  assignment the output of the Kuhn-Munkres algorithm, indicating the index of the assigned B hit for each A hit (or -1 if unmatched)
      *  @param  nA the number of A hits
      *  @param  nB the number of B hits
-     *  @param  costMatrix the cost matrix that was used as input to the Kuhne-Munkres algorithm
+     *  @param  costMatrix the cost matrix that was used as input to the Kuhn-Munkres algorithm
      *  @param  chi2Threshold the chi-squared threshold below which a pair is considered a valid match
      *
      *  @return The list of UV pairs
@@ -141,13 +146,13 @@ private:
     PairVector BuildPairs(const pandora::IntVector &assignment, int nA, int nB, const CostMatrix& costMatrix, float chi2Threshold) const;
 
     /**
-     *  @brief  Build the list of triplets based on the assignment of constraint hits to AB pairs from the second pass of the Kuhne-Munkres algorithm
+     *  @brief  Build the list of triplets based on the assignment of constraint hits to AB pairs from the second pass of the Kuhn-Munkres algorithm
      *
      *  @param  pairs the list of AB pairs to be considered for triplet matching
-     *  @param  assignment the output of the Kuhne-Munkres algorithm, indicating the index of the assigned constraint hit for each AB pair
+     *  @param  assignment the output of the Kuhn-Munkres algorithm, indicating the index of the assigned constraint hit for each AB pair
      *          (or -1 if unmatched)
      *  @param  nC the number of constraint hits
-     *  @param  costMatrix the cost matrix that was used as input to the Kuhne-Munkres algorithm
+     *  @param  costMatrix the cost matrix that was used as input to the Kuhn-Munkres algorithm
      *  @param  constraintView the view that was used as the constraint in the chi-squared calculation
      *  @param  chi2Threshold the chi-squared threshold below which a triplet is considered a valid match
      *
@@ -178,7 +183,9 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
+    int m_chi2Threshold; ///< The chi-squared threshold below which a triplet is considered a valid match
     std::string m_caloHitListName; ///< The name of the calo hit list containing all of the 2D hits
+    std::string m_eventContextName; ///< The name of the EventContext object in which to persist the relationships between the 2D hits
     VolumeToReadoutMap m_planeToReadoutMap; ///< A map from volume, to readout plane, to the 2D hits in that plane
 };
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
@@ -93,10 +93,12 @@ private:
      *  @param  planetoHitsMap the map of the 2D hits, keyed by view
      *  @param  unmatchedCost the cost to be assigned to unmatched hits
      *  @param  constraintView the view to be used as the constraint in the chi-squared calculation
+     *  @param  usedHits the set of hits that have already been used in a match
      *
      *  @return The cost matrix for the hits in the slice
      */
-    CostMatrix ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost, const pandora::HitType constraintView) const;
+    CostMatrix ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost, const pandora::HitType constraintView,
+        const pandora::CaloHitSet &usedHits) const;
 
     /**
      *  @brief  Compute the cost matrix for the hits, where the cost is based on the chi-squared value for hit triplets.
@@ -107,11 +109,12 @@ private:
      *  @param  planetoHitsMap the map of the 2D hits, keyed by view
      *  @param  unmatchedCost the cost to be assigned to unmatched hits
      *  @param  constraintView the view to be used as the constraint in the chi-squared calculation
+     *  @param  usedHits the set of hits that have already been used in a match
      *
      *  @return The cost matrix for the hits in the slice
      */
     CostMatrix ComputeTripletCostMatrix(const PairVector &pairs, const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost,
-        const pandora::HitType constraintView) const;
+        const pandora::HitType constraintView, const pandora::CaloHitSet &usedHits) const;
 
     /**
      *  @brief  Implementation of the Kunhne-Munkres (aka Hungarian) algorithm to solve the optimal matching between UV pairs and W hits.
@@ -131,10 +134,11 @@ private:
      *  @param  nA the number of A hits
      *  @param  nB the number of B hits
      *  @param  costMatrix the cost matrix that was used as input to the Kuhne-Munkres algorithm
+     *  @param  chi2Threshold the chi-squared threshold below which a pair is considered a valid match
      *
      *  @return The list of UV pairs
      */
-    PairVector BuildPairs(const pandora::IntVector &assignment, int nA, int nB, const CostMatrix& costMatrix) const;
+    PairVector BuildPairs(const pandora::IntVector &assignment, int nA, int nB, const CostMatrix& costMatrix, float chi2Threshold) const;
 
     /**
      *  @brief  Build the list of triplets based on the assignment of constraint hits to AB pairs from the second pass of the Kuhne-Munkres algorithm
@@ -145,11 +149,12 @@ private:
      *  @param  nC the number of constraint hits
      *  @param  costMatrix the cost matrix that was used as input to the Kuhne-Munkres algorithm
      *  @param  constraintView the view that was used as the constraint in the chi-squared calculation
+     *  @param  chi2Threshold the chi-squared threshold below which a triplet is considered a valid match
      *
      *  @return The list of triplets, where unmatched AB pairs are indicated with a constraint index of -1
      */
     TripletVector BuildTriplets(const PairVector& pairs, const pandora::IntVector& assignment, int nC, const CostMatrix& costMatrix,
-        const pandora::HitType constraintView) const;
+        const pandora::HitType constraintView, float chi2Threshold) const;
 
     /**
      *  @brief  Create a 3D hit from a triplet of U, V and W hits

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
@@ -49,10 +49,11 @@ private:
         }
     };
 
-    struct UVPair
+    struct Pair
     {
-        int m_uIndex;
-        int m_vIndex;
+        int m_aIndex;
+        int m_bIndex;
+        float m_cost;
     };
 
     struct Triplet
@@ -60,13 +61,14 @@ private:
         int m_uIndex;
         int m_vIndex;
         int m_wIndex;
+        float m_cost;
     };
 
     typedef std::unordered_map<pandora::HitType, pandora::CaloHitVector> PlaneToHitsMap;
     typedef std::unordered_map<Volume, PlaneToHitsMap, VolumeHash> VolumeToReadoutMap;
     typedef std::vector<std::vector<int>> IndexMatrix;
     typedef std::vector<std::vector<float>> CostMatrix;
-    typedef std::vector<UVPair> PairVector;
+    typedef std::vector<Pair> PairVector;
     typedef std::vector<Triplet> TripletVector;
 
     pandora::StatusCode Run();
@@ -85,28 +87,31 @@ private:
 
     /**
      *  @brief  Compute the cost matrix for the hits, where the cost is based on the chi-squared value for hit triplets.
-     *          This function computes the cost of matching a UV pair, using the W hits to provide a constraint, but allows for the W hits
-     *          to be used more than once.
+     *          This function computes the cost of matching a pair, using the constraint hits to provide a constraint, but allows for the
+     *          constraint hits to be used more than once.
      *
      *  @param  planetoHitsMap the map of the 2D hits, keyed by view
      *  @param  unmatchedCost the cost to be assigned to unmatched hits
+     *  @param  constraintView the view to be used as the constraint in the chi-squared calculation
      *
      *  @return The cost matrix for the hits in the slice
      */
-    CostMatrix ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost) const;
+    CostMatrix ComputeCostMatrix(const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost, const pandora::HitType constraintView) const;
 
     /**
      *  @brief  Compute the cost matrix for the hits, where the cost is based on the chi-squared value for hit triplets.
-     *          This function starts with the UV pairs from the first pass of the Kuhne-Munkres algorithm, and computes the cost of matching
-     *          each UV pair to a unique W hit, constructing triplet matches where possible, but retaining the doublet matches otherwise.
+     *          This function starts with the pairs from the first pass of the Kuhne-Munkres algorithm, and computes the cost of matching
+     *          each pair to a unique constraint hit, constructing triplet matches where possible, but retaining the doublet matches otherwise.
      *
-     *  @param  uVPairs the list of UV pairs to be considered for triplet matching
+     *  @param  pairs the list of pairs to be considered for triplet matching
      *  @param  planetoHitsMap the map of the 2D hits, keyed by view
      *  @param  unmatchedCost the cost to be assigned to unmatched hits
+     *  @param  constraintView the view to be used as the constraint in the chi-squared calculation
      *
      *  @return The cost matrix for the hits in the slice
      */
-    CostMatrix ComputeTripletCostMatrix(const PairVector &uvPairs, const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost) const;
+    CostMatrix ComputeTripletCostMatrix(const PairVector &pairs, const PlaneToHitsMap &planeToHitsMap, const float unmatchedCost,
+        const pandora::HitType constraintView) const;
 
     /**
      *  @brief  Implementation of the Kunhne-Munkres (aka Hungarian) algorithm to solve the optimal matching between UV pairs and W hits.
@@ -120,35 +125,31 @@ private:
     pandora::IntVector KuhneMunkres(const CostMatrix& cost) const;
 
     /**
-     *  @brief  Build the list of UV pairs based on the assignment of V hits to U hits from the Kuhne-Munkres algorithm
+     *  @brief  Build the list of AB pairs based on the assignment of B hits to A hits from the Kuhne-Munkres algorithm
      *
-     *  @param  assignment the output of the Kuhne-Munkres algorithm, indicating the index of the assigned V hit for each U hit (or -1 if unmatched)
-     *  @param  nU the number of U hits
-     *  @param  nV the number of V hits
+     *  @param  assignment the output of the Kuhne-Munkres algorithm, indicating the index of the assigned B hit for each A hit (or -1 if unmatched)
+     *  @param  nA the number of A hits
+     *  @param  nB the number of B hits
+     *  @param  costMatrix the cost matrix that was used as input to the Kuhne-Munkres algorithm
      *
      *  @return The list of UV pairs
      */
-    PairVector BuildUVPairs(const pandora::IntVector &assignment, int nU, int nV) const;
+    PairVector BuildPairs(const pandora::IntVector &assignment, int nA, int nB, const CostMatrix& costMatrix) const;
 
     /**
-     *  @brief  Build the list of triplets based on the assignment of W hits to UV pairs from the second pass of the Kuhne-Munkres algorithm
+     *  @brief  Build the list of triplets based on the assignment of constraint hits to AB pairs from the second pass of the Kuhne-Munkres algorithm
      *
-     *  @param  uvPairs the list of UV pairs to be considered for triplet matching
-     *  @param  assignment the output of the Kuhne-Munkres algorithm, indicating the index of the assigned W hit for each UV pair (or -1 if unmatched)
-     *  @param  nW the number of W hits
+     *  @param  pairs the list of AB pairs to be considered for triplet matching
+     *  @param  assignment the output of the Kuhne-Munkres algorithm, indicating the index of the assigned constraint hit for each AB pair
+     *          (or -1 if unmatched)
+     *  @param  nC the number of constraint hits
+     *  @param  costMatrix the cost matrix that was used as input to the Kuhne-Munkres algorithm
+     *  @param  constraintView the view that was used as the constraint in the chi-squared calculation
      *
-     *  @return The list of triplets, where unmatched UV pairs are indicated with a W index of -1
+     *  @return The list of triplets, where unmatched AB pairs are indicated with a constraint index of -1
      */
-    TripletVector BuildTriplets(const PairVector& uvPairs, const pandora::IntVector& assignment, int nW) const;
-
-    /**
-     *  @brief  Create a 3D hit from a double of U and V hits
-     *
-     *  @param  pCaloHitU the U view hit
-     *  @param  pCaloHitV the V view hit
-     *  @param[out] pCaloHit3D the 3D hit to be created
-     */
-    void CreateThreeDHit(const pandora::CaloHit *const pCaloHitU, const pandora::CaloHit *const pCaloHitV, const pandora::CaloHit *&pCaloHit3D) const;
+    TripletVector BuildTriplets(const PairVector& pairs, const pandora::IntVector& assignment, int nC, const CostMatrix& costMatrix,
+        const pandora::HitType constraintView) const;
 
     /**
      *  @brief  Create a 3D hit from a triplet of U, V and W hits
@@ -160,6 +161,15 @@ private:
      */
     void CreateThreeDHit(const pandora::CaloHit *const pCaloHitU, const pandora::CaloHit *const pCaloHitV, const pandora::CaloHit *const pCaloHitW,
         const pandora::CaloHit *&pCaloHit3D) const;
+
+    /**
+     *  @brief  Select the pairing views based on the specified constraint view
+     *
+     *  @param  constraintView the view to be used as the constraint in the chi-squared calculation
+     *  @param[out] viewA the first view to be used for pairing
+     *  @param[out] viewB the second view to be used for pairing
+     */
+    void SelectViewPair(const pandora::HitType constraintView, pandora::HitType &viewA, pandora::HitType &viewB) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
@@ -66,6 +66,7 @@ private:
 
     typedef std::unordered_map<pandora::HitType, pandora::CaloHitVector> PlaneToHitsMap;
     typedef std::unordered_map<Volume, PlaneToHitsMap, VolumeHash> VolumeToReadoutMap;
+    typedef std::unordered_map<int, PlaneToHitsMap> DriftBinToHitsMap;
     typedef std::vector<std::vector<int>> IndexMatrix;
     typedef std::vector<std::vector<float>> CostMatrix;
     typedef std::vector<Pair> PairVector;
@@ -79,6 +80,14 @@ private:
      *  @param  caloHitList the list of 2D hits to be mapped
      */
     void FillHitMap(const pandora::CaloHitList &caloHitList);
+
+    /**
+     *  @brief  Bins the hits by their drift time, to allow for a more efficient matching of hits in the same drift bin.
+     *
+     *  @param  hitsByPlane the map of 2D hits to be binned, by plane
+     *  @param[out] driftBinToHitsMap the map of drift bins to the 2D hits in that bin
+     */
+    void BinHitsByDrift(const PlaneToHitsMap &hitsByPlane, DriftBinToHitsMap &driftBinToHitsMap) const;
 
     /**
      *  @brief  Solve for the optimal set of triplet and doublet relationships between the 2D hits
@@ -187,6 +196,7 @@ private:
     std::string m_caloHitListName; ///< The name of the calo hit list containing all of the 2D hits
     std::string m_eventContextName; ///< The name of the EventContext object in which to persist the relationships between the 2D hits
     VolumeToReadoutMap m_planeToReadoutMap; ///< A map from volume, to readout plane, to the 2D hits in that plane
+    bool m_visualize; ///< Whether to visualize the hit matching process
 };
 
 } // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h
@@ -192,7 +192,7 @@ private:
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
-    int m_chi2Threshold; ///< The chi-squared threshold below which a triplet is considered a valid match
+    float m_chi2Threshold; ///< The chi-squared threshold below which a triplet is considered a valid match
     std::string m_caloHitListName; ///< The name of the calo hit list containing all of the 2D hits
     std::string m_eventContextName; ///< The name of the EventContext object in which to persist the relationships between the 2D hits
     VolumeToReadoutMap m_planeToReadoutMap; ///< A map from volume, to readout plane, to the 2D hits in that plane

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -32,7 +32,8 @@ StatusCode TrackRecoveryAlgorithm::Run()
 {
     // Get the list of track-like PFOs
     const PfoList *pPfoList(nullptr);
-    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
+    if (STATUS_CODE_SUCCESS != PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList))
+        return STATUS_CODE_SUCCESS;
 
     // Get maps between PFOs, views, clusters and hits
     PfoToViewClusterMap pfoToViewClusterMap;
@@ -109,23 +110,42 @@ StatusCode TrackRecoveryAlgorithm::Run()
             newPosU.emplace_back(pCaloHit->GetPositionVector());
         for (const CaloHit *const pCaloHit : mergeHitsU)
             newPosU.emplace_back(pCaloHit->GetPositionVector());
-        TwoDSlidingFitResult sfrU(&newPosU, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U));
+        try
+        {
+            TwoDSlidingFitResult sfrU(&newPosU, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U));
+            this->FilterHitsToMerge(sfrU, mergeHitsU);
+        }
+        catch (const StatusCodeException &)
+        {
+        }
+
         CartesianPointVector newPosV;
         for (const CaloHit *const pCaloHit : hitsV)
             newPosV.emplace_back(pCaloHit->GetPositionVector());
         for (const CaloHit *const pCaloHit : mergeHitsV)
             newPosV.emplace_back(pCaloHit->GetPositionVector());
-        TwoDSlidingFitResult sfrV(&newPosV, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V));
+        try
+        {
+            TwoDSlidingFitResult sfrV(&newPosV, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V));
+            this->FilterHitsToMerge(sfrV, mergeHitsV);
+        }
+        catch (const StatusCodeException &)
+        {
+        }
+
         CartesianPointVector newPosW;
         for (const CaloHit *const pCaloHit : hitsW)
             newPosW.emplace_back(pCaloHit->GetPositionVector());
         for (const CaloHit *const pCaloHit : mergeHitsW)
             newPosW.emplace_back(pCaloHit->GetPositionVector());
-        TwoDSlidingFitResult sfrW(&newPosW, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W));
-
-        this->FilterHitsToMerge(sfrU, mergeHitsU);
-        this->FilterHitsToMerge(sfrV, mergeHitsV);
-        this->FilterHitsToMerge(sfrW, mergeHitsW);
+        try
+        {
+            TwoDSlidingFitResult sfrW(&newPosW, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W));
+            this->FilterHitsToMerge(sfrW, mergeHitsW);
+        }
+        catch (const StatusCodeException &)
+        {
+        }
 
         for (const CaloHit *const pCaloHit : mergeHitsU)
         {

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -1,0 +1,89 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+ *
+ *  @brief  Implementation of the particle recovery algorithm class.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArHelpers/LArClusterHelper.h"
+#include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
+#include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+
+#include "larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h"
+
+#include <algorithm>
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+TrackRecoveryAlgorithm::TrackRecoveryAlgorithm()
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TrackRecoveryAlgorithm::Run()
+{
+    // Get the list of track-like PFOs
+    const PfoList *pPfoList(nullptr);
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, m_inputPfoListName, pPfoList));
+
+    // Get maps between PFOs, views, clusters and hits
+    PfoToViewClusterMap pfoToViewClusterMap;
+    ClusterToPfoMap clusterToPfoMap;
+    ClusterToHitMap clusterToHitMap;
+    HitToClusterToMap hitToClusterMap;
+    for (const Pfo *const pPfo : *pPfoList)
+    {
+        for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, TPC_3D})
+        {
+            ClusterList pfoClusters;
+            LArPfoHelper::GetClusters(pPfo, view, pfoClusters);
+            if (!pfoClusters.empty())
+            {
+                const Cluster *pCluster{pfoClusters.front()};
+                pfoToViewClusterMap[pPfo][view] = pCluster;
+                clusterToPfoMap[pCluster] = pPfo;
+                if (view != TPC_3D)
+                    this->FitAndOrderCluster(pCluster, clusterToHitMap[pCluster]);
+                else
+                    LArClusterHelper::GetAllHits(pCluster, clusterToHitMap[pCluster]);
+                for (const CaloHit *const pCaloHit : clusterToHitMap[pCluster])
+                    hitToClusterMap[pCaloHit] = pCluster;
+            }
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TrackRecoveryAlgorithm::FitAndOrderCluster(const Cluster *const pCluster, CaloHitList &orderedHits) const
+{
+    if (pCluster->GetNCaloHits() < 3)
+    {
+        LArClusterHelper::GetAllHits(pCluster, orderedHits);
+        return;
+    }
+    const HitType view{LArClusterHelper::GetClusterHitType(pCluster)};
+    TwoDSlidingFitResult sfr(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), view));
+    LArClusterHelper::OrderHitsAlongTrajectory(pCluster, sfr, orderedHits);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode TrackRecoveryAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadVectorOfValues(xmlHandle, "InputClusterListNames", m_inputClusterListNames));
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, XmlHelper::ReadValue(xmlHandle, "InputPfoListName", m_inputPfoListName));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -244,9 +244,9 @@ void TrackRecoveryAlgorithm::FindUnmatchedHits(const CaloHitList &hitsA, const C
         auto bIterator{std::find(hitsB.begin(), hitsB.end(), pHitB)};
         auto cIterator{std::find(hitsC.begin(), hitsC.end(), pHitC)};
         // Only flag hits as unmatched if the other hits in the triplet are present in the PFO
-        if (bIterator == hitsB.end() && cIterator != hitsC.end())
+        if (pHitB && bIterator == hitsB.end() && cIterator != hitsC.end())
             unmatchedHitsB.insert(pHitB);
-        if (cIterator == hitsC.end() && bIterator != hitsB.end())
+        if (pHitC && cIterator == hitsC.end() && bIterator != hitsB.end())
             unmatchedHitsC.insert(pHitC);
     }
 }

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -40,7 +40,6 @@ StatusCode TrackRecoveryAlgorithm::Run()
     ClusterToHitMap clusterToHitMap;
     ClusterToFitMap clusterToFitMap;
     HitToClusterToMap hitToClusterMap;
-    ViewToHitsMap viewToHitsMap;
     for (const Pfo *const pPfo : *pPfoList)
     {
         for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, TPC_3D})
@@ -61,16 +60,29 @@ StatusCode TrackRecoveryAlgorithm::Run()
                 else
                     LArClusterHelper::GetAllHits(pCluster, clusterToHitMap[pCluster]);
                 for (const CaloHit *const pCaloHit : clusterToHitMap[pCluster])
-                {
                     hitToClusterMap[pCaloHit] = pCluster;
-                    viewToHitsMap[view].emplace_back(pCaloHit);
-                }
+            }
+        }
+    }
+    // Loop over all clusters to catch any that aren't associated to a PFO
+    for (const std::string &clusterListName : m_inputClusterListNames)
+    {
+        const ClusterList *pClusterList(nullptr);
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetList(*this, clusterListName, pClusterList));
+        for (const Cluster *const pCluster : *pClusterList)
+        {
+            if (clusterToPfoMap.find(pCluster) == clusterToPfoMap.end())
+            {
+                LArClusterHelper::GetAllHits(pCluster, clusterToHitMap[pCluster]);
+                for (const CaloHit *const pCaloHit : clusterToHitMap[pCluster])
+                    hitToClusterMap[pCaloHit] = pCluster;
             }
         }
     }
 
     // Loop over the PFOs and project 3D hits from two views into the third view to look for unassociated hits
     PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
+    std::unordered_map<const Pfo *, std::unordered_map<HitType, CaloHitList>> pfoToMergeHitsMap;
     for (const Pfo *const pPfo : *pPfoList)
     {
         const Cluster *const pClusterU{pfoToViewClusterMap[pPfo][TPC_VIEW_U]}, *const pClusterV{pfoToViewClusterMap[pPfo][TPC_VIEW_V]},
@@ -83,9 +95,6 @@ StatusCode TrackRecoveryAlgorithm::Run()
         this->FindUnmatchedHits(hitsV, hitsU, hitsW, unmatchedHitsU, unmatchedHitsW);
         this->FindUnmatchedHits(hitsW, hitsU, hitsV, unmatchedHitsU, unmatchedHitsV);
 
-        std::cout << "PFO has " << unmatchedHitsU.size() << " unmatched U hits, "
-                  << unmatchedHitsV.size() << " unmatched V hits and " << unmatchedHitsW.size() << " unmatched W hits." << std::endl;
-
         // Construct 3D hits from the combinatorics of each view pair and project into the third view
         PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsU, "U", RED));
         PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsV, "V", GREEN));
@@ -95,31 +104,77 @@ StatusCode TrackRecoveryAlgorithm::Run()
         this->IdentifyHitsToMerge(pClusterV, hitsV, unmatchedHitsV, clusterToFitMap, mergeHitsV);
         this->IdentifyHitsToMerge(pClusterW, hitsW, unmatchedHitsW, clusterToFitMap, mergeHitsW);
 
+        CartesianPointVector newPosU;
+        for (const CaloHit *const pCaloHit : hitsU)
+            newPosU.emplace_back(pCaloHit->GetPositionVector());
+        for (const CaloHit *const pCaloHit : mergeHitsU)
+            newPosU.emplace_back(pCaloHit->GetPositionVector());
+        TwoDSlidingFitResult sfrU(&newPosU, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U));
+        CartesianPointVector newPosV;
+        for (const CaloHit *const pCaloHit : hitsV)
+            newPosV.emplace_back(pCaloHit->GetPositionVector());
+        for (const CaloHit *const pCaloHit : mergeHitsV)
+            newPosV.emplace_back(pCaloHit->GetPositionVector());
+        TwoDSlidingFitResult sfrV(&newPosV, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V));
+        CartesianPointVector newPosW;
+        for (const CaloHit *const pCaloHit : hitsW)
+            newPosW.emplace_back(pCaloHit->GetPositionVector());
+        for (const CaloHit *const pCaloHit : mergeHitsW)
+            newPosW.emplace_back(pCaloHit->GetPositionVector());
+        TwoDSlidingFitResult sfrW(&newPosW, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W));
+
+        this->FilterHitsToMerge(sfrU, mergeHitsU);
+        this->FilterHitsToMerge(sfrV, mergeHitsV);
+        this->FilterHitsToMerge(sfrW, mergeHitsW);
+
         for (const CaloHit *const pCaloHit : mergeHitsU)
         {
+            pfoToMergeHitsMap[pPfo][TPC_VIEW_U].emplace_back(pCaloHit);
             const CartesianVector position{pCaloHit->GetPositionVector()};
             PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge U", RED, 2.f));
-            float rL{0.f}, rT{0.f};
-            clusterToFitMap.at(pClusterU).GetLocalPosition(position, rL, rT);
-            std::cout << "Merge U hit has rL = " << rL << " and rT = " << rT << std::endl;
         }
         for (const CaloHit *const pCaloHit : mergeHitsV)
         {
+            pfoToMergeHitsMap[pPfo][TPC_VIEW_V].emplace_back(pCaloHit);
             const CartesianVector position{pCaloHit->GetPositionVector()};
             PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge V", GREEN, 2.f));
-            float rL{0.f}, rT{0.f};
-            clusterToFitMap.at(pClusterV).GetLocalPosition(position, rL, rT);
-            std::cout << "Merge V hit has rL = " << rL << " and rT = " << rT << std::endl;
         }
         for (const CaloHit *const pCaloHit : mergeHitsW)
         {
+            pfoToMergeHitsMap[pPfo][TPC_VIEW_W].emplace_back(pCaloHit);
             const CartesianVector position{pCaloHit->GetPositionVector()};
             PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge W", BLUE, 2.f));
-            float rL{0.f}, rT{0.f};
-            clusterToFitMap.at(pClusterW).GetLocalPosition(position, rL, rT);
-            std::cout << "Merge W hit has rL = " << rL << " and rT = " << rT << std::endl;
         }
         PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+    }
+
+    std::map<const CaloHit *, int> hitToNumMergesMap;
+    for (auto &[pPfo, viewToMergeHitsMap] : pfoToMergeHitsMap)
+    {
+        for (auto &[view, mergeHits] : viewToMergeHitsMap)
+        {
+            const Cluster *pNewCluster{pfoToViewClusterMap[pPfo][view]};
+            // Need to allow for the possibility that the view was entirely missing, in which case we need to create a new cluster to merge into
+            for (const CaloHit *const pCaloHit : mergeHits)
+            {
+                if (hitToNumMergesMap.find(pCaloHit) == hitToNumMergesMap.end())
+                    hitToNumMergesMap[pCaloHit] = 0;
+                hitToNumMergesMap[pCaloHit]++;
+                if (hitToClusterMap.find(pCaloHit) != hitToClusterMap.end())
+                {
+                    const Cluster *pOldCluster{hitToClusterMap[pCaloHit]};
+                    PandoraContentApi::RemoveFromCluster(*this, pOldCluster, pCaloHit);
+                    CaloHitList &oldClusterHits{clusterToHitMap[pOldCluster]};
+                    std::remove(oldClusterHits.begin(), oldClusterHits.end(), pCaloHit);
+                }
+                CaloHitList preHitList;
+                LArClusterHelper::GetAllHits(pNewCluster, preHitList);
+                PandoraContentApi::AddToCluster(*this, pNewCluster, pCaloHit);
+                CaloHitList postHitList;
+                LArClusterHelper::GetAllHits(pNewCluster, postHitList);
+                hitToClusterMap[pCaloHit] = pNewCluster;
+            }
+        }
     }
 
     return STATUS_CODE_SUCCESS;
@@ -207,6 +262,45 @@ void TrackRecoveryAlgorithm::IdentifyHitsToMerge(const Cluster *pCluster, const 
         // Entire view is missing, or has less than 3 hits, so we should merge all unmatched hits
         for (const CaloHit *const pCaloHit : unmatchedHits)
             mergeHits.emplace_back(pCaloHit);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TrackRecoveryAlgorithm::FilterHitsToMerge(const TwoDSlidingFitResult &sfr, CaloHitList &mergeHits) const
+{
+    for (auto iter = mergeHits.begin(); iter != mergeHits.end();)
+    {
+        const CaloHit *const pCaloHit{*iter};
+        const CartesianVector position{pCaloHit->GetPositionVector()};
+        float rL(0.f), rT(0.f);
+        sfr.GetLocalPosition(position, rL, rT);
+
+        CartesianVector fitPosition(0, 0, 0);
+        if (STATUS_CODE_SUCCESS != sfr.GetGlobalFitPosition(rL, fitPosition))
+        {
+            mergeHits.erase(iter++);
+            continue;
+        }
+
+        float rTFit(0.f), dummy(0.f);
+        sfr.GetLocalPosition(fitPosition, dummy, rTFit);
+
+        CartesianVector fitDirection(0, 0, 0);
+        if (STATUS_CODE_SUCCESS != sfr.GetGlobalFitDirection(rL, fitDirection))
+        {
+            mergeHits.erase(iter++);
+            continue;
+        }
+
+        float dTdL(0.f);
+        sfr.GetLocalDirection(fitDirection, dTdL);
+
+        const float residual{(rT - rTFit) / std::sqrt(1.f + dTdL * dTdL)};
+        if (std::abs(residual) > 0.5f)
+            mergeHits.erase(iter++);
+        else
+            ++iter;
     }
 }
 

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -188,7 +188,7 @@ StatusCode TrackRecoveryAlgorithm::Run()
                     const Cluster *pOldCluster{hitToClusterMap[pCaloHit]};
                     PandoraContentApi::RemoveFromCluster(*this, pOldCluster, pCaloHit);
                     CaloHitList &oldClusterHits{clusterToHitMap[pOldCluster]};
-                    std::remove(oldClusterHits.begin(), oldClusterHits.end(), pCaloHit);
+                    oldClusterHits.remove(pCaloHit);
                 }
                 CaloHitList preHitList;
                 LArClusterHelper::GetAllHits(pNewCluster, preHitList);

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -11,6 +11,7 @@
 #include "larpandoracontent/LArHelpers/LArClusterHelper.h"
 #include "larpandoracontent/LArHelpers/LArGeometryHelper.h"
 #include "larpandoracontent/LArHelpers/LArPfoHelper.h"
+#include "larpandoracontent/LArObjects/LArPlaneContextObject.h"
 
 #include "larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h"
 
@@ -37,7 +38,9 @@ StatusCode TrackRecoveryAlgorithm::Run()
     PfoToViewClusterMap pfoToViewClusterMap;
     ClusterToPfoMap clusterToPfoMap;
     ClusterToHitMap clusterToHitMap;
+    ClusterToFitMap clusterToFitMap;
     HitToClusterToMap hitToClusterMap;
+    ViewToHitsMap viewToHitsMap;
     for (const Pfo *const pPfo : *pPfoList)
     {
         for (const HitType view : {TPC_VIEW_U, TPC_VIEW_V, TPC_VIEW_W, TPC_3D})
@@ -50,13 +53,73 @@ StatusCode TrackRecoveryAlgorithm::Run()
                 pfoToViewClusterMap[pPfo][view] = pCluster;
                 clusterToPfoMap[pCluster] = pPfo;
                 if (view != TPC_3D)
-                    this->FitAndOrderCluster(pCluster, clusterToHitMap[pCluster]);
+                {
+                    auto result = this->FitAndOrderCluster(pCluster, clusterToHitMap[pCluster]);
+                    if (result)
+                        clusterToFitMap.emplace(pCluster, *result);
+                }
                 else
                     LArClusterHelper::GetAllHits(pCluster, clusterToHitMap[pCluster]);
                 for (const CaloHit *const pCaloHit : clusterToHitMap[pCluster])
+                {
                     hitToClusterMap[pCaloHit] = pCluster;
+                    viewToHitsMap[view].emplace_back(pCaloHit);
+                }
             }
         }
+    }
+
+    // Loop over the PFOs and project 3D hits from two views into the third view to look for unassociated hits
+    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
+    for (const Pfo *const pPfo : *pPfoList)
+    {
+        const Cluster *const pClusterU{pfoToViewClusterMap[pPfo][TPC_VIEW_U]}, *const pClusterV{pfoToViewClusterMap[pPfo][TPC_VIEW_V]},
+            *const pClusterW{pfoToViewClusterMap[pPfo][TPC_VIEW_W]};
+        const CaloHitList &hitsU{clusterToHitMap[pClusterU]}, &hitsV{clusterToHitMap[pClusterV]}, &hitsW{clusterToHitMap[pClusterW]};
+
+        CaloHitSet unmatchedHitsU, unmatchedHitsV, unmatchedHitsW;
+        CaloHitList mergeHitsU, mergeHitsV, mergeHitsW;
+        this->FindUnmatchedHits(hitsU, hitsV, hitsW, unmatchedHitsV, unmatchedHitsW);
+        this->FindUnmatchedHits(hitsV, hitsU, hitsW, unmatchedHitsU, unmatchedHitsW);
+        this->FindUnmatchedHits(hitsW, hitsU, hitsV, unmatchedHitsU, unmatchedHitsV);
+
+        std::cout << "PFO has " << unmatchedHitsU.size() << " unmatched U hits, "
+                  << unmatchedHitsV.size() << " unmatched V hits and " << unmatchedHitsW.size() << " unmatched W hits." << std::endl;
+
+        // Construct 3D hits from the combinatorics of each view pair and project into the third view
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsU, "U", RED));
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsV, "V", GREEN));
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsW, "W", BLUE));
+
+        this->IdentifyHitsToMerge(pClusterU, hitsU, unmatchedHitsU, clusterToFitMap, mergeHitsU);
+        this->IdentifyHitsToMerge(pClusterV, hitsV, unmatchedHitsV, clusterToFitMap, mergeHitsV);
+        this->IdentifyHitsToMerge(pClusterW, hitsW, unmatchedHitsW, clusterToFitMap, mergeHitsW);
+
+        for (const CaloHit *const pCaloHit : mergeHitsU)
+        {
+            const CartesianVector position{pCaloHit->GetPositionVector()};
+            PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge U", RED, 2.f));
+            float rL{0.f}, rT{0.f};
+            clusterToFitMap.at(pClusterU).GetLocalPosition(position, rL, rT);
+            std::cout << "Merge U hit has rL = " << rL << " and rT = " << rT << std::endl;
+        }
+        for (const CaloHit *const pCaloHit : mergeHitsV)
+        {
+            const CartesianVector position{pCaloHit->GetPositionVector()};
+            PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge V", GREEN, 2.f));
+            float rL{0.f}, rT{0.f};
+            clusterToFitMap.at(pClusterV).GetLocalPosition(position, rL, rT);
+            std::cout << "Merge V hit has rL = " << rL << " and rT = " << rT << std::endl;
+        }
+        for (const CaloHit *const pCaloHit : mergeHitsW)
+        {
+            const CartesianVector position{pCaloHit->GetPositionVector()};
+            PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge W", BLUE, 2.f));
+            float rL{0.f}, rT{0.f};
+            clusterToFitMap.at(pClusterW).GetLocalPosition(position, rL, rT);
+            std::cout << "Merge W hit has rL = " << rL << " and rT = " << rT << std::endl;
+        }
+        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
     }
 
     return STATUS_CODE_SUCCESS;
@@ -64,16 +127,87 @@ StatusCode TrackRecoveryAlgorithm::Run()
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-void TrackRecoveryAlgorithm::FitAndOrderCluster(const Cluster *const pCluster, CaloHitList &orderedHits) const
+std::optional<TwoDSlidingFitResult> TrackRecoveryAlgorithm::FitAndOrderCluster(const Cluster *const pCluster, CaloHitList &orderedHits) const
 {
     if (pCluster->GetNCaloHits() < 3)
     {
         LArClusterHelper::GetAllHits(pCluster, orderedHits);
-        return;
+        return std::nullopt;
     }
     const HitType view{LArClusterHelper::GetClusterHitType(pCluster)};
     TwoDSlidingFitResult sfr(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), view));
     LArClusterHelper::OrderHitsAlongTrajectory(pCluster, sfr, orderedHits);
+
+    return sfr;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TrackRecoveryAlgorithm::FindUnmatchedHits(const CaloHitList &hitsA, const CaloHitList &hitsB, const CaloHitList &hitsC, CaloHitSet &unmatchedHitsB,
+    CaloHitSet &unmatchedHitsC) const
+{
+    if (hitsA.empty() || hitsB.empty() || hitsC.empty())
+        return;
+    const LArPlaneContextObject *pPlaneContextObject{dynamic_cast<const LArPlaneContextObject*>(PandoraContentApi::GetEventContextObject(
+        *this, "PlaneContext"))};
+    const HitType viewB{hitsB.front()->GetHitType()}, viewC{hitsC.front()->GetHitType()};
+    for (const CaloHit *const pCaloHitA : hitsA)
+    {
+        const LArPlaneContextObject::HitTriplet *pTriplet{pPlaneContextObject->GetHitTriplet(pCaloHitA)};
+        if (!pTriplet)
+            continue;
+        const CaloHit *const pHitB{viewB == TPC_VIEW_W ? pTriplet->m_wHit : viewB == TPC_VIEW_V ? pTriplet->m_vHit : pTriplet->m_uHit};
+        const CaloHit *const pHitC{viewC == TPC_VIEW_W ? pTriplet->m_wHit : viewC == TPC_VIEW_V ? pTriplet->m_vHit : pTriplet->m_uHit};
+        auto bIterator{std::find(hitsB.begin(), hitsB.end(), pHitB)};
+        auto cIterator{std::find(hitsC.begin(), hitsC.end(), pHitC)};
+        // Only flag hits as unmatched if the other hits in the triplet are present in the PFO
+        if (bIterator == hitsB.end() && cIterator != hitsC.end())
+            unmatchedHitsB.insert(pHitB);
+        if (cIterator == hitsC.end() && bIterator != hitsB.end())
+            unmatchedHitsC.insert(pHitC);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void TrackRecoveryAlgorithm::IdentifyHitsToMerge(const Cluster *pCluster, const CaloHitList &clusterHits, const CaloHitSet &unmatchedHits,
+    const ClusterToFitMap &clusterToFitMap, CaloHitList &mergeHits) const
+{
+    if (pCluster && (clusterHits.size() > 1) && (clusterToFitMap.find(pCluster) != clusterToFitMap.end()))
+    {
+        float rLFront{0.f}, rLBack{0.f}, dummy{0.f};
+        clusterToFitMap.at(pCluster).GetLocalPosition(clusterHits.front()->GetPositionVector(), rLFront, dummy);
+        clusterToFitMap.at(pCluster).GetLocalPosition(clusterHits.back()->GetPositionVector(), rLBack, dummy);
+        for (const CaloHit *const pCaloHit : unmatchedHits)
+        {
+            float rL{0.f};
+            clusterToFitMap.at(pCluster).GetLocalPosition(pCaloHit->GetPositionVector(), rL, dummy);
+            if (rLFront <= rL && rL <= rLBack)
+            {
+                // We're along the track, look for this hit acting as a blocking path
+                for (auto iter = clusterHits.begin(); iter != std::prev(clusterHits.end()); ++iter)
+                {
+                    const CaloHit *const pHit1{*iter}, *const pHit2{*(std::next(iter))};
+                    if (LArClusterHelper::HasBlockedPath({pCaloHit}, pHit1, pHit2))
+                    {
+                        mergeHits.emplace_back(pCaloHit);
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                // We're outside the track, extend it
+                mergeHits.emplace_back(pCaloHit);
+            }
+        }
+    }
+    else
+    {
+        // Entire view is missing, or has less than 3 hits, so we should merge all unmatched hits
+        for (const CaloHit *const pCaloHit : unmatchedHits)
+            mergeHits.emplace_back(pCaloHit);
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -190,11 +190,7 @@ StatusCode TrackRecoveryAlgorithm::Run()
                     CaloHitList &oldClusterHits{clusterToHitMap[pOldCluster]};
                     oldClusterHits.remove(pCaloHit);
                 }
-                CaloHitList preHitList;
-                LArClusterHelper::GetAllHits(pNewCluster, preHitList);
                 PandoraContentApi::AddToCluster(*this, pNewCluster, pCaloHit);
-                CaloHitList postHitList;
-                LArClusterHelper::GetAllHits(pNewCluster, postHitList);
                 hitToClusterMap[pCaloHit] = pNewCluster;
             }
         }

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -82,7 +82,6 @@ StatusCode TrackRecoveryAlgorithm::Run()
     }
 
     // Loop over the PFOs and project 3D hits from two views into the third view to look for unassociated hits
-    //PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
     std::unordered_map<const Pfo *, std::unordered_map<HitType, CaloHitList>> pfoToMergeHitsMap;
     for (const Pfo *const pPfo : *pPfoList)
     {
@@ -97,10 +96,6 @@ StatusCode TrackRecoveryAlgorithm::Run()
         this->FindUnmatchedHits(hitsW, hitsU, hitsV, unmatchedHitsU, unmatchedHitsV);
 
         // Construct 3D hits from the combinatorics of each view pair and project into the third view
-        /*PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsU, "U", RED));
-        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsV, "V", GREEN));
-        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsW, "W", BLUE));*/
-
         this->IdentifyHitsToMerge(pClusterU, hitsU, unmatchedHitsU, clusterToFitMap, mergeHitsU);
         this->IdentifyHitsToMerge(pClusterV, hitsV, unmatchedHitsV, clusterToFitMap, mergeHitsV);
         this->IdentifyHitsToMerge(pClusterW, hitsW, unmatchedHitsW, clusterToFitMap, mergeHitsW);
@@ -148,24 +143,11 @@ StatusCode TrackRecoveryAlgorithm::Run()
         }
 
         for (const CaloHit *const pCaloHit : mergeHitsU)
-        {
             pfoToMergeHitsMap[pPfo][TPC_VIEW_U].emplace_back(pCaloHit);
-            //const CartesianVector position{pCaloHit->GetPositionVector()};
-            //PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge U", RED, 2.f));
-        }
         for (const CaloHit *const pCaloHit : mergeHitsV)
-        {
             pfoToMergeHitsMap[pPfo][TPC_VIEW_V].emplace_back(pCaloHit);
-            //const CartesianVector position{pCaloHit->GetPositionVector()};
-            //PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge V", GREEN, 2.f));
-        }
         for (const CaloHit *const pCaloHit : mergeHitsW)
-        {
             pfoToMergeHitsMap[pPfo][TPC_VIEW_W].emplace_back(pCaloHit);
-            //const CartesianVector position{pCaloHit->GetPositionVector()};
-            //PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge W", BLUE, 2.f));
-        }
-        //PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
     }
 
     PfoVector sortedPfos;

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -231,6 +231,8 @@ void TrackRecoveryAlgorithm::FindUnmatchedHits(const CaloHitList &hitsA, const C
         return;
     const LArPlaneContextObject *pPlaneContextObject{dynamic_cast<const LArPlaneContextObject*>(PandoraContentApi::GetEventContextObject(
         *this, "PlaneContext"))};
+    if (!pPlaneContextObject)
+        return;
     const HitType viewB{hitsB.front()->GetHitType()}, viewC{hitsC.front()->GetHitType()};
     for (const CaloHit *const pCaloHitA : hitsA)
     {

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -147,39 +147,42 @@ StatusCode TrackRecoveryAlgorithm::Run()
         {
         }
 
-/*        for (const CaloHit *const pCaloHit : mergeHitsU)
+        for (const CaloHit *const pCaloHit : mergeHitsU)
         {
             pfoToMergeHitsMap[pPfo][TPC_VIEW_U].emplace_back(pCaloHit);
-            const CartesianVector position{pCaloHit->GetPositionVector()};
-            PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge U", RED, 2.f));
+            //const CartesianVector position{pCaloHit->GetPositionVector()};
+            //PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge U", RED, 2.f));
         }
         for (const CaloHit *const pCaloHit : mergeHitsV)
         {
             pfoToMergeHitsMap[pPfo][TPC_VIEW_V].emplace_back(pCaloHit);
-            const CartesianVector position{pCaloHit->GetPositionVector()};
-            PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge V", GREEN, 2.f));
+            //const CartesianVector position{pCaloHit->GetPositionVector()};
+            //PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge V", GREEN, 2.f));
         }
         for (const CaloHit *const pCaloHit : mergeHitsW)
         {
             pfoToMergeHitsMap[pPfo][TPC_VIEW_W].emplace_back(pCaloHit);
-            const CartesianVector position{pCaloHit->GetPositionVector()};
-            PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge W", BLUE, 2.f));
+            //const CartesianVector position{pCaloHit->GetPositionVector()};
+            //PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge W", BLUE, 2.f));
         }
-        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));*/
+        //PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
     }
 
-    std::map<const CaloHit *, int> hitToNumMergesMap;
-    for (auto &[pPfo, viewToMergeHitsMap] : pfoToMergeHitsMap)
+    PfoVector sortedPfos;
+    sortedPfos.reserve(pfoToMergeHitsMap.size());
+    for (const auto &[pPfo, viewToMergeHitsMap] : pfoToMergeHitsMap)
+        sortedPfos.emplace_back(pPfo);
+    std::sort(sortedPfos.begin(), sortedPfos.end(), LArPfoHelper::SortByNHits);
+
+    for (const Pfo *const pPfo : sortedPfos)
     {
+        auto &viewToMergeHitsMap{pfoToMergeHitsMap.at(pPfo)};
         for (auto &[view, mergeHits] : viewToMergeHitsMap)
         {
             const Cluster *pNewCluster{pfoToViewClusterMap[pPfo][view]};
             // Need to allow for the possibility that the view was entirely missing, in which case we need to create a new cluster to merge into
             for (const CaloHit *const pCaloHit : mergeHits)
             {
-                if (hitToNumMergesMap.find(pCaloHit) == hitToNumMergesMap.end())
-                    hitToNumMergesMap[pCaloHit] = 0;
-                hitToNumMergesMap[pCaloHit]++;
                 if (hitToClusterMap.find(pCaloHit) != hitToClusterMap.end())
                 {
                     const Cluster *pOldCluster{hitToClusterMap[pCaloHit]};
@@ -255,12 +258,16 @@ void TrackRecoveryAlgorithm::FindUnmatchedHits(const CaloHitList &hitsA, const C
 void TrackRecoveryAlgorithm::IdentifyHitsToMerge(const Cluster *pCluster, const CaloHitList &clusterHits, const CaloHitSet &unmatchedHits,
     const ClusterToFitMap &clusterToFitMap, CaloHitList &mergeHits) const
 {
+    CaloHitVector sortedHits;
+    std::copy(unmatchedHits.begin(), unmatchedHits.end(), std::back_inserter(sortedHits));
+    std::sort(sortedHits.begin(), sortedHits.end(), LArClusterHelper::SortHitsByPosition);
+
     if (pCluster && (clusterHits.size() > 1) && (clusterToFitMap.find(pCluster) != clusterToFitMap.end()))
     {
         float rLFront{0.f}, rLBack{0.f}, dummy{0.f};
         clusterToFitMap.at(pCluster).GetLocalPosition(clusterHits.front()->GetPositionVector(), rLFront, dummy);
         clusterToFitMap.at(pCluster).GetLocalPosition(clusterHits.back()->GetPositionVector(), rLBack, dummy);
-        for (const CaloHit *const pCaloHit : unmatchedHits)
+        for (const CaloHit *const pCaloHit : sortedHits)
         {
             float rL{0.f};
             clusterToFitMap.at(pCluster).GetLocalPosition(pCaloHit->GetPositionVector(), rL, dummy);
@@ -287,7 +294,7 @@ void TrackRecoveryAlgorithm::IdentifyHitsToMerge(const Cluster *pCluster, const 
     else
     {
         // Entire view is missing, or has less than 3 hits, so we should merge all unmatched hits
-        for (const CaloHit *const pCaloHit : unmatchedHits)
+        for (const CaloHit *const pCaloHit : sortedHits)
             mergeHits.emplace_back(pCaloHit);
     }
 }

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -82,7 +82,7 @@ StatusCode TrackRecoveryAlgorithm::Run()
     }
 
     // Loop over the PFOs and project 3D hits from two views into the third view to look for unassociated hits
-    PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
+    //PANDORA_MONITORING_API(SetEveDisplayParameters(this->GetPandora(), true, DETECTOR_VIEW_XZ, -1.f, 1.f, 1.f));
     std::unordered_map<const Pfo *, std::unordered_map<HitType, CaloHitList>> pfoToMergeHitsMap;
     for (const Pfo *const pPfo : *pPfoList)
     {
@@ -97,9 +97,9 @@ StatusCode TrackRecoveryAlgorithm::Run()
         this->FindUnmatchedHits(hitsW, hitsU, hitsV, unmatchedHitsU, unmatchedHitsV);
 
         // Construct 3D hits from the combinatorics of each view pair and project into the third view
-        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsU, "U", RED));
+        /*PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsU, "U", RED));
         PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsV, "V", GREEN));
-        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsW, "W", BLUE));
+        PANDORA_MONITORING_API(VisualizeCaloHits(this->GetPandora(), &hitsW, "W", BLUE));*/
 
         this->IdentifyHitsToMerge(pClusterU, hitsU, unmatchedHitsU, clusterToFitMap, mergeHitsU);
         this->IdentifyHitsToMerge(pClusterV, hitsV, unmatchedHitsV, clusterToFitMap, mergeHitsV);
@@ -147,7 +147,7 @@ StatusCode TrackRecoveryAlgorithm::Run()
         {
         }
 
-        for (const CaloHit *const pCaloHit : mergeHitsU)
+/*        for (const CaloHit *const pCaloHit : mergeHitsU)
         {
             pfoToMergeHitsMap[pPfo][TPC_VIEW_U].emplace_back(pCaloHit);
             const CartesianVector position{pCaloHit->GetPositionVector()};
@@ -165,7 +165,7 @@ StatusCode TrackRecoveryAlgorithm::Run()
             const CartesianVector position{pCaloHit->GetPositionVector()};
             PANDORA_MONITORING_API(AddMarkerToVisualization(this->GetPandora(), &position, "Merge W", BLUE, 2.f));
         }
-        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));
+        PANDORA_MONITORING_API(ViewEvent(this->GetPandora()));*/
     }
 
     std::map<const CaloHit *, int> hitToNumMergesMap;
@@ -210,10 +210,17 @@ std::optional<TwoDSlidingFitResult> TrackRecoveryAlgorithm::FitAndOrderCluster(c
         return std::nullopt;
     }
     const HitType view{LArClusterHelper::GetClusterHitType(pCluster)};
-    TwoDSlidingFitResult sfr(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), view));
-    LArClusterHelper::OrderHitsAlongTrajectory(pCluster, sfr, orderedHits);
-
-    return sfr;
+    try
+    {
+        TwoDSlidingFitResult sfr(pCluster, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), view));
+        LArClusterHelper::OrderHitsAlongTrajectory(pCluster, sfr, orderedHits);
+        return sfr;
+    }
+    catch (const StatusCodeException &)
+    {
+        LArClusterHelper::GetAllHits(pCluster, orderedHits);
+        return std::nullopt;
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.cc
@@ -100,47 +100,27 @@ StatusCode TrackRecoveryAlgorithm::Run()
         this->IdentifyHitsToMerge(pClusterV, hitsV, unmatchedHitsV, clusterToFitMap, mergeHitsV);
         this->IdentifyHitsToMerge(pClusterW, hitsW, unmatchedHitsW, clusterToFitMap, mergeHitsW);
 
-        CartesianPointVector newPosU;
-        for (const CaloHit *const pCaloHit : hitsU)
-            newPosU.emplace_back(pCaloHit->GetPositionVector());
-        for (const CaloHit *const pCaloHit : mergeHitsU)
-            newPosU.emplace_back(pCaloHit->GetPositionVector());
-        try
+        auto filterMergeHits = [this](const CaloHitList &hits, CaloHitList &mergeHits, const HitType view)
         {
-            TwoDSlidingFitResult sfrU(&newPosU, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_U));
-            this->FilterHitsToMerge(sfrU, mergeHitsU);
-        }
-        catch (const StatusCodeException &)
-        {
-        }
+            CartesianPointVector newPos;
+            for (const CaloHit *const pCaloHit : hits)
+                newPos.emplace_back(pCaloHit->GetPositionVector());
+            for (const CaloHit *const pCaloHit : mergeHits)
+                newPos.emplace_back(pCaloHit->GetPositionVector());
 
-        CartesianPointVector newPosV;
-        for (const CaloHit *const pCaloHit : hitsV)
-            newPosV.emplace_back(pCaloHit->GetPositionVector());
-        for (const CaloHit *const pCaloHit : mergeHitsV)
-            newPosV.emplace_back(pCaloHit->GetPositionVector());
-        try
-        {
-            TwoDSlidingFitResult sfrV(&newPosV, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_V));
-            this->FilterHitsToMerge(sfrV, mergeHitsV);
-        }
-        catch (const StatusCodeException &)
-        {
-        }
+            try
+            {
+                TwoDSlidingFitResult sfr(&newPos, 3, LArGeometryHelper::GetWirePitch(this->GetPandora(), view));
+                this->FilterHitsToMerge(sfr, mergeHits);
+            }
+            catch (const StatusCodeException &)
+            {
+            }
+        };
 
-        CartesianPointVector newPosW;
-        for (const CaloHit *const pCaloHit : hitsW)
-            newPosW.emplace_back(pCaloHit->GetPositionVector());
-        for (const CaloHit *const pCaloHit : mergeHitsW)
-            newPosW.emplace_back(pCaloHit->GetPositionVector());
-        try
-        {
-            TwoDSlidingFitResult sfrW(&newPosW, 2, LArGeometryHelper::GetWirePitch(this->GetPandora(), TPC_VIEW_W));
-            this->FilterHitsToMerge(sfrW, mergeHitsW);
-        }
-        catch (const StatusCodeException &)
-        {
-        }
+        filterMergeHits(hitsU, mergeHitsU, TPC_VIEW_U);
+        filterMergeHits(hitsV, mergeHitsV, TPC_VIEW_V);
+        filterMergeHits(hitsW, mergeHitsW, TPC_VIEW_W);
 
         for (const CaloHit *const pCaloHit : mergeHitsU)
             pfoToMergeHitsMap[pPfo][TPC_VIEW_U].emplace_back(pCaloHit);

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
@@ -1,0 +1,52 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
+ *
+ *  @brief  Header file for the track recovery algorithm class.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_TRACK_RECOVERY_ALGORITHM_H
+#define LAR_TRACK_RECOVERY_ALGORITHM_H 1
+
+#include "Pandora/Algorithm.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  TrackRecoveryAlgorithm class
+ */
+class TrackRecoveryAlgorithm : public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    TrackRecoveryAlgorithm();
+
+private:
+    typedef std::unordered_map<pandora::HitType, const pandora::Cluster *> ViewToClusterMap;
+    typedef std::unordered_map<const pandora::Pfo *, ViewToClusterMap> PfoToViewClusterMap;
+    typedef std::unordered_map<const pandora::Cluster *, pandora::CaloHitList> ClusterToHitMap;
+    typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterToMap;
+    typedef std::unordered_map<const pandora::Cluster *, const pandora::Pfo *> ClusterToPfoMap;
+
+    pandora::StatusCode Run();
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief  Performs a sliding linear fit to get an ordered set of hits along a cluster trajectory.
+     *
+     *  @param  pCluster the cluster for which hits should be ordered
+     *  @param  orderedHits the list in which to store the ordered hits
+     */
+    void FitAndOrderCluster(const pandora::Cluster *const pCluster, pandora::CaloHitList &orderedHits) const;
+
+    std::string m_inputPfoListName; ///< The name of the input PFO list containing track-like PFOs
+    pandora::StringVector m_inputClusterListNames; ///< The list of cluster list names to consider when looking for clusters to recover
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_TRACK_RECOVERY_ALGORITHM_H

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
@@ -33,7 +33,6 @@ private:
     typedef std::unordered_map<const pandora::Cluster *, const TwoDSlidingFitResult> ClusterToFitMap;
     typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterToMap;
     typedef std::unordered_map<const pandora::Cluster *, const pandora::Pfo *> ClusterToPfoMap;
-    typedef std::unordered_map<pandora::HitType, pandora::CaloHitList> ViewToHitsMap;
 
     pandora::StatusCode Run();
 
@@ -74,6 +73,15 @@ private:
      */
     void IdentifyHitsToMerge(const pandora::Cluster *pCluster, const pandora::CaloHitList &clusterHits, const pandora::CaloHitSet &unmatchedHits,
         const ClusterToFitMap &clusterToFitMap, pandora::CaloHitList &mergeHits) const;
+
+    /**
+     *  @brief  Filters a list of hits to merge based on their perpendicular distance to the sliding fit for the cluster.
+     *          This is a final quality cut to ensure we only merge hits that are consistent with the existing cluster.
+     *
+     *  @param  sfr the sliding fit result for the cluster
+     *  @param[in,out]  mergeHits the list of hits provisionally identified for merging, which is filtered in place
+     */
+    void FilterHitsToMerge(const TwoDSlidingFitResult &sfr, pandora::CaloHitList &mergeHits) const;
 
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
@@ -10,7 +10,10 @@
 
 #include "Pandora/Algorithm.h"
 
+#include "larpandoracontent/LArObjects/LArTwoDSlidingFitResult.h"
+
 #include <optional>
+#include <unordered_map>
 
 namespace lar_content
 {

--- a/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
+++ b/larpandoracontent/LArThreeDReco/LArPfoRecovery/TrackRecoveryAlgorithm.h
@@ -10,6 +10,8 @@
 
 #include "Pandora/Algorithm.h"
 
+#include <optional>
+
 namespace lar_content
 {
 
@@ -28,12 +30,12 @@ private:
     typedef std::unordered_map<pandora::HitType, const pandora::Cluster *> ViewToClusterMap;
     typedef std::unordered_map<const pandora::Pfo *, ViewToClusterMap> PfoToViewClusterMap;
     typedef std::unordered_map<const pandora::Cluster *, pandora::CaloHitList> ClusterToHitMap;
+    typedef std::unordered_map<const pandora::Cluster *, const TwoDSlidingFitResult> ClusterToFitMap;
     typedef std::unordered_map<const pandora::CaloHit *, const pandora::Cluster *> HitToClusterToMap;
     typedef std::unordered_map<const pandora::Cluster *, const pandora::Pfo *> ClusterToPfoMap;
+    typedef std::unordered_map<pandora::HitType, pandora::CaloHitList> ViewToHitsMap;
 
     pandora::StatusCode Run();
-
-    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     /**
      *  @brief  Performs a sliding linear fit to get an ordered set of hits along a cluster trajectory.
@@ -41,7 +43,39 @@ private:
      *  @param  pCluster the cluster for which hits should be ordered
      *  @param  orderedHits the list in which to store the ordered hits
      */
-    void FitAndOrderCluster(const pandora::Cluster *const pCluster, pandora::CaloHitList &orderedHits) const;
+    std::optional<TwoDSlidingFitResult> FitAndOrderCluster(const pandora::Cluster *const pCluster, pandora::CaloHitList &orderedHits) const;
+
+    /**
+     *  @brief  Identifies hits that are missing from the PFO based on independent triplet matching. hitsA acts as the reference list to look
+     *          up the hit triplets. Hits are deemed missing if two of the three hits in a triplet are present in the PFO.
+     *
+     *  @param  hitsA the list of hits in the reference view
+     *  @param  hitsB the list of hits in the second view
+     *  @param  hitsC the list of hits in the third view
+     *  @param  unmatchedHitsB the set in which to store hits missing in only the second view
+     *  @param  unmatchedHitsC the set in which to store hits missing in only the third view
+     */
+    void FindUnmatchedHits(const pandora::CaloHitList &hitsA, const pandora::CaloHitList &hitsB, const pandora::CaloHitList &hitsC,
+        pandora::CaloHitSet &unmatchedHitsB, pandora::CaloHitSet &unmatchedHitsC) const;
+
+    /**
+     *  @brief  Identifies hits to merge from a collection of hits provisionally identified as being missing from a cluster.
+     *          If a candidate hit lies along the existing set of hits, we look for a gap in the existing set that could be filled by this hit.
+     *          If we find one, we consider this a valid addition. Alternatively, if a candidate hit lies outside the existing set of hits, we
+     *          assume this is an extension of the track and consider this a valid addition. If there are no existing hits in the cluster, we
+     *          assume the view was missing, and add all hits. The key assumption here is that the unmatched hits are already considered good
+     *          candidates based on the triplet matching.
+     *
+     *  @param  pCluster the cluster for which to identify hits to merge
+     *  @param  clusterHits the list of hits already associated to the cluster
+     *  @param  unmatchedHits the set of hits not in the cluster, under consideration for merging
+     *  @param  clusterToFitMap the map containing sliding fit results for clusters
+     *  @param  mergeHits the list in which to store hits to merge
+     */
+    void IdentifyHitsToMerge(const pandora::Cluster *pCluster, const pandora::CaloHitList &clusterHits, const pandora::CaloHitSet &unmatchedHits,
+        const ClusterToFitMap &clusterToFitMap, pandora::CaloHitList &mergeHits) const;
+
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
 
     std::string m_inputPfoListName; ///< The name of the input PFO list containing track-like PFOs
     pandora::StringVector m_inputClusterListNames; ///< The list of cluster list names to consider when looking for clusters to recover

--- a/larpandoradlcontent/LArTrackShowerId/DlTrackCharacterisationAlgorithm.cc
+++ b/larpandoradlcontent/LArTrackShowerId/DlTrackCharacterisationAlgorithm.cc
@@ -233,8 +233,7 @@ pandora::StatusCode DlTrackCharacterisationAlgorithm::GetAllTrackFeatures(PfoToT
         std::advance(iter, p);
 
         CaloHitList trackHits;
-        // This actually gets all 2D calo hits
-        LArPfoHelper::GetAllCaloHits(*iter, trackHits);
+        LArPfoHelper::GetAllCaloHits2D(*iter, trackHits);
         if (trackHits.empty())
             continue;
 
@@ -300,7 +299,7 @@ void DlTrackCharacterisationAlgorithm::GetTrackAuxillaryInfo(const ParticleFlowO
         if (pDescendantPfo == pPfo)
             continue;
         CaloHitList descendantHits;
-        LArPfoHelper::GetAllCaloHits(pDescendantPfo, descendantHits);
+        LArPfoHelper::GetAllCaloHits2D(pDescendantPfo, descendantHits);
         nDescendantHits += descendantHits.size();
     }
     trackFeatures.AddAuxillaryValue(nDescendantHits);


### PR DESCRIPTION
This PR adds algorithms to try to recover tracks that have been merged into other particles. Supporting this is a `PlaneSolverAlgorithm` that produces an orthogonal 2D->3D hit matching as a cross-check for inter-view matching.

- Discontinuities in the rate of charge deposition are identified and correlated across views, with particles being split if a discontinuity exists.
- Tracks that exist in two views, but not the third are re-analysed to identify clusters that might be extracted for a full three view matching.