### PR TITLE
Make more extensive geometry information available to Pandora algorithms

### DIFF
--- a/cmake/LArContent_sources.cmake
+++ b/cmake/LArContent_sources.cmake
@@ -102,6 +102,7 @@ set(LAR_CONTENT_SRCS
     larpandoracontent/LArObjects/LArTwoDSlidingShowerFitResult.cc
     larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
     larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
+    larpandoracontent/LArPersistency/LArTPCFactory.cc
     larpandoracontent/LArPlugins/LArParticleIdPlugins.cc
     larpandoracontent/LArPlugins/LArPseudoLayerPlugin.cc
     larpandoracontent/LArPlugins/LArRotationalTransformationPlugin.cc

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -1104,6 +1104,8 @@ void MasterAlgorithm::AppendReadoutVolumeParameters(const LArTPC &larTPC, const 
             object_creation::LArReadoutUnitParameters unitParams;
             unitParams.m_id = readoutUnit.GetId();
             unitParams.m_view = readoutUnit.GetView();
+            unitParams.m_referenceCoordinate = readoutUnit.GetReferenceCoordinate();
+            unitParams.m_pitch = readoutUnit.GetPitch();
 
             for (const LArReadoutChannel &channel : readoutUnit.GetReadoutChannels())
             {

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -1106,6 +1106,8 @@ void MasterAlgorithm::AppendReadoutVolumeParameters(const LArTPC &larTPC, const 
             unitParams.m_view = readoutUnit.GetView();
             unitParams.m_referenceCoordinate = readoutUnit.GetReferenceCoordinate();
             unitParams.m_pitch = readoutUnit.GetPitch();
+            unitParams.m_unitCenter = readoutUnit.GetUnitCenter();
+            unitParams.m_unitSize = readoutUnit.GetUnitSize();
 
             for (const LArReadoutChannel &channel : readoutUnit.GetReadoutChannels())
             {

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.cc
@@ -658,6 +658,19 @@ StatusCode MasterAlgorithm::Copy(const Pandora *const pPandora, const CaloHit *c
     }
     LArCaloHitParameters parameters;
     pLArCaloHit->FillParameters(parameters);
+
+    // For merged worker instances, remap the hit's volume ids to match the merged LArTPC's renumbered readout volumes
+    if ((pPandora == m_pSlicingWorkerInstance) || (pPandora == m_pSliceNuWorkerInstance) || (pPandora == m_pSliceCRWorkerInstance))
+    {
+        const auto offsetIter(m_daughterVolumeIdOffsetMap.find(pLArCaloHit->GetLArTPCVolumeId()));
+
+        if (m_daughterVolumeIdOffsetMap.end() == offsetIter)
+            return STATUS_CODE_FAILURE;
+
+        parameters.m_larTPCVolumeId = 0;
+        parameters.m_daughterVolumeId = offsetIter->second + pLArCaloHit->GetDaughterVolumeId();
+    }
+
     PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::CaloHit::Create(*pPandora, parameters, m_larCaloHitFactory));
 
     if (m_passMCParticlesToWorkerInstances)
@@ -940,6 +953,7 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(
     larTPCParameters.m_wireAngleW = larTPC.GetWireAngleW();
     larTPCParameters.m_sigmaUVW = larTPC.GetSigmaUVW();
     larTPCParameters.m_isDriftInPositiveX = larTPC.IsDriftInPositiveX();
+    this->AppendReadoutVolumeParameters(larTPC, 0, larTPCParameters.m_readoutVolumeParametersVector);
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LArTPC::Create(*pPandora, larTPCParameters));
 
     const float tpcMinX(larTPC.GetCenterX() - 0.5f * larTPC.GetWidthX()), tpcMaxX(larTPC.GetCenterX() + 0.5f * larTPC.GetWidthX());
@@ -1036,6 +1050,19 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(
     larTPCParameters.m_wireAngleW = pFirstLArTPC->GetWireAngleW();
     larTPCParameters.m_sigmaUVW = pFirstLArTPC->GetSigmaUVW();
     larTPCParameters.m_isDriftInPositiveX = pFirstLArTPC->IsDriftInPositiveX();
+
+    // Merge in readout volumes from every child TPC, keeping ids unique, and record the offset used for each original LArTPC so hits copied
+    // into this worker can be remapped consistently in Copy()
+    unsigned int idOffset(0);
+    for (const LArTPCMap::value_type &mapEntry : larTPCMap)
+    {
+        const LArTPC *const pLArTPC(mapEntry.second);
+        // ATTN: This gets rebuilt on each call at startup (slicing), but it's always consistent, so it's fine to do this.
+        m_daughterVolumeIdOffsetMap[pLArTPC->GetLArTPCVolumeId()] = idOffset;
+        this->AppendReadoutVolumeParameters(*pLArTPC, idOffset, larTPCParameters.m_readoutVolumeParametersVector);
+        idOffset += pLArTPC->GetReadoutVolumes().size();
+    }
+
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::Geometry::LArTPC::Create(*pPandora, larTPCParameters));
 
     // The Gaps
@@ -1058,6 +1085,37 @@ const Pandora *MasterAlgorithm::CreateWorkerInstance(
     // Configuration
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraApi::ReadSettings(*pPandora, settingsFile));
     return pPandora;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void MasterAlgorithm::AppendReadoutVolumeParameters(const LArTPC &larTPC, const unsigned int idOffset,
+    object_creation::LArReadoutVolumeParametersVector &readoutVolumeParametersVector) const
+{
+    for (const auto &[_, readoutVolume] : larTPC.GetReadoutVolumes())
+    {
+        object_creation::LArReadoutVolumeParameters readoutVolumeParams;
+        readoutVolumeParams.m_id = idOffset + readoutVolume.GetId();
+        readoutVolumeParams.m_center = readoutVolume.GetCenter();
+        readoutVolumeParams.m_size = readoutVolume.GetSize();
+
+        for (const LArReadoutUnit &readoutUnit : readoutVolume.GetReadoutUnits())
+        {
+            object_creation::LArReadoutUnitParameters unitParams;
+            unitParams.m_id = readoutUnit.GetId();
+            unitParams.m_view = readoutUnit.GetView();
+
+            for (const LArReadoutChannel &channel : readoutUnit.GetReadoutChannels())
+            {
+                object_creation::LArReadoutChannelParameters channelParams;
+                channelParams.m_id = channel.GetId();
+                channelParams.m_channelIntervalArray = channel.GetChannelIntervals();
+                unitParams.m_channelParametersVector.push_back(channelParams);
+            }
+            readoutVolumeParams.m_readoutUnitParametersVector.push_back(unitParams);
+        }
+        readoutVolumeParametersVector.push_back(readoutVolumeParams);
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArControlFlow/MasterAlgorithm.h
+++ b/larpandoracontent/LArControlFlow/MasterAlgorithm.h
@@ -288,6 +288,17 @@ protected:
         const std::string &settingsFile, const std::string &name) const;
 
     /**
+     *  @brief  Append the readout volume parameters from a given LArTPC into a readout volume parameters vector, offsetting each readout volume's
+     *          id to maintain uniqueness when merging multiple LArTPCs into one worker instance
+     *
+     *  @param  larTPC the source LArTPC
+     *  @param  idOffset the offset to apply to each readout volume's id
+     *  @param  readoutVolumeParametersVector the vector to append to
+     */
+    void AppendReadoutVolumeParameters(const pandora::LArTPC &larTPC, const unsigned int idOffset,
+        object_creation::LArReadoutVolumeParametersVector &readoutVolumeParametersVector) const;
+
+    /**
      *  @brief  Register custom content, such as algorithms or algorithm tools, with a specified pandora instance
      *
      *  @param  pPandora the address of the pandora instance
@@ -327,6 +338,7 @@ protected:
     const pandora::Pandora *m_pSlicingWorkerInstance; ///< The slicing worker instance
     const pandora::Pandora *m_pSliceNuWorkerInstance; ///< The per-slice neutrino reconstruction worker instance
     const pandora::Pandora *m_pSliceCRWorkerInstance; ///< The per-slice cosmic-ray reconstruction worker instance
+    mutable std::map<unsigned int, unsigned int> m_daughterVolumeIdOffsetMap; ///< Maps original LArTPC volume id -> id offset for merged instances
 
     bool m_fullWidthCRWorkerWireGaps;        ///< Whether wire-type line gaps in cosmic-ray worker instances should cover all drift time
     bool m_passMCParticlesToWorkerInstances; ///< Whether to pass mc particle details (and links to calo hits) to worker instances

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.cc
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.cc
@@ -640,4 +640,48 @@ bool LArGeometryHelper::IsInDetector(const DetectorBoundaries &detectorBoundarie
     return true;
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const LArTPC &LArGeometryHelper::GetLArTPC(const Pandora &pandora, const LArCaloHit &caloHit)
+{
+    const LArTPCMap &larTPCMap(pandora.GetGeometry()->GetLArTPCMap());
+    LArTPCMap::const_iterator iter(larTPCMap.find(caloHit.GetLArTPCVolumeId()));
+
+    if (larTPCMap.end() == iter)
+        throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+
+    return *(iter->second);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const LArReadoutVolume &LArGeometryHelper::GetReadoutVolume(const Pandora &pandora, const LArCaloHit &caloHit)
+{
+    const LArTPC &larTPC(LArGeometryHelper::GetLArTPC(pandora, caloHit));
+    return larTPC.GetReadoutVolume(caloHit.GetDaughterVolumeId());
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const LArReadoutUnit &LArGeometryHelper::GetReadoutUnit(const Pandora &pandora, const LArCaloHit &caloHit)
+{
+    const LArReadoutVolume &readoutVolume(LArGeometryHelper::GetReadoutVolume(pandora, caloHit));
+
+    for (const LArReadoutUnit &readoutUnit : readoutVolume.GetReadoutUnits())
+    {
+        if (readoutUnit.GetView() == caloHit.GetHitType())
+            return readoutUnit;
+    }
+
+    throw StatusCodeException(STATUS_CODE_NOT_FOUND);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+const LArReadoutChannel &LArGeometryHelper::GetReadoutChannel(const Pandora &pandora, const LArCaloHit &caloHit)
+{
+    const LArReadoutUnit &readoutUnit(LArGeometryHelper::GetReadoutUnit(pandora, caloHit));
+    return readoutUnit.GetReadoutChannel(caloHit.GetChannelId());
+}
+
 } // namespace lar_content

--- a/larpandoracontent/LArHelpers/LArGeometryHelper.h
+++ b/larpandoracontent/LArHelpers/LArGeometryHelper.h
@@ -8,6 +8,12 @@
 #ifndef LAR_GEOMETRY_HELPER_H
 #define LAR_GEOMETRY_HELPER_H 1
 
+#include "larpandoracontent/LArObjects/LArCaloHit.h"
+
+#include "Geometry/LArReadoutChannel.h"
+#include "Geometry/LArReadoutUnit.h"
+#include "Geometry/LArReadoutVolume.h"
+#include "Geometry/LArTPC.h"
 #include "Objects/Cluster.h"
 #include "Pandora/PandoraEnumeratedTypes.h"
 #include "Pandora/StatusCodes.h"
@@ -304,6 +310,38 @@ public:
      *  @return Whether the input position is within the detector
      */
     static bool IsInDetector(const DetectorBoundaries &detectorBoundaries, const pandora::CartesianVector &position);
+
+    /**
+     *  @brief  Get the LArTPC associated with a given calo hit
+     *
+     *  @param  pandora the associated pandora instance
+     *  @param  caloHit the calo hit
+     */
+    static const pandora::LArTPC &GetLArTPC(const pandora::Pandora &pandora, const LArCaloHit &caloHit);
+
+    /**
+     *  @brief  Get the readout volume associated with a given calo hit
+     *
+     *  @param  pandora the associated pandora instance
+     *  @param  caloHit the calo hit
+     */
+    static const pandora::LArReadoutVolume &GetReadoutVolume(const pandora::Pandora &pandora, const LArCaloHit &caloHit);
+
+    /**
+     *  @brief  Get the readout unit associated with a given calo hit
+     *
+     *  @param  pandora the associated pandora instance
+     *  @param  caloHit the calo hit
+     */
+    static const pandora::LArReadoutUnit &GetReadoutUnit(const pandora::Pandora &pandora, const LArCaloHit &caloHit);
+
+    /**
+     *  @brief  Get the readout channel associated with a given calo hit
+     *
+     *  @param  pandora the associated pandora instance
+     *  @param  caloHit the calo hit
+     */
+    static const pandora::LArReadoutChannel &GetReadoutChannel(const pandora::Pandora &pandora, const LArCaloHit &caloHit);
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArObjects/LArCaloHit.h
+++ b/larpandoracontent/LArObjects/LArCaloHit.h
@@ -24,8 +24,10 @@ namespace lar_content
 class LArCaloHitParameters : public object_creation::CaloHit::Parameters
 {
 public:
-    pandora::InputUInt m_larTPCVolumeId;    ///< The lar tpc volume id
-    pandora::InputUInt m_daughterVolumeId;  ///< The daughter volume id
+    pandora::InputUInt m_larTPCVolumeId;   ///< The lar tpc volume id
+    pandora::InputUInt m_daughterVolumeId; ///< The daughter volume id
+    pandora::InputUInt m_channelId;        ///< The channel (wire) id
+
     pandora::FloatVector m_hitScores;       ///< Hit scores
     pandora::StringVector m_hitScoreLabels; ///< Labels for the hit scores
 };
@@ -58,6 +60,13 @@ public:
      *  @return the daughter volume id
      */
     unsigned int GetDaughterVolumeId() const;
+
+    /**
+     *  @brief  Get the channel (wire) id
+     *
+     *  @return the channel id
+     */
+    unsigned int GetChannelId() const;
 
     /**
      *  @brief  Fill the parameters associated with this calo hit
@@ -111,6 +120,7 @@ public:
 private:
     unsigned int m_larTPCVolumeId;          ///< The lar tpc volume id
     unsigned int m_daughterVolumeId;        ///< The daughter volume id
+    unsigned int m_channelId;               ///< The channel (wire) id
     pandora::FloatVector m_hitScores;       ///< Hit scores
     pandora::StringVector m_hitScoreLabels; ///< Labels for the hit scores
     pandora::InputFloat m_pTrack;           ///< The probability that the hit is track-like
@@ -164,6 +174,7 @@ inline LArCaloHit::LArCaloHit(const LArCaloHitParameters &parameters) :
     object_creation::CaloHit::Object(parameters),
     m_larTPCVolumeId(parameters.m_larTPCVolumeId.Get()),
     m_daughterVolumeId(parameters.m_daughterVolumeId.IsInitialized() ? parameters.m_daughterVolumeId.Get() : 0),
+    m_channelId(parameters.m_channelId.IsInitialized() ? parameters.m_channelId.Get() : 0),
     m_hitScores(parameters.m_hitScores),
     m_hitScoreLabels(parameters.m_hitScoreLabels)
 {
@@ -185,7 +196,14 @@ inline unsigned int LArCaloHit::GetDaughterVolumeId() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline const pandora::FloatVector  &LArCaloHit::GetHitScores() const
+inline unsigned int LArCaloHit::GetChannelId() const
+{
+    return m_channelId;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const pandora::FloatVector &LArCaloHit::GetHitScores() const
 {
     return m_hitScores;
 }
@@ -224,6 +242,7 @@ inline void LArCaloHit::FillParameters(LArCaloHitParameters &parameters) const
     parameters.m_pParentAddress = static_cast<const void *>(this);
     parameters.m_larTPCVolumeId = this->GetLArTPCVolumeId();
     parameters.m_daughterVolumeId = this->GetDaughterVolumeId();
+    parameters.m_channelId = this->GetChannelId();
     parameters.m_hitScores = this->GetHitScores();
     parameters.m_hitScoreLabels = this->GetHitScoreLabels();
 }

--- a/larpandoracontent/LArObjects/LArCaloHit.h
+++ b/larpandoracontent/LArObjects/LArCaloHit.h
@@ -13,10 +13,7 @@
 #include "Pandora/ObjectCreation.h"
 #include "Pandora/PandoraObjectFactories.h"
 
-#include "Persistency/BinaryFileReader.h"
-#include "Persistency/BinaryFileWriter.h"
-#include "Persistency/XmlFileReader.h"
-#include "Persistency/XmlFileWriter.h"
+#include "Persistency/FieldMap.h"
 
 namespace lar_content
 {
@@ -27,9 +24,8 @@ namespace lar_content
 class LArCaloHitParameters : public object_creation::CaloHit::Parameters
 {
 public:
-    pandora::InputUInt m_larTPCVolumeId;   ///< The lar tpc volume id
-    pandora::InputUInt m_daughterVolumeId; ///< The daughter volume id
-
+    pandora::InputUInt m_larTPCVolumeId;    ///< The lar tpc volume id
+    pandora::InputUInt m_daughterVolumeId;  ///< The daughter volume id
     pandora::FloatVector m_hitScores;       ///< Hit scores
     pandora::StringVector m_hitScoreLabels; ///< Labels for the hit scores
 };
@@ -130,13 +126,6 @@ class LArCaloHitFactory : public pandora::ObjectFactory<object_creation::CaloHit
 {
 public:
     /**
-     *  @brief  Constructor
-     *
-     *  @param  version the LArCaloHit version
-     */
-    LArCaloHitFactory(const unsigned int version = 1);
-
-    /**
      *  @brief  Create new parameters instance on the heap (memory-management to be controlled by user)
      *
      *  @return the address of the new parameters instance
@@ -144,12 +133,12 @@ public:
     Parameters *NewParameters() const;
 
     /**
-     *  @brief  Read any additional (derived class only) object parameters from file using the specified file reader
-     *
-     *  @param  parameters the parameters to pass in constructor
-     *  @param  fileReader the file reader, used to extract any additional parameters from file
+     *  @brief  Read additional (LArCaloHit-specific) parameters from the FieldMap.
+     *          Fields: larTPCVolumeId, daughterVolumeId, nHitScores,
+     *                  hitScore_N, hitScoreLabel_N (indexed per score).
+     *          All fields use GetOrDefault so files without them are handled gracefully.
      */
-    pandora::StatusCode Read(Parameters &parameters, pandora::FileReader &fileReader) const;
+    pandora::StatusCode Read(Parameters &parameters, const pandora::FieldMap &fields) const;
 
     /**
      *  @brief  Persist any additional (derived class only) object parameters using the specified file writer
@@ -157,7 +146,7 @@ public:
      *  @param  pObject the address of the object to persist
      *  @param  fileWriter the file writer
      */
-    pandora::StatusCode Write(const Object *const pObject, pandora::FileWriter &fileWriter) const;
+    pandora::StatusCode Write(const Object *const pObject, pandora::FieldMap &fields) const;
 
     /**
      *  @brief  Create an object with the given parameters
@@ -166,9 +155,6 @@ public:
      *  @param  pObject to receive the address of the object created
      */
     pandora::StatusCode Create(const Parameters &parameters, const Object *&pObject) const;
-
-private:
-    unsigned int m_version; ///< The LArCaloHit version
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -199,7 +185,7 @@ inline unsigned int LArCaloHit::GetDaughterVolumeId() const
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline const pandora::FloatVector &LArCaloHit::GetHitScores() const
+inline const pandora::FloatVector  &LArCaloHit::GetHitScores() const
 {
     return m_hitScores;
 }
@@ -215,10 +201,10 @@ inline const pandora::StringVector &LArCaloHit::GetHitScoreLabels() const
 
 inline void LArCaloHit::FillParameters(LArCaloHitParameters &parameters) const
 {
+    parameters.m_cellGeometry = this->GetCellGeometry();
     parameters.m_positionVector = this->GetPositionVector();
     parameters.m_expectedDirection = this->GetExpectedDirection();
     parameters.m_cellNormalVector = this->GetCellNormalVector();
-    parameters.m_cellGeometry = this->GetCellGeometry();
     parameters.m_cellSize0 = this->GetCellSize0();
     parameters.m_cellSize1 = this->GetCellSize1();
     parameters.m_cellThickness = this->GetCellThickness();
@@ -279,13 +265,6 @@ inline void LArCaloHit::SetShowerProbability(const float probability)
 //------------------------------------------------------------------------------------------------------------------------------------------
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline LArCaloHitFactory::LArCaloHitFactory(const unsigned int version) :
-    m_version(version)
-{
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
 inline LArCaloHitFactory::Parameters *LArCaloHitFactory::NewParameters() const
 {
     return (new LArCaloHitParameters);
@@ -303,127 +282,50 @@ inline pandora::StatusCode LArCaloHitFactory::Create(const Parameters &parameter
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, pandora::FileReader &fileReader) const
+inline pandora::StatusCode LArCaloHitFactory::Read(Parameters &parameters, const pandora::FieldMap &fields) const
 {
-    // ATTN: To receive this call-back must have already set file reader mc particle factory to this factory
-    unsigned int larTPCVolumeId(std::numeric_limits<unsigned int>::max());
-    unsigned int daughterVolumeId(0);
-    unsigned int nLabels(0);
-    pandora::FloatVector hitScores;
-    pandora::StringVector hitScoreLabels;
+    LArCaloHitParameters &p(dynamic_cast<LArCaloHitParameters &>(parameters));
 
-    if (pandora::BINARY == fileReader.GetFileType())
+    p.m_larTPCVolumeId   = fields.GetOrDefault<unsigned int>("larTPCVolumeId",  0u);
+    p.m_daughterVolumeId = fields.GetOrDefault<unsigned int>("daughterVolumeId", 0u);
+
+    const unsigned int nHitScores = fields.GetOrDefault<unsigned int>("nHitScores", 0u);
+    p.m_hitScores.reserve(nHitScores);
+    p.m_hitScoreLabels.reserve(nHitScores);
+
+    for (unsigned int i = 0; i < nHitScores; ++i)
     {
-        pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader &>(fileReader));
-        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(larTPCVolumeId));
-        if (m_version > 1)
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(daughterVolumeId));
-        if (m_version > 2)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(nLabels));
-            hitScores.reserve(nLabels);
-            hitScoreLabels.reserve(nLabels);
-            for (unsigned int i = 0; i < nLabels; ++i)
-            {
-                float score;
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(score));
-                hitScores.emplace_back(std::move(score));
-
-                std::string label;
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(label));
-                hitScoreLabels.emplace_back(std::move(label));
-            }
-        }
+        p.m_hitScores.push_back(fields.GetOrDefault<float>(
+            "hitScore_" + std::to_string(i), 0.f));
+        p.m_hitScoreLabels.push_back(fields.GetOrDefault<std::string>(
+            "hitScoreLabel_" + std::to_string(i), std::string()));
     }
-    else if (pandora::XML == fileReader.GetFileType())
-    {
-        pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader &>(fileReader));
-        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("LArTPCVolumeId", larTPCVolumeId));
-        if (m_version > 1)
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("DaughterVolumeId", daughterVolumeId));
-        if (m_version > 2)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("NHitLabels", nLabels));
-            hitScores.reserve(nLabels);
-            hitScoreLabels.reserve(nLabels);
-            for (unsigned int i = 0; i < nLabels; ++i)
-            {
-                float score;
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("HitScore", score));
-                hitScores.emplace_back(std::move(score));
-
-                std::string label;
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("HitScoreLabel", label));
-                hitScoreLabels.emplace_back(std::move(label));
-            }
-        }
-    }
-    else
-    {
-        return pandora::STATUS_CODE_INVALID_PARAMETER;
-    }
-
-    LArCaloHitParameters &larCaloHitParameters(dynamic_cast<LArCaloHitParameters &>(parameters));
-    larCaloHitParameters.m_larTPCVolumeId = larTPCVolumeId;
-    larCaloHitParameters.m_daughterVolumeId = daughterVolumeId;
-    larCaloHitParameters.m_hitScores = std::move(hitScores);
-    larCaloHitParameters.m_hitScoreLabels = std::move(hitScoreLabels);
 
     return pandora::STATUS_CODE_SUCCESS;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArCaloHitFactory::Write(const Object *const pObject, pandora::FileWriter &fileWriter) const
