### PR TITLE
New 3D Hit Creation algorithm based on the PlaneSolverAlgorithm

### DIFF
--- a/cmake/LArContent_sources.cmake
+++ b/cmake/LArContent_sources.cmake
@@ -157,6 +157,7 @@ set(LAR_CONTENT_SRCS
     larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedLongitudinalTrackHitsTool.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedTransverseTrackHitsTool.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.cc
+    larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/ShowerHitsBaseTool.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.cc
     larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.cc

--- a/larpandoracontent/LArContent.cc
+++ b/larpandoracontent/LArContent.cc
@@ -123,6 +123,7 @@
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedLongitudinalTrackHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/MultiValuedTransverseTrackHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverAlgorithm.h"
+#include "larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/ThreeDHitCreationAlgorithm.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/ThreeViewShowerHitsTool.h"
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/TwoViewShowerHitsTool.h"
@@ -426,6 +427,7 @@
     d("LArDeltaRayShowerHits",                  DeltaRayShowerHitsTool)                                                         \
     d("LArMultiValuedLongitudinalTrackHits",    MultiValuedLongitudinalTrackHitsTool)                                           \
     d("LArMultiValuedTransverseTrackHits",      MultiValuedTransverseTrackHitsTool)                                             \
+    d("LArPlaneSolverHits",                     PlaneSolverHitsTool)                                                            \
     d("LArThreeViewShowerHits",                 ThreeViewShowerHitsTool)                                                        \
     d("LArTwoViewShowerHits",                   TwoViewShowerHitsTool)                                                          \
     d("LArClearLongitudinalTracks",             ClearLongitudinalTracksTool)                                                    \

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.cc
@@ -1,0 +1,88 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.cc
+ *
+ *  @brief  Implementation of the plane solver-based hit creation tool.
+ *
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "larpandoracontent/LArObjects/LArPlaneContextObject.h"
+
+#include "larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.h"
+
+using namespace pandora;
+
+namespace lar_content
+{
+
+PlaneSolverHitsTool::PlaneSolverHitsTool() :
+    m_planeSolverContextName("PlaneContext")
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void PlaneSolverHitsTool::Run(ThreeDHitCreationAlgorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pPfo,
+    const pandora::CaloHitVector &inputTwoDHits, ProtoHitVector &protoHitVector)
+{
+
+    const LArPlaneContextObject *pPlaneContextObject{
+        dynamic_cast<const LArPlaneContextObject *>(PandoraContentApi::GetEventContextObject(*pAlgorithm, "PlaneContext"))};
+
+    if (!pPlaneContextObject)
+        return;
+
+    for (auto const *pCaloHit2D : inputTwoDHits)
+    {
+        const LArPlaneContextObject::HitTriplet *pTriplet{pPlaneContextObject->GetHitTriplet(pCaloHit2D)};
+        if (!pTriplet)
+            continue;
+
+        std::unordered_map<HitType, const CaloHit *> hitTypeToCaloHitMap;
+        hitTypeToCaloHitMap[TPC_VIEW_U] = pTriplet->m_uHit;
+        hitTypeToCaloHitMap[TPC_VIEW_V] = pTriplet->m_vHit;
+        hitTypeToCaloHitMap[TPC_VIEW_W] = pTriplet->m_wHit;
+
+        const HitType hitType{pCaloHit2D->GetHitType()};
+        const HitType hitType1((TPC_VIEW_U == hitType) ? TPC_VIEW_V : (TPC_VIEW_V == hitType) ? TPC_VIEW_W : TPC_VIEW_U);
+        const HitType hitType2((TPC_VIEW_U == hitType) ? TPC_VIEW_W : (TPC_VIEW_V == hitType) ? TPC_VIEW_U : TPC_VIEW_V);
+
+        bool canUseHit1{false};
+        if (hitTypeToCaloHitMap[hitType1] != nullptr)
+            canUseHit1 = std::find(inputTwoDHits.begin(), inputTwoDHits.end(), hitTypeToCaloHitMap[hitType1]) != inputTwoDHits.end();
+
+        bool canUseHit2{false};
+        if (hitTypeToCaloHitMap[hitType2] != nullptr)
+            canUseHit2 = std::find(inputTwoDHits.begin(), inputTwoDHits.end(), hitTypeToCaloHitMap[hitType2]) != inputTwoDHits.end();
+
+        // If we don't have any hits then move on
+        if (!canUseHit1 && !canUseHit2)
+            continue;
+
+        CartesianPointVector fitPositions1, fitPositions2;
+        if (canUseHit1)
+            fitPositions1.emplace_back(hitTypeToCaloHitMap[hitType1]->GetPositionVector());
+        if (canUseHit2)
+            fitPositions2.emplace_back(hitTypeToCaloHitMap[hitType2]->GetPositionVector());
+
+        ProtoHit protoHit(pCaloHit2D);
+        this->GetBestPosition3D(hitType1, hitType2, fitPositions1, fitPositions2, protoHit);
+
+        if (protoHit.IsPositionSet() && (protoHit.GetChi2() < m_chiSquaredCut))
+            protoHitVector.emplace_back(protoHit);
+    }
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PlaneSolverHitsTool::ReadSettings(const pandora::TiXmlHandle xmlHandle)
+{
+    PANDORA_RETURN_RESULT_IF_AND_IF(
+        STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle, "PlaneSolverContextName", m_planeSolverContextName));
+
+    return HitCreationBaseTool::ReadSettings(xmlHandle);
+}
+
+} // namespace lar_content

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.cc
@@ -12,6 +12,8 @@
 
 #include "larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.h"
 
+#include <unordered_map>
+
 using namespace pandora;
 
 namespace lar_content
@@ -67,11 +69,16 @@ void PlaneSolverHitsTool::Run(ThreeDHitCreationAlgorithm *const pAlgorithm, cons
         if (canUseHit2)
             fitPositions2.emplace_back(hitTypeToCaloHitMap[hitType2]->GetPositionVector());
 
-        ProtoHit protoHit(pCaloHit2D);
-        this->GetBestPosition3D(hitType1, hitType2, fitPositions1, fitPositions2, protoHit);
-
-        if (protoHit.IsPositionSet() && (protoHit.GetChi2() < m_chiSquaredCut))
-            protoHitVector.emplace_back(protoHit);
+        try
+        {
+            ProtoHit protoHit(pCaloHit2D);
+            this->GetBestPosition3D(hitType1, hitType2, fitPositions1, fitPositions2, protoHit);
+            if (protoHit.IsPositionSet() && (protoHit.GetChi2() < m_chiSquaredCut))
+                protoHitVector.emplace_back(protoHit);
+        }
+        catch (StatusCodeException &)
+        {
+        }
     }
 }
 

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.cc
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.cc
@@ -29,7 +29,7 @@ void PlaneSolverHitsTool::Run(ThreeDHitCreationAlgorithm *const pAlgorithm, cons
 {
 
     const LArPlaneContextObject *pPlaneContextObject{
-        dynamic_cast<const LArPlaneContextObject *>(PandoraContentApi::GetEventContextObject(*pAlgorithm, "PlaneContext"))};
+        dynamic_cast<const LArPlaneContextObject *>(PandoraContentApi::GetEventContextObject(*pAlgorithm, m_planeSolverContextName))};
 
     if (!pPlaneContextObject)
         return;

--- a/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.h
+++ b/larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.h
@@ -1,0 +1,48 @@
+/**
+ *  @file   larpandoracontent/LArThreeDReco/LArHitCreation/PlaneSolverHitsTool.h
+ *
+ *  @brief  Header file for the plane solver-based hit creation tool.
+ *
+ *  $Log: $
+ */
+#ifndef LAR_PLANE_SOLVER_HITS_TOOL_H
+#define LAR_PLANE_SOLVER_HITS_TOOL_H 1
+
+#include "Pandora/AlgorithmTool.h"
+
+#include "larpandoracontent/LArThreeDReco/LArHitCreation/HitCreationBaseTool.h"
+
+namespace lar_content
+{
+
+/**
+ *  @brief  PlaneSolverHitsTool class
+ */
+class PlaneSolverHitsTool : public HitCreationBaseTool
+{
+public:
+    /**
+     *  @brief  Default constructor
+     */
+    PlaneSolverHitsTool();
+
+    /**
+     *  @brief  Run the algorithm tool
+     *
+     *  @param  pAlgorithm address of the calling algorithm
+     *  @param  pPfo the address of the pfo
+     *  @param  inputTwoDHits the vector of input two dimensional hits
+     *  @param  protoHitVector to receive the new three dimensional proto hits
+     */
+    void Run(ThreeDHitCreationAlgorithm *const pAlgorithm, const pandora::ParticleFlowObject *const pPfo,
+        const pandora::CaloHitVector &inputTwoDHits, ProtoHitVector &protoHitVector);
+
+private:
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    std::string m_planeSolverContextName; ///< Name of the LArPlaneContextObject produced by PlaneSolverAlgorithm
+};
+
+} // namespace lar_content
+
+#endif // #ifndef LAR_PLANE_SOLVER_HITS_TOOL_H


### PR DESCRIPTION
A new 3D hit creation algorithm using the PlaneContextObject produced by the PlaneSolver. When placed first in the 3D hit creation tool list for tracks we get an increase in hit reconstruction efficiency and an improved resolution. This will be followed up with a few quality of life improvements for 3D hit-making generally.