+inline pandora::StatusCode LArCaloHitFactory::Write(const Object *const pObject, pandora::FieldMap &fields) const
 {
-    // ATTN: To receive this call-back must have already set file writer mc particle factory to this factory
     const LArCaloHit *const pLArCaloHit(dynamic_cast<const LArCaloHit *>(pObject));
 
     if (!pLArCaloHit)
         return pandora::STATUS_CODE_INVALID_PARAMETER;
 
-    if (pandora::BINARY == fileWriter.GetFileType())
+    fields.Set("larTPCVolumeId", pLArCaloHit->GetLArTPCVolumeId());
+    fields.Set("daughterVolumeId", pLArCaloHit->GetDaughterVolumeId());
+
+    const pandora::FloatVector &hitScores(pLArCaloHit->GetHitScores());
+    const pandora::StringVector &hitScoreLabels(pLArCaloHit->GetHitScoreLabels());
+    const unsigned int nHitScores(static_cast<unsigned int>(hitScores.size()));
+
+    fields.Set("nHitScores", nHitScores);
+
+    for (unsigned int i = 0; i < nHitScores; ++i)
     {
-        pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter &>(fileWriter));
-        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetLArTPCVolumeId()));
-        if (m_version > 1)
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArCaloHit->GetDaughterVolumeId()));
-        if (m_version > 2)
-        {
-            const pandora::FloatVector &hitScores(pLArCaloHit->GetHitScores());
-            const pandora::StringVector &hitScoreLabels(pLArCaloHit->GetHitScoreLabels());
-            const unsigned int nLabels(hitScores.size());
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(nLabels));
-            for (unsigned int i = 0; i < nLabels; ++i)
-            {
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(hitScores.at(i)));
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(hitScoreLabels.at(i)));
-            }
-        }
-    }
-    else if (pandora::XML == fileWriter.GetFileType())
-    {
-        pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter &>(fileWriter));
-        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("LArTPCVolumeId", pLArCaloHit->GetLArTPCVolumeId()));
-        if (m_version > 1)
-            PANDORA_RETURN_RESULT_IF(
-                pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("DaughterVolumeId", pLArCaloHit->GetDaughterVolumeId()));
-        if (m_version > 2)
-        {
-            const pandora::FloatVector &hitScores(pLArCaloHit->GetHitScores());
-            const pandora::StringVector &hitScoreLabels(pLArCaloHit->GetHitScoreLabels());
-            const unsigned int nLabels(hitScores.size());
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("NHitLabels", nLabels));
-            for (unsigned int i = 0; i < nLabels; ++i)
-            {
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("HitScore", hitScores.at(i)));
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("HitScoreLabel", hitScoreLabels.at(i)));
-            }
-        }
-    }
-    else
-    {
-        return pandora::STATUS_CODE_INVALID_PARAMETER;
+        fields.Set("hitScore_" + std::to_string(i), hitScores.at(i));
+        fields.Set("hitScoreLabel_" + std::to_string(i), hitScoreLabels.at(i));
     }
 
     return pandora::STATUS_CODE_SUCCESS;

--- a/larpandoracontent/LArObjects/LArMCParticle.h
+++ b/larpandoracontent/LArObjects/LArMCParticle.h
@@ -13,10 +13,7 @@
 #include "Pandora/ObjectCreation.h"
 #include "Pandora/PandoraObjectFactories.h"
 
-#include "Persistency/BinaryFileReader.h"
-#include "Persistency/BinaryFileWriter.h"
-#include "Persistency/XmlFileReader.h"
-#include "Persistency/XmlFileWriter.h"
+#include "Persistency/FieldMap.h"
 
 namespace lar_content
 {
@@ -85,11 +82,11 @@ class LArMCParticleParameters : public object_creation::MCParticle::Parameters
 public:
     pandora::InputInt m_nuanceCode;               ///< The nuance code
     pandora::InputInt m_process;                  ///< The process creating the particle
-    pandora::InputBool m_isCC;                    ///< Whether the neutrino interacts via a CC interaction (always false for non-neutrinos)
+    pandora::InputBool m_isCC;                    ///< Whether the neutrino interacts via a CC interaction
     pandora::InputFloat m_visibleEnergy;          ///< Energy 'seen' in the detector
-    pandora::InputCartesianVector m_endDirection; ///< Obtained from the momentum at the penultimate trajectory point
+    pandora::InputCartesianVector m_endDirection; ///< From momentum at penultimate trajectory point
     pandora::InputInt m_nTrajPoints;              ///< Number of trajectory points
-    pandora::CartesianPointVector m_trajPoints;   ///< the MCParticle trajectory points
+    pandora::CartesianPointVector m_trajPoints;   ///< The MCParticle trajectory points
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -136,6 +133,7 @@ public:
      */
     bool GetIsCC() const;
 
+
     /**
      *  @brief  Get the visible energy
      *
@@ -167,12 +165,12 @@ public:
 
 private:
     int m_nuanceCode;                           ///< The nuance code
-    int m_process;                              ///< The process that created the particle
-    bool m_isCC;                                ///< Whether the neutrino interacts via a CC interaction (always false for non-neutrinos)
+    int m_process;                              ///< The process creating the particle
+    bool m_isCC;                                ///< Whether the neutrino interacts via a CC interaction
     float m_visibleEnergy;                      ///< Energy 'seen' in the detector
-    pandora::CartesianVector m_endDirection;    ///< Obtained from the momentum at the penultimate trajectory point
-    int m_nTrajPoints;                          ///< The number of trajectory points
-    pandora::CartesianPointVector m_trajPoints; ///< the MCParticle trajectory points
+    pandora::CartesianVector m_endDirection;    ///< From momentum at penultimate trajectory point
+    int m_nTrajPoints;                          ///< Number of trajectory points
+    pandora::CartesianPointVector m_trajPoints; ///< The MCParticle trajectory points
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -184,13 +182,6 @@ class LArMCParticleFactory : public pandora::ObjectFactory<object_creation::MCPa
 {
 public:
     /**
-     *  @brief  Constructor
-     *
-     *  @param  version the LArMCParticle version
-     */
-    LArMCParticleFactory(const unsigned int version = 3);
-
-    /**
      *  @brief  Create new parameters instance on the heap (memory-management to be controlled by user)
      *
      *  @return the address of the new parameters instance
@@ -198,12 +189,12 @@ public:
     Parameters *NewParameters() const;
 
     /**
-     *  @brief  Read any additional (derived class only) object parameters from file using the specified file reader
-     *
-     *  @param  parameters the parameters to pass in constructor
-     *  @param  fileReader the file reader, used to extract any additional parameters from file
+     *  @brief  Read additional (LArMCParticle-specific) parameters from the FieldMap.
+     *          Fields: nuanceCode, process, isCC, visibleEnergy, endDirection,
+     *                  nTrajPoints, trajPoint_N (CartesianVector, indexed).
+     *          All fields use GetOrDefault so files without them are handled gracefully.
      */
-    pandora::StatusCode Read(Parameters &parameters, pandora::FileReader &fileReader) const;
+    pandora::StatusCode Read(Parameters &parameters, const pandora::FieldMap &fields) const;
 
     /**
      *  @brief  Persist any additional (derived class only) object parameters using the specified file writer
@@ -211,7 +202,7 @@ public:
      *  @param  pObject the address of the object to persist
      *  @param  fileWriter the file writer
      */
-    pandora::StatusCode Write(const Object *const pObject, pandora::FileWriter &fileWriter) const;
+    pandora::StatusCode Write(const Object *const pObject, pandora::FieldMap &fields) const;
 
     /**
      *  @brief  Create an object with the given parameters
@@ -220,9 +211,6 @@ public:
      *  @param  pObject to receive the address of the object created
      */
     pandora::StatusCode Create(const Parameters &parameters, const Object *&pObject) const;
-
-private:
-    unsigned int m_version; ///< The LArMCParticle version
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -245,6 +233,13 @@ inline LArMCParticle::LArMCParticle(const LArMCParticleParameters &parameters) :
 inline int LArMCParticle::GetNuanceCode() const
 {
     return m_nuanceCode;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline MCProcess LArMCParticle::GetProcess() const
+{
+    return MCProcess(m_process);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -287,37 +282,23 @@ inline const pandora::CartesianPointVector &LArMCParticle::GetTrajPoints() const
 inline void LArMCParticle::FillParameters(LArMCParticleParameters &parameters) const
 {
     parameters.m_nuanceCode = this->GetNuanceCode();
+    parameters.m_process = this->GetProcess();
+    parameters.m_isCC = this->GetIsCC();
     parameters.m_visibleEnergy = this->GetVisibleEnergy();
     parameters.m_endDirection = this->GetEndDirection();
     parameters.m_nTrajPoints = this->GetNTrajPoints();
     parameters.m_trajPoints = this->GetTrajPoints();
-    parameters.m_process = this->GetProcess();
-    parameters.m_isCC = this->GetIsCC();
     parameters.m_energy = this->GetEnergy();
     parameters.m_momentum = this->GetMomentum();
     parameters.m_vertex = this->GetVertex();
     parameters.m_endpoint = this->GetEndpoint();
     parameters.m_particleId = this->GetParticleId();
-    parameters.m_mcParticleType = this->GetMCParticleType();
+    parameters.m_mcParticleType= this->GetMCParticleType();
     // ATTN Set the parent address to the original owner of the mc particle
     parameters.m_pParentAddress = static_cast<const void *>(this);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
-
-inline MCProcess LArMCParticle::GetProcess() const
-{
-    return MCProcess(m_process);
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline LArMCParticleFactory::LArMCParticleFactory(const unsigned int version) :
-    m_version(version)
-{
-}
-
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 inline LArMCParticleFactory::Parameters *LArMCParticleFactory::NewParameters() const
@@ -337,167 +318,51 @@ inline pandora::StatusCode LArMCParticleFactory::Create(const Parameters &parame
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArMCParticleFactory::Read(Parameters &parameters, pandora::FileReader &fileReader) const
+inline pandora::StatusCode LArMCParticleFactory::Read(Parameters &parameters, const pandora::FieldMap &fields) const
 {
-    // ATTN: To receive this call-back must have already set file reader mc particle factory to this factory
-    int nuanceCode(0);
-    int process(0);
-    bool isCC(false);
-    float visibleEnergy(0.f);
-    pandora::CartesianVector endDirection(0.f, 0.f, 0.f);
-    int nTrajPoints(0);
-    pandora::CartesianPointVector trajPoints;
+    LArMCParticleParameters &p(dynamic_cast<LArMCParticleParameters &>(parameters));
 
-    if (pandora::BINARY == fileReader.GetFileType())
+    p.m_nuanceCode = fields.GetOrDefault<int>("nuanceCode", 0);
+    p.m_process = fields.GetOrDefault<int>("process", static_cast<int>(MC_PROC_UNKNOWN));
+    p.m_isCC = fields.GetOrDefault<bool>("isCC", false);
+    p.m_visibleEnergy = fields.GetOrDefault<float>("visibleEnergy", 0.f);
+    p.m_endDirection = fields.GetOrDefault<pandora::CartesianVector>("endDirection", pandora::CartesianVector(0.f, 0.f, 0.f));
+
+    const int nTrajPoints = fields.GetOrDefault<int>("nTrajPoints", 0);
+    p.m_nTrajPoints = nTrajPoints;
+    p.m_trajPoints.reserve(static_cast<std::size_t>(nTrajPoints));
+
+    for (int i = 0; i < nTrajPoints; ++i)
     {
-        pandora::BinaryFileReader &binaryFileReader(dynamic_cast<pandora::BinaryFileReader &>(fileReader));
-        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(nuanceCode));
-
-        if (m_version > 1)
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(process));
-
-        if (m_version > 2)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(isCC));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(visibleEnergy));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(endDirection));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(nTrajPoints));
-
-            for (int iTraj = 0; iTraj < nTrajPoints; ++iTraj)
-            {
-                float trajPointX(0.f), trajPointY(0.f), trajPointZ(0.f);
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(trajPointX));
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(trajPointY));
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileReader.ReadVariable(trajPointZ));
-                trajPoints.emplace_back(pandora::CartesianVector(trajPointX, trajPointY, trajPointZ));
-            }
-        }
+        p.m_trajPoints.push_back(fields.GetOrDefault<pandora::CartesianVector>(
+            "trajPoint_" + std::to_string(i), pandora::CartesianVector(0.f, 0.f, 0.f)));
     }
-    else if (pandora::XML == fileReader.GetFileType())
-    {
-        pandora::XmlFileReader &xmlFileReader(dynamic_cast<pandora::XmlFileReader &>(fileReader));
-        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("NuanceCode", nuanceCode));
-
-        if (m_version > 1)
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("Process", process));
-
-        if (m_version > 2)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("IsCC", isCC));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("VisibleEnergy", visibleEnergy));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("EndDirection", endDirection));
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("NTrajPoints", nTrajPoints));
-
-            for (int iTraj = 0; iTraj < nTrajPoints; ++iTraj)
-            {
-                float trajPointX(0.f), trajPointY(0.f), trajPointZ(0.f);
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("TrajPointX", trajPointX));
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("TrajPointY", trajPointY));
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileReader.ReadVariable("TrajPointZ", trajPointZ));
-                trajPoints.emplace_back(pandora::CartesianVector(trajPointX, trajPointY, trajPointZ));
-            }
-        }
-    }
-    else
-    {
-        return pandora::STATUS_CODE_INVALID_PARAMETER;
-    }
-
-    LArMCParticleParameters &larMCParticleParameters(dynamic_cast<LArMCParticleParameters &>(parameters));
-    larMCParticleParameters.m_nuanceCode = nuanceCode;
-    larMCParticleParameters.m_process = process;
-    larMCParticleParameters.m_isCC = isCC;
-    larMCParticleParameters.m_visibleEnergy = visibleEnergy;
-    larMCParticleParameters.m_endDirection = endDirection;
-    larMCParticleParameters.m_nTrajPoints = nTrajPoints;
-    larMCParticleParameters.m_trajPoints = trajPoints;
 
     return pandora::STATUS_CODE_SUCCESS;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArMCParticleFactory::Write(const Object *const pObject, pandora::FileWriter &fileWriter) const
+inline pandora::StatusCode LArMCParticleFactory::Write(const Object *const pObject, pandora::FieldMap &fields) const
 {
-    // ATTN: To receive this call-back must have already set file writer mc particle factory to this factory
     const LArMCParticle *const pLArMCParticle(dynamic_cast<const LArMCParticle *>(pObject));
 
     if (!pLArMCParticle)
         return pandora::STATUS_CODE_INVALID_PARAMETER;
 
-    if (pandora::BINARY == fileWriter.GetFileType())
-    {
-        pandora::BinaryFileWriter &binaryFileWriter(dynamic_cast<pandora::BinaryFileWriter &>(fileWriter));
-        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArMCParticle->GetNuanceCode()));
+    fields.Set("nuanceCode", pLArMCParticle->GetNuanceCode());
+    fields.Set("process", static_cast<int>(pLArMCParticle->GetProcess()));
+    fields.Set("isCC", pLArMCParticle->GetIsCC());
+    fields.Set("visibleEnergy", pLArMCParticle->GetVisibleEnergy());
+    fields.Set("endDirection", pLArMCParticle->GetEndDirection());
 
-        if (m_version > 1)
-            PANDORA_RETURN_RESULT_IF(
-                pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(static_cast<int>(pLArMCParticle->GetProcess())));
+    const pandora::CartesianPointVector &trajPoints(pLArMCParticle->GetTrajPoints());
+    const int nTrajPoints(pLArMCParticle->GetNTrajPoints());
 
-        if (m_version > 2)
-        {
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(static_cast<bool>(pLArMCParticle->GetIsCC())));
+    fields.Set("nTrajPoints", nTrajPoints);
 
-            PANDORA_RETURN_RESULT_IF(
-                pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(static_cast<float>(pLArMCParticle->GetVisibleEnergy())));
-
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(pLArMCParticle->GetEndDirection()));
-
-            const int nTrajPoints(pLArMCParticle->GetNTrajPoints());
-
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(static_cast<int>(nTrajPoints)));
-
-            for (const pandora::CartesianVector &trajPoint : pLArMCParticle->GetTrajPoints())
-            {
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(static_cast<float>(trajPoint.GetX())));
-
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(static_cast<float>(trajPoint.GetY())));
-
-                PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, binaryFileWriter.WriteVariable(static_cast<float>(trajPoint.GetZ())));
-            }
-        }
-    }
-    else if (pandora::XML == fileWriter.GetFileType())
-    {
-        pandora::XmlFileWriter &xmlFileWriter(dynamic_cast<pandora::XmlFileWriter &>(fileWriter));
-        PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("NuanceCode", pLArMCParticle->GetNuanceCode()));
-
-        if (m_version > 1)
-            PANDORA_RETURN_RESULT_IF(
-                pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("Process", static_cast<int>(pLArMCParticle->GetProcess())));
-
-        if (m_version > 2)
-        {
-            PANDORA_RETURN_RESULT_IF(
-                pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("IsCC", static_cast<bool>(pLArMCParticle->GetIsCC())));
-
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,
-                xmlFileWriter.WriteVariable("VisibleEnergy", static_cast<float>(pLArMCParticle->GetVisibleEnergy())));
-
-            PANDORA_RETURN_RESULT_IF(
-                pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("EndDirection", (pLArMCParticle->GetEndDirection())));
-
-            const int nTrajPoints(pLArMCParticle->GetNTrajPoints());
-
-            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("NTrajPoints", static_cast<int>(nTrajPoints)));
-
-            for (const pandora::CartesianVector &trajPoint : pLArMCParticle->GetTrajPoints())
-            {
-                PANDORA_RETURN_RESULT_IF(
-                    pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("TrajPointX", static_cast<float>(trajPoint.GetX())));
-
-                PANDORA_RETURN_RESULT_IF(
-                    pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("TrajPointY", static_cast<float>(trajPoint.GetY())));
-
-                PANDORA_RETURN_RESULT_IF(
-                    pandora::STATUS_CODE_SUCCESS, !=, xmlFileWriter.WriteVariable("TrajPointZ", static_cast<float>(trajPoint.GetZ())));
-            }
-        }
-    }
-    else
-    {
-        return pandora::STATUS_CODE_INVALID_PARAMETER;
-    }
+    for (int i = 0; i < nTrajPoints; ++i)
+        fields.Set("trajPoint_" + std::to_string(i), trajPoints.at(static_cast<std::size_t>(i)));
 
     return pandora::STATUS_CODE_SUCCESS;
 }

--- a/larpandoracontent/LArObjects/LArShowerPfo.h
+++ b/larpandoracontent/LArObjects/LArShowerPfo.h
@@ -135,17 +135,17 @@ public:
      *  @brief  Read any additional (derived class only) object parameters from file using the specified file reader
      *
      *  @param  parameters the parameters to pass in constructor
-     *  @param  fileReader the file reader, used to extract any additional parameters from file
+     *  @param  fields the field map to read from
      */
-    pandora::StatusCode Read(Parameters &parameters, pandora::FileReader &fileReader) const;
+    pandora::StatusCode Read(Parameters &parameters, const pandora::FieldMap &fields) const;
 
     /**
      *  @brief  Persist any additional (derived class only) object parameters using the specified file writer
      *
      *  @param  pObject the address of the object to persist
-     *  @param  fileWriter the file writer
+     *  @param  fields the field map to write to
      */
-    pandora::StatusCode Write(const Object *const pObject, pandora::FileWriter &fileWriter) const;
+    pandora::StatusCode Write(const Object *const pObject, pandora::FieldMap &fields) const;
 
     /**
      *  @brief  Create an object with the given parameters
@@ -247,7 +247,7 @@ inline pandora::StatusCode LArShowerPfoFactory::Create(const Parameters &paramet
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArShowerPfoFactory::Read(Parameters &, pandora::FileReader &) const
+inline pandora::StatusCode LArShowerPfoFactory::Read(Parameters &, const pandora::FieldMap &) const
 {
     // TODO: Provide this functionality if necessary
 
@@ -256,7 +256,7 @@ inline pandora::StatusCode LArShowerPfoFactory::Read(Parameters &, pandora::File
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArShowerPfoFactory::Write(const pandora::ParticleFlowObject *, pandora::FileWriter &) const
+inline pandora::StatusCode LArShowerPfoFactory::Write(const pandora::ParticleFlowObject *, pandora::FieldMap &) const
 {
     // TODO: Provide this functionality if necessary
 

--- a/larpandoracontent/LArObjects/LArTrackPfo.h
+++ b/larpandoracontent/LArObjects/LArTrackPfo.h
@@ -95,17 +95,17 @@ public:
      *  @brief  Read any additional (derived class only) object parameters from file using the specified file reader
      *
      *  @param  parameters the parameters to pass in constructor
-     *  @param  fileReader the file reader, used to extract any additional parameters from file
+     *  @param  fields the field map to read from
      */
-    pandora::StatusCode Read(Parameters &parameters, pandora::FileReader &fileReader) const;
+    pandora::StatusCode Read(Parameters &parameters, const pandora::FieldMap &fields) const;
 
     /**
      *  @brief  Persist any additional (derived class only) object parameters using the specified file writer
      *
      *  @param  pObject the address of the object to persist
-     *  @param  fileWriter the file writer
+     *  @param  fields the field map to write to
      */
-    pandora::StatusCode Write(const pandora::ParticleFlowObject *const pObject, pandora::FileWriter &fileWriter) const;
+    pandora::StatusCode Write(const pandora::ParticleFlowObject *const pObject, pandora::FieldMap &fields) const;
 
     /**
      *  @brief  Create an object with the given parameters
@@ -136,7 +136,7 @@ inline pandora::StatusCode LArTrackPfoFactory::Create(const Parameters &paramete
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArTrackPfoFactory::Read(Parameters &, pandora::FileReader &) const
+inline pandora::StatusCode LArTrackPfoFactory::Read(Parameters &, const pandora::FieldMap &) const
 {
     // TODO: Provide this functionality when necessary
 
@@ -145,7 +145,7 @@ inline pandora::StatusCode LArTrackPfoFactory::Read(Parameters &, pandora::FileR
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
-inline pandora::StatusCode LArTrackPfoFactory::Write(const pandora::ParticleFlowObject *, pandora::FileWriter &) const
+inline pandora::StatusCode LArTrackPfoFactory::Write(const pandora::ParticleFlowObject *, pandora::FieldMap &) const
 {
     // TODO: Provide this functionality when necessary
 

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
@@ -15,6 +15,7 @@
 #include "larpandoracontent/LArObjects/LArMCParticle.h"
 
 #include "larpandoracontent/LArPersistency/EventReadingAlgorithm.h"
+#include "larpandoracontent/LArPersistency/LArTPCFactory.h"
 
 #include <algorithm>
 
@@ -49,12 +50,14 @@ StatusCode EventReadingAlgorithm::Initialize()
         if (BINARY == geometryFileType)
         {
             BinaryFileReader fileReader(this->GetPandora(), m_geometryFileName);
+            fileReader.SetFactory(new LArTPCFactory());
             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, fileReader.ReadGlobalHeader());
             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, fileReader.ReadGeometry());
         }
         else if (XML == geometryFileType)
         {
             XmlFileReader fileReader(this->GetPandora(), m_geometryFileName);
+            fileReader.SetFactory(new LArTPCFactory());
             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, fileReader.ReadGlobalHeader());
             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, fileReader.ReadGeometry());
         }

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.cc
@@ -25,11 +25,8 @@ namespace lar_content
 
 EventReadingAlgorithm::EventReadingAlgorithm() :
     m_skipToEvent(0),
-    m_isEnhancedEventFile(false),
     m_useLArCaloHits(true),
-    m_larCaloHitVersion(1),
     m_useLArMCParticles(true),
-    m_larMCParticleVersion(2),
     m_pEventFileReader(nullptr)
 {
 }
@@ -52,11 +49,13 @@ StatusCode EventReadingAlgorithm::Initialize()
         if (BINARY == geometryFileType)
         {
             BinaryFileReader fileReader(this->GetPandora(), m_geometryFileName);
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, fileReader.ReadGlobalHeader());
             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, fileReader.ReadGeometry());
         }
         else if (XML == geometryFileType)
         {
             XmlFileReader fileReader(this->GetPandora(), m_geometryFileName);
+            PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, fileReader.ReadGlobalHeader());
             PANDORA_RETURN_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, fileReader.ReadGeometry());
         }
         else
@@ -68,10 +67,7 @@ StatusCode EventReadingAlgorithm::Initialize()
     if (!m_eventFileName.empty())
     {
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReplaceEventFileReader(m_eventFileName));
-
-        if (m_isEnhancedEventFile)
-            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileReader->ReadGlobalHeader());
-
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileReader->ReadGlobalHeader());
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileReader->GoToEvent(m_skipToEvent));
     }
 
@@ -109,9 +105,7 @@ void EventReadingAlgorithm::MoveToNextEventFile()
     m_eventFileName = m_eventFileNameVector.back();
     m_eventFileNameVector.pop_back();
     PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->ReplaceEventFileReader(m_eventFileName));
-
-    if (m_isEnhancedEventFile)
-        PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileReader->ReadGlobalHeader());
+    PANDORA_THROW_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pEventFileReader->ReadGlobalHeader());
 
     try
     {
@@ -134,23 +128,17 @@ StatusCode EventReadingAlgorithm::ReplaceEventFileReader(const std::string &file
     const FileType eventFileType(this->GetFileType(fileName));
 
     if (BINARY == eventFileType)
-    {
         m_pEventFileReader = new BinaryFileReader(this->GetPandora(), fileName);
-    }
     else if (XML == eventFileType)
-    {
         m_pEventFileReader = new XmlFileReader(this->GetPandora(), fileName);
-    }
     else
-    {
         return STATUS_CODE_FAILURE;
-    }
 
     if (m_useLArCaloHits)
-        m_pEventFileReader->SetFactory(new LArCaloHitFactory(m_larCaloHitVersion));
+        m_pEventFileReader->SetFactory(new LArCaloHitFactory());
 
     if (m_useLArMCParticles)
-        m_pEventFileReader->SetFactory(new LArMCParticleFactory(m_larMCParticleVersion));
+        m_pEventFileReader->SetFactory(new LArMCParticleFactory());
 
     return STATUS_CODE_SUCCESS;
 }
@@ -163,13 +151,9 @@ FileType EventReadingAlgorithm::GetFileType(const std::string &fileName) const
     std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), ::tolower);
 
     if (std::string(".xml") == fileExtension)
-    {
         return XML;
-    }
     else if (std::string(".pndr") == fileExtension)
-    {
         return BINARY;
-    }
     else
     {
         std::cout << "EventReadingAlgorithm: Unknown file type specified " << fileName << std::endl;
@@ -192,24 +176,16 @@ StatusCode EventReadingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     }
 
     if (pExternalParameters && !pExternalParameters->m_geometryFileName.empty())
-    {
         m_geometryFileName = pExternalParameters->m_geometryFileName;
-    }
     else
-    {
         PANDORA_RETURN_RESULT_IF_AND_IF(
             STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "GeometryFileName", m_geometryFileName));
-    }
 
     if (pExternalParameters && !pExternalParameters->m_eventFileNameList.empty())
-    {
         XmlHelper::TokenizeString(pExternalParameters->m_eventFileNameList, m_eventFileNameVector, ":");
-    }
     else
-    {
         PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
             XmlHelper::ReadVectorOfValues(xmlHandle, "EventFileNameList", m_eventFileNameVector));
-    }
 
     if (!m_eventFileNameVector.empty())
     {
@@ -219,13 +195,10 @@ StatusCode EventReadingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     }
 
     if (pExternalParameters && pExternalParameters->m_skipToEvent.IsInitialized())
-    {
         m_skipToEvent = pExternalParameters->m_skipToEvent.Get();
-    }
     else
-    {
-        PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SkipToEvent", m_skipToEvent));
-    }
+        PANDORA_RETURN_RESULT_IF_AND_IF(
+            STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "SkipToEvent", m_skipToEvent));
 
     if (m_geometryFileName.empty() && m_eventFileName.empty())
     {
@@ -234,15 +207,7 @@ StatusCode EventReadingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     }
 
     PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "IsEnhancedEventFile", m_isEnhancedEventFile));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArCaloHits", m_useLArCaloHits));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LArCaloHitVersion", m_larCaloHitVersion));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LArMCParticleVersion", m_larMCParticleVersion));
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArCaloHits", m_useLArCaloHits));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(
         STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArMCParticles", m_useLArMCParticles));

--- a/larpandoracontent/LArPersistency/EventReadingAlgorithm.h
+++ b/larpandoracontent/LArPersistency/EventReadingAlgorithm.h
@@ -46,9 +46,9 @@ public:
     class ExternalEventReadingParameters : public pandora::ExternalParameters
     {
     public:
-        std::string m_geometryFileName;   ///< Name of the file containing geometry information
-        std::string m_eventFileNameList;  ///< Colon-separated list of file names to be processed
-        pandora::InputUInt m_skipToEvent; ///< Index of first event to consider in input file
+        std::string m_geometryFileName;     ///< Name of the file containing geometry information
+        std::string m_eventFileNameList;    ///< Colon-separated list of file names to be processed
+        pandora::InputUInt m_skipToEvent;   ///< Index of first event to consider in input file
     };
 
 private:
@@ -82,12 +82,9 @@ private:
     std::string m_eventFileName;                 ///< Name of the current file containing event information
     pandora::StringVector m_eventFileNameVector; ///< Vector of file names to be processed
 
-    unsigned int m_skipToEvent;          ///< Index of first event to consider in first input file
-    bool m_isEnhancedEventFile;          ///< Whether the event file has a 'file describing' block
-    bool m_useLArCaloHits;               ///< Whether to read lar calo hits, or standard pandora calo hits
-    unsigned int m_larCaloHitVersion;    ///< LArCaloHit version for LArCaloHitFactory
-    bool m_useLArMCParticles;            ///< Whether to read lar mc particles, or standard pandora mc particles
-    unsigned int m_larMCParticleVersion; ///< LArMCParticle version for LArMCParticleFactory
+    unsigned int m_skipToEvent; ///< Index of first event to consider in first input file
+    bool m_useLArCaloHits;      ///< Whether to read lar calo hits, or standard pandora calo hits
+    bool m_useLArMCParticles;   ///< Whether to read lar mc particles, or standard pandora mc particles
 
     pandora::FileReader *m_pEventFileReader; ///< Address of the event file reader
 };

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
@@ -32,15 +32,12 @@ EventWritingAlgorithm::EventWritingAlgorithm() :
     m_shouldWriteGeometry(false),
     m_writtenGeometry(false),
     m_shouldWriteEvents(true),
-    m_fileMajorVersion(2),
-    m_fileMinorVersion(0),
     m_writtenEventGlobalHeader(false),
     m_shouldWriteMCRelationships(true),
     m_shouldWriteTrackRelationships(true),
     m_shouldOverwriteEventFile(false),
     m_shouldOverwriteGeometryFile(false),
     m_useLArCaloHits(true),
-    m_larCaloHitVersion(1),
     m_useLArMCParticles(true),
     m_shouldFilterByNuanceCode(false),
     m_filterNuanceCode(0),
@@ -83,17 +80,11 @@ StatusCode EventWritingAlgorithm::Initialize()
         const FileMode fileMode(m_shouldOverwriteGeometryFile ? OVERWRITE : APPEND);
 
         if (BINARY == m_geometryFileType)
-        {
-            m_pGeometryFileWriter = new BinaryFileWriter(this->GetPandora(), m_geometryFileName, fileMode, m_fileMajorVersion, m_fileMinorVersion);
-        }
+            m_pGeometryFileWriter = new BinaryFileWriter(this->GetPandora(), m_geometryFileName, fileMode);
         else if (XML == m_geometryFileType)
-        {
-            m_pGeometryFileWriter = new XmlFileWriter(this->GetPandora(), m_geometryFileName, fileMode, m_fileMajorVersion, m_fileMinorVersion);
-        }
+            m_pGeometryFileWriter = new XmlFileWriter(this->GetPandora(), m_geometryFileName, fileMode);
         else
-        {
             return STATUS_CODE_FAILURE;
-        }
     }
 
     if (m_shouldWriteEvents)
@@ -101,23 +92,17 @@ StatusCode EventWritingAlgorithm::Initialize()
         const FileMode fileMode(m_shouldOverwriteEventFile ? OVERWRITE : APPEND);
 
         if (BINARY == m_eventFileType)
-        {
-            m_pEventFileWriter = new BinaryFileWriter(this->GetPandora(), m_eventFileName, fileMode, m_fileMajorVersion, m_fileMinorVersion);
-        }
+            m_pEventFileWriter = new BinaryFileWriter(this->GetPandora(), m_eventFileName, fileMode);
         else if (XML == m_eventFileType)
-        {
-            m_pEventFileWriter = new XmlFileWriter(this->GetPandora(), m_eventFileName, fileMode, m_fileMajorVersion, m_fileMinorVersion);
-        }
+            m_pEventFileWriter = new XmlFileWriter(this->GetPandora(), m_eventFileName, fileMode);
         else
-        {
             return STATUS_CODE_FAILURE;
-        }
 
         if (m_useLArCaloHits)
-            m_pEventFileWriter->SetFactory(new LArCaloHitFactory(m_larCaloHitVersion));
+            m_pEventFileWriter->SetFactory(new LArCaloHitFactory());
 
         if (m_useLArMCParticles)
-            m_pEventFileWriter->SetFactory(new LArMCParticleFactory);
+            m_pEventFileWriter->SetFactory(new LArMCParticleFactory());
     }
 
     return STATUS_CODE_SUCCESS;
@@ -130,6 +115,7 @@ StatusCode EventWritingAlgorithm::Run()
     // ATTN Should complete geometry creation in LArSoft begin job, but some channel status service functionality unavailable at that point
     if (!m_writtenGeometry && m_pGeometryFileWriter && m_shouldWriteGeometry)
     {
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pGeometryFileWriter->WriteGlobalHeader());
         PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, m_pGeometryFileWriter->WriteGeometry());
         m_writtenGeometry = true;
     }
@@ -283,16 +269,12 @@ StatusCode EventWritingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), ::tolower);
 
         if (std::string(".xml") == fileExtension)
-        {
             m_geometryFileType = XML;
-        }
         else if (std::string(".pndr") == fileExtension)
-        {
             m_geometryFileType = BINARY;
-        }
         else
         {
-            std::cout << "EventReadingAlgorithm: Unknown geometry file type specified " << std::endl;
+            std::cout << "EventWritingAlgorithm: Unknown geometry file type specified" << std::endl;
             return STATUS_CODE_INVALID_PARAMETER;
         }
     }
@@ -308,25 +290,15 @@ StatusCode EventWritingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
         std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), ::tolower);
 
         if (std::string(".xml") == fileExtension)
-        {
             m_eventFileType = XML;
-        }
         else if (std::string(".pndr") == fileExtension)
-        {
             m_eventFileType = BINARY;
-        }
         else
         {
-            std::cout << "EventReadingAlgorithm: Unknown event file type specified " << std::endl;
+            std::cout << "EventWritingAlgorithm: Unknown event file type specified" << std::endl;
             return STATUS_CODE_INVALID_PARAMETER;
         }
     }
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FileMajorVersion", m_fileMajorVersion));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "FileMinorVersion", m_fileMinorVersion));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "ShouldWriteMCRelationships", m_shouldWriteMCRelationships));
@@ -340,13 +312,11 @@ StatusCode EventWritingAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "ShouldOverwriteGeometryFile", m_shouldOverwriteGeometryFile));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArCaloHits", m_useLArCaloHits));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseLArCaloHits", m_useLArCaloHits));
 
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "LArCaloHitVersion", m_larCaloHitVersion));
-
-    PANDORA_RETURN_RESULT_IF_AND_IF(
-        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "UseLArMCParticles", m_useLArMCParticles));
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
+        XmlHelper::ReadValue(xmlHandle, "UseLArMCParticles", m_useLArMCParticles));
 
     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=,
         XmlHelper::ReadValue(xmlHandle, "ShouldFilterByNuanceCode", m_shouldFilterByNuanceCode));

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.cc
@@ -18,6 +18,7 @@
 #include "larpandoracontent/LArObjects/LArMCParticle.h"
 
 #include "larpandoracontent/LArPersistency/EventWritingAlgorithm.h"
+#include "larpandoracontent/LArPersistency/LArTPCFactory.h"
 
 using namespace pandora;
 
@@ -85,6 +86,8 @@ StatusCode EventWritingAlgorithm::Initialize()
             m_pGeometryFileWriter = new XmlFileWriter(this->GetPandora(), m_geometryFileName, fileMode);
         else
             return STATUS_CODE_FAILURE;
+
+        m_pGeometryFileWriter->SetFactory(new LArTPCFactory());
     }
 
     if (m_shouldWriteEvents)

--- a/larpandoracontent/LArPersistency/EventWritingAlgorithm.h
+++ b/larpandoracontent/LArPersistency/EventWritingAlgorithm.h
@@ -78,8 +78,6 @@ private:
     bool m_shouldWriteEvents;    ///< Whether to write events to a specified file
     std::string m_eventFileName; ///< Name of the output event file
 
-    unsigned int m_fileMajorVersion; ///< Major version of the output file
-    unsigned int m_fileMinorVersion; ///< Minor version of the output file
     bool m_writtenEventGlobalHeader; ///< Whether the global header has been written to the output event file
 
     bool m_shouldWriteMCRelationships;    ///< Whether to write mc relationship information to the events file
@@ -88,9 +86,8 @@ private:
     bool m_shouldOverwriteEventFile;    ///< Whether to overwrite existing event file with specified name, or append
     bool m_shouldOverwriteGeometryFile; ///< Whether to overwrite existing geometry file with specified name, or append
 
-    bool m_useLArCaloHits;            ///< Whether to write lar calo hits, or standard pandora calo hits
-    unsigned int m_larCaloHitVersion; ///< LArCaloHit version for LArCaloHitFactory
-    bool m_useLArMCParticles;         ///< Whether to write lar mc particles, or standard pandora mc particles
+    bool m_useLArCaloHits;    ///< Whether to write lar calo hits, or standard pandora calo hits
+    bool m_useLArMCParticles; ///< Whether to write lar mc particles, or standard pandora mc particles
 
     bool m_shouldFilterByNuanceCode; ///< Whether to filter output by nuance code
     int m_filterNuanceCode;          ///< The filter nuance code (required if specify filter by nuance code)

--- a/larpandoracontent/LArPersistency/LArTPCFactory.cc
+++ b/larpandoracontent/LArPersistency/LArTPCFactory.cc
@@ -1,0 +1,204 @@
+/**
+ *  @file   larpandoracontent/LArPersistency/LArTPCFactory.cc
+ *
+ *  @brief  Implementation of the lar tpc factory class.
+ *
+ *  $Log: $
+ */
+
+#include "Geometry/LArReadoutChannel.h"
+#include "Geometry/LArReadoutUnit.h"
+#include "Geometry/LArReadoutVolume.h"
+#include "Geometry/LArTPC.h"
+
+#include "larpandoracontent/LArPersistency/LArTPCFactory.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+StatusCode LArTPCFactory::Write(const Object *const pObject, FieldMap &fields) const
+{
+    fields.Set("nReadoutVolumes", static_cast<unsigned int>(pObject->GetReadoutVolumes().size()));
+
+    for (const auto &volumeEntry : pObject->GetReadoutVolumes())
+    {
+        const LArReadoutVolume &volume(volumeEntry.second);
+        const std::string vPrefix("readoutVolume" + std::to_string(volume.GetId()) + "_");
+
+        fields.Set(vPrefix + "center", volume.GetCenter());
+        fields.Set(vPrefix + "size", volume.GetSize());
+        fields.Set(vPrefix + "nUnits", static_cast<unsigned int>(volume.GetReadoutUnits().size()));
+
+        for (const LArReadoutUnit &unit : volume.GetReadoutUnits())
+        {
+            const std::string uPrefix(vPrefix + "unit" + std::to_string(unit.GetId()) + "_");
+
+            fields.Set(uPrefix + "view", unit.GetView());
+            fields.Set(uPrefix + "nChannels", static_cast<unsigned int>(unit.GetReadoutChannels().size()));
+            fields.Set(uPrefix + "referenceCoordinate", unit.GetReferenceCoordinate());
+            fields.Set(uPrefix + "pitch", unit.GetPitch());
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode LArTPCFactory::Read(Parameters &parameters, const FieldMap &fields) const
+{
+    // ATTN Wire angles are read directly from the field map (rather than from parameters), since the caller populates the base LArTPC
+    // fields on parameters only after this method returns.
+    const float thetaU(fields.GetOrDefault<float>("wireAngleU", 0.f));
+    const float thetaV(fields.GetOrDefault<float>("wireAngleV", 0.f));
+    const float thetaW(fields.GetOrDefault<float>("wireAngleW", 0.f));
+
+    const unsigned int nReadoutVolumes(fields.GetOrDefault<unsigned int>("nReadoutVolumes", 0u));
+
+    for (unsigned int v = 0; v < nReadoutVolumes; ++v)
+    {
+        const std::string vPrefix("readoutVolume" + std::to_string(v) + "_");
+
+        object_creation::LArReadoutVolumeParameters volumeParams;
+        volumeParams.m_id = v;
+        volumeParams.m_center = fields.GetOrDefault<CartesianVector>(vPrefix + "center", CartesianVector(0.f, 0.f, 0.f));
+        volumeParams.m_size = fields.GetOrDefault<CartesianVector>(vPrefix + "size", CartesianVector(0.f, 0.f, 0.f));
+
+        const unsigned int nUnits(fields.GetOrDefault<unsigned int>(vPrefix + "nUnits", 0u));
+
+        UnitInfoVector unitInfoVector;
+        for (unsigned int u = 0; u < nUnits; ++u)
+        {
+            const std::string uPrefix(vPrefix + "unit" + std::to_string(u) + "_");
+
+            UnitInfo unitInfo;
+            unitInfo.m_view = fields.GetOrDefault<HitType>(uPrefix + "view", TPC_VIEW_U);
+            unitInfo.m_nChannels = fields.GetOrDefault<unsigned int>(uPrefix + "nChannels", 0u);
+            unitInfo.m_referenceCoordinate = fields.GetOrDefault<float>(uPrefix + "referenceCoordinate", 0.f);
+            unitInfo.m_pitch = fields.GetOrDefault<float>(uPrefix + "pitch", 1.f);
+            unitInfoVector.push_back(unitInfo);
+        }
+
+        for (unsigned int u = 0; u < nUnits; ++u)
+        {
+            const UnitInfo &unitInfo(unitInfoVector.at(u));
+            const float theta(LArTPCFactory::GetWireAngle(unitInfo.m_view, thetaU, thetaV, thetaW));
+
+            object_creation::LArReadoutUnitParameters unitParams;
+            unitParams.m_id = u;
+            unitParams.m_view = unitInfo.m_view;
+            unitParams.m_referenceCoordinate = unitInfo.m_referenceCoordinate;
+            unitParams.m_pitch = unitInfo.m_pitch;
+
+            // Regenerate the per-channel cross-view intervals for this readout unit
+            for (unsigned int c = 0; c < unitInfo.m_nChannels; ++c)
+            {
+                const float selfCoordinate(unitInfo.m_referenceCoordinate + static_cast<float>(c) * unitInfo.m_pitch);
+
+                CartesianVector point1(0.f, 0.f, 0.f), point2(0.f, 0.f, 0.f);
+                LArTPCFactory::ClipLineAgainstBox(selfCoordinate, theta, volumeParams.m_center, volumeParams.m_size, point1, point2);
+
+                object_creation::LArReadoutChannelParameters channelParams;
+                channelParams.m_id = c;
+                std::size_t slot(0);
+
+                for (unsigned int other = 0; other < nUnits; ++other)
+                {
+                    if (other == u)
+                        continue;
+
+                    const UnitInfo &otherInfo(unitInfoVector.at(other));
+                    const float otherTheta(LArTPCFactory::GetWireAngle(otherInfo.m_view, thetaU, thetaV, thetaW));
+
+                    const float coordinate1(LArTPCFactory::ProjectCoordinate(point1.GetY(), point1.GetZ(), otherTheta));
+                    const float coordinate2(LArTPCFactory::ProjectCoordinate(point2.GetY(), point2.GetZ(), otherTheta));
+
+                    const auto toIndex = [&](const float coordinate) -> unsigned int
+                    {
+                        const int rawIndex(static_cast<int>(std::round((coordinate - otherInfo.m_referenceCoordinate) / otherInfo.m_pitch)));
+                        const int clampedIndex(std::max(0, std::min(rawIndex, static_cast<int>(otherInfo.m_nChannels) - 1)));
+                        return static_cast<unsigned int>(clampedIndex);
+                    };
+
+                    const unsigned int index1(toIndex(coordinate1)), index2(toIndex(coordinate2));
+
+                    channelParams.m_channelIntervalArray[slot++] = {otherInfo.m_view,
+                        LArReadoutChannel::ChannelInterval{std::min(index1, index2), std::max(index1, index2)}};
+                }
+
+                unitParams.m_channelParametersVector.push_back(channelParams);
+            }
+
+            volumeParams.m_readoutUnitParametersVector.push_back(unitParams);
+        }
+
+        parameters.m_readoutVolumeParametersVector.push_back(volumeParams);
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LArTPCFactory::ProjectCoordinate(const float y, const float z, const float thetaView)
+{
+    return z * std::cos(thetaView) - y * std::sin(thetaView);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void LArTPCFactory::ClipLineAgainstBox(const float coordinate, const float thetaView, const CartesianVector &boxCenter,
+    const CartesianVector &boxSize, CartesianVector &point1, CartesianVector &point2)
+{
+    const float cosTheta(std::cos(thetaView)), sinTheta(std::sin(thetaView));
+    const float dirY(cosTheta), dirZ(sinTheta);
+
+    const float y0(boxCenter.GetY());
+    const float z0((std::fabs(cosTheta) > 1e-6f) ? (coordinate + y0 * sinTheta) / cosTheta : boxCenter.GetZ());
+
+    const float yMin(boxCenter.GetY() - 0.5f * boxSize.GetY()), yMax(boxCenter.GetY() + 0.5f * boxSize.GetY());
+    const float zMin(boxCenter.GetZ() - 0.5f * boxSize.GetZ()), zMax(boxCenter.GetZ() + 0.5f * boxSize.GetZ());
+
+    float tMin(-std::numeric_limits<float>::max()), tMax(std::numeric_limits<float>::max());
+
+    const auto clip = [&](const float p, const float d, const float lo, const float hi)
+    {
+        if (std::fabs(d) < 1e-9f)
+            return;
+
+        const float t0((lo - p) / d), t1((hi - p) / d);
+        tMin = std::max(tMin, std::min(t0, t1));
+        tMax = std::min(tMax, std::max(t0, t1));
+    };
+
+    clip(y0, dirY, yMin, yMax);
+    clip(z0, dirZ, zMin, zMax);
+
+    point1 = CartesianVector(0.f, y0 + tMin * dirY, z0 + tMin * dirZ);
+    point2 = CartesianVector(0.f, y0 + tMax * dirY, z0 + tMax * dirZ);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float LArTPCFactory::GetWireAngle(const HitType view, const float thetaU, const float thetaV, const float thetaW)
+{
+    switch (view)
+    {
+        case TPC_VIEW_U:
+            return thetaU;
+        case TPC_VIEW_V:
+            return thetaV;
+        case TPC_VIEW_W:
+        default:
+            return thetaW;
+    }
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArPersistency/LArTPCFactory.cc
+++ b/larpandoracontent/LArPersistency/LArTPCFactory.cc
@@ -107,10 +107,6 @@ StatusCode LArTPCFactory::Read(Parameters &parameters, const FieldMap &fields) c
             for (unsigned int c = 0; c < unitInfo.m_nChannels; ++c)
             {
                 const float selfCoordinate(unitInfo.m_referenceCoordinate + static_cast<float>(c) * unitInfo.m_pitch);
-
-                CartesianVector point1(0.f, 0.f, 0.f), point2(0.f, 0.f, 0.f);
-                LArTPCFactory::ClipLineAgainstBox(selfCoordinate, theta, unitInfo.m_unitCenter, unitInfo.m_unitSize, point1, point2);
-
                 object_creation::LArReadoutChannelParameters channelParams;
                 channelParams.m_id = c;
                 std::size_t slot(0);
@@ -123,20 +119,9 @@ StatusCode LArTPCFactory::Read(Parameters &parameters, const FieldMap &fields) c
                     const UnitInfo &otherInfo(unitInfoVector.at(other));
                     const float otherTheta(LArTPCFactory::GetWireAngle(otherInfo.m_view, thetaU, thetaV, thetaW));
 
-                    const float coordinate1(LArTPCFactory::ProjectCoordinate(point1.GetY(), point1.GetZ(), otherTheta));
-                    const float coordinate2(LArTPCFactory::ProjectCoordinate(point2.GetY(), point2.GetZ(), otherTheta));
-
-                    const auto toIndex = [&](const float coordinate) -> unsigned int
-                    {
-                        const int rawIndex(static_cast<int>(std::round((coordinate - otherInfo.m_referenceCoordinate) / otherInfo.m_pitch)));
-                        const int clampedIndex(std::max(0, std::min(rawIndex, static_cast<int>(otherInfo.m_nChannels) - 1)));
-                        return static_cast<unsigned int>(clampedIndex);
-                    };
-
-                    const unsigned int index1(toIndex(coordinate1)), index2(toIndex(coordinate2));
-
                     channelParams.m_channelIntervalArray[slot++] = {otherInfo.m_view,
-                        LArReadoutChannel::ChannelInterval{std::min(index1, index2), std::max(index1, index2)}};
+                        LArTPCFactory::ComputeChannelInterval(selfCoordinate, theta, unitInfo.m_unitCenter, unitInfo.m_unitSize,
+                            otherTheta, otherInfo.m_referenceCoordinate, otherInfo.m_pitch, otherInfo.m_nChannels)};
                 }
 
                 unitParams.m_channelParametersVector.push_back(channelParams);
@@ -189,6 +174,29 @@ void LArTPCFactory::ClipLineAgainstBox(const float coordinate, const float theta
 
     point1 = CartesianVector(0.f, y0 + tMin * dirY, z0 + tMin * dirZ);
     point2 = CartesianVector(0.f, y0 + tMax * dirY, z0 + tMax * dirZ);
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+LArReadoutChannel::ChannelInterval LArTPCFactory::ComputeChannelInterval(const float selfCoordinate, const float thetaSelf,
+    const CartesianVector &selfUnitCenter, const CartesianVector &selfUnitSize, const float thetaOther,
+    const float otherReferenceCoordinate, const float otherPitch, const unsigned int otherNChannels)
+{
+    CartesianVector point1(0.f, 0.f, 0.f), point2(0.f, 0.f, 0.f);
+    LArTPCFactory::ClipLineAgainstBox(selfCoordinate, thetaSelf, selfUnitCenter, selfUnitSize, point1, point2);
+
+    const float coordinate1(LArTPCFactory::ProjectCoordinate(point1.GetY(), point1.GetZ(), thetaOther));
+    const float coordinate2(LArTPCFactory::ProjectCoordinate(point2.GetY(), point2.GetZ(), thetaOther));
+
+    const auto toIndex = [&](const float coordinate) -> unsigned int
+    {
+        const int rawIndex(static_cast<int>(std::round((coordinate - otherReferenceCoordinate) / otherPitch)));
+        const int clampedIndex(std::max(0, std::min(rawIndex, static_cast<int>(otherNChannels) - 1)));
+        return static_cast<unsigned int>(clampedIndex);
+    };
+
+    const unsigned int index1(toIndex(coordinate1)), index2(toIndex(coordinate2));
+    return LArReadoutChannel::ChannelInterval{std::min(index1, index2), std::max(index1, index2)};
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/larpandoracontent/LArPersistency/LArTPCFactory.cc
+++ b/larpandoracontent/LArPersistency/LArTPCFactory.cc
@@ -44,6 +44,8 @@ StatusCode LArTPCFactory::Write(const Object *const pObject, FieldMap &fields) c
             fields.Set(uPrefix + "nChannels", static_cast<unsigned int>(unit.GetReadoutChannels().size()));
             fields.Set(uPrefix + "referenceCoordinate", unit.GetReferenceCoordinate());
             fields.Set(uPrefix + "pitch", unit.GetPitch());
+            fields.Set(uPrefix + "unitCenter", unit.GetUnitCenter());
+            fields.Set(uPrefix + "unitSize", unit.GetUnitSize());
         }
     }
 
@@ -83,6 +85,8 @@ StatusCode LArTPCFactory::Read(Parameters &parameters, const FieldMap &fields) c
             unitInfo.m_nChannels = fields.GetOrDefault<unsigned int>(uPrefix + "nChannels", 0u);
             unitInfo.m_referenceCoordinate = fields.GetOrDefault<float>(uPrefix + "referenceCoordinate", 0.f);
             unitInfo.m_pitch = fields.GetOrDefault<float>(uPrefix + "pitch", 1.f);
+            unitInfo.m_unitCenter = fields.GetOrDefault<CartesianVector>(uPrefix + "unitCenter", CartesianVector(0.f, 0.f, 0.f));
+            unitInfo.m_unitSize = fields.GetOrDefault<CartesianVector>(uPrefix + "unitSize", CartesianVector(0.f, 0.f, 0.f));
             unitInfoVector.push_back(unitInfo);
         }
 
@@ -96,6 +100,8 @@ StatusCode LArTPCFactory::Read(Parameters &parameters, const FieldMap &fields) c
             unitParams.m_view = unitInfo.m_view;
             unitParams.m_referenceCoordinate = unitInfo.m_referenceCoordinate;
             unitParams.m_pitch = unitInfo.m_pitch;
+            unitParams.m_unitCenter = unitInfo.m_unitCenter;
+            unitParams.m_unitSize = unitInfo.m_unitSize;
 
             // Regenerate the per-channel cross-view intervals for this readout unit
             for (unsigned int c = 0; c < unitInfo.m_nChannels; ++c)
@@ -103,7 +109,7 @@ StatusCode LArTPCFactory::Read(Parameters &parameters, const FieldMap &fields) c
                 const float selfCoordinate(unitInfo.m_referenceCoordinate + static_cast<float>(c) * unitInfo.m_pitch);
 
                 CartesianVector point1(0.f, 0.f, 0.f), point2(0.f, 0.f, 0.f);
-                LArTPCFactory::ClipLineAgainstBox(selfCoordinate, theta, volumeParams.m_center, volumeParams.m_size, point1, point2);
+                LArTPCFactory::ClipLineAgainstBox(selfCoordinate, theta, unitInfo.m_unitCenter, unitInfo.m_unitSize, point1, point2);
 
                 object_creation::LArReadoutChannelParameters channelParams;
                 channelParams.m_id = c;

--- a/larpandoracontent/LArPersistency/LArTPCFactory.h
+++ b/larpandoracontent/LArPersistency/LArTPCFactory.h
@@ -1,0 +1,105 @@
+/**
+ *  @file   larpandoracontent/LArPersistency/LArTPCFactory.h
+ *
+ *  @brief  Header file for the lar tpc factory class, responsible for persisting the readout volume/unit/channel
+ *          geometry associated with a LArTPC.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_TPC_FACTORY_H
+#define LAR_TPC_FACTORY_H 1
+
+#include "Objects/CartesianVector.h"
+
+#include "Pandora/ObjectCreation.h"
+#include "Pandora/PandoraObjectFactories.h"
+
+#include "Persistency/FieldMap.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  LArTPCFactory class. Responsible for persisting and reconstructing the readout volume/unit/channel geometry associated with a
+ *          LArTPC.
+ *
+ *          Only the generative parameters of each readout unit are persisted (view, channel count, a reference coordinate for channel 0,
+ *          and the signed pitch between adjacent channels); the per-channel cross-view intervals are recomputed on read, rather than being
+ *          persisted to keep geometry files compact.
+ */
+class LArTPCFactory : public pandora::PandoraObjectFactory<object_creation::Geometry::LArTPC::Parameters, object_creation::Geometry::LArTPC::Object>
+{
+public:
+    /**
+     *  @brief  Read the readout volume/unit/channel parameters from the supplied field map, regenerating the per-channel cross-view
+     *          intervals from the persisted generative parameters.
+     *
+     *  @param  parameters the parameters to populate
+     *  @param  fields the field map from which to read the parameters
+     */
+    pandora::StatusCode Read(Parameters &parameters, const pandora::FieldMap &fields) const;
+
+    /**
+     *  @brief  Write the readout volume/unit/channel parameters into the supplied field map.
+     *
+     *  @param  pObject the address of the lar tpc to persist
+     *  @param  fields the field map into which to write the parameters
+     */
+    pandora::StatusCode Write(const Object *const pObject, pandora::FieldMap &fields) const;
+
+private:
+    /**
+     *  @brief  Collection of per-readout-unit information required while regenerating channel intervals.
+     */
+    class UnitInfo
+    {
+    public:
+        pandora::HitType m_view;     ///< The view of the readout unit
+        unsigned int m_nChannels;    ///< The number of channels in the readout unit
+        float m_referenceCoordinate; ///< The wire-coordinate of channel 0's midpoint
+        float m_pitch;               ///< The signed wire-coordinate difference between adjacent channels
+    };
+
+    typedef std::vector<UnitInfo> UnitInfoVector;
+
+    /**
+     *  @brief  Project a point in the Y-Z plane onto a view's wire-coordinate axis.
+     *
+     *  @param  y the y coordinate
+     *  @param  z the z coordinate
+     *  @param  thetaView the wire angle (to the vertical) of the view being projected onto
+     *
+     *  @return the wire coordinate
+     */
+    static float ProjectCoordinate(const float y, const float z, const float thetaView);
+
+    /**
+     *  @brief  Find the two points at which the line of constant wire-coordinate (for the given view) crosses the Y-Z bounding box of a
+     *          readout volume.
+     *
+     *  @param  coordinate the wire coordinate defining the line
+     *  @param  thetaView the wire angle (to the vertical) of the view the line belongs to
+     *  @param  boxCenter the centre of the readout volume's bounding box
+     *  @param  boxSize the extent of the readout volume's bounding box
+     *  @param  point1 to receive the first crossing point
+     *  @param  point2 to receive the second crossing point
+     */
+    static void ClipLineAgainstBox(const float coordinate, const float thetaView, const pandora::CartesianVector &boxCenter,
+        const pandora::CartesianVector &boxSize, pandora::CartesianVector &point1, pandora::CartesianVector &point2);
+
+    /**
+     *  @brief  Get the wire angle associated with a given view.
+     *
+     *  @param  view the view
+     *  @param  thetaU the u wire angle
+     *  @param  thetaV the v wire angle
+     *  @param  thetaW the w wire angle
+     *
+     *  @return the wire angle associated with the specified view
+     */
+    static float GetWireAngle(const pandora::HitType view, const float thetaU, const float thetaV, const float thetaW);
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_TPC_FACTORY_H

--- a/larpandoracontent/LArPersistency/LArTPCFactory.h
+++ b/larpandoracontent/LArPersistency/LArTPCFactory.h
@@ -58,6 +58,8 @@ private:
         unsigned int m_nChannels;    ///< The number of channels in the readout unit
         float m_referenceCoordinate; ///< The wire-coordinate of channel 0's midpoint
         float m_pitch;               ///< The signed wire-coordinate difference between adjacent channels
+        pandora::CartesianVector m_unitCenter{0.f, 0.f, 0.f}; ///< The center of the readout unit's own active-area box (X unused)
+        pandora::CartesianVector m_unitSize{0.f, 0.f, 0.f};   ///< The size of the readout unit's own active-area box (X unused)
     };
 
     typedef std::vector<UnitInfo> UnitInfoVector;

--- a/larpandoracontent/LArPersistency/LArTPCFactory.h
+++ b/larpandoracontent/LArPersistency/LArTPCFactory.h
@@ -47,6 +47,26 @@ public:
      */
     pandora::StatusCode Write(const Object *const pObject, pandora::FieldMap &fields) const;
 
+    /**
+     *  @brief  Compute the cross-view channel interval for a single channel against a single other view, from the generative
+     *          parameters of both readout units. Used both when regenerating persisted intervals on read, and by LArPandora when
+     *          computing intervals live, so both paths agree exactly.
+     *
+     *  @param  selfCoordinate the wire coordinate of the channel under consideration
+     *  @param  thetaSelf the wire angle of the channel's own view
+     *  @param  selfUnitCenter the centre of the channel's own readout unit active-area box (X unused)
+     *  @param  selfUnitSize the extent of the channel's own readout unit active-area box (X unused)
+     *  @param  thetaOther the wire angle (to the vertical) of the other view
+     *  @param  otherReferenceCoordinate the reference coordinate of the other readout unit
+     *  @param  otherPitch the signed pitch of the other readout unit
+     *  @param  otherNChannels the number of channels in the other readout unit
+     *
+     *  @return the channel interval in the other view
+     */
+    static pandora::LArReadoutChannel::ChannelInterval ComputeChannelInterval(const float selfCoordinate, const float thetaSelf,
+        const pandora::CartesianVector &selfUnitCenter, const pandora::CartesianVector &selfUnitSize, const float thetaOther,
+        const float otherReferenceCoordinate, const float otherPitch, const unsigned int otherNChannels);
+
 private:
     /**
      *  @brief  Collection of per-readout-unit information required while regenerating channel intervals.


### PR DESCRIPTION
This PR enriches the available LArTPC geometry information that is available to algorithms. Child volume information is retained, along with helpers to identify neighbouring volumes (useful for stitching considerations, for example), and wire overlap intervals are calculated to allow for fast identification of candidate inter-plane hit matches. The new structure is

TPC (existing) -> Volume -> Readout Unit (e.g. plane) ->Channel

Hits can be mapped back to any of these structures via helper functions.

There are corresponding SDK and LArPandora branches